### PR TITLE
chore(frontend): 统一设置面板加载行为

### DIFF
--- a/frontend/src/features/settings/components/agent-definitions-settings.tsx
+++ b/frontend/src/features/settings/components/agent-definitions-settings.tsx
@@ -24,7 +24,7 @@ import { ModelIdSelect, type ModelIdSelectOption } from "@/components";
 import { fetchSkills } from "@/lib/api-client";
 import type { Skill } from "@/lib/skill.types";
 import { useLlmModelOptions } from "@/lib/use-llm-model-options";
-import { ContextMenu, type ContextMenuItem, toast, ConfirmDialog } from "@/components";
+import { ContextMenu, type ContextMenuItem, toast, ConfirmDialog, Spinner } from "@/components";
 import {
   fetchAgentToolCategories,
   fetchAgentDefinitions,
@@ -474,14 +474,22 @@ export function AgentDefinitionsSettings({
     refetchOnMount: "always",
   });
 
-  const { data: toolCategoryOptions = [] } = useQuery({
+  const {
+    data: toolCategoryOptions = [],
+    isLoading: isToolCategoriesLoading,
+    isFetching: isToolCategoriesFetching,
+  } = useQuery({
     queryKey: ["agent-tool-categories"],
     queryFn: fetchAgentToolCategories,
     staleTime: 0,
     refetchOnMount: "always",
   });
 
-  const { data: skillsData } = useQuery({
+  const {
+    data: skillsData,
+    isLoading: isSkillsLoading,
+    isFetching: isSkillsFetching,
+  } = useQuery({
     queryKey: ["skills"],
     queryFn: () => fetchSkills({ page: 1, pageSize: 100 }),
     staleTime: 0,
@@ -489,12 +497,16 @@ export function AgentDefinitionsSettings({
   });
   const skills = useMemo(() => skillsData?.items ?? [], [skillsData?.items]);
 
-  const { data: settings } = useQuery({
+  const {
+    data: settings,
+    isLoading: isSettingsLoading,
+    isFetching: isSettingsFetching,
+  } = useQuery({
     queryKey: ["settings"],
     queryFn: fetchSettings,
   });
 
-  const { options: llmModelOptions } = useLlmModelOptions();
+  const { options: llmModelOptions, isLoading: isModelOptionsLoading } = useLlmModelOptions();
   const modelOptions = useMemo(
     () => buildAgentModelOptions(
       llmModelOptions,
@@ -526,6 +538,18 @@ export function AgentDefinitionsSettings({
     onMobilePageChange?.(page);
     if (mobilePage === undefined) setInternalMobilePage(page);
   }, [controlledMobileDirection, mobilePage, onMobilePageChange]);
+
+  const isContentLoading =
+    isLoading ||
+    isFetching ||
+    isToolCategoriesLoading ||
+    isToolCategoriesFetching ||
+    isSkillsLoading ||
+    isSkillsFetching ||
+    isSettingsLoading ||
+    isSettingsFetching ||
+    isModelOptionsLoading ||
+    !settings;
 
   useEffect(() => {
     onMobileDetailTitleChange?.(selectedDef?.display_name || null);
@@ -843,7 +867,11 @@ export function AgentDefinitionsSettings({
 
   return (
     <>
-      {isMobile ? (
+      {isContentLoading ? (
+        <Flex align="center" justify="center" style={{ height: "100%" }}>
+          <Spinner size={18} />
+        </Flex>
+      ) : isMobile ? (
         <Flex direction="column" className="agent-definitions-layout agent-definitions-layout--mobile">
           <Box className="settings-dialog-mobile-page-stack">
             <AnimatePresence initial={false} custom={currentMobileDirection} mode="sync">
@@ -882,13 +910,13 @@ export function AgentDefinitionsSettings({
           </Box>
         </Flex>
       ) : (
-      <Flex className="agent-definitions-layout">
-        {listContent}
+        <Flex className="agent-definitions-layout">
+          {listContent}
 
-        <Box className="agent-definitions-detail-panel">
-          {detailContent}
-        </Box>
-      </Flex>
+          <Box className="agent-definitions-detail-panel">
+            {detailContent}
+          </Box>
+        </Flex>
       )}
 
       <ContextMenu position={menuState?.position ?? null} items={menuItems} onClose={closeMenu} />

--- a/frontend/src/features/settings/components/connections-settings.tsx
+++ b/frontend/src/features/settings/components/connections-settings.tsx
@@ -45,7 +45,6 @@ export function ConnectionsSettings() {
   } = useQuery({
     queryKey: ["model-providers"],
     queryFn: fetchProviders,
-    staleTime: 5 * 60 * 1000, // 5分钟内不重新请求
   });
 
   const externalConnections = useMemo(
@@ -56,7 +55,6 @@ export function ConnectionsSettings() {
   const { data: catalogProviders, isLoading: isCatalogProvidersLoading } = useQuery({
     queryKey: ["model-provider-catalog", "providers"],
     queryFn: fetchModelProviderCatalogProviders,
-    staleTime: 5 * 60 * 1000,
   });
 
   const {
@@ -66,7 +64,6 @@ export function ConnectionsSettings() {
   } = useQuery({
     queryKey: ["model-provider-catalog", "status"],
     queryFn: fetchModelProviderCatalogStatus,
-    staleTime: 60 * 1000,
   });
 
   // 创建连接
@@ -180,6 +177,14 @@ export function ConnectionsSettings() {
     isCatalogStatusLoading ||
     isCatalogStatusFetching;
 
+  if (isContentLoading) {
+    return (
+      <Flex align="center" justify="center" style={{ height: "100%" }}>
+        <Spinner size={18} />
+      </Flex>
+    );
+  }
+
   return (
     <Box>
       <Flex direction="column" gap="4">
@@ -188,19 +193,13 @@ export function ConnectionsSettings() {
           {t("connections.description")}
         </Text>
 
-        {isContentLoading ? (
-            <Flex align="center" justify="center" style={{ height: 200 }}>
-              <Spinner size={18} />
-            </Flex>
-        ) : (
-          <>
-            <Box
-              style={{
-                border: "1px solid var(--gray-a4)",
-                borderRadius: "var(--radius-3)",
-                padding: "var(--space-4)",
-              }}
-            >
+        <Box
+          style={{
+            border: "1px solid var(--gray-a4)",
+            borderRadius: "var(--radius-3)",
+            padding: "var(--space-4)",
+          }}
+        >
               <Flex align="start" justify="between" gap="3">
                 <Flex direction="column" gap="1">
                   <Text size="2" weight="medium">
@@ -254,21 +253,21 @@ export function ConnectionsSettings() {
                   </IconButton>
                 </Box>
               </Flex>
-            </Box>
+        </Box>
 
-            {/* 新建按钮 */}
-            <Flex>
-              <Button onClick={handleCreate}>
-                <Plus size={16} />
-                {t("connections.newConnection")}
-              </Button>
-            </Flex>
+        {/* 新建按钮 */}
+        <Flex>
+          <Button onClick={handleCreate}>
+            <Plus size={16} />
+            {t("connections.newConnection")}
+          </Button>
+        </Flex>
 
-            {/* 连接列表 */}
-            {externalConnections.length > 0 ? (
-              <Flex direction="column">
-                {externalConnections.map((connection, index) => (
-                  <Box key={connection.id} className="list-item-hover">
+        {/* 连接列表 */}
+        {externalConnections.length > 0 ? (
+          <Flex direction="column">
+            {externalConnections.map((connection, index) => (
+              <Box key={connection.id} className="list-item-hover">
                     <Flex
                       align="center"
                       justify="between"
@@ -328,21 +327,21 @@ export function ConnectionsSettings() {
 
                       {/* 操作按钮 */}
                       <Flex gap="2">
-                          <IconButton
-                            variant="ghost"
-                            color="gray"
-                            onClick={() => handleEdit(connection)}
-                          >
-                            <Edit size={16} />
-                          </IconButton>
-                          <IconButton
-                            variant="ghost"
-                            color="red"
-                            onClick={() => handleDelete(connection)}
-                          >
-                            <Trash2 size={16} />
-                          </IconButton>
-                        </Flex>
+                        <IconButton
+                          variant="ghost"
+                          color="gray"
+                          onClick={() => handleEdit(connection)}
+                        >
+                          <Edit size={16} />
+                        </IconButton>
+                        <IconButton
+                          variant="ghost"
+                          color="red"
+                          onClick={() => handleDelete(connection)}
+                        >
+                          <Trash2 size={16} />
+                        </IconButton>
+                      </Flex>
                     </Flex>
                     {index < externalConnections.length - 1 && (
                       <Box
@@ -354,23 +353,21 @@ export function ConnectionsSettings() {
                         }}
                       />
                     )}
-                  </Box>
-                ))}
-              </Flex>
-            ) : (
-              <Flex
-                direction="column"
-                align="center"
-                justify="center"
-                gap="3"
-                style={{ height: 200 }}
-              >
-                <Text size="2" color="gray">
-                  {t("connections.noConnections")}
-                </Text>
-              </Flex>
-            )}
-          </>
+              </Box>
+            ))}
+          </Flex>
+        ) : (
+          <Flex
+            direction="column"
+            align="center"
+            justify="center"
+            gap="3"
+            style={{ height: 200 }}
+          >
+            <Text size="2" color="gray">
+              {t("connections.noConnections")}
+            </Text>
+          </Flex>
         )}
       </Flex>
 

--- a/frontend/src/features/settings/components/index-settings.tsx
+++ b/frontend/src/features/settings/components/index-settings.tsx
@@ -86,16 +86,26 @@ export function IndexSettings() {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
 
-  const { data: settings } = useQuery({ queryKey: ["settings"], queryFn: fetchSettings });
-  const { data: models } = useQuery({
+  const {
+    data: settings,
+    isLoading: isSettingsLoading,
+    isFetching: isSettingsFetching,
+  } = useQuery({ queryKey: ["settings"], queryFn: fetchSettings });
+  const {
+    data: models,
+    isLoading: isModelsLoading,
+    isFetching: isModelsFetching,
+  } = useQuery({
     queryKey: ["models"],
     queryFn: () => fetchModels(),
-    staleTime: 5 * 60 * 1000,
   });
-  const { data: projectsData } = useQuery({
+  const {
+    data: projectsData,
+    isLoading: isProjectsLoading,
+    isFetching: isProjectsFetching,
+  } = useQuery({
     queryKey: ["projects", "all-for-index"],
     queryFn: () => fetchProjects({ page: 1, pageSize: 100 }),
-    staleTime: 60 * 1000,
   });
   const overall = useOverallIndexStatus(Boolean(settings));
 
@@ -320,9 +330,20 @@ export function IndexSettings() {
     [updateSettingsMutation]
   );
 
-  if (!settings) {
+  const isContentLoading =
+    isSettingsLoading ||
+    isSettingsFetching ||
+    isModelsLoading ||
+    isModelsFetching ||
+    isProjectsLoading ||
+    isProjectsFetching ||
+    overall.isLoading ||
+    overall.isFetching ||
+    !settings;
+
+  if (isContentLoading) {
     return (
-      <Flex align="center" justify="center" style={{ height: 200 }}>
+      <Flex align="center" justify="center" style={{ height: "100%" }}>
         <Spinner size={18} />
       </Flex>
     );

--- a/frontend/src/features/settings/components/models-settings.tsx
+++ b/frontend/src/features/settings/components/models-settings.tsx
@@ -76,7 +76,6 @@ export function ModelsSettings({
   } = useQuery({
     queryKey: ["models"],
     queryFn: () => fetchModels(),
-    staleTime: 5 * 60 * 1000, // 5分钟内不重新请求
   });
 
   // 获取所有提供商（用于显示提供商名称）
@@ -87,7 +86,6 @@ export function ModelsSettings({
   } = useQuery({
     queryKey: ["model-providers"],
     queryFn: fetchProviders,
-    staleTime: 5 * 60 * 1000,
   });
 
   // 获取设置
@@ -98,7 +96,6 @@ export function ModelsSettings({
   } = useQuery({
     queryKey: ["settings"],
     queryFn: fetchSettings,
-    staleTime: 5 * 60 * 1000,
   });
 
   // 更新设置
@@ -160,7 +157,6 @@ export function ModelsSettings({
       return new Map(responses);
     },
     enabled: llmCatalogProviderTypes.length > 0,
-    staleTime: 5 * 60 * 1000,
   });
 
   const llmModelOptions: ModelIdSelectOption[] = useMemo(() => {
@@ -312,6 +308,14 @@ export function ModelsSettings({
     [onActiveTabChange]
   );
 
+  if (isContentLoading) {
+    return (
+      <Flex align="center" justify="center" style={{ height: "100%" }}>
+        <Spinner size={18} />
+      </Flex>
+    );
+  }
+
   return (
     <Box>
       <Flex direction="column" gap="4">
@@ -320,76 +324,70 @@ export function ModelsSettings({
           {t("models.description")}
         </Text>
 
-        {isContentLoading ? (
-          <Flex align="center" justify="center" style={{ height: 200 }}>
-            <Spinner size={18} />
+        {/* 默认模型 & 轻量模型 */}
+        <Flex direction="column" gap="4">
+          <Flex direction="column" gap="1" style={{ maxWidth: 400, minWidth: 0 }}>
+            <Text size="2" weight="medium">
+              {t("models.defaultModel")}
+            </Text>
+            <Text size="1" color="gray" style={{ marginBottom: "var(--space-1)" }}>
+              {t("models.defaultModelDesc")}
+            </Text>
+            <ModelIdSelect
+              value={settings?.defaultModel || ""}
+              onChange={handleDefaultModelChange}
+              models={llmModelOptions}
+              placeholder={t("models.selectModelPlaceholder")}
+              editable={false}
+              allowCustomValue={false}
+              emptyOptionLabel={`（${t("models.selectModelPlaceholder")}）`}
+            />
           </Flex>
-        ) : (
-          <>
-            {/* 默认模型 & 轻量模型 */}
-            <Flex direction="column" gap="4">
-              <Flex direction="column" gap="1" style={{ maxWidth: 400, minWidth: 0 }}>
-                <Text size="2" weight="medium">
-                  {t("models.defaultModel")}
-                </Text>
-                <Text size="1" color="gray" style={{ marginBottom: "var(--space-1)" }}>
-                  {t("models.defaultModelDesc")}
-                </Text>
-                <ModelIdSelect
-                  value={settings?.defaultModel || ""}
-                  onChange={handleDefaultModelChange}
-                  models={llmModelOptions}
-                  placeholder={t("models.selectModelPlaceholder")}
-                  editable={false}
-                  allowCustomValue={false}
-                  emptyOptionLabel={`（${t("models.selectModelPlaceholder")}）`}
-                />
-              </Flex>
 
-              <Flex direction="column" gap="1" style={{ maxWidth: 400, minWidth: 0 }}>
-                <Text size="2" weight="medium">
-                  {t("models.lightModel")}
-                </Text>
-                <Text size="1" color="gray" style={{ marginBottom: "var(--space-1)" }}>
-                  {t("models.lightModelDesc")}
-                </Text>
-                <ModelIdSelect
-                  value={settings?.lightModel || ""}
-                  onChange={handleLightModelChange}
-                  models={llmModelOptions}
-                  placeholder={t("models.selectModelPlaceholder")}
-                  editable={false}
-                  allowCustomValue={false}
-                  emptyOptionLabel={`（${t("models.selectModelPlaceholder")}）`}
-                />
-              </Flex>
-            </Flex>
+          <Flex direction="column" gap="1" style={{ maxWidth: 400, minWidth: 0 }}>
+            <Text size="2" weight="medium">
+              {t("models.lightModel")}
+            </Text>
+            <Text size="1" color="gray" style={{ marginBottom: "var(--space-1)" }}>
+              {t("models.lightModelDesc")}
+            </Text>
+            <ModelIdSelect
+              value={settings?.lightModel || ""}
+              onChange={handleLightModelChange}
+              models={llmModelOptions}
+              placeholder={t("models.selectModelPlaceholder")}
+              editable={false}
+              allowCustomValue={false}
+              emptyOptionLabel={`（${t("models.selectModelPlaceholder")}）`}
+            />
+          </Flex>
+        </Flex>
 
-            {/* 新建按钮 */}
-            <Flex>
-              <Button onClick={handleCreate}>
-                <Plus size={16} />
-                {t("models.newModel")}
-              </Button>
-            </Flex>
+        {/* 新建按钮 */}
+        <Flex>
+          <Button onClick={handleCreate}>
+            <Plus size={16} />
+            {t("models.newModel")}
+          </Button>
+        </Flex>
 
-            {/* Tab导航 */}
-            <Tabs.Root
-              value={activeTab}
-              onValueChange={handleActiveTabChange}
-            >
-              <Tabs.List>
-                <Tabs.Trigger value="llm">{t("models.llmModels")}</Tabs.Trigger>
-                <Tabs.Trigger value="embedding">{t("models.embeddingModels")}</Tabs.Trigger>
-                <Tabs.Trigger value="rerank">{t("models.rerankModels")}</Tabs.Trigger>
-              </Tabs.List>
-            </Tabs.Root>
+        {/* Tab导航 */}
+        <Tabs.Root
+          value={activeTab}
+          onValueChange={handleActiveTabChange}
+        >
+          <Tabs.List>
+            <Tabs.Trigger value="llm">{t("models.llmModels")}</Tabs.Trigger>
+            <Tabs.Trigger value="embedding">{t("models.embeddingModels")}</Tabs.Trigger>
+            <Tabs.Trigger value="rerank">{t("models.rerankModels")}</Tabs.Trigger>
+          </Tabs.List>
+        </Tabs.Root>
 
-            {/* 模型列表 */}
-            {filteredModels.length > 0 ? (
-              <Flex direction="column">
-                {filteredModels.map((model, index) => (
-                  <Box key={model.id} className="list-item-hover">
+        {/* 模型列表 */}
+        {filteredModels.length > 0 ? (
+          <Flex direction="column">
+            {filteredModels.map((model, index) => (
+              <Box key={model.id} className="list-item-hover">
                     <Flex direction="column" gap="3" style={{ padding: "var(--space-4)" }}>
                       <Flex align="center" justify="between">
                         <Flex direction="column" gap="1" style={{ flex: 1 }}>
@@ -485,23 +483,21 @@ export function ModelsSettings({
                         }}
                       />
                     )}
-                  </Box>
-                ))}
-              </Flex>
-            ) : (
-              <Flex
-                direction="column"
-                align="center"
-                justify="center"
-                gap="3"
-                style={{ height: 200 }}
-              >
-                <Text size="2" color="gray">
-                  {t("models.noModels")}
-                </Text>
-              </Flex>
-            )}
-          </>
+              </Box>
+            ))}
+          </Flex>
+        ) : (
+          <Flex
+            direction="column"
+            align="center"
+            justify="center"
+            gap="3"
+            style={{ height: 200 }}
+          >
+            <Text size="2" color="gray">
+              {t("models.noModels")}
+            </Text>
+          </Flex>
         )}
       </Flex>
 

--- a/frontend/src/features/settings/components/settings-content.tsx
+++ b/frontend/src/features/settings/components/settings-content.tsx
@@ -31,6 +31,7 @@ import {
   applyFontFamily,
   loadConfiguredFonts,
 } from "@/lib/font-utils";
+import { OVERALL_INDEX_STATUS_QUERY_KEY } from "@/lib/index-status";
 
 const MotionBox = motion.create(Box);
 
@@ -217,13 +218,58 @@ export function SettingsContent({ appearance, onAppearanceChange, onClose, route
       ? mobileSubpageTitle
       : t(CATEGORY_TITLE_KEY_MAP[activeCategory]);
 
+  const clearCategoryQueries = useCallback((category: SettingsCategory) => {
+    const removeQuery = (queryKey: readonly unknown[]) => {
+      queryClient.removeQueries({ queryKey });
+    };
+
+    if (category === "general") removeQuery(["settings"]);
+    if (category === "connections") {
+      removeQuery(["model-providers"]);
+      removeQuery(["model-provider-catalog"]);
+    }
+    if (category === "models") {
+      removeQuery(["models"]);
+      removeQuery(["model-providers"]);
+      removeQuery(["settings"]);
+      removeQuery(["model-provider-catalog"]);
+    }
+    if (category === "index") {
+      removeQuery(["settings"]);
+      removeQuery(["models"]);
+      removeQuery(["projects", "all-for-index"]);
+      removeQuery(OVERALL_INDEX_STATUS_QUERY_KEY);
+    }
+    if (category === "agent-tools") {
+      removeQuery(["settings"]);
+      removeQuery(["agent-tools"]);
+    }
+    if (category === "rules") removeQuery(["agent-rules"]);
+    if (category === "skills") removeQuery(["skills"]);
+    if (category === "agents") {
+      removeQuery(["agent-definitions"]);
+      removeQuery(["agent-tool-categories"]);
+      removeQuery(["skills"]);
+      removeQuery(["settings"]);
+      removeQuery(["models"]);
+      removeQuery(["model-providers"]);
+      removeQuery(["model-provider-catalog"]);
+    }
+  }, [queryClient]);
+
   const handleMobileCategorySelect = useCallback((category: SettingsCategory) => {
+    clearCategoryQueries(category);
     setMobileDirection(1);
     setActiveCategory(category);
     setMobileSubpage("list");
     setMobileSubpageTitle(null);
     setMobileView("detail");
-  }, []);
+  }, [clearCategoryQueries]);
+
+  const handleDesktopCategorySelect = useCallback((category: SettingsCategory) => {
+    clearCategoryQueries(category);
+    setActiveCategory(category);
+  }, [clearCategoryQueries]);
 
   const handleMobileBack = useCallback(() => {
     if (isMobileListView) {
@@ -256,7 +302,7 @@ export function SettingsContent({ appearance, onAppearanceChange, onClose, route
             : "settings-dialog-content-scroll"}
       >
         {isCategoryLoading ? (
-          <Flex align="center" justify="center" className="settings-dialog-loading-state">
+          <Flex align="center" justify="center" style={{ height: "100%" }}>
             <Spinner size={18} />
           </Flex>
         ) : displaySettings ? (
@@ -323,7 +369,7 @@ export function SettingsContent({ appearance, onAppearanceChange, onClose, route
         <Box className="settings-dialog-sidebar-shell">
           <SettingsSidebar
             activeCategory={activeCategory}
-            onCategoryChange={setActiveCategory}
+            onCategoryChange={handleDesktopCategorySelect}
           />
         </Box>
       ) : null}

--- a/frontend/src/lib/use-llm-model-options.ts
+++ b/frontend/src/lib/use-llm-model-options.ts
@@ -19,13 +19,14 @@ export function useLlmModelOptions(): UseLlmModelOptionsResult {
   const { data: models, isLoading: isModelsLoading, error: modelsError } = useQuery({
     queryKey: ["models"],
     queryFn: () => fetchModels(),
-    staleTime: 5 * 60 * 1000,
   });
 
-  const { data: providers } = useQuery({
+  const {
+    data: providers,
+    isLoading: isProvidersLoading,
+  } = useQuery({
     queryKey: ["model-providers"],
     queryFn: fetchProviders,
-    staleTime: 5 * 60 * 1000,
   });
 
   const llmModels = useMemo(
@@ -45,7 +46,10 @@ export function useLlmModelOptions(): UseLlmModelOptionsResult {
     );
   }, [llmModels, providers]);
 
-  const { data: catalogMetadata } = useQuery({
+  const {
+    data: catalogMetadata,
+    isLoading: isCatalogMetadataLoading,
+  } = useQuery({
     queryKey: ["model-provider-catalog", "llm-model-metadata", catalogProviderTypes],
     queryFn: async () => {
       const responses = await Promise.all(
@@ -57,7 +61,6 @@ export function useLlmModelOptions(): UseLlmModelOptionsResult {
       return new Map(responses);
     },
     enabled: catalogProviderTypes.length > 0,
-    staleTime: 5 * 60 * 1000,
   });
 
   const options = useMemo<ModelIdSelectOption[]>(() => {
@@ -90,7 +93,10 @@ export function useLlmModelOptions(): UseLlmModelOptionsResult {
 
   return {
     options,
-    isLoading: isModelsLoading,
+    isLoading:
+      isModelsLoading ||
+      isProvidersLoading ||
+      (catalogProviderTypes.length > 0 && isCatalogMetadataLoading),
     error: modelsError,
   };
 }


### PR DESCRIPTION
## PR 标题

chore(frontend): 统一设置面板加载行为

## 变更说明

- 问题: 设置面板中除“规则”“技能”外的内容区会读取旧缓存，且加载态与现有分栏页不一致。
- 重要性: 会导致切换设置项时展示旧数据或局部渲染，和当前面板预期交互不一致。
- 变化: 点击设置列表进入各项时清理对应查询缓存并重新请求。
- 变化: 统一 connections、models、index、agents 内容区为依赖接口全部完成后再显示内容。
- 变化: 调整 LLM 模型选项加载判断，避免依赖未完成时提前渲染表单内容。

## 关联 Issue / PR (如有)

#XXXX

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因(如有)

设置面板内不同内容区的查询策略和加载布局不一致，部分页面保留了较长的缓存有效期，且在依赖接口未全部完成时就开始渲染内容，导致进入体验和“规则”“技能”页不统一。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 本次仅调整前端设置面板查询与加载行为，未改动后端接口。
- 本地已执行 `pnpm type-check` 与 `pnpm lint`。