### PR TITLE
ci(release): 修复每次 PR 都触发发版

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,15 +27,18 @@ jobs:
         if: ${{ steps.release.outputs.pr }}
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+
       - uses: actions/setup-python@v6
         if: ${{ steps.release.outputs.pr }}
         with:
           python-version: '3.12'
+
       - uses: astral-sh/setup-uv@v5
         if: ${{ steps.release.outputs.pr }}
         with:
           enable-cache: true
           cache-dependency-glob: backend/uv.lock
+
       - name: 同步 backend uv.lock
         if: ${{ steps.release.outputs.pr }}
         env:
@@ -62,44 +65,3 @@ jobs:
           git add backend/uv.lock
           git commit -m "chore(backend): 同步 uv.lock 版本"
           git push origin HEAD:"$PR_HEAD_REF"
-      - name: 启用 release PR auto-merge
-        if: ${{ steps.release.outputs.pr }}
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
-          PR_JSON: ${{ steps.release.outputs.pr }}
-        run: |
-          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
-
-          for attempt in {1..18}; do
-            echo "Attempt $attempt: enable auto-merge for release PR #${PR_NUMBER}"
-
-            MERGEABLE=$(gh pr view "$PR_NUMBER" --json mergeable -q '.mergeable')
-            MERGE_STATE=$(gh pr view "$PR_NUMBER" --json mergeStateStatus -q '.mergeStateStatus')
-            echo "mergeable=${MERGEABLE} mergeStateStatus=${MERGE_STATE}"
-
-            if [[ "$MERGEABLE" == "CONFLICTING" || "$MERGE_STATE" == "DIRTY" ]]; then
-              echo "Release PR has merge conflicts and cannot be auto-merged"
-              exit 1
-            fi
-
-            if [[ "$MERGEABLE" == "UNKNOWN" ]]; then
-              sleep 10
-              continue
-            fi
-
-            if gh pr merge "$PR_NUMBER" --auto --squash --delete-branch 2>merge-error.log; then
-              exit 0
-            fi
-
-            ERROR=$(cat merge-error.log)
-            echo "$ERROR"
-
-            if [[ "$ERROR" != *"Base branch was modified"* && "$ERROR" != *"Pull Request is not mergeable"* ]]; then
-              exit 1
-            fi
-
-            sleep 10
-          done
-
-          echo "Release PR auto-merge failed after retries"
-          exit 1


### PR DESCRIPTION
## PR 标题

ci(release): 修复每次 PR 都触发发版

## 变更说明

- 问题: release 工作流会在创建 release PR 后继续尝试启用 auto-merge，导致每次 PR 都进入发版链路。
- 重要性: 该行为会让普通 PR 受到发版流程干扰，增加误触发和排查成本。
- 变化: 删除 release PR auto-merge 步骤，仅保留 `backend/uv.lock` 同步与推送逻辑。
- 变化: 新建独立修复分支，确保本次 PR 不包含旧的前端提交。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因(如有)

release 工作流中包含“启用 release PR auto-merge”步骤。该步骤会在 release-please 创建 PR 后主动对 PR 执行自动合并逻辑，造成普通 PR 场景下也持续进入发版处理路径。

## 自查清单

- [ ] 已添加/更新必要的测试
- [ ] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

已执行验证：
- `rtk git diff --check`
- `rtk uv run python -c "...yaml.safe_load(...)..."`，确认工作流 YAML 可解析，且已移除 `启用 release PR auto-merge` 步骤。
