### PR TITLE
fix(ci): 修复 release PR 合并命令参数解析

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,8 +28,12 @@ jobs:
       # 改为直接合并（普通合并路径，不依赖 auto-merge 设置）。
       # release PR 仅含版本号 bump + CHANGELOG，无代码逻辑，立即合并安全。
       # 用 PAT 合并，确保该 push 能触发下一次 release-please 运行去打 tag。
+      # steps.release.outputs.pr 是 JSON 字符串，需用 jq 提取 number 字段。
       - name: 合并 release PR
         if: ${{ steps.release.outputs.pr }}
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-        run: gh pr merge ${{ steps.release.outputs.pr }} --squash --delete-branch
+          PR_JSON: ${{ steps.release.outputs.pr }}
+        run: |
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+          gh pr merge "$PR_NUMBER" --squash --delete-branch


### PR DESCRIPTION
## PR 标题

fix(ci): 修复 release PR 合并命令参数解析

## 变更说明

- 问题: release-please workflow 合并 release PR 时报错 `accepts at most 1 arg(s), received 7`
- 重要性: release PR 无法自动合并，自动发版流程中断在最后一步
- 变化: 用 `jq` 从 `steps.release.outputs.pr` 的 JSON 字符串提取 `number` 字段，再传给 `gh pr merge`

## 关联 Issue / PR

承接 #5（发版已成功触发，但合并步骤失败）

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 构建/工具链 (chore)

## 问题原因(如有)

`steps.release.outputs.pr` 是 release-please-action v4 输出的 JSON 字符串（如 `{"number":6,...}`），直接拼接进 `gh pr merge` 命令后，JSON 中的空格与字段被 shell 当作多个参数，触发 `accepts at most 1 arg(s)` 错误。改用 `jq -r '.number'` 提取 PR 号。

## 自查清单

- [ ] 已添加/更新必要的测试
- [ ] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

YAML 语法已校验。合并后，已存在的 release PR #6（chore(main): release 0.2.0）可在下次 release-please 运行时被正确自动合并。
