### PR TITLE
fix(ci): 修复 release-please 冷启动不发版

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "f7064e5029b83a8215ea890b19e281e64381c7a7",
   "release-type": "python",
   "include-component-in-tag": false,
   "package-name": "openfic",


### PR DESCRIPTION
## PR 标题

fix(ci): 修复 release-please 冷启动不发版

## 变更说明

- 问题: 全新仓库合并 feat 提交到 main 后，release-please 运行 success 但不开 release PR、不打 tag，日志显示 `Splitting 0 commits by path`
- 重要性: 导致自动发版流水线无法触发首个版本
- 变化: 在 `release-please-config.json` 添加 `bootstrap-sha` 指向初始 commit `f7064e5`

## 关联 Issue / PR

承接 #1

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 构建/工具链 (chore)

## 问题原因(如有)

全新干净启动的仓库没有任何历史 Release/Tag。release-please 的 manifest 模式默认需以上次 Release 作锚点收集后续 commit；找不到锚点时，扫描到的 commit 被判定为无法归属，最终 0 个进入发版范围，故静默结束不开 PR。配置 `bootstrap-sha` 显式指定初始 commit 作为收集起点，解决冷启动。

## 自查清单

- [ ] 已添加/更新必要的测试
- [ ] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

JSON 语法已校验。合并到 main 后，release-please 将以 `bootstrap-sha` 为起点收集首个 `feat:` 提交，开出 v0.1.0 release PR。
