### PR TITLE
ci(release): 等待 release PR 可合并

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,22 @@ jobs:
         run: |
           PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
 
-          for attempt in {1..12}; do
+          for attempt in {1..18}; do
             echo "Attempt $attempt: enable auto-merge for release PR #${PR_NUMBER}"
+
+            MERGEABLE=$(gh pr view "$PR_NUMBER" --json mergeable -q '.mergeable')
+            MERGE_STATE=$(gh pr view "$PR_NUMBER" --json mergeStateStatus -q '.mergeStateStatus')
+            echo "mergeable=${MERGEABLE} mergeStateStatus=${MERGE_STATE}"
+
+            if [[ "$MERGEABLE" == "CONFLICTING" || "$MERGE_STATE" == "DIRTY" ]]; then
+              echo "Release PR has merge conflicts and cannot be auto-merged"
+              exit 1
+            fi
+
+            if [[ "$MERGEABLE" == "UNKNOWN" ]]; then
+              sleep 10
+              continue
+            fi
 
             if gh pr merge "$PR_NUMBER" --auto --squash --delete-branch 2>merge-error.log; then
               exit 0
@@ -80,7 +94,7 @@ jobs:
             ERROR=$(cat merge-error.log)
             echo "$ERROR"
 
-            if [[ "$ERROR" != *"Base branch was modified"* ]]; then
+            if [[ "$ERROR" != *"Base branch was modified"* && "$ERROR" != *"Pull Request is not mergeable"* ]]; then
               exit 1
             fi
 


### PR DESCRIPTION
## PR 标题

ci(release): 等待 release PR 可合并

## 变更说明

- 问题: Release Please 创建或更新 release PR 后，GitHub 可能仍在重新计算 PR 的可合并状态。
- 重要性: 当前 workflow 会立即执行 `gh pr merge --auto`，遇到 `Pull Request is not mergeable` 会直接失败，导致 release 自动化链路不稳定。
- 变化: 自动合并前轮询 `mergeable` 和 `mergeStateStatus`，等待状态稳定。
- 变化: 对 `Base branch was modified` 和 `Pull Request is not mergeable` 这两类瞬态错误保留有限重试，其它错误仍立即失败。

## 关联 Issue / PR (如有)

#XXXX

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因(如有)

Release Please 可能会更新 release PR 分支，GitHub 需要时间重新计算 `mergeable` 状态。此前 workflow 在状态仍为 `UNKNOWN` 或暂不可合并时立即调用 merge mutation，触发失败。

## 自查清单

- [ ] 已添加/更新必要的测试
- [ ] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证记录:

- `pnpm dlx js-yaml .github/workflows/release.yml >/tmp/kilo/release-yaml-mergeable-wait.txt`
