### PR TITLE
fix(ci): 修复 release-please 未更新后端版本号及镜像版本

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,12 +25,11 @@ jobs:
       version: ${{ steps.meta.outputs.version }}
       release_tag: ${{ steps.meta.outputs.release_tag }}
     steps:
-      - uses: actions/checkout@v7
       - id: meta
         run: |
-          VERSION=$(python3 -c "import tomllib;print(tomllib.loads(open('backend/pyproject.toml','rb').read().decode())['project']['version'])")
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "release_tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          RELEASE_TAG=${GITHUB_REF#refs/tags/}
+          echo "version=${RELEASE_TAG#v}" >> "$GITHUB_OUTPUT"
+          echo "release_tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
 
   # ---------------------------------------------------------------- test gate
   test-frontend:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openfic-backend"
-version = "0.2.0"
+version = "0.2.4"
 description = "Ready for adding."
 readme = "README.md"
 requires-python = ">=3.12,<3.14"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2005,7 +2005,7 @@ wheels = [
 
 [[package]]
 name = "openfic-backend"
-version = "0.2.0"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiocache" },

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,7 +25,11 @@
           "path": "frontend/package.json",
           "jsonpath": "$.version"
         },
-        "backend/pyproject.toml"
+        {
+          "type": "toml",
+          "path": "backend/pyproject.toml",
+          "jsonpath": "$.project.version"
+        }
       ]
     }
   }


### PR DESCRIPTION
## PR 标题

fix(ci): 修复 release-please 未更新后端版本号及镜像版本

## 变更说明

- 问题: release-please 自 0.2.0 起从未更新 `backend/pyproject.toml` 的版本号，且 Docker 镜像 tag 永远停留在 `0.2.0`。
- 重要性: 版本号长期错位导致镜像 tag 失真，无法按版本回溯/锁定镜像，桌面端与后端版本也不一致。
- 变化:
  - `release-please-config.json`：将 `backend/pyproject.toml` 从纯字符串改为带 `jsonpath: "$.project.version"` 的 toml 条目。根因是 GenericToml 默认查顶层 `$.version`，而 pyproject 的版本在 `$.project.version`，故此前从未命中。
  - `.github/workflows/release.yml`：`context` job 的 `version` 改为从 git tag 派生（`${tag#v}`），不再读 `backend/pyproject.toml`。这样镜像 tag 与 git tag/release 始终一致，不再依赖 pyproject 是否被及时 bump。
  - `backend/pyproject.toml` + `backend/uv.lock`：将对齐到当前已发布版本 `0.2.4`，消除历史漂移。

## 关联 Issue / PR

无。

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 构建/工具链 (chore)

## 问题原因

1. `backend/pyproject.toml` 在 `extra-files` 中以纯字符串列出，release-please 据文件后缀 `.toml` 选用 GenericToml 更新器，而该更新器默认更新**顶层** `version` 键。pyproject.toml 的版本位于 `[project]` 表下（`$.project.version`），顶层无 `version`，故更新器找不到目标，每次 release PR 都跳过该文件。`frontend/package.json` 因显式指定 `jsonpath: "$.version"` 才正常工作。
2. Docker 镜像版本取自 `release.yml` 的 `context` job，而该 job 通过解析 `backend/pyproject.toml` 读取版本号。由于 (1) 导致 pyproject 卡在 `0.2.0`，镜像 tag 也就恒为 `0.2.0`。即便修好 (1)，镜像版本也不应耦合于 pyproject，故改为从 git tag 派生。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证记录：
- 本地 `uv lock` 后 `uv.lock` 仅 1 行变动（`openfic-backend` 版本 `0.2.0` → `0.2.4`），无依赖漂移。
- `release-please-config.json` 的 toml + jsonpath 写法依据 release-please 官方文档（`Updating arbitrary TOML files`）。
