### PR TITLE
chore(frontend): 调整设置面板自动保存

### DIFF
--- a/frontend/src/features/settings/components/agent-tools-settings.tsx
+++ b/frontend/src/features/settings/components/agent-tools-settings.tsx
@@ -20,6 +20,7 @@ interface AgentToolsSettingsProps {
   tools: AgentToolMetadata[];
   errorMessage?: string;
   onSettingsChange: (settings: Settings) => void;
+  isSaving?: boolean;
 }
 
 const PERMISSION_OPTIONS: AgentToolPermissionMode[] = ["allow", "ask", "deny"];
@@ -29,6 +30,7 @@ export function AgentToolsSettings({
   tools,
   errorMessage,
   onSettingsChange,
+  isSaving = false,
 }: AgentToolsSettingsProps) {
   const { t } = useTranslation();
 
@@ -104,6 +106,7 @@ export function AgentToolsSettings({
                 value={permissionMap.get(tool.key) ?? "ask"}
                 options={permissionOptions}
                 onChange={(value) => handlePermissionChange(tool.key, value)}
+                disabled={isSaving}
                 triggerStyle={{ width: 120 }}
               />
             </Flex>

--- a/frontend/src/features/settings/components/general-settings.tsx
+++ b/frontend/src/features/settings/components/general-settings.tsx
@@ -17,11 +17,13 @@ interface GeneralSettingsProps {
   settings: Settings;
   /** 设置变更回调 */
   onSettingsChange: (settings: Settings) => void;
+  isSaving?: boolean;
 }
 
 export function GeneralSettings({
   settings,
   onSettingsChange,
+  isSaving = false,
 }: GeneralSettingsProps) {
   const { t } = useTranslation();
 
@@ -57,6 +59,7 @@ export function GeneralSettings({
             label: lang.name,
           }))}
           onChange={handleLanguageChange}
+          disabled={isSaving}
           triggerStyle={{ width: 200 }}
         />
 
@@ -68,6 +71,7 @@ export function GeneralSettings({
           <SegmentedControl.Root
             value={settings.theme}
             onValueChange={handleThemeChange}
+            disabled={isSaving}
             style={{ width: 200 }}
           >
             <SegmentedControl.Item value="light">
@@ -85,6 +89,7 @@ export function GeneralSettings({
           value={settings.fontFamily}
           options={FONT_OPTIONS}
           onChange={handleFontChange}
+          disabled={isSaving}
           triggerStyle={{ width: 200 }}
         />
 
@@ -94,6 +99,7 @@ export function GeneralSettings({
           value={settings.codeFontFamily || "JetBrainsMapleMono"}
           options={CODE_FONT_OPTIONS}
           onChange={handleCodeFontChange}
+          disabled={isSaving}
           triggerStyle={{ width: 200 }}
         />
       </Flex>

--- a/frontend/src/features/settings/components/settings-content.tsx
+++ b/frontend/src/features/settings/components/settings-content.tsx
@@ -1,11 +1,12 @@
 import { useState, useCallback, useEffect, useMemo } from "react";
-import { Box, Button, Flex, IconButton, Text } from "@radix-ui/themes";
+import { Box, Flex, IconButton, Text } from "@radix-ui/themes";
 import { ChevronLeft, ChevronRight, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { AnimatePresence, motion } from "motion/react";
 import axios from "axios";
-import { Spinner } from "@/components";
+import { Spinner, toast } from "@/components";
+import { saveLanguagePreference } from "@/i18n";
 import "./settings-dialog.css";
 
 import { SettingsSidebar } from "../components/settings-sidebar";
@@ -144,14 +145,6 @@ export function SettingsContent({ appearance, onAppearanceChange, onClose, route
     };
   }, [serverSettings, editedSettings, i18n.language, appearance]);
 
-  const hasChanges = useMemo(() => {
-    if (!serverSettings) return false;
-    const hasLocalEdits = Object.keys(editedSettings).length > 0;
-    const languageChanged = i18n.language !== serverSettings.language;
-    const themeChanged = appearance !== serverSettings.theme;
-    return hasLocalEdits || languageChanged || themeChanged;
-  }, [serverSettings, editedSettings, i18n.language, appearance]);
-
   const saveMutation = useMutation({
     mutationFn: async (settings: Settings) => {
       const request: SettingsUpdateRequest = {
@@ -166,27 +159,47 @@ export function SettingsContent({ appearance, onAppearanceChange, onClose, route
       };
       return updateSettings(request);
     },
+    onMutate: async (nextSettings) => {
+      await queryClient.cancelQueries({ queryKey: ["settings"] });
+      const previousSettings = queryClient.getQueryData<Settings>(["settings"]) ?? null;
+      queryClient.setQueryData(["settings"], nextSettings);
+      setEditedSettings({});
+      return { previousSettings };
+    },
+    onError: (_error, _variables, context) => {
+      const previousSettings = context?.previousSettings;
+
+      if (previousSettings) {
+        queryClient.setQueryData(["settings"], previousSettings);
+        setEditedSettings({});
+        void i18n.changeLanguage(previousSettings.language);
+        saveLanguagePreference(previousSettings.language);
+        onAppearanceChange(previousSettings.theme);
+        applyFontFamily(previousSettings.fontFamily);
+        applyCodeFontFamily(previousSettings.codeFontFamily);
+        void loadConfiguredFonts(previousSettings.fontFamily, previousSettings.codeFontFamily);
+      }
+
+      toast.error(t("settings.saveFailed"));
+    },
     onSuccess: (savedSettings) => {
       queryClient.setQueryData(["settings"], savedSettings);
       setEditedSettings({});
+      toast.success(t("settings.saved"));
     },
   });
 
   const handleSettingsChange = useCallback((newSettings: Settings) => {
+    void i18n.changeLanguage(newSettings.language);
+    saveLanguagePreference(newSettings.language);
     onAppearanceChange(newSettings.theme);
     applyFontFamily(newSettings.fontFamily);
     applyCodeFontFamily(newSettings.codeFontFamily);
     void loadConfiguredFonts(newSettings.fontFamily, newSettings.codeFontFamily);
     setEditedSettings(newSettings);
-  }, [onAppearanceChange]);
+    saveMutation.mutate(newSettings);
+  }, [i18n, onAppearanceChange, saveMutation]);
 
-  const handleSave = useCallback(() => {
-    if (displaySettings) saveMutation.mutate(displaySettings);
-  }, [displaySettings, saveMutation]);
-
-  const shouldShowSaveButton =
-    ((activeCategory === "general" && !isCategoryLoading) ||
-      (activeCategory === "agent-tools" && !isAgentToolsLoading));
   const isSplitPanelCategory =
     activeCategory === "agents" || activeCategory === "skills" || activeCategory === "rules";
   const shouldUseFormPagePadding =
@@ -251,6 +264,7 @@ export function SettingsContent({ appearance, onAppearanceChange, onClose, route
             {activeCategory === "general" ? (
               <GeneralSettings
                 settings={displaySettings}
+                isSaving={saveMutation.isPending}
                 onSettingsChange={handleSettingsChange}
               />
             ) : null}
@@ -267,6 +281,7 @@ export function SettingsContent({ appearance, onAppearanceChange, onClose, route
                 settings={displaySettings}
                 tools={agentTools}
                 errorMessage={agentToolsErrorMessage}
+                isSaving={saveMutation.isPending}
                 onSettingsChange={handleSettingsChange}
               />
             ) : null}
@@ -299,19 +314,6 @@ export function SettingsContent({ appearance, onAppearanceChange, onClose, route
           </>
         ) : null}
       </Box>
-
-      {shouldShowSaveButton ? (
-        <Box className="settings-dialog-savebar">
-          <Button
-            size="3"
-            disabled={!hasChanges || saveMutation.isPending}
-            onClick={handleSave}
-          >
-            {saveMutation.isPending ? <Spinner size={18} /> : null}
-            {t("settings.save")}
-          </Button>
-        </Box>
-      ) : null}
     </>
   );
 


### PR DESCRIPTION
## PR 标题

chore(frontend): 调整设置面板自动保存

## 变更说明

- 问题: 设置面板中的通用设置与工具权限仍依赖底部保存栏，交互不一致，变更反馈也不及时。
- 重要性: 这两个页面属于高频设置入口，保存时机不明确会增加误操作和状态不一致风险。
- 变化: 移除手动保存栏，改为设置变更后立即生效并立即持久化。
- 变化: 为通用设置与工具权限补充乐观更新、失败回滚，以及保存成功/失败 toast 提示。

## 关联 Issue / PR (如有)

#XXXX

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因(如有)

N/A

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 已执行 `pnpm type-check` 与 `pnpm lint`。
- 本次未新增测试，依据当前指令未补前端测试。
