### PR TITLE
fix(agent): 修复 subagent 回滚状态恢复

### DIFF
--- a/backend/app/agent_runtime/persistence/child_runs.py
+++ b/backend/app/agent_runtime/persistence/child_runs.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import random
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
@@ -9,6 +10,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
+from app.agent_runtime.persistence import repo as message_repo
 from app.agent_runtime.persistence.model import (
     AgentChildRun,
     AgentChildRunRequest,
@@ -38,6 +40,12 @@ SUBAGENT_AGENT_NUMBER_SPACE = (
 )
 _PARENT_SUBAGENT_NUMBER_LOCKS: dict[str, asyncio.Lock] = {}
 _PARENT_SUBAGENT_NUMBER_LOCKS_GUARD = asyncio.Lock()
+
+
+@dataclass(frozen=True)
+class ChildRunRollbackResult:
+    checkpoint_boundaries: list[tuple[str, str | None]]
+    child_run_ids: list[str]
 
 
 def _ensure_status(value: str, allowed: set[str], field_name: str) -> None:
@@ -105,6 +113,10 @@ async def create_child_run(
     request: dict[str, Any],
     status: str = "queued",
     metadata: dict[str, Any] | None = None,
+    parent_revision_id: str | None = None,
+    child_user_message_id: str | None = None,
+    child_user_message_seq: int | None = None,
+    pre_request_checkpoint_id: str | None = None,
 ) -> AgentChildRun:
     _ensure_status(status, CHILD_RUN_STATUSES, "child run status")
     now = datetime.now(UTC)
@@ -133,6 +145,7 @@ async def create_child_run(
             status=status,
             is_active=True,
             metadata_json=metadata_payload,
+            parent_revision_id=parent_revision_id,
             recycled_at=None,
             last_assistant_content=None,
             last_user_message_at=now,
@@ -146,6 +159,10 @@ async def create_child_run(
             request_kind="dispatch",
             content=str(request.get("task") or ""),
             status=_initial_request_status(status),
+            parent_revision_id=parent_revision_id,
+            child_user_message_id=child_user_message_id,
+            child_user_message_seq=child_user_message_seq,
+            pre_request_checkpoint_id=pre_request_checkpoint_id,
             seq=0,
             started_at=now if status in {"running", "waiting_user"} else None,
             completed_at=now if status in TERMINAL_CHILD_RUN_REQUEST_STATUSES else None,
@@ -379,6 +396,10 @@ async def enqueue_child_run_request(
     child_run_id: str,
     request_kind: str,
     content: str,
+    parent_revision_id: str | None = None,
+    child_user_message_id: str | None = None,
+    child_user_message_seq: int | None = None,
+    pre_request_checkpoint_id: str | None = None,
 ) -> AgentChildRunRequest:
     row = await session.get(AgentChildRun, child_run_id)
     if row is None:
@@ -394,6 +415,10 @@ async def enqueue_child_run_request(
         request_kind=request_kind,
         content=content,
         status="pending",
+        parent_revision_id=parent_revision_id,
+        child_user_message_id=child_user_message_id,
+        child_user_message_seq=child_user_message_seq,
+        pre_request_checkpoint_id=pre_request_checkpoint_id,
         seq=await _next_child_request_seq(session, child_run_id),
     )
     if row.status != "waiting_user":
@@ -404,6 +429,119 @@ async def enqueue_child_run_request(
     await session.commit()
     await session.refresh(request_row)
     return request_row
+
+
+async def update_child_run_request_boundaries(
+    session: AsyncSession,
+    request_id: str,
+    *,
+    child_user_message_id: str | None = None,
+    child_user_message_seq: int | None = None,
+    pre_request_checkpoint_id: str | None = None,
+) -> AgentChildRunRequest:
+    request_row = await session.get(AgentChildRunRequest, request_id)
+    if request_row is None:
+        raise ValueError(f"child run request not found: {request_id}")
+    if child_user_message_id is not None:
+        request_row.child_user_message_id = child_user_message_id
+    if child_user_message_seq is not None:
+        request_row.child_user_message_seq = child_user_message_seq
+    if pre_request_checkpoint_id is not None:
+        request_row.pre_request_checkpoint_id = pre_request_checkpoint_id
+    request_row.updated_at = datetime.now(UTC)
+    session.add(request_row)
+    await session.commit()
+    await session.refresh(request_row)
+    return request_row
+
+
+async def rollback_child_runs_for_parent_revisions(
+    session: AsyncSession,
+    *,
+    parent_revision_ids: list[str],
+) -> ChildRunRollbackResult:
+    if not parent_revision_ids:
+        return ChildRunRollbackResult(checkpoint_boundaries=[], child_run_ids=[])
+
+    result = await session.execute(
+        select(AgentChildRunRequest)
+        .where(col(AgentChildRunRequest.parent_revision_id).in_(parent_revision_ids))
+        .order_by(
+            col(AgentChildRunRequest.child_run_id).asc(),
+            col(AgentChildRunRequest.seq).asc(),
+        )
+    )
+    grouped: dict[str, AgentChildRunRequest] = {}
+    for request_row in result.scalars().all():
+        grouped.setdefault(request_row.child_run_id, request_row)
+
+    checkpoint_boundaries: list[tuple[str, str | None]] = []
+    child_run_ids: list[str] = []
+    now = datetime.now(UTC)
+    for child_run_id, first_request in grouped.items():
+        row = await session.get(AgentChildRun, child_run_id)
+        if row is None:
+            continue
+        child_run_ids.append(child_run_id)
+
+        if first_request.child_user_message_seq is not None:
+            await message_repo.delete_from_seq(
+                session,
+                row.child_thread_id,
+                first_request.child_user_message_seq,
+            )
+        if first_request.pre_request_checkpoint_id:
+            checkpoint_boundaries.append(
+                (row.child_thread_id, first_request.pre_request_checkpoint_id)
+            )
+        elif first_request.seq == 0:
+            checkpoint_boundaries.append((row.child_thread_id, None))
+
+        affected = await session.execute(
+            select(AgentChildRunRequest).where(
+                col(AgentChildRunRequest.child_run_id) == child_run_id,
+                col(AgentChildRunRequest.seq) >= first_request.seq,
+            )
+        )
+        for request_row in affected.scalars().all():
+            request_row.status = "cancelled"
+            request_row.error = "parent revision rolled back"
+            request_row.completed_at = now
+            request_row.updated_at = now
+
+        previous_result = await session.execute(
+            select(AgentChildRunRequest)
+            .where(
+                col(AgentChildRunRequest.child_run_id) == child_run_id,
+                col(AgentChildRunRequest.seq) < first_request.seq,
+                col(AgentChildRunRequest.status) == "completed",
+            )
+            .order_by(col(AgentChildRunRequest.seq).desc())
+            .limit(1)
+        )
+        previous = previous_result.scalar_one_or_none()
+        row.pending_approval_id = None
+        row.pending_approval_json = None
+        row.updated_at = now
+        if first_request.seq == 0:
+            row.is_active = False
+            row.status = "cancelled"
+            row.completed_at = now
+            row.last_completed_at = now
+            row.last_assistant_content = None
+            row.error = "parent revision rolled back"
+        else:
+            row.is_active = True
+            row.status = "completed" if previous is not None else "queued"
+            row.last_assistant_content = previous.assistant_content if previous else None
+            row.last_completed_at = previous.completed_at if previous else None
+            row.error = None
+
+    await session.flush()
+    return ChildRunRollbackResult(
+        checkpoint_boundaries=list(dict.fromkeys(checkpoint_boundaries)),
+        child_run_ids=list(dict.fromkeys(child_run_ids)),
+    )
 
 
 async def claim_next_child_run_request(

--- a/backend/app/agent_runtime/persistence/model.py
+++ b/backend/app/agent_runtime/persistence/model.py
@@ -160,6 +160,7 @@ class AgentChildRun(SQLModel, table=True):
         default_factory=dict,
         sa_column=Column(JSON, nullable=False, default=dict),
     )
+    parent_revision_id: str | None = Field(default=None, index=True, max_length=64)
     started_at: datetime | None = Field(default=None, index=True)
     completed_at: datetime | None = Field(default=None, index=True)
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC), index=True)
@@ -183,6 +184,10 @@ class AgentChildRunRequest(SQLModel, table=True):
         sa_column=Column(Text, nullable=True),
     )
     error: str | None = Field(default=None, sa_column=Column(Text, nullable=True))
+    parent_revision_id: str | None = Field(default=None, index=True, max_length=64)
+    child_user_message_id: str | None = Field(default=None, index=True, max_length=64)
+    child_user_message_seq: int | None = Field(default=None, index=True)
+    pre_request_checkpoint_id: str | None = Field(default=None, index=True, max_length=128)
     seq: int = Field(index=True, ge=0)
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC), index=True)
     started_at: datetime | None = Field(default=None, index=True)

