### PR TITLE
fix(ci): 改用 last-release-sha 设定发版基线

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "bootstrap-sha": "f7064e5029b83a8215ea890b19e281e64381c7a7",
+  "last-release-sha": "f7064e5029b83a8215ea890b19e281e64381c7a7",
   "release-type": "python",
   "include-component-in-tag": false,
   "package-name": "openfic",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "bootstrap-sha": "f7064e5029b83a8215ea890b19e281e64381c7a7",
   "release-type": "python",
   "include-component-in-tag": false,
   "package-name": "openfic",


### PR DESCRIPTION
## PR 标题

fix(ci): 改用 last-release-sha 设定发版基线

## 变更说明

- 问题: bootstrap-sha 未生效，release-please 仍报 `Splitting 0 commits`，不发版
- 重要性: 自动发版仍无法触发
- 变化: 将 `bootstrap-sha` 改为 `last-release-sha`

## 关联 Issue / PR

承接 #2

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 构建/工具链 (chore)

## 问题原因(如有)

`bootstrap-sha` 仅在 release-please 内部判定 `needsBootstrap` 为真时才作为收集边界使用；全新仓库因找不到上次 Release，仍走「查找历史 release 锚点」路径，命中 `Could not find releases` 后放弃收集，导致 0 commits。`last-release-sha` 对任意 release 都强制作为基线点（源码中遇此 SHA 即 break 迭代），绕过「找不到 release」的死循环。

## 自查清单

- [ ] 已添加/更新必要的测试
- [ ] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

JSON 语法已校验。合并 main 后，release-please 将以 `f7064e5` 为基线收集其后的 feat commit，开出 v0.1.0 release PR。
