### PR TITLE
fix(ci): 同步 uv.lock 并修正后端包名

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,6 +34,41 @@ jobs:
         if: ${{ steps.release.outputs.pr }}
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+      - uses: actions/setup-python@v6
+        if: ${{ steps.release.outputs.pr }}
+        with:
+          python-version: '3.12'
+      - uses: astral-sh/setup-uv@v5
+        if: ${{ steps.release.outputs.pr }}
+        with:
+          enable-cache: true
+          cache-dependency-glob: backend/uv.lock
+      - name: 同步 backend uv.lock
+        if: ${{ steps.release.outputs.pr }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          PR_JSON: ${{ steps.release.outputs.pr }}
+        run: |
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
+          PR_HEAD_REF=$(gh pr view "$PR_NUMBER" --json headRefName -q '.headRefName')
+
+          git fetch origin "$PR_HEAD_REF:$PR_HEAD_REF"
+          git checkout "$PR_HEAD_REF"
+
+          pushd backend
+          uv lock
+          popd
+
+          if git diff --quiet -- backend/uv.lock; then
+            echo "backend/uv.lock 无需更新"
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add backend/uv.lock
+          git commit -m "chore(backend): 同步 uv.lock 版本"
+          git push origin HEAD:"$PR_HEAD_REF"
       - name: 合并 release PR
         if: ${{ steps.release.outputs.pr }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,6 +192,9 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: backend/uv.lock
       - name: 安装后端依赖并打包
         working-directory: backend
         run: |
@@ -217,7 +220,11 @@ jobs:
       - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
-          path: dist-electron/*
+          path: |
+            dist-electron/*.exe
+            dist-electron/*.zip
+            dist-electron/*.dmg
+            dist-electron/*.blockmap
 
   # ---------------------------------------------------------------- release
   publish-release:

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -29,7 +29,7 @@ def _read_version() -> str:
     try:
         from importlib.metadata import PackageNotFoundError, version
 
-        return version("openfic-backend")
+        return version("openfic")
     except (PackageNotFoundError, Exception):
         return "0.0.0"
 

--- a/backend/packaging/openfic.spec
+++ b/backend/packaging/openfic.spec
@@ -29,7 +29,7 @@ _DYNAMIC_PACKAGES = [
     "langchain_nvidia_ai_endpoints", "langchain_openrouter",
     "langchain_amazon_nova", "langgraph_checkpoint_sqlite",
     "lancedb", "fastembed", "onnxruntime", "tiktoken", "mem0ai",
-    "aiocache", "argon2", "cryptography", "pyzmq", "fastembed",
+    "aiocache", "argon2", "cryptography", "pyzmq",
 ]
 for _pkg in _DYNAMIC_PACKAGES:
     try:

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "openfic-backend"
+name = "openfic"
 version = "0.2.5"
 description = "Ready for adding."
 readme = "README.md"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -2004,8 +2004,8 @@ wheels = [
 ]
 
 [[package]]
-name = "openfic-backend"
-version = "0.2.4"
+name = "openfic"
+version = "0.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiocache" },


### PR DESCRIPTION
## PR 标题

fix(ci): 同步 uv.lock 并修正后端包名

## 变更说明

- 问题: release-please 更新版本号后不会同步 `backend/uv.lock`，导致后续运行后端命令时产生无关 lock 文件漂移；同时后端包名仍为 `openfic-backend`，与发布配置中的 `openfic` 不一致。
- 重要性: 该问题会持续污染工作区，并增加发布流程与本地环境之间的版本不一致风险。
- 变化: 在 `release-please` 自动合并前新增 `uv lock` 同步步骤，并在有变更时自动提交回 release PR 分支；将后端项目包名统一为 `openfic`，同步更新 CLI 版本读取与本地 `uv.lock`。
- 变化: 保留上一轮桌面发布优化，包含桌面 `uv` 缓存、桌面产物上传范围收敛，以及 PyInstaller 重复 `fastembed` 收集去重。

## 关联 Issue / PR (如有)

N/A

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 构建/工具链 (chore)

## 问题原因(如有)

release-please 只能更新显式配置的版本文件，不会自动重建 `uv.lock` 这类生成型锁文件；同时后端包名与 release 配置中的包名不一致，放大了版本同步后的工作区漂移问题。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证结果：
- `uv run ruff check .`
- `uv run mypy app`
- `uv run pytest -q` -> `931 passed in 148.75s (0:02:28)`
- `uv run python -c "from importlib.metadata import version; print(version('openfic'))"` -> `0.2.5`