--- a/backend/app/agent_runtime/revisions.py
+++ b/backend/app/agent_runtime/revisions.py
@@ -10,6 +10,7 @@ from typing import Literal
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.persistence import compaction_repo, repo as message_repo
+from app.agent_runtime.persistence.child_runs import rollback_child_runs_for_parent_revisions
 from app.agent_runtime.persistence.model import AgentRunMessage
 from app.core.errors import NotFoundError
 from app.storage.models.chapter import Chapter
@@ -94,6 +95,8 @@ class AgentRollbackResult:
     affected_world_entries: list[str]
     restored_message_content: str
     restored_checkpoint_id: str | None
+    child_checkpoint_boundaries: list[tuple[str, str | None]]
+    affected_child_run_ids: list[str]
 
 
 def current_revision_id_from_state(state: dict) -> str | None:
@@ -945,6 +948,10 @@ async def rollback_revision_for_session(
         target.user_message_seq,
     )
     await message_repo.delete_from_seq(session, agent_session_id, target.user_message_seq)
+    child_rollback_result = await rollback_child_runs_for_parent_revisions(
+        session,
+        parent_revision_ids=[revision.id for revision in revisions],
+    )
 
     for revision in revisions:
         await revision_repo.update_status(session, revision.id, "rolled_back")
@@ -970,4 +977,6 @@ async def rollback_revision_for_session(
         affected_world_entries=list(dict.fromkeys(affected_world_entries)),
         restored_message_content=restored_message_content,
         restored_checkpoint_id=target.pre_run_checkpoint_id,
+        child_checkpoint_boundaries=child_rollback_result.checkpoint_boundaries,
+        affected_child_run_ids=child_rollback_result.child_run_ids,
     )

--- a/backend/app/agent_runtime/runner/checkpointer.py
+++ b/backend/app/agent_runtime/runner/checkpointer.py
@@ -103,6 +103,26 @@ async def delete_checkpoints_after_for_thread(
         await conn.close()
 
 
+async def latest_checkpoint_id_for_thread(thread_id: str) -> str | None:
+    if not thread_id:
+        return None
+
+    db_path = _get_db_path()
+    Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+
+    conn = await aiosqlite.connect(db_path)
+    try:
+        cursor = await conn.execute(
+            "SELECT checkpoint_id FROM checkpoints WHERE thread_id = ? "
+            "ORDER BY checkpoint_id DESC LIMIT 1",
+            (thread_id,),
+        )
+        row = await cursor.fetchone()
+        return str(row[0]) if row and row[0] else None
+    finally:
+        await conn.close()
+
+
 async def init_checkpointer() -> AsyncSqliteSaver:
     return await get_checkpointer()
 

--- a/backend/app/agent_runtime/runner/subagent_runner.py
+++ b/backend/app/agent_runtime/runner/subagent_runner.py
@@ -280,11 +280,13 @@ class SubagentRunner:
         self,
         row: AgentChildRun,
         content: str,
+        *,
+        parent_revision_id: str | None = None,
     ) -> dict[str, Any]:
         session = await _open_session(self.session_factory)
         try:
             task = await task_service.get_task(session, row.parent_task_id)
