### PR TITLE
fix(assistant): 使用稳定的 diff section type

### DIFF
--- a/backend/app/agent_runtime/tools/impls/chapter/diff_preview.py
+++ b/backend/app/agent_runtime/tools/impls/chapter/diff_preview.py
@@ -72,7 +72,7 @@ def build_chapter_diff_preview(
 
     if before is None or after is None or before.title != after.title:
         sections.append({
-            "label": "标题",
+            "type": "title",
             "lines": _build_diff_lines(
                 before.title if before else "",
                 after.title if after else "",
@@ -81,7 +81,7 @@ def build_chapter_diff_preview(
 
     if before is None or after is None or before.content != after.content:
         sections.append({
-            "label": "内容",
+            "type": "content",
             "lines": _build_diff_lines(
                 before.content if before else "",
                 after.content if after else "",

--- a/backend/app/agent_runtime/tools/impls/note/edit_note.py
+++ b/backend/app/agent_runtime/tools/impls/note/edit_note.py
@@ -134,7 +134,7 @@ class EditNoteTool(AgentTool):
             diff_lines = _build_diff_lines(before_content, note.content)
             note_diff = {
                 "operation": "update",
-                "sections": [{"label": "内容", "lines": diff_lines}],
+                "sections": [{"type": "content", "lines": diff_lines}],
                 "note_id": note.id,
                 "note_title": note.title,
             }

--- a/backend/app/agent_runtime/tools/impls/note/write_note.py
+++ b/backend/app/agent_runtime/tools/impls/note/write_note.py
@@ -112,7 +112,7 @@ class WriteNoteTool(AgentTool):
             ]
             note_diff = {
                 "operation": "create",
-                "sections": [{"label": "内容", "lines": diff_lines}],
+                "sections": [{"type": "content", "lines": diff_lines}],
                 "note_id": note.id,
                 "note_title": note.title,
             }

--- a/backend/tests/agent_runtime/persistence/test_task_projection.py
+++ b/backend/tests/agent_runtime/persistence/test_task_projection.py
@@ -621,7 +621,7 @@ async def test_projects_completed_write_tool_result_keeps_chapter_diff_for_reloa
         task_id=sample_task.id,
         project_id=sample_task.project_id,
         role="tool",
-        content='{"type":"ok","success":true,"tool_name":"write_chapter","message":"章节已写入","word_count":2,"chapter":{"id":"chapter_1","title":"第一章","content":"正文","order":1},"chapter_diff":{"operation":"create","chapter_id":"chapter_1","chapter_title":"第一章","order":1,"sections":[{"label":"内容","lines":[{"type":"added","before_line_number":null,"after_line_number":1,"text":"正文"}]}]},"affected_chapters":["chapter_1"]}',
+        content='{"type":"ok","success":true,"tool_name":"write_chapter","message":"章节已写入","word_count":2,"chapter":{"id":"chapter_1","title":"第一章","content":"正文","order":1},"chapter_diff":{"operation":"create","chapter_id":"chapter_1","chapter_title":"第一章","order":1,"sections":[{"type":"content","lines":[{"type":"added","before_line_number":null,"after_line_number":1,"text":"正文"}]}]},"affected_chapters":["chapter_1"]}',
         status="complete",
         tool_call_id="call_write",
         tool_name="write_chapter",
@@ -635,3 +635,4 @@ async def test_projects_completed_write_tool_result_keeps_chapter_diff_for_reloa
     assert tool_messages[0].payload["tool_result"]["data"]["chapter"]["id"] == "chapter_1"
     assert tool_messages[0].payload["tool_result"]["data"]["chapter_diff"]["operation"] == "create"
     assert tool_messages[0].payload["tool_result"]["data"]["chapter_diff"]["chapter_id"] == "chapter_1"
+    assert tool_messages[0].payload["tool_result"]["data"]["chapter_diff"]["sections"][0]["type"] == "content"

--- a/backend/tests/agent_runtime/tools/test_chapter_tools.py
+++ b/backend/tests/agent_runtime/tools/test_chapter_tools.py
@@ -227,6 +227,7 @@ async def test_write_chapter_appends_to_volume_and_returns_volume_id() -> None:
     assert data["chapter"]["volume_id"] == "vol-1"
     assert data["chapter_diff"]["operation"] == "create"
     assert data["chapter_diff"]["chapter_id"] == "chap-new"
+    assert [section["type"] for section in data["chapter_diff"]["sections"]] == ["title", "content"]
     assert data["affected_chapters"] == ["chap-new"]
     mock_repo.get_max_order.assert_awaited_once_with(mock_session, "vol-1")
     created_chapter = mock_repo.create.call_args[0][1]
@@ -293,6 +294,7 @@ async def test_write_chapter_insert_order_shifts_within_volume() -> None:
     assert data["word_count"] == 4
     assert data["chapter"]["order"] == 2
     assert data["chapter_diff"]["operation"] == "create"
+    assert [section["type"] for section in data["chapter_diff"]["sections"]] == ["title", "content"]
     mock_repo.shift_orders.assert_awaited_once_with(mock_session, "vol-1", 2, 5, 1)
 
 
@@ -345,6 +347,7 @@ async def test_edit_chapter_resolves_inside_volume() -> None:
     assert data["chapter"]["volume_id"] == "vol-1"
     assert data["chapter_diff"]["operation"] == "update"
     assert data["chapter_diff"]["chapter_id"] == "chap-1"
+    assert data["chapter_diff"]["sections"][0]["type"] == "title"
     assert data["affected_chapters"] == ["chap-1"]
     mock_repo.list_by_volume.assert_awaited_once_with(mock_session, "vol-1")
 

--- a/backend/tests/agent_runtime/tools/test_note_tools.py
+++ b/backend/tests/agent_runtime/tools/test_note_tools.py
@@ -255,6 +255,8 @@ async def test_write_note_creates_note_and_returns_success() -> None:
     assert data["tool_name"] == "write_note"
     assert data["note"]["title"] == "新笔记"
     assert data["revision_id"] == "rev-1"
+    assert data["note_diff"]["operation"] == "create"
+    assert data["note_diff"]["sections"][0]["type"] == "content"
 
 
 async def test_move_note_rejects_locked_note() -> None:

--- a/frontend/src/features/assistant/components/agent/message-blocks/messages/tool/tool-message.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/messages/tool/tool-message.tsx
@@ -10,6 +10,7 @@ import {
   getChapterDiffPreview,
   summarizeChapterDiffSection,
   type ChapterDiffSection,
+  type ChapterDiffSectionType,
 } from "@/features/assistant/lib/chapter-tool-preview";
 
 import { getToolDescriptor } from "../../tools/shared/tool-message-registry";
@@ -71,6 +72,11 @@ function asString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value : undefined;
 }
 
+function normalizeSectionType(value: unknown): ChapterDiffSectionType | null {
+  if (value === "content" || value === "title") return value;
+  return null;
+}
+
 function getToolResultDataRecord(message: AgentMessage): Record<string, unknown> | null {
   const resultData = message.toolResult?.data;
   if (isRecord(resultData)) return resultData;
@@ -91,18 +97,22 @@ function getNoteDiffPreview(message: AgentMessage): {
     note_id: asString(rawPreview.note_id),
     sections: rawPreview.sections
       .filter(isRecord)
-      .map((section) => ({
-        label: asString(section.label) ?? "",
-        lines: Array.isArray(section.lines)
-          ? section.lines.filter(isRecord).map((line) => ({
-            type: (line.type === "added" || line.type === "removed" ? line.type : "context") as ChapterDiffSection["lines"][0]["type"],
-            before_line_number: typeof line.before_line_number === "number" ? line.before_line_number : null,
-            after_line_number: typeof line.after_line_number === "number" ? line.after_line_number : null,
-            text: typeof line.text === "string" ? line.text : "",
-          }))
-          : [],
-      }))
-      .filter((section) => section.label),
+      .map((section) => {
+        const sectionType = normalizeSectionType(section.type);
+        if (!sectionType) return null;
+        return {
+          type: sectionType,
+          lines: Array.isArray(section.lines)
+            ? section.lines.filter(isRecord).map((line) => ({
+              type: (line.type === "added" || line.type === "removed" ? line.type : "context") as ChapterDiffSection["lines"][0]["type"],
+              before_line_number: typeof line.before_line_number === "number" ? line.before_line_number : null,
+              after_line_number: typeof line.after_line_number === "number" ? line.after_line_number : null,
+              text: typeof line.text === "string" ? line.text : "",
+            }))
+            : [],
+        };
+      })
+      .filter((section): section is ChapterDiffSection => section !== null),
   };
 }
 
@@ -129,7 +139,7 @@ export function ToolMessage({ message }: ToolMessageProps) {
   const title = descriptor?.getTitle(message) ?? "未注册工具";
   const detail = descriptor ? descriptor.getDetail?.(message) : message.toolName ?? "未知";
   const chapterDiffBodySection = getChapterDiffBodySection(chapterDiffPreview);
-  const noteDiffBodySection = noteDiffPreview?.sections.find((s) => s.label === "内容") ?? null;
+  const noteDiffBodySection = noteDiffPreview?.sections.find((s) => s.type === "content") ?? null;
   const diffBodySection = chapterDiffBodySection ?? noteDiffBodySection;
   const diffChangeSummary = summarizeChapterDiffSection(diffBodySection);
   const chapter = getChapterPayload(message);

--- a/frontend/src/features/assistant/components/agent/message-blocks/tools/chapter/chapter-tool-message.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/tools/chapter/chapter-tool-message.tsx
@@ -56,7 +56,7 @@ export function ChapterToolMessage({ message }: ChapterToolMessageProps) {
     const copyText = buildChapterDiffCopyText(diffSection);
     const isTitleOnlyChange =
       !diffSection &&
-      diffPreview.sections.some((section) => section.label === "标题");
+      diffPreview.sections.some((section) => section.type === "title");
 
     const handleCopy = async () => {
       if (!copyText) {

--- a/frontend/src/features/assistant/components/agent/message-blocks/tools/note/note-tool-message.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/tools/note/note-tool-message.tsx
@@ -4,7 +4,11 @@ import { Check, Copy } from "lucide-react";
 
 import type { AgentMessage } from "@/lib/agent.types";
 import i18n from "@/i18n";
-import type { ChapterDiffLine, ChapterDiffSection } from "@/features/assistant/lib/chapter-tool-preview";
+import type {
+  ChapterDiffLine,
+  ChapterDiffSection,
+  ChapterDiffSectionType,
+} from "@/features/assistant/lib/chapter-tool-preview";
 import {
   buildChapterDiffCopyText,
   getChapterDiffDisplayLineNumber,
@@ -43,6 +47,11 @@ function normalizeDiffLineType(value: unknown): ChapterDiffLine["type"] {
   return "context";
 }
 
+function normalizeDiffSectionType(value: unknown): ChapterDiffSectionType | null {
+  if (value === "content" || value === "title") return value;
+  return null;
+}
+
 function getToolResultDataRecord(message: AgentMessage): Record<string, unknown> | null {
   const resultData = message.toolResult?.data;
   if (isRecord(resultData)) return resultData;
@@ -61,18 +70,22 @@ function getNoteDiffPreview(message: AgentMessage): NoteDiffPreview | null {
     note_title: asString(rawPreview.note_title),
     sections: rawPreview.sections
       .filter(isRecord)
-      .map((section) => ({
-        label: asString(section.label) ?? "",
-        lines: Array.isArray(section.lines)
-          ? section.lines.filter(isRecord).map((line) => ({
-            type: normalizeDiffLineType(line.type),
-            before_line_number: typeof line.before_line_number === "number" ? line.before_line_number : null,
-            after_line_number: typeof line.after_line_number === "number" ? line.after_line_number : null,
-            text: typeof line.text === "string" ? line.text : "",
-          }))
-          : [],
-      }))
-      .filter((section) => section.label),
+      .map((section) => {
+        const sectionType = normalizeDiffSectionType(section.type);
+        if (!sectionType) return null;
+        return {
+          type: sectionType,
+          lines: Array.isArray(section.lines)
+            ? section.lines.filter(isRecord).map((line) => ({
+              type: normalizeDiffLineType(line.type),
+              before_line_number: typeof line.before_line_number === "number" ? line.before_line_number : null,
+              after_line_number: typeof line.after_line_number === "number" ? line.after_line_number : null,
+              text: typeof line.text === "string" ? line.text : "",
+            }))
+            : [],
+        };
+      })
+      .filter((section): section is ChapterDiffSection => section !== null),
   };
 }
 
@@ -114,7 +127,7 @@ export function WriteNoteToolMessage({ message }: NoteToolMessageProps) {
   }, []);
 
   if (diffPreview) {
-    const contentSection = diffPreview.sections.find((s) => s.label === "内容") ?? null;
+    const contentSection = diffPreview.sections.find((s) => s.type === "content") ?? null;
     const changeSummary = summarizeChapterDiffSection(contentSection);
     const copyText = buildChapterDiffCopyText(contentSection);
 
@@ -222,7 +235,7 @@ export function EditNoteToolMessage({ message }: NoteToolMessageProps) {
   }, []);
 
   if (diffPreview) {
-    const contentSection = diffPreview.sections.find((s) => s.label === "内容") ?? null;
+    const contentSection = diffPreview.sections.find((s) => s.type === "content") ?? null;
     const changeSummary = summarizeChapterDiffSection(contentSection);
     const copyText = buildChapterDiffCopyText(contentSection);
 

--- a/frontend/src/features/assistant/lib/chapter-tool-preview.ts
+++ b/frontend/src/features/assistant/lib/chapter-tool-preview.ts
@@ -7,8 +7,10 @@ export interface ChapterDiffLine {
   text: string;
 }
 
+export type ChapterDiffSectionType = "content" | "title";
+
 export interface ChapterDiffSection {
-  label: string;
+  type: ChapterDiffSectionType;
   lines: ChapterDiffLine[];
 }
 
@@ -36,6 +38,11 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function asString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function normalizeChapterDiffSectionType(value: unknown): ChapterDiffSectionType | null {
+  if (value === "content" || value === "title") return value;
+  return null;
 }
 
 function getDiffLinePrefix(type: ChapterDiffLine["type"]): string {
@@ -69,18 +76,22 @@ export function getChapterDiffPreview(message: AgentMessage): ChapterDiffPreview
     order: typeof rawPreview.order === "number" ? rawPreview.order : undefined,
     sections: rawPreview.sections
       .filter(isRecord)
-      .map((section) => ({
-        label: asString(section.label) ?? "",
-        lines: Array.isArray(section.lines)
-          ? section.lines.filter(isRecord).map((line) => ({
-            type: normalizeChapterDiffLineType(line.type),
-            before_line_number: typeof line.before_line_number === "number" ? line.before_line_number : null,
-            after_line_number: typeof line.after_line_number === "number" ? line.after_line_number : null,
-            text: typeof line.text === "string" ? line.text : "",
-          }))
-          : [],
-      }))
-      .filter((section) => section.label),
+      .map((section) => {
+        const sectionType = normalizeChapterDiffSectionType(section.type);
+        if (!sectionType) return null;
+        return {
+          type: sectionType,
+          lines: Array.isArray(section.lines)
+            ? section.lines.filter(isRecord).map((line) => ({
+              type: normalizeChapterDiffLineType(line.type),
+              before_line_number: typeof line.before_line_number === "number" ? line.before_line_number : null,
+              after_line_number: typeof line.after_line_number === "number" ? line.after_line_number : null,
+              text: typeof line.text === "string" ? line.text : "",
+            }))
+            : [],
+        };
+      })
+      .filter((section): section is ChapterDiffSection => section !== null),
   };
 }
 
@@ -88,9 +99,9 @@ export function getChapterDiffBodySection(
   preview: ChapterDiffPreview | null
 ): ChapterDiffSection | null {
   if (!preview) return null;
-  const contentSection = preview.sections.find((section) => section.label === "内容");
+  const contentSection = preview.sections.find((section) => section.type === "content");
   if (contentSection) return contentSection;
-  return preview.sections.find((section) => section.label !== "标题") ?? null;
+  return preview.sections.find((section) => section.type !== "title") ?? null;
 }
 
 export function summarizeChapterDiffSection(


### PR DESCRIPTION
## PR 标题

fix(assistant): 使用稳定的 diff section type

## 变更说明

- 问题: assistant diff 预览把 `sections.label` 的中文展示文案当作协议字段使用，前端逻辑依赖 `"内容"` / `"标题"` 做判断，无法正常支撑 i18n。
- 重要性: 协议层与展示层耦合会让多语言扩展和后续维护变得脆弱，也会让旧字符串成为前端逻辑分支的隐式依赖。
- 变化: 后端统一输出稳定的 `sections[].type` 字段，取值为 `content` / `title`；前端全部改为按 `type` 解析和渲染，并移除对旧 `label` 兼容分支。
- 变化: 同步更新后端相关测试与持久化加载断言，确保章节和笔记 diff 结果都走新协议。
- 验证: 已运行后端测试、Ruff、Mypy，以及前端类型检查和 Lint，结果全部通过。

## 关联 Issue / PR (如有)

#XXXX

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

前端此前把后端返回的中文 `label` 当作稳定协议字段使用，导致展示文案与内部判断耦合；一旦进入 i18n 场景，协议语义就不再稳定。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

测试与检查结果：
- `uv run pytest tests/agent_runtime/tools/test_note_tools.py tests/agent_runtime/tools/test_chapter_tools.py tests/agent_runtime/persistence/test_task_projection.py` -> `27 passed`
- `uv run ruff check .` -> `All checks passed!`
- `uv run mypy app` -> `Success: no issues found in 447 source files`
- `pnpm type-check` -> 通过
- `pnpm lint` -> 通过
