### PR TITLE
docs: 完善项目文档并修复 release-please 配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,71 @@
 # OpenFic
+<p>
+  <img src="https://img.shields.io/badge/Python-3.12%2B-3776AB?style=flat-square&logo=python&logoColor=white" alt="Python 3.12+">
+  <img src="https://img.shields.io/badge/react-19-149ECA?style=flat-square&logo=react&logoColor=white" alt="React 19">
+  <img src="https://img.shields.io/badge/fastapi-0.127%2B-009688?style=flat-square&logo=fastapi&logoColor=white" alt="FastAPI">
+</p>
 
+
+**OpenFic** 是AI Agent时代专为小说创作打造的一站式写作平台，构建设定、设计角色、定制工作流，让Agent适应你的写作流程，而非反之。与OpenFic一起，将你的脑海中的世界变为现实。
+
+## 特性
+
+- 🚀开箱即用：使用Docker或pip快速安装，无需复杂配置
+- 🤝全面的模型支持：无缝集成来自数十家提供商的模型，或是任何兼容OpenAI API的模型
+- 📱响应式UI：在桌面端、移动端和浏览器上享受无缝的流畅体验
+- 🧩定制化工作流：高度可配置的Agent系统，自由的修改任何Prompt，构建属于你的工作流
+- ✒️以写作为中心：与Agent深度集成的辅助创作，发散思维、构建情节、协同编辑，告别抽卡式的一键生成
+- 💾本地持久化：所有项目数据保存在本地，零云存储依赖
+- 🧠语义化检索：基于向量的Agentic RAG，让Agent能够在百万字级别的项目中高效检索过往信息
+- ⚖️成本优先的上下文管理：智能压缩、动态截断、稳定缓存，尽可能降低使用成本
+
+
+## 安装
+
+### 🐳 Docker（推荐）
+
+如果使用容器方式安装进行自托管是推荐的安装方式。
+
+#### 1. 拉取镜像
+
+```bash
+docker pull ghcr.io/syrizelink/openfic:latest
+```
+
+#### 2. 运行容器
+
+```bash
+docker run -d -p 8000:8000 -v "openfic:/data" --name openfic ghcr.io/syrizelink/openfic:latest
+```
+
+#### 3. 启动后访问
+
+```text
+http://localhost:8000
+```
+
+### 🐍 Python pip
+
+在开始安装前，确保你已经安装了Python3.12+
+
+#### 1. 安装OpenFic
+
+```bash
+pip install openfic
+```
+
+#### 2. 启动服务
+
+```bash
+openfic serve
+```
+
+#### 3. 启动后访问
+
+```text
+http://localhost:8000
+```
+
+### 桌面应用
+
+前往 <https://github.com/syrizelink/OpenFic/releases> 下载桌面应用，在你的系统上原生运行，而无需额外步骤。

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,9 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "python",
+  "last-release-sha": "f7064e5029b83a8215ea890b19e281e64381c7a7",
   "include-component-in-tag": false,
-  "package-name": "openfic",
-  "changelog-path": "CHANGELOG.md",
   "changelog-sections": [
     { "type": "feat", "section": "✨ 新功能" },
     { "type": "fix", "section": "🐛 问题修复" },
@@ -15,11 +13,18 @@
     { "type": "ci", "section": "👷 CI/CD", "hidden": false },
     { "type": "style", "section": "💄 格式", "hidden": true }
   ],
-  "extra-files": [
-    {
-      "type": "json",
-      "path": "frontend/package.json",
-      "jsonpath": "$.version"
+  "packages": {
+    ".": {
+      "release-type": "python",
+      "package-name": "openfic",
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "frontend/package.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
-  ]
+  }
 }


### PR DESCRIPTION
## PR 标题

docs: 完善项目文档并修复 release-please 配置

## 变更说明

- 补充项目 README 文档：项目介绍、特性和快速开始
- 修正 release-please manifest 配置结构：将组件配置移入 `packages."."` 块，配合 `last-release-sha` 设定基线，解决全新仓库冷启动 `Splitting 0 commits` 不发版问题

## 关联 Issue / PR

无（承接历史失败的 #1/#2/#3，main 已 reset 重来）

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [x] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 构建/工具链 (chore)

## 问题原因(如有)

release-please manifest 模式按 `packages` 路径块加载策略，根组件配置必须放在 `packages."."` 下。此前 `release-type` 放在顶层，未关联到根组件，导致策略未加载、`last-release-sha` 不生效，日志显示 `Splitting 0 commits`。同时全新仓库无历史 Release 锚点，需 `last-release-sha` 显式指定基线 commit。

## 自查清单

- [ ] 已添加/更新必要的测试
- [ ] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

两个原子提交：`docs:` README 文档、`fix:` release-please 配置结构修正。JSON 语法已校验。合并 main 后，release-please 将以 `last-release-sha` 为基线、按 `packages."."` 策略收集首个 feat 提交并发版。

注：本 PR 的 `docs:` 提交不触发发版，需后续 `feat:` 提交才会开出首个 release PR。
