### PR TITLE
fix(frontend): 修复 Agent 消息完成态闪动

### DIFF
--- a/frontend/src/components/streaming-markdown.tsx
+++ b/frontend/src/components/streaming-markdown.tsx
@@ -159,20 +159,24 @@ function StreamingMarkdownLinkSafetyDialog({
   );
 }
 
-export function StreamingMarkdown({ content, isStreaming = false, className }: StreamingMarkdownProps) {
+export function StreamingMarkdown({
+  content,
+  isStreaming = false,
+  className,
+}: StreamingMarkdownProps) {
   const markdownClassName = className ? `streaming-markdown ${className}` : "streaming-markdown";
 
   return (
     <Streamdown
-      animated={isStreaming ? STREAMING_ANIMATION : false}
+      animated={STREAMING_ANIMATION}
       className={markdownClassName}
       controls={STREAMDOWN_CONTROLS}
       data-streaming={isStreaming ? "true" : undefined}
       isAnimating={isStreaming}
       lineNumbers
       linkSafety={STREAMDOWN_LINK_SAFETY}
-      mode={isStreaming ? "streaming" : "static"}
-      parseIncompleteMarkdown={isStreaming}
+      mode="streaming"
+      parseIncompleteMarkdown
       plugins={STREAMDOWN_PLUGINS}
       remarkPlugins={STREAMDOWN_REMARK_PLUGINS}
     >

--- a/frontend/src/features/assistant/components/agent/display/agent-message-blocks.ts
+++ b/frontend/src/features/assistant/components/agent/display/agent-message-blocks.ts
@@ -74,6 +74,7 @@ export function buildAgentMessageBlocks(
   let resumableNodeBlock: ResumableNodeBlock | null = null;
   let activeAgentRoundId: string | undefined;
   let fallbackRoundCount = 0;
+  let agentBlockCount = 0;
 
   const ensureAgentRoundId = () => {
     if (!activeAgentRoundId) {
@@ -169,8 +170,9 @@ export function buildAgentMessageBlocks(
 
     if (!currentAgentBlock) {
       const agentRoundId = ensureAgentRoundId();
+      agentBlockCount += 1;
       currentAgentBlock = {
-        id: `agent:${message.id}`,
+        id: `agent:${agentRoundId}:${agentBlockCount}`,
         type: "agent",
         messages: [],
         sourceRevisionId: pendingUserRevisionId,

--- a/frontend/src/features/assistant/components/agent/display/agent-message-display-items.ts
+++ b/frontend/src/features/assistant/components/agent/display/agent-message-display-items.ts
@@ -56,7 +56,7 @@ function isToolMessage(message: AgentBlockDisplayMessage): message is ToolDispla
 
 function pushMessageItem(items: AgentDisplayItem[], message: AgentBlockDisplayMessage): void {
   items.push({
-    id: `message:${message.id}`,
+    id: `message:${items.length}`,
     type: "message",
     message,
   });
@@ -125,7 +125,7 @@ function pushExplorationItem(
     return;
   }
   items.push({
-    id: `exploration:${explorationMessages[0]?.id ?? items.length}`,
+    id: `exploration:${items.length}`,
     type: "exploration",
     messages: explorationMessages,
     summary: buildExplorationSummary(explorationMessages),

--- a/frontend/src/features/assistant/components/agent/message-blocks/blocks/exploration/exploration-message.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/blocks/exploration/exploration-message.tsx
@@ -153,9 +153,9 @@ function ExplorationMessageView({
         visible={hasContent && isExpanded}
       >
         <Box className="agent-exploration-content">
-          {messages.map((message) => (
+          {messages.map((message, index) => (
             <AgentMessageRenderer
-              key={message.id}
+              key={`exploration-message:${index}`}
               message={message}
             />
           ))}

--- a/frontend/src/features/assistant/components/assistant-sidebar.css
+++ b/frontend/src/features/assistant/components/assistant-sidebar.css
@@ -214,10 +214,6 @@
   animation: agentCardSlideIn 0.3s ease-out;
 }
 
-.agent-message-card[data-streaming="true"] {
-  animation: none;
-}
-
 @keyframes agentCardSlideIn {
   from {
     opacity: 0;

--- a/frontend/src/features/assistant/lib/agent-transcript-state.ts
+++ b/frontend/src/features/assistant/lib/agent-transcript-state.ts
@@ -123,6 +123,17 @@ function isSameToolMessageByFallback(item: AgentMessage, message: AgentMessage):
   return true;
 }
 
+function isAssistantOutputMessage(message: AgentMessage): boolean {
+  return (message.type === "text" && message.role === "assistant") || message.type === "agent_output";
+}
+
+function isSameAssistantOutputByFallback(item: AgentMessage, message: AgentMessage): boolean {
+  if (!isAssistantOutputMessage(item) || !isAssistantOutputMessage(message)) return false;
+  if (!item.isStreaming && item.status !== "running") return false;
+  if (item.agent && message.agent && item.agent !== message.agent) return false;
+  return true;
+}
+
 function isSameOptimisticUserMessage(item: AgentMessage, message: AgentMessage): boolean {
   if (!item.isDraft) return false;
   if (item.type !== "user_request" && !(item.type === "text" && item.role === "user")) return false;
@@ -237,6 +248,7 @@ function isSameStreamMessage(item: AgentMessage, message: AgentMessage): boolean
   if (isSameCompactionMessage(item, message)) return true;
   if (message.correlationId && item.correlationId === message.correlationId) return true;
   if (isSameOptimisticUserMessage(item, message)) return true;
+  if (isSameAssistantOutputByFallback(item, message)) return true;
   if (item.type !== "tool" || message.type !== "tool") return false;
   const itemToolCallId = getMessageToolCallId(item);
   const messageToolCallId = getMessageToolCallId(message);


### PR DESCRIPTION
## PR 标题

fix(frontend): 修复 Agent 消息完成态闪动

## 变更说明

- 问题: Agent 回复从运行态切换到完成态时，消息块会短暂重放进入动画，视觉上像重新挂载。
- 重要性: 该闪动会打断阅读，尤其在回复包含标题等块级 Markdown 内容时更明显。
- 变化: 稳定 Agent 消息块和展示项 key，避免完成态消息 ID 变化导致渲染身份漂移。
- 变化: 保持 Streamdown 的 streaming 渲染路径，仅切换动画状态，避免完成态重建 Markdown DOM。
- 变化: 移除 streaming 状态结束时重新触发消息卡片进入动画的 CSS 规则。

## 关联 Issue / PR (如有)

#XXXX

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

Agent 消息完成态会引起多处渲染身份和动画状态变化：部分列表 key 依赖消息 ID，完成态消息可能产生不同 ID；Streamdown 从 streaming/static 路径切换时会重建部分 Markdown DOM；同时消息卡片在移除 `data-streaming` 后会重新应用进入动画，导致整块消息短暂闪动。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令:

- `pnpm type-check`
- `pnpm lint`

未涉及后端、数据库或依赖变更。
