### PR TITLE
style(frontend): 调整设置列表主题变量

### DIFF
--- a/frontend/src/features/settings/components/settings-dialog.css
+++ b/frontend/src/features/settings/components/settings-dialog.css
@@ -59,7 +59,7 @@
   width: 216px;
   flex-shrink: 0;
   border-right: 1px solid var(--gray-a4);
-  background: #f6f8fb;
+  background: var(--gray-a2);
   overflow: auto;
   scrollbar-width: thin;
 }
@@ -490,7 +490,7 @@
   }
 
   .settings-dialog-mobile-topbar .rt-IconButton {
-    color: #000;
+    color: var(--gray-12);
   }
 
   .settings-dialog-mobile-topbar-leading,
@@ -537,15 +537,15 @@
 
   .settings-dialog-mobile-category-item {
     padding: 0 4px;
-    color: #000;
+    color: var(--gray-12);
   }
 
   .settings-dialog-mobile-category-item-content {
-    color: #000;
+    color: var(--gray-12);
   }
 
   .settings-dialog-mobile-category-item-icon {
-    color: #000;
+    color: currentColor;
   }
 
   .skills-settings--settings .skills-settings-list-item,
@@ -553,7 +553,7 @@
   .skills-settings--settings .skills-settings-list-item--selected:hover,
   .skills-settings--settings .skills-settings-list-item--selected.skills-settings-list-item--menu-open {
     background: transparent;
-    color: #000;
+    color: var(--gray-12);
   }
 
   .skills-settings--settings .skills-settings-list-item:hover:not(.skills-settings-list-item--selected),
@@ -566,7 +566,7 @@
   .agent-definition-item--active:hover,
   .agent-definition-item--active.agent-definition-item--menu-open {
     background: transparent;
-    color: #000;
+    color: var(--gray-12);
   }
 
   .agent-definitions-layout {


### PR DESCRIPTION
## PR 标题

style(frontend): 调整设置列表主题变量

## 变更说明

- 问题: 设置页列表区域使用了固定浅色值，切换到暗色主题后显示不一致
- 重要性: 影响设置页侧边栏、移动端类目列表与相关列表项的主题一致性
- 变化: 将 `settings-dialog.css` 中的硬编码背景色与文字色替换为 Radix 主题变量
- 变化: 保持现有交互与结构不变，仅修正样式取值

## 关联 Issue / PR (如有)

N/A

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [x] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

设置项列表样式中存在 `#f6f8fb`、`#000` 等硬编码颜色，导致该区域未随主题变量切换。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

已运行：`pnpm type-check`、`pnpm lint`。
未运行自动化测试，本次仅包含 CSS 样式调整。
