### PR TITLE
fix(desktop): 修复 Windows 构建样式解析

### DIFF
--- a/desktop/farm.config.ts
+++ b/desktop/farm.config.ts
@@ -10,6 +10,7 @@ const reactDomPath = require.resolve("react-dom");
 const reactDomClientPath = require.resolve("react-dom/client");
 const schedulerPath = require.resolve("scheduler");
 const lucideReactPath = require.resolve("lucide-react");
+const radixThemesStylesPath = require.resolve("@radix-ui/themes/styles.css");
 
 export default defineConfig({
   compilation: {
@@ -31,6 +32,7 @@ export default defineConfig({
         "react-dom/client": reactDomClientPath,
         scheduler: schedulerPath,
         "lucide-react": lucideReactPath,
+        "@radix-ui/themes/styles.css": radixThemesStylesPath,
       },
     },
   },


### PR DESCRIPTION
## PR 标题

fix(desktop): 修复 Windows 构建样式解析

## 变更说明

- 问题: Windows 桌面端 CI 构建从 `../frontend/src/styles/index.css` 解析 `@radix-ui/themes/styles.css` 时失败。
- 重要性: 该问题会阻断 Windows 桌面安装包发布。
- 变化: 在 `desktop/farm.config.ts` 中为 `@radix-ui/themes/styles.css` 增加显式解析 alias。

## 关联 Issue / PR (如有)

#XXXX

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

桌面端构建会导入前端源码样式。Windows 环境下 Farm 对跨目录 CSS 中的 package import 解析不稳定，未能自动解析到 Radix Themes 的 CSS 文件。

## 自查清单

- [ ] 已添加/更新必要的测试
- [ ] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证记录:

- `git pull --ff-only origin main`
- `pnpm build`（desktop）
