### PR TITLE
fix(ci): 合并 release PR 前增加 checkout

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,6 +29,11 @@ jobs:
       # release PR 仅含版本号 bump + CHANGELOG，无代码逻辑，立即合并安全。
       # 用 PAT 合并，确保该 push 能触发下一次 release-please 运行去打 tag。
       # steps.release.outputs.pr 是 JSON 字符串，需用 jq 提取 number 字段。
+      # --delete-branch 需本地 git 仓库，故合并前先 checkout。
+      - uses: actions/checkout@v4
+        if: ${{ steps.release.outputs.pr }}
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
       - name: 合并 release PR
         if: ${{ steps.release.outputs.pr }}
         env:


### PR DESCRIPTION
## PR 标题

fix(ci): 合并 release PR 前增加 checkout

## 变更说明

- 问题: release PR 合并步骤报错 `failed to run git: fatal: not a git repository`
- 重要性: release PR 仍无法自动合并，自动发版流程中断
- 变化: 在 `gh pr merge --delete-branch` 前加 `actions/checkout`，提供本地 git 仓库

## 关联 Issue / PR

承接 #7

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 构建/工具链 (chore)

## 问题原因(如有)

`gh pr merge --delete-branch` 会执行本地 git 操作（删除分支引用），但该 job 此前未 `actions/checkout`，工作目录不是 git 仓库，故报 `not a git repository`。在合并步骤前加 `actions/checkout`（用 PAT token）解决。

## 自查清单

- [ ] 已添加/更新必要的测试
- [ ] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

YAML 语法已校验。合并后，已存在的 release PR #6 可在下次 release-please 运行时被正确自动合并。
