### PR TITLE
ci(package): 优化发布缓存复用

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -17,6 +17,7 @@ env:
   PYTHON_VERSION: '3.12'
   NODE_VERSION: '22'
   PNPM_VERSION: '11.8.0'
+  UV_CACHE_DIR: ${{ github.workspace }}/.uv-cache
 
 jobs:
   # ---------------------------------------------------------------- context
@@ -53,8 +54,16 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-          cache-dependency-path: frontend/pnpm-lock.yaml
+      - name: 配置 pnpm store
+        run: pnpm config set store-dir "${{ github.workspace }}/.pnpm-store"
+      - uses: actions/cache/restore@v5
+        id: pnpm-cache
+        with:
+          path: .pnpm-store
+          key: ${{ runner.os }}-${{ runner.arch }}-pnpm-${{ env.PNPM_VERSION }}-frontend-${{ hashFiles('frontend/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-pnpm-${{ env.PNPM_VERSION }}-frontend-
+            ${{ runner.os }}-${{ runner.arch }}-pnpm-${{ env.PNPM_VERSION }}-
       - name: 构建前端产物
         working-directory: frontend
         run: |
@@ -64,10 +73,15 @@ jobs:
         with:
           name: frontend-dist
           path: frontend/dist/
+      - uses: actions/cache/save@v5
+        if: ${{ steps.pnpm-cache.outputs.cache-hit != 'true' }}
+        with:
+          path: .pnpm-store
+          key: ${{ steps.pnpm-cache.outputs.cache-primary-key }}
 
   # ---------------------------------------------------------------- pypi
   pypi:
-    needs: [context]
+    needs: [context, build-frontend]
     runs-on: ubuntu-latest
     environment: pypi
     steps:
@@ -78,18 +92,64 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-          cache-dependency-path: frontend/pnpm-lock.yaml
+      - name: 配置 pnpm store
+        run: pnpm config set store-dir "${{ github.workspace }}/.pnpm-store"
+      - uses: actions/cache/restore@v5
+        id: pnpm-cache
+        with:
+          path: .pnpm-store
+          key: ${{ runner.os }}-${{ runner.arch }}-pnpm-${{ env.PNPM_VERSION }}-frontend-${{ hashFiles('frontend/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-pnpm-${{ env.PNPM_VERSION }}-frontend-
+            ${{ runner.os }}-${{ runner.arch }}-pnpm-${{ env.PNPM_VERSION }}-
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - uses: astral-sh/setup-uv@v5
+      - name: 生成 uv 缓存 key lock
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          source = Path("backend/uv.lock")
+          target = Path("backend/.uv-cache-key.lock")
+          lines = source.read_text(encoding="utf-8").splitlines()
+          normalized: list[str] = []
+          is_openfic_package = False
+
+          for line in lines:
+              if line == "[[package]]":
+                  is_openfic_package = False
+              elif line == 'name = "openfic"':
+                  is_openfic_package = True
+
+              if is_openfic_package and line.startswith("version = "):
+                  continue
+
+              normalized.append(line)
+
+          target.write_text("\n".join(normalized) + "\n", encoding="utf-8")
+          PY
+      - uses: actions/cache/restore@v5
+        id: uv-cache
         with:
-          enable-cache: true
-          cache-dependency-glob: backend/uv.lock
+          path: .uv-cache
+          key: ${{ runner.os }}-${{ runner.arch }}-uv-${{ env.PYTHON_VERSION }}-${{ hashFiles('backend/.uv-cache-key.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-uv-${{ env.PYTHON_VERSION }}-
       - name: 构建后端 Python 包
         working-directory: backend
         run: uv build
+      - uses: actions/cache/save@v5
+        if: ${{ steps.pnpm-cache.outputs.cache-hit != 'true' }}
+        with:
+          path: .pnpm-store
+          key: ${{ steps.pnpm-cache.outputs.cache-primary-key }}
+      - uses: actions/cache/save@v5
+        if: ${{ steps.uv-cache.outputs.cache-hit != 'true' }}
+        with:
+          path: .uv-cache
+          key: ${{ steps.uv-cache.outputs.cache-primary-key }}
       - name: 发布到 PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
@@ -186,6 +246,9 @@ jobs:
             electron_args: '--mac --arm64'
             artifact_name: desktop-mac-arm64
     runs-on: ${{ matrix.os }}
+    env:
+      ELECTRON_CACHE: ${{ github.workspace }}/.electron-cache
+      ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.electron-builder-cache
     steps:
       - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
@@ -198,10 +261,26 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
-          cache-dependency-path: |
-            desktop/pnpm-lock.yaml
-            frontend/pnpm-lock.yaml
+      - name: 配置 pnpm store
+        run: pnpm config set store-dir "${{ github.workspace }}/.pnpm-store"
+      - uses: actions/cache/restore@v5
+        id: pnpm-cache
+        with:
+          path: .pnpm-store
+          key: ${{ runner.os }}-${{ runner.arch }}-pnpm-${{ env.PNPM_VERSION }}-desktop-${{ hashFiles('desktop/pnpm-lock.yaml', 'frontend/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-pnpm-${{ env.PNPM_VERSION }}-desktop-
+            ${{ runner.os }}-${{ runner.arch }}-pnpm-${{ env.PNPM_VERSION }}-frontend-
+            ${{ runner.os }}-${{ runner.arch }}-pnpm-${{ env.PNPM_VERSION }}-
+      - uses: actions/cache/restore@v5
+        id: electron-cache
+        with:
+          path: |
+            .electron-cache
+            .electron-builder-cache
+          key: ${{ runner.os }}-${{ runner.arch }}-electron-${{ hashFiles('desktop/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-electron-
       - name: 安装前端依赖
         working-directory: frontend
         run: pnpm install --frozen-lockfile
@@ -225,6 +304,18 @@ jobs:
             desktop/dist-electron/*.zip
             desktop/dist-electron/*.dmg
             desktop/dist-electron/*.blockmap
+      - uses: actions/cache/save@v5
+        if: ${{ steps.pnpm-cache.outputs.cache-hit != 'true' }}
+        with:
+          path: .pnpm-store
+          key: ${{ steps.pnpm-cache.outputs.cache-primary-key }}
+      - uses: actions/cache/save@v5
+        if: ${{ steps.electron-cache.outputs.cache-hit != 'true' }}
+        with:
+          path: |
+            .electron-cache
+            .electron-builder-cache
+          key: ${{ steps.electron-cache.outputs.cache-primary-key }}
 
   # ---------------------------------------------------------------- release
   publish-release:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ FROM --platform=$BUILDPLATFORM node:22-slim AS frontend
 WORKDIR /build
 RUN corepack enable
 COPY frontend/package.json frontend/pnpm-lock.yaml frontend/pnpm-workspace.yaml ./
-RUN pnpm install --frozen-lockfile
+RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
+    pnpm install --frozen-lockfile --store-dir /pnpm/store
 COPY frontend/ ./
 RUN pnpm build
 
@@ -23,7 +24,8 @@ WORKDIR /app
 
 # 先装依赖（利用层缓存）
 COPY backend/pyproject.toml backend/uv.lock ./
-RUN uv sync --frozen --no-dev --no-install-project
+RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-install-project
 
 # 复制后端源码
 COPY backend/ ./

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -26,6 +26,11 @@
           "jsonpath": "$.version"
         },
         {
+          "type": "json",
+          "path": "desktop/package.json",
+          "jsonpath": "$.version"
+        },
+        {
           "type": "toml",
           "path": "backend/pyproject.toml",
           "jsonpath": "$.project.version"


### PR DESCRIPTION
## PR 标题

ci(package): 优化发布缓存复用

## 变更说明

- 问题: 发布工作流中多个依赖缓存会因版本号变更或独立 key 频繁重建，缓存复用率低
- 重要性: 减少 tag 发布时重复下载依赖与 Electron 资源，降低 Actions 缓存数量增长速度
- 变化: 将 pnpm/uv/Electron 缓存改为显式 restore/save，并为 uv 使用 normalized lock 作为缓存 key 输入
- 变化: 为 Dockerfile 的 pnpm install 和 uv sync 增加 BuildKit cache mount
- 变化: 将 desktop/package.json 加入 release-please 版本同步文件

## 关联 Issue / PR (如有)

#XXXX

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因(如有)

发布流程中的缓存 key 直接依赖 lockfile 或使用 setup-node 内置缓存。后端 uv.lock 会记录根包自身版本号，导致仅版本号变化也会生成新的 uv cache key；桌面端 Electron 下载缓存此前也没有单独缓存。

## 自查清单

- [ ] 已添加/更新必要的测试
- [ ] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证已执行:

- `python3` 解析 `.github/workflows/package.yml` 通过
- normalized uv lock 行为检查通过: 只改 openfic 自身版本时 hash 不变，改依赖版本时 hash 变化
- Dockerfile cache mount 标记检查通过

未执行完整发布构建；本地环境无 Docker CLI，无法执行 `docker buildx build --check .`。
