### PR TITLE
fix(ci): 修复 Docker 推送 403 与版本号同步缺失

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,6 +133,8 @@ jobs:
   docker:
     needs: [context, preflight, test-frontend, test-backend]
     runs-on: ubuntu-latest
+    env:
+      BUILDX_NO_DEFAULT_ATTESTATIONS: true
     steps:
       - uses: actions/checkout@v7
       - uses: docker/setup-qemu-action@v4
@@ -154,6 +156,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          provenance: false
           tags: ${{ steps.tags.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openfic-backend"
-version = "0.0.0"
+version = "0.2.0"
 description = "Ready for adding."
 readme = "README.md"
 requires-python = ">=3.12,<3.14"

--- a/frontend/electron/electron-builder.yml
+++ b/frontend/electron/electron-builder.yml
@@ -19,7 +19,12 @@ extraResources:
 win:
   target:
     - target: nsis
+      arch:
+        - x64
+      artifactName: OpenFic-${version}-win-setup.${ext}
     - target: zip
+      arch:
+        - x64
 
 nsis:
   oneClick: false

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -23,7 +23,8 @@
           "type": "json",
           "path": "frontend/package.json",
           "jsonpath": "$.version"
-        }
+        },
+        "backend/pyproject.toml"
       ]
     }
   }


### PR DESCRIPTION
## 变更说明

修复 release 流程中三个问题：

- **Docker 推送 403 Forbidden**：buildx 默认启用 `provenance` attestation，多平台构建推送到 ghcr.io 时触发 403。通过 `BUILDX_NO_DEFAULT_ATTESTATIONS: true` 环境变量与 `provenance: false` 关闭
- **镜像版本号显示 0.0.0**：release-please 的 python release-type 默认只查找根目录 `pyproject.toml`，后端在 `backend/` 子目录导致版本号未同步 bump。将 `backend/pyproject.toml` 加入 `extra-files`，并手动对齐版本至 `0.2.0` 基线
- **NSIS 安装包命名**：默认 `OpenFic Setup 0.2.1.exe` 不符合预期，自定义 `artifactName` 为 `OpenFic-${version}-win-setup.${ext}`

## 关联 Issue

无

## 变更类型

- [x] Bug 修复（fix）

## 验证方式

- v0.2.1 release 的 docker job 日志确认 403 根因为 provenance attestation
- docker/build-push-action 文档确认 `BUILDX_NO_DEFAULT_ATTESTATIONS` 关闭默认 attestation
- electron-builder 文档确认 `artifactName` 宏语法与 target 级别配置

## Pre-flight Checklist

- [x] 提交信息符合 Conventional Commits
- [x] 本地 lint / typecheck 通过（配置文件变更，无代码逻辑）
