### PR TITLE
fix(build): 修正 electron-builder 配置并启用 changelog 作者显示

### DIFF
--- a/frontend/electron/electron-builder.yml
+++ b/frontend/electron/electron-builder.yml
@@ -21,7 +21,6 @@ win:
     - target: nsis
       arch:
         - x64
-      artifactName: OpenFic-${version}-win-setup.${ext}
     - target: zip
       arch:
         - x64
@@ -29,6 +28,7 @@ win:
 nsis:
   oneClick: false
   allowToChangeInstallationDirectory: true
+  artifactName: OpenFic-${version}-win-setup.${ext}
 
 mac:
   target:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "last-release-sha": "f7064e5029b83a8215ea890b19e281e64381c7a7",
   "include-component-in-tag": false,
+  "include-commit-authors": true,
   "changelog-sections": [
     { "type": "feat", "section": "✨ 新功能" },
     { "type": "fix", "section": "🐛 问题修复" },


### PR DESCRIPTION
## 变更内容

- **fix(build)**: 修正 `electron-builder.yml` 中 `artifactName` 的配置位置
  - 原置于 `win.target` 数组元素内，触发 electron-builder 25.x schema 校验报错（`unknown property 'artifactName'`）
  - 移至 `nsis` 配置块下，符合 target-specific options 规范
- **chore(ci)**: release-please 启用 `include-commit-authors`
  - changelog 每条变更将追加 commit 作者 `@username`，在 GitHub Release 页面渲染为可点击链接

## 测试

- [x] 配置项位置已按 electron-builder schema 修正
- [x] release-please 配置已添加 `include-commit-authors: true`
- [ ] 等待 CI 验证 electron-builder 构建通过

## 说明

本 PR 用于验证 squash 合并方式。squash 合并后 GitHub 会自动在 commit message 追加 `(#PR编号)`，release-please 据此在 changelog 中生成可点击的 PR 链接。