### PR TITLE
fix(desktop): 修复本地运行时安装

### DIFF
--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -83,7 +83,7 @@ async function startLocalBackend(installDir: string | null): Promise<void> {
   const runtimeDir = resolveRuntimeDir(installDir);
   const python = await ensurePortablePython(runtimeDir, () => undefined, () => undefined);
   const runtime = await ensureOpenFicRuntime(python, runtimeDir, () => undefined);
-  const backend = await startLocalOpenFicBackend(runtime.uvPath);
+  const backend = await startLocalOpenFicBackend(runtime.venvPythonPath);
   setBackend(backend);
   setBackendBaseUrl(backend.baseUrl);
 }

--- a/desktop/src/main/runtime/openfic-commands.ts
+++ b/desktop/src/main/runtime/openfic-commands.ts
@@ -1,0 +1,24 @@
+interface SpawnCommand {
+  command: string;
+  args: string[];
+}
+
+export function createOpenFicProbeCommand(venvPythonPath: string): SpawnCommand {
+  return {
+    command: venvPythonPath,
+    args: ["-m", "pip", "show", "openfic"],
+  };
+}
+
+export function createOpenFicInstallCommand(venvPythonPath: string): Omit<SpawnCommand, "command"> {
+  return {
+    args: ["pip", "install", "--python", venvPythonPath, "openfic"],
+  };
+}
+
+export function createOpenFicServeCommand(venvPythonPath: string, port: number): SpawnCommand {
+  return {
+    command: venvPythonPath,
+    args: ["-m", "openfic", "serve", "--host", "127.0.0.1", "--port", String(port)],
+  };
+}

--- a/desktop/src/main/runtime/openfic.ts
+++ b/desktop/src/main/runtime/openfic.ts
@@ -5,6 +5,7 @@ import { findFreePort } from "../ports.js";
 import { startBackendProcess, type BackendProcessHandle } from "../process.js";
 import { waitForBackend } from "../health.js";
 import type { PortablePython } from "./python.js";
+import { createOpenFicInstallCommand, createOpenFicProbeCommand, createOpenFicServeCommand } from "./openfic-commands.js";
 
 export type OpenFicRuntimeStep = "create-venv" | "install-uv" | "install-openfic";
 
@@ -24,6 +25,10 @@ function getUvPath(runtimeDir: string): string {
 
 export function resolveUvPath(runtimeDir: string): string {
   return getUvPath(runtimeDir);
+}
+
+export function resolveVenvPythonPath(runtimeDir: string): string {
+  return getVenvPythonPath(runtimeDir);
 }
 
 async function pathExists(filePath: string): Promise<boolean> {
@@ -66,7 +71,7 @@ export async function ensureOpenFicRuntime(
   python: PortablePython,
   runtimeDir: string,
   onProgress: (step: OpenFicRuntimeStep, message: string) => void,
-): Promise<{ uvPath: string }> {
+): Promise<{ uvPath: string; venvPythonPath: string }> {
   const venvDir = getVenvDir(runtimeDir);
   const venvPythonPath = getVenvPythonPath(runtimeDir);
   const uvPath = getUvPath(runtimeDir);
@@ -83,19 +88,22 @@ export async function ensureOpenFicRuntime(
     await run(venvPythonPath, ["-m", "pip", "install", "uv"], runtimeDir);
   }
 
-  if (!(await succeeds(uvPath, ["pip", "show", "openfic"], runtimeDir))) {
+  const probeCommand = createOpenFicProbeCommand(venvPythonPath);
+  if (!(await succeeds(probeCommand.command, probeCommand.args, runtimeDir))) {
     onProgress("install-openfic", "安装 OpenFic 后端");
-    await run(uvPath, ["pip", "install", "openfic"], runtimeDir);
+    const installCommand = createOpenFicInstallCommand(venvPythonPath);
+    await run(uvPath, installCommand.args, runtimeDir);
   }
 
-  return { uvPath };
+  return { uvPath, venvPythonPath };
 }
 
-export async function startLocalOpenFicBackend(uvPath: string): Promise<BackendProcessHandle> {
+export async function startLocalOpenFicBackend(venvPythonPath: string): Promise<BackendProcessHandle> {
   const port = await findFreePort();
+  const command = createOpenFicServeCommand(venvPythonPath, port);
   const handle = startBackendProcess({
-    command: uvPath,
-    args: ["run", "openfic", "serve", "--host", "127.0.0.1", "--port", String(port)],
+    command: command.command,
+    args: command.args,
     port,
   });
   await waitForBackend(handle.baseUrl);

--- a/desktop/src/main/runtime/setup-runner.ts
+++ b/desktop/src/main/runtime/setup-runner.ts
@@ -1,7 +1,7 @@
 import type { WebContents } from "electron";
 import { IpcChannels, type SetupProgressEvent } from "../../shared/ipc.js";
 import { describeDownloadProgress, ensurePortablePython, resolveRuntimeDir } from "./python.js";
-import { ensureOpenFicRuntime, resolveUvPath, startLocalOpenFicBackend } from "./openfic.js";
+import { ensureOpenFicRuntime, resolveVenvPythonPath, startLocalOpenFicBackend } from "./openfic.js";
 import type { BackendProcessHandle } from "../process.js";
 
 function emitProgress(webContents: WebContents, event: SetupProgressEvent): void {
@@ -53,5 +53,5 @@ export async function installLocalRuntime(webContents: WebContents, installDir: 
 
 export async function startLocalBackendFromInstall(installDir: string): Promise<BackendProcessHandle> {
   const runtimeDir = resolveRuntimeDir(installDir);
-  return startLocalOpenFicBackend(resolveUvPath(runtimeDir));
+  return startLocalOpenFicBackend(resolveVenvPythonPath(runtimeDir));
 }


### PR DESCRIPTION
## PR 标题

fix(desktop): 修复本地运行时安装

## 变更说明

- 问题: Windows 桌面端在安装本地运行时阶段直接执行 `uv pip install openfic`，未显式绑定目标虚拟环境，可能导致安装失败。
- 重要性: 该问题会阻塞桌面版用户完成本地服务安装，影响核心使用路径。
- 变化: 将 OpenFic 安装探测切换为虚拟环境 Python 执行的 `pip show`，安装命令改为 `uv pip install --python <venv-python> openfic`。
- 变化: 本地后端启动统一改为使用虚拟环境 Python 执行 `-m openfic serve`，避免继续依赖 `uv` 的环境发现逻辑。
- 变化: 抽出桌面端运行时命令构造逻辑，收敛安装、探测与启动命令的生成方式。

## 关联 Issue / PR (如有)

N/A

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

桌面端将位于虚拟环境中的 `uv` 可执行文件直接当作该虚拟环境的上下文入口使用，但 `uv pip` 的目标环境发现依赖激活环境或显式 `--python` 参数，导致未激活场景下可能安装到错误环境或直接失败。

## 自查清单

- [ ] 已添加/更新必要的测试
- [ ] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 类型检查: 已运行 `pnpm type-check`，通过。
- lint: 未纳入本次通过项，当前桌面端仓库存在既有 ESLint 配置与 CommonJS/ESM 兼容问题。
- 自动化测试: 本次未新增测试文件，符合当前分支保留内容。
