### PR TITLE
fix(ci): 修复桌面发布流程

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Package
 
 on:
   push:
@@ -176,9 +176,12 @@ jobs:
           - os: windows-latest
             electron_args: '--win --x64'
             artifact_name: desktop-win-x64
-          - os: macos-13
-            electron_args: '--mac --x64'
-            artifact_name: desktop-mac-x64
+          - os: ubuntu-latest
+            electron_args: '--linux --x64'
+            artifact_name: desktop-linux-x64
+          - os: ubuntu-24.04-arm
+            electron_args: '--linux --arm64'
+            artifact_name: desktop-linux-arm64
           - os: macos-14
             electron_args: '--mac --arm64'
             artifact_name: desktop-mac-arm64
@@ -196,7 +199,12 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
-          cache-dependency-path: desktop/pnpm-lock.yaml
+          cache-dependency-path: |
+            desktop/pnpm-lock.yaml
+            frontend/pnpm-lock.yaml
+      - name: 安装前端依赖
+        working-directory: frontend
+        run: pnpm install --frozen-lockfile
       - name: 安装桌面端依赖
         working-directory: desktop
         run: pnpm install --frozen-lockfile
@@ -212,6 +220,8 @@ jobs:
           name: ${{ matrix.artifact_name }}
           path: |
             desktop/dist-electron/*.exe
+            desktop/dist-electron/*.AppImage
+            desktop/dist-electron/*.tar.gz
             desktop/dist-electron/*.zip
             desktop/dist-electron/*.dmg
             desktop/dist-electron/*.blockmap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release Please
+name: Release
 
 on:
   push:
@@ -69,4 +69,23 @@ jobs:
           PR_JSON: ${{ steps.release.outputs.pr }}
         run: |
           PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
-          gh pr merge "$PR_NUMBER" --auto --squash --delete-branch
+
+          for attempt in {1..12}; do
+            echo "Attempt $attempt: enable auto-merge for release PR #${PR_NUMBER}"
+
+            if gh pr merge "$PR_NUMBER" --auto --squash --delete-branch 2>merge-error.log; then
+              exit 0
+            fi
+
+            ERROR=$(cat merge-error.log)
+            echo "$ERROR"
+
+            if [[ "$ERROR" != *"Base branch was modified"* ]]; then
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+          echo "Release PR auto-merge failed after retries"
+          exit 1

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -38,3 +38,15 @@ mac:
         - arm64
   category: public.app-category.productivity
   identity: null
+
+linux:
+  target:
+    - target: AppImage
+      arch:
+        - x64
+        - arm64
+    - target: tar.gz
+      arch:
+        - x64
+        - arm64
+  category: Utility


### PR DESCRIPTION
## PR 标题

fix(ci): 修复桌面发布流程

## 变更说明

- 问题: 桌面端 CI 构建会引用前端源码样式，但桌面打包 job 未安装前端依赖，导致 Farm 无法解析前端 CSS 依赖。
- 问题: Release Please 自动合并 release PR 时，遇到 base 分支瞬时更新会直接失败。
- 重要性: 这些问题会阻断 tag 发布和 release PR 自动合并，影响版本发布链路稳定性。
- 变化: 桌面打包 job 安装前端依赖，并移除 macOS x64 桌面包，新增 Linux x64/arm64 桌面包。
- 变化: release PR 自动合并针对 `Base branch was modified` 增加有限重试。

## 关联 Issue / PR (如有)

#XXXX

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

桌面端构建链路依赖 `frontend/src/styles/index.css`，但 CI 中桌面 job 只安装 `desktop` 依赖，缺少前端依赖解析环境。release PR 自动合并则没有处理 GitHub 返回的 base 分支瞬时更新竞态。

## 自查清单

- [ ] 已添加/更新必要的测试
- [ ] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证记录:

- `git pull --ff-only origin main`
- `pnpm dlx js-yaml .github/workflows/release.yml >/tmp/kilo/release-yaml-followups.txt && pnpm dlx js-yaml .github/workflows/package.yml >/tmp/kilo/package-yaml-followups.txt && pnpm dlx js-yaml desktop/electron-builder.yml >/tmp/kilo/electron-builder-yaml-followups.txt`
- `pnpm build`（desktop）