-            current_revision_id = task.current_revision_id
+            current_revision_id = parent_revision_id or task.current_revision_id
         finally:
             await _close_session(session)
 
@@ -843,7 +845,11 @@ class SubagentRunner:
 
         definition = await self._load_agent_definition(row.agent_key)
         history = await self._load_history(row.child_thread_id)
-        runtime_state = await self._build_runtime_state(row, request_row.content)
+        runtime_state = await self._build_runtime_state(
+            row,
+            request_row.content,
+            parent_revision_id=request_row.parent_revision_id,
+        )
         graph = await self._build_graph(row, definition, runtime_state)
         graph_input: Any
         if resume_payload is None:

--- a/backend/app/agent_runtime/tools/impls/orchestration/common.py
+++ b/backend/app/agent_runtime/tools/impls/orchestration/common.py
@@ -9,6 +9,7 @@ from langchain_core.runnables import RunnableConfig
 from loguru import logger
 
 from app.agent_runtime.persistence import repo as message_repo
+from app.agent_runtime.persistence.types import PersistedMessage
 from app.agent_runtime.persistence.child_runs import (
     get_child_run_agent_number,
     get_child_run_for_parent,
@@ -128,7 +129,7 @@ async def persist_child_user_message(
     task_id: str,
     project_id: str,
     content: str,
-) -> None:
+) -> PersistedMessage:
     session = await open_session(session_factory)
     try:
         message = await message_repo.insert_message(
@@ -166,6 +167,7 @@ async def persist_child_user_message(
             payload,
             room=agent_subagent_session_room(child_thread_id),
         )
+    return message
 
 
 async def resolve_child_run(

--- a/backend/app/agent_runtime/tools/impls/orchestration/dispatch_subagent.py
+++ b/backend/app/agent_runtime/tools/impls/orchestration/dispatch_subagent.py
@@ -14,7 +14,9 @@ from app.agent_runtime.persistence.child_runs import (
     get_child_run_request_by_seq,
     get_running_child_run_request,
     get_waiting_child_run_for_tool_call,
+    update_child_run_request_boundaries,
 )
+from app.agent_runtime.runner.checkpointer import latest_checkpoint_id_for_thread
 from app.agent_runtime.tools.base import AgentTool
 from app.agent_runtime.tools.errors import ToolExecutionError
 from app.agent_runtime.tools.impls.orchestration.common import (
@@ -147,6 +149,9 @@ class DispatchSubagentTool(AgentTool):
                 tool_call_id=tool_call_id,
                 request={"task": task, "input": input, "metadata": metadata},
                 metadata={"tool_metadata": metadata},
+                parent_revision_id=self._state.get("current_revision_id")
+                if isinstance(self._state.get("current_revision_id"), str)
+                else None,
             )
         finally:
             await close_session(session)
@@ -264,7 +269,10 @@ class DispatchSubagentTool(AgentTool):
                 configurable=configurable,
                 tool_call_id=tool_call_id,
             )
-            await persist_child_user_message(
+            pre_request_checkpoint_id = await latest_checkpoint_id_for_thread(
+                row.child_thread_id
+            )
+            child_user_message = await persist_child_user_message(
                 session_factory=configurable.get("session_factory"),
                 child_thread_id=row.child_thread_id,
                 task_id=str(self._state["task_id"]),
@@ -275,6 +283,17 @@ class DispatchSubagentTool(AgentTool):
                 configurable=configurable,
                 child_run_id=row.id,
             )
+            session = await open_session(configurable.get("session_factory"))
+            try:
+                await update_child_run_request_boundaries(
+                    session,
+                    request_id,
+                    child_user_message_id=child_user_message.id,
+                    child_user_message_seq=child_user_message.seq,
+                    pre_request_checkpoint_id=pre_request_checkpoint_id,
+                )
+            finally:
+                await close_session(session)
         runner = make_subagent_runner(state=self._state, configurable=configurable)
         await runner.publish_parent_subagent_status(row.id)
 

--- a/backend/app/agent_runtime/tools/impls/orchestration/notify_subagent.py
+++ b/backend/app/agent_runtime/tools/impls/orchestration/notify_subagent.py
@@ -5,7 +5,11 @@ from typing import Any
 
 from pydantic import BaseModel, Field, model_validator
 
-from app.agent_runtime.persistence.child_runs import enqueue_child_run_request
+from app.agent_runtime.persistence.child_runs import (
+    enqueue_child_run_request,
+    update_child_run_request_boundaries,
+)
+from app.agent_runtime.runner.checkpointer import latest_checkpoint_id_for_thread
 from app.agent_runtime.tools.base import AgentTool
 from app.agent_runtime.tools.errors import ToolExecutionError
 from app.agent_runtime.tools.impls.orchestration.common import (
@@ -109,6 +113,9 @@ class NotifySubagentTool(AgentTool):
         if not row.is_active:
             raise ToolExecutionError("subagent thread is inactive")
         tool_call_id = self.tool_call_id or generate_id()
+        current_revision_id = self._state.get("current_revision_id")
+        parent_revision_id = current_revision_id if isinstance(current_revision_id, str) else None
+        pre_request_checkpoint_id = await latest_checkpoint_id_for_thread(row.child_thread_id)
 
         session = await open_session(configurable.get("session_factory"))
         try:
@@ -117,17 +124,29 @@ class NotifySubagentTool(AgentTool):
                 child_run_id=row.id,
                 request_kind="notify",
                 content=message,
+                parent_revision_id=parent_revision_id,
+                pre_request_checkpoint_id=pre_request_checkpoint_id,
             )
         finally:
             await close_session(session)
 
-        await persist_child_user_message(
+        child_user_message = await persist_child_user_message(
             session_factory=configurable.get("session_factory"),
             child_thread_id=row.child_thread_id,
             task_id=str(self._state["task_id"]),
             project_id=str(self._state["project_id"]),
             content=message,
         )
+        session = await open_session(configurable.get("session_factory"))
+        try:
+            await update_child_run_request_boundaries(
+                session,
+                request_row.id,
+                child_user_message_id=child_user_message.id,
+                child_user_message_seq=child_user_message.seq,
+            )
+        finally:
+            await close_session(session)
 
         runner = make_subagent_runner(state=self._state, configurable=configurable)
         await runner.publish_parent_subagent_status(row.id)

--- a/backend/app/api/routers/agent_runtime.py
+++ b/backend/app/api/routers/agent_runtime.py
@@ -34,6 +34,7 @@ from app.agent_runtime.revisions import rollback_revision_for_session
 from app.agent_runtime.fork import fork_agent_session_at_revision
 from app.agent_runtime.runner.checkpointer import (
     delete_checkpoints_after_for_thread,
+    delete_checkpoints_for_thread,
 )
 from app.agent_runtime.runner.session_runner import SessionRunner
 from app.agent_runtime.runner.subagent_runner import SubagentRunner
@@ -69,8 +70,9 @@ from app.settings import settings
 from app.background.jobs.session_title_jobs import enqueue_session_title_job
 from app.background.jobs import service as background_service
 from app.socket import emit
-from app.socket.handlers import background_project_room
+from app.socket.handlers import agent_session_room, background_project_room
 from app.storage.database import get_session
+from app.storage.models.chapter import Chapter
 from app.storage.services import task_service
 
 router = APIRouter(tags=["Agent"])
@@ -1055,6 +1057,50 @@ async def rollback_agent_session(
         except Exception:
             logger.bind(session_id=session_id).opt(exception=True).error(
                 "Agent graph checkpoint rollback failed after revision rollback"
+            )
+            raise
+    if result.affected_child_run_ids:
+        status_publisher = SubagentRunner(
+            session_factory=sessionmaker(  # type: ignore[call-overload]
+                session.bind,
+                class_=AsyncSession,
+                expire_on_commit=False,
+            ),
+            model_config=runner.model_config if runner is not None else {"max_context_tokens": 1},
+            project_id=runner.project_id if runner is not None else "",
+        )
+        for child_run_id in result.affected_child_run_ids:
+            await status_publisher.publish_parent_subagent_status(child_run_id)
+    emitted_global_chapter_refresh = False
+    for chapter_id in result.affected_chapters:
+        payload = {
+            "session_id": session_id,
+            "project_id": result.rollback_revision.project_id,
+            "created_at": datetime.now(UTC).isoformat(),
+        }
+        if await session.get(Chapter, chapter_id) is not None:
+            payload["chapter_id"] = chapter_id
+        elif emitted_global_chapter_refresh:
+            continue
+        else:
+            emitted_global_chapter_refresh = True
+        await emit(
+            "agent:chapter_refresh",
+            payload,
+            room=agent_session_room(session_id),
+        )
+    for child_thread_id, checkpoint_id in result.child_checkpoint_boundaries:
+        try:
+            if checkpoint_id:
+                await delete_checkpoints_after_for_thread(child_thread_id, checkpoint_id)
+            else:
+                await delete_checkpoints_for_thread(child_thread_id)
+        except Exception:
+            logger.bind(
+                session_id=session_id,
+                child_thread_id=child_thread_id,
+            ).opt(exception=True).error(
+                "Agent subagent checkpoint rollback failed after revision rollback"
             )
             raise
 

--- a/backend/app/storage/migrations/versions/1004_add_subagent_rollback_boundaries.py
+++ b/backend/app/storage/migrations/versions/1004_add_subagent_rollback_boundaries.py
@@ -1,0 +1,55 @@
+"""add subagent rollback boundaries
+
+Revision ID: 1004
+Revises: 1003
+Create Date: 2026-07-03 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "1004"
+down_revision: Union[str, Sequence[str], None] = "1003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    with op.batch_alter_table("agent_child_runs", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("parent_revision_id", sa.String(length=64), nullable=True))
+        batch_op.create_index(batch_op.f("ix_agent_child_runs_parent_revision_id"), ["parent_revision_id"], unique=False)
+
+    with op.batch_alter_table("agent_child_run_requests", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("parent_revision_id", sa.String(length=64), nullable=True))
+        batch_op.add_column(sa.Column("child_user_message_id", sa.String(length=64), nullable=True))
+        batch_op.add_column(sa.Column("child_user_message_seq", sa.Integer(), nullable=True))
+        batch_op.add_column(sa.Column("pre_request_checkpoint_id", sa.String(length=128), nullable=True))
+        batch_op.create_index(batch_op.f("ix_agent_child_run_requests_parent_revision_id"), ["parent_revision_id"], unique=False)
+        batch_op.create_index(batch_op.f("ix_agent_child_run_requests_child_user_message_id"), ["child_user_message_id"], unique=False)
+        batch_op.create_index(batch_op.f("ix_agent_child_run_requests_child_user_message_seq"), ["child_user_message_seq"], unique=False)
+        batch_op.create_index(batch_op.f("ix_agent_child_run_requests_pre_request_checkpoint_id"), ["pre_request_checkpoint_id"], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    with op.batch_alter_table("agent_child_run_requests", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_agent_child_run_requests_pre_request_checkpoint_id"))
+        batch_op.drop_index(batch_op.f("ix_agent_child_run_requests_child_user_message_seq"))
+        batch_op.drop_index(batch_op.f("ix_agent_child_run_requests_child_user_message_id"))
+        batch_op.drop_index(batch_op.f("ix_agent_child_run_requests_parent_revision_id"))
+        batch_op.drop_column("pre_request_checkpoint_id")
+        batch_op.drop_column("child_user_message_seq")
+        batch_op.drop_column("child_user_message_id")
+        batch_op.drop_column("parent_revision_id")
+
+    with op.batch_alter_table("agent_child_runs", schema=None) as batch_op:
+        batch_op.drop_index(batch_op.f("ix_agent_child_runs_parent_revision_id"))
+        batch_op.drop_column("parent_revision_id")

--- a/backend/tests/agent_runtime/persistence/test_child_runs.py
+++ b/backend/tests/agent_runtime/persistence/test_child_runs.py
@@ -1,17 +1,23 @@
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
 
 from app.agent_runtime.persistence.child_runs import (
+    complete_child_run_request,
     create_child_run,
+    enqueue_child_run_request,
     get_child_run_by_pending_approval,
     get_waiting_child_run_for_tool_call,
     list_child_runs_for_parent,
     record_child_run_pending_approval,
+    rollback_child_runs_for_parent_revisions,
     update_child_run_status,
 )
 from app.agent_runtime.persistence.loader import load_history
 from app.agent_runtime.persistence.model import (
     AgentChildRun,
+    AgentChildRunRequest,
     AgentRunMessage,
 )
 from app.agent_runtime.persistence.task_projection import (
@@ -157,6 +163,127 @@ async def test_list_child_runs_for_parent_orders_by_creation(
     rows = await list_child_runs_for_parent(db_session, "parent-session")
 
     assert [row.child_thread_id for row in rows] == ["child-1", "child-2"]
+
+
+@pytest.mark.asyncio
+async def test_rollback_child_runs_restores_notify_request_to_previous_completed_state(
+    db_session: AsyncSession,
+    sample_task,
+):
+    row = await create_child_run(
+        db_session,
+        parent_session_id="parent-session",
+        parent_task_id=sample_task.id,
+        parent_thread_id="parent-thread",
+        child_thread_id="child-thread",
+        agent_key="writer",
+        dispatch_id="dispatch-1",
+        tool_call_id="tool-call-1",
+        request={},
+        parent_revision_id="rev-1",
+        child_user_message_id="child-user-1",
+        child_user_message_seq=0,
+        pre_request_checkpoint_id="cp-before-dispatch",
+    )
+    request_result = await db_session.execute(
+        select(AgentChildRunRequest).where(
+            col(AgentChildRunRequest.child_run_id) == row.id,
+            col(AgentChildRunRequest.seq) == 0,
+        )
+    )
+    first_request = request_result.scalar_one()
+
+    db_session.add_all(
+        [
+            AgentRunMessage(
+                session_id="child-thread",
+                task_id=sample_task.id,
+                project_id=sample_task.project_id,
+                role="user",
+                content="第一轮任务",
+                status="sent",
+                message_type="user_request",
+                seq=0,
+            ),
+            AgentRunMessage(
+                session_id="child-thread",
+                task_id=sample_task.id,
+                project_id=sample_task.project_id,
+                role="assistant",
+                content="第一轮结果",
+                status="complete",
+                seq=1,
+            ),
+        ]
+    )
+    await complete_child_run_request(
+        db_session,
+        first_request.id,
+        assistant_content="第一轮结果",
+    )
+
+    notify_request = await enqueue_child_run_request(
+        db_session,
+        child_run_id=row.id,
+        request_kind="notify",
+        content="第二轮任务",
+        parent_revision_id="rev-2",
+        child_user_message_id="child-user-2",
+        child_user_message_seq=2,
+        pre_request_checkpoint_id="cp-before-notify",
+    )
+    db_session.add_all(
+        [
+            AgentRunMessage(
+                session_id="child-thread",
+                task_id=sample_task.id,
+                project_id=sample_task.project_id,
+                role="user",
+                content="第二轮任务",
+                status="sent",
+                message_type="user_request",
+                seq=2,
+            ),
+            AgentRunMessage(
+                session_id="child-thread",
+                task_id=sample_task.id,
+                project_id=sample_task.project_id,
+                role="assistant",
+                content="第二轮结果",
+                status="complete",
+                seq=3,
+            ),
+        ]
+    )
+    await complete_child_run_request(
+        db_session,
+        notify_request.id,
+        assistant_content="第二轮结果",
+    )
+
+    rollback_result = await rollback_child_runs_for_parent_revisions(
+        db_session,
+        parent_revision_ids=["rev-2"],
+    )
+
+    restored = await db_session.get(AgentChildRun, row.id)
+    rolled_back_request = await db_session.get(AgentChildRunRequest, notify_request.id)
+    message_result = await db_session.execute(
+        select(AgentRunMessage)
+        .where(col(AgentRunMessage.session_id) == "child-thread")
+        .order_by(col(AgentRunMessage.seq).asc())
+    )
+    messages = list(message_result.scalars().all())
+
+    assert rollback_result.checkpoint_boundaries == [("child-thread", "cp-before-notify")]
+    assert rollback_result.child_run_ids == [row.id]
+    assert restored is not None
+    assert restored.is_active is True
+    assert restored.status == "completed"
+    assert restored.last_assistant_content == "第一轮结果"
+    assert rolled_back_request is not None
+    assert rolled_back_request.status == "cancelled"
+    assert [message.content for message in messages] == ["第一轮任务", "第一轮结果"]
 
 @pytest.mark.asyncio
 async def test_hidden_system_reminder_remains_visible_to_llm_history(

--- a/backend/tests/agent_runtime/runner/test_subagent_runner.py
+++ b/backend/tests/agent_runtime/runner/test_subagent_runner.py
@@ -296,6 +296,99 @@ async def test_subagent_runner_uses_child_thread_history_and_parent_task(
 
 
 @pytest.mark.asyncio
+async def test_subagent_runner_uses_request_parent_revision_for_notify_turn(
+    db_session_factory,
+    monkeypatch,
+):
+    from app.agent_runtime.runner.subagent_runner import SubagentRunner
+
+    async with db_session_factory() as session:
+        task = await session.get(Task, "task-1")
+        assert task is not None
+        task.current_revision_id = "rev-stale"
+        session.add(task)
+        row = await create_child_run(
+            session,
+            parent_session_id="parent-session",
+            parent_task_id="task-1",
+            parent_thread_id="parent-session",
+            child_thread_id="child-thread-revision",
+            agent_key="writer",
+            dispatch_id="dispatch-revision",
+            tool_call_id="tool-call-revision",
+            request={"task": "first", "input": {}},
+            status="completed",
+            parent_revision_id="rev-1",
+        )
+        await enqueue_child_run_request(
+            session,
+            child_run_id=row.id,
+            request_kind="notify",
+            content="second",
+            parent_revision_id="rev-2",
+        )
+        await session.commit()
+
+    captured: dict = {}
+
+    class FakeGraph:
+        async def astream_events(self, initial_state, config=None, version=None):
+            captured["runtime_state"] = config["configurable"]["runtime_state"]
+            yield {
+                "event": "on_chat_model_end",
+                "run_id": "child-run-revision",
+                "tags": ["subagent_child"],
+                "data": {"output": AIMessage(content="second done")},
+            }
+            yield {
+                "event": "on_chain_end",
+                "tags": ["subagent_child"],
+                "data": {"output": {
+                    "messages": [AIMessage(content="second done")],
+                    "iteration_count": 1,
+                    "is_done": True,
+                    "final_output": None,
+                }},
+            }
+
+        async def ainvoke(self, initial_state, config=None):
+            return {
+                "messages": [AIMessage(content="second done")],
+                "iteration_count": 1,
+                "is_done": True,
+                "final_output": None,
+            }
+
+    async def fake_emit(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr("app.agent_runtime.runner.subagent_runner.emit", fake_emit)
+    monkeypatch.setattr(
+        "app.agent_runtime.runner.subagent_runner.create_chat_model",
+        lambda _config: object(),
+    )
+    monkeypatch.setattr(
+        "app.agent_runtime.runner.subagent_runner.create_react_agent",
+        lambda *_args, **_kwargs: FakeGraph(),
+    )
+
+    runner = SubagentRunner(
+        session_factory=db_session_factory,
+        model_config={
+            "provider_type": "openai",
+            "base_url": "",
+            "api_key": "key",
+            "model_id": "gpt-test",
+            "max_context_tokens": 8000,
+        },
+        project_id="project-1",
+    )
+    await runner.run(row.id)
+
+    assert captured["runtime_state"]["current_revision_id"] == "rev-2"
+
+
+@pytest.mark.asyncio
 async def test_subagent_runner_passes_compaction_sinks_to_child_graph(
     db_session_factory,
     monkeypatch,

--- a/backend/tests/agent_runtime/test_agent_revision_rollback.py
+++ b/backend/tests/agent_runtime/test_agent_revision_rollback.py
@@ -222,6 +222,127 @@ async def test_write_chapter_records_current_revision_and_structured_result(revi
 
 
 @pytest.mark.asyncio
+async def test_rollback_second_subagent_revision_restores_chapter_to_first_revision_content(
+    revision_db,
+    monkeypatch,
+):
+    from app.agent_runtime.revisions import begin_user_revision, rollback_revision_for_session
+    from app.agent_runtime.tools.impls.chapter.edit_chapter import EditChapterTool
+    from app.agent_runtime.tools.impls.chapter.write_chapter import WriteChapterTool
+    from app.storage.repos import chapter_repo
+
+    async def create_test_session():
+        return revision_db()
+
+    monkeypatch.setattr(
+        "app.agent_runtime.tools.impls.chapter.edit_chapter.create_session",
+        create_test_session,
+    )
+
+    async with revision_db() as session:
+        first_user = await message_repo.insert_message(
+            session,
+            session_id="sess-1",
+            task_id="task-1",
+            project_id="proj-1",
+            role="user",
+            status="sent",
+            content="委派 subagent 创建章节",
+        )
+        first_revision = await begin_user_revision(
+            session,
+            project_id="proj-1",
+            task_id="task-1",
+            agent_session_id="sess-1",
+            user_message_id=first_user.id,
+            user_message_seq=first_user.seq,
+            message="用户消息: 委派 subagent 创建章节",
+            pre_run_checkpoint_id="cp-before-first",
+            graph_thread_id="sess-1",
+        )
+        await session.commit()
+
+    write_tool = WriteChapterTool(
+        _state={
+            "session_id": "sess-1:child:writer",
+            "task_id": "task-1",
+            "project_id": "proj-1",
+            "current_revision_id": first_revision.id,
+        }
+    )
+    write_result = json.loads(
+        await write_tool.ainvoke(
+            {
+                "volume_ref": {"type": "order", "value": 1},
+                "title": "Subagent 章节",
+                "content": "你好",
+            }
+        )
+    )
+    chapter_id = write_result["chapter"]["id"]
+
+    async with revision_db() as session:
+        second_user = await message_repo.insert_message(
+            session,
+            session_id="sess-1",
+            task_id="task-1",
+            project_id="proj-1",
+            role="user",
+            status="sent",
+            content="通知 subagent 修改章节",
+        )
+        second_revision = await begin_user_revision(
+            session,
+            project_id="proj-1",
+            task_id="task-1",
+            agent_session_id="sess-1",
+            user_message_id=second_user.id,
+            user_message_seq=second_user.seq,
+            message="用户消息: 通知 subagent 修改章节",
+            pre_run_checkpoint_id="cp-before-second",
+            graph_thread_id="sess-1",
+        )
+        await session.commit()
+
+    edit_tool = EditChapterTool(
+        _state={
+            "session_id": "sess-1:child:writer",
+            "task_id": "task-1",
+            "project_id": "proj-1",
+            "current_revision_id": second_revision.id,
+        }
+    )
+    edit_result = json.loads(
+        await edit_tool.ainvoke(
+            {
+                "volume_ref": {"type": "order", "value": 1},
+                "chapter_ref": {"type": "title", "value": "Subagent 章节"},
+                "old_content": "你好",
+                "new_content": "Hello",
+            }
+        )
+    )
+    assert edit_result.get("success") is True, edit_result
+
+    async with revision_db() as session:
+        edited = await chapter_repo.get_by_id(session, chapter_id)
+        assert edited is not None
+        assert edited.content == "Hello"
+        await rollback_revision_for_session(
+            session,
+            agent_session_id="sess-1",
+            revision_id=second_revision.id,
+        )
+        await session.commit()
+
+    async with revision_db() as session:
+        restored = await chapter_repo.get_by_id(session, chapter_id)
+
+    assert restored is not None
+    assert restored.content == "你好"
+
+
+@pytest.mark.asyncio
 async def test_rollback_revision_restores_chapters_and_messages(revision_db):
     from app.agent_runtime.revisions import (
         begin_user_revision,

--- a/backend/tests/api/test_agent.py
+++ b/backend/tests/api/test_agent.py
@@ -5,6 +5,7 @@ import asyncio
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY
 
 import pytest
 import pytest_asyncio
@@ -22,7 +23,7 @@ from app.agent_runtime.runner.checkpointer import reset_checkpointer
 from app.agent_runtime.runner.run_registry import get_agent_run_registry
 from app.agent_runtime.streaming.replay_buffer import get_agent_event_replay_buffer
 from app.api.routers.agent_runtime import _SESSION_RUNNERS
-from app.socket.handlers import agent_subagents_room
+from app.socket.handlers import agent_session_room, agent_subagents_room
 from app.storage.models.chapter import Chapter
 from app.storage.models.commit import Commit
 from app.storage.models.project import Project
@@ -1849,6 +1850,8 @@ class TestAgentAPI:
         client: AsyncClient,
         session,
     ) -> None:
+        buffer = get_agent_event_replay_buffer()
+        buffer.clear_all()
         session.add(Project(id="proj-rollback", title="回滚项目"))
         session.add(
             Volume(
@@ -1941,14 +1944,32 @@ class TestAgentAPI:
             status="complete",
             content="已改写",
         )
+        child = await create_child_run(
+            session,
+            parent_session_id="sess-rollback",
+            parent_task_id="task-rollback",
+            parent_thread_id="sess-rollback",
+            child_thread_id="sess-rollback:child:rollback",
+            agent_key="writer",
+            dispatch_id="dispatch-rollback",
+            tool_call_id="tool-call-rollback",
+            request={"task": "write", "input": {}, "metadata": {}},
+            status="completed",
+            parent_revision_id=revision.id,
+            child_user_message_seq=0,
+        )
         await session.commit()
 
         fake_runner = SimpleNamespace(
             cancel=MagicMock(),
+            model_config={"max_context_tokens": 1},
+            project_id="proj-rollback",
         )
         _SESSION_RUNNERS["sess-rollback"] = cast(Any, fake_runner)
         fake_registry = SimpleNamespace(cancel=AsyncMock())
         delete_checkpoints_after_mock = AsyncMock()
+        delete_checkpoints_for_thread_mock = AsyncMock()
+        emit_mock = AsyncMock()
 
         with (
             patch(
@@ -1958,6 +1979,18 @@ class TestAgentAPI:
             patch(
                 "app.api.routers.agent_runtime.delete_checkpoints_after_for_thread",
                 delete_checkpoints_after_mock,
+            ),
+            patch(
+                "app.api.routers.agent_runtime.delete_checkpoints_for_thread",
+                delete_checkpoints_for_thread_mock,
+            ),
+            patch(
+                "app.api.routers.agent_runtime.emit",
+                new=emit_mock,
+            ),
+            patch(
+                "app.agent_runtime.runner.subagent_runner.emit",
+                new=emit_mock,
             ),
         ):
             response = await client.post(
@@ -1973,14 +2006,162 @@ class TestAgentAPI:
         assert data["affected_chapters"] == ["chap-rollback"]
         assert data["affected_world_entries"] == []
         assert data["revision_id"]
+        emit_mock.assert_any_await(
+            "agent:chapter_refresh",
+            {
+                "session_id": "sess-rollback",
+                "project_id": "proj-rollback",
+                "created_at": ANY,
+                "chapter_id": "chap-rollback",
+            },
+            room=agent_session_room("sess-rollback"),
+        )
         fake_runner.cancel.assert_called_once()
         fake_registry.cancel.assert_awaited_once_with("sess-rollback")
         delete_checkpoints_after_mock.assert_awaited_once_with(
             "sess-rollback", "cp-before"
         )
+        delete_checkpoints_for_thread_mock.assert_awaited_once_with(child.child_thread_id)
+        replayed = buffer.replay_events_unlocked("sess-rollback")
+        rollback_statuses = [
+            event.data
+            for event in replayed
+            if event.name == "agent:subagent_status"
+            and event.data.get("child_run_id") == child.id
+        ]
+        assert rollback_statuses == [
+            {
+                "parent_session_id": "sess-rollback",
+                "child_run_id": child.id,
+                "child_thread_id": child.child_thread_id,
+                "agent_key": "writer",
+                "agent_number": child.metadata_json["agent_number"],
+                "status": "cancelled",
+                "queued_messages": 0,
+                "is_active": False,
+                "pending_approval": None,
+            }
+        ]
+        emit_mock.assert_any_await(
+            "agent:subagent_status",
+            rollback_statuses[0],
+            room=agent_subagents_room("sess-rollback"),
+        )
         rolled_back_task = await session.get(Task, "task-rollback")
         assert rolled_back_task is not None
         await session.refresh(rolled_back_task)
+        buffer.clear_all()
+
+    async def test_rollback_created_chapter_emits_global_chapter_refresh_only(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        session.add(Project(id="proj-rollback-created", title="回滚新建章节项目"))
+        session.add(
+            Volume(
+                id="vol-rollback-created",
+                project_id="proj-rollback-created",
+                title="第一卷",
+                order=1,
+                chapter_count=1,
+            )
+        )
+        session.add(
+            Task(
+                id="task-rollback-created",
+                project_id="proj-rollback-created",
+                title="Agent Session",
+                mode="agent",
+                agent_session_id="sess-rollback-created",
+            )
+        )
+        await session.commit()
+
+        user_message = await message_repo.insert_message(
+            session,
+            session_id="sess-rollback-created",
+            task_id="task-rollback-created",
+            project_id="proj-rollback-created",
+            role="user",
+            status="sent",
+            content="新建章节",
+        )
+        revision = await begin_user_revision(
+            session,
+            project_id="proj-rollback-created",
+            task_id="task-rollback-created",
+            agent_session_id="sess-rollback-created",
+            user_message_id=user_message.id,
+            user_message_seq=user_message.seq,
+            message="用户消息: 新建章节",
+            pre_run_checkpoint_id="cp-before-created",
+            graph_thread_id="sess-rollback-created",
+        )
+        session.add(
+            Chapter(
+                id="chap-created-rollback",
+                project_id="proj-rollback-created",
+                volume_id="vol-rollback-created",
+                title="新章节",
+                content="新内容",
+                word_count=3,
+                order=1,
+            )
+        )
+        session.add(
+            RevisionChapterSnapshot(
+                revision_id=revision.id,
+                chapter_id="chap-created-rollback",
+                project_id="proj-rollback-created",
+                exists=False,
+            )
+        )
+        await session.commit()
+
+        fake_runner = SimpleNamespace(
+            cancel=MagicMock(),
+            model_config={"max_context_tokens": 1},
+            project_id="proj-rollback-created",
+        )
+        _SESSION_RUNNERS["sess-rollback-created"] = cast(Any, fake_runner)
+        fake_registry = SimpleNamespace(cancel=AsyncMock())
+        emit_mock = AsyncMock()
+
+        with (
+            patch(
+                "app.api.routers.agent_runtime.get_agent_run_registry",
+                return_value=fake_registry,
+            ),
+            patch(
+                "app.api.routers.agent_runtime.delete_checkpoints_after_for_thread",
+                AsyncMock(),
+            ),
+            patch(
+                "app.api.routers.agent_runtime.emit",
+                new=emit_mock,
+            ),
+        ):
+            response = await client.post(
+                "/api/v1/agent/sessions/sess-rollback-created/rollback",
+                json={"revision_id": revision.id},
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        emit_mock.assert_any_await(
+            "agent:chapter_refresh",
+            {
+                "session_id": "sess-rollback-created",
+                "project_id": "proj-rollback-created",
+                "created_at": ANY,
+            },
+            room=agent_session_room("sess-rollback-created"),
+        )
+        assert not any(
+            call.args[0] == "agent:chapter_refresh"
+            and call.args[1].get("chapter_id") == "chap-created-rollback"
+            for call in emit_mock.await_args_list
+        )
 
     async def test_rollback_rejects_checkpoint_id_request_body(
         self,


### PR DESCRIPTION
## PR 标题

fix(agent): 修复 subagent 回滚状态恢复

## 变更说明

- 问题: 父 Agent 会话回滚时，已派发 subagent 的后续 notify 轮次无法完整恢复到中间态，且章节刷新事件可能触发已删除章节详情查询 404。
- 重要性: 回滚应同时恢复业务数据、subagent 会话状态、子线程 checkpoint 和前端可见刷新状态，否则用户需要刷新页面或会看到错误日志。
- 变化: 为 child run request 增加父 revision、child 用户消息和 checkpoint 边界，父会话回滚时按 request 边界恢复 subagent，并发布 subagent 状态与章节刷新事件。
- 变化: 回滚新建章节导致章节被删除时，仅发布全量章节刷新，避免前端请求已不存在的章节详情。
- 变化: 补充 subagent 回滚、章节中间态恢复、API 状态推送和刷新事件相关测试。

## 关联 Issue / PR (如有)

#XXXX

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [x] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

subagent 后续 notify 执行时仍可能使用任务上的当前 revision，而不是 request 自身所属的父 revision，导致业务快照归属不准确；同时父会话回滚只清理父线程状态，没有按 child request 边界恢复 subagent 状态和 checkpoint。章节刷新事件之前对所有受影响章节都携带 `chapter_id`，当回滚删除本轮新建章节时会触发已删除章节的详情查询。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令：

- `uv run pytest tests/api/test_agent.py -k "rollback or subagent"`
- `uv run pytest tests/agent_runtime/test_agent_revision_rollback.py`
- `uv run pytest tests/agent_runtime/runner/test_subagent_runner.py`
- `uv run pytest tests/agent_runtime/persistence/test_child_runs.py`
- `uv run mypy app`
- `uv run ruff check .`
- `pnpm type-check`
