### PR TITLE
fix(frontend): 修复 Agent 消息流式展示顺序

### DIFF
--- a/frontend/src/features/assistant/components/agent/agent-messages-scroll.ts
+++ b/frontend/src/features/assistant/components/agent/agent-messages-scroll.ts
@@ -26,6 +26,13 @@ export function shouldTrackStreamingFollowBottom(isRunning: boolean): boolean {
   return isRunning;
 }
 
+export function shouldResetFollowBottomForRun(
+  previousIsRunning: boolean,
+  nextIsRunning: boolean
+): boolean {
+  return !previousIsRunning && nextIsRunning;
+}
+
 export function resolveFollowBottomStateOnScroll({
   previous,
   next,

--- a/frontend/src/features/assistant/components/agent/agent-messages.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-messages.tsx
@@ -28,6 +28,7 @@ import {
   shouldAutoScrollOnFrameChange,
   shouldFollowBottom,
   shouldResetFollowBottomForLoad,
+  shouldResetFollowBottomForRun,
   shouldScheduleLoadedSessionBottomRestoreImmediately,
   shouldTrackStreamingFollowBottom,
   type ScrollViewportMetrics,
@@ -174,6 +175,7 @@ export function AgentMessages({
   const restoreAttemptRef = useRef(0);
   const resizeFrameRef = useRef<{ scrollHeight: number; clientHeight: number; } | null>(null);
   const viewportMetricsRef = useRef<ScrollViewportMetrics | null>(null);
+  const previousIsRunningRef = useRef(isRunning);
   const lastLoadScrollKeyRef = useRef<string | null | undefined>(null);
   const copyFeedbackTimerRef = useRef<number | null>(null);
   const restoreScrollRafRef = useRef<number | null>(null);
@@ -201,7 +203,6 @@ export function AgentMessages({
 
   const scrollContainerToBottom = useCallback((container: HTMLElement) => {
     container.scrollTop = container.scrollHeight;
-    bottomRef.current?.scrollIntoView({ block: "end" });
   }, []);
 
   const scheduleStreamingScrollToBottom = useCallback(() => {
@@ -328,6 +329,12 @@ export function AgentMessages({
   }, [isRunning, onAtBottomChange, scheduleLoadedSessionBottomRestore, scheduleStreamingScrollToBottom]);
 
   useEffect(() => {
+    const previousIsRunning = previousIsRunningRef.current;
+    previousIsRunningRef.current = isRunning;
+    if (shouldResetFollowBottomForRun(previousIsRunning, isRunning)) {
+      shouldFollowBottomRef.current = true;
+      scheduleStreamingScrollToBottom();
+    }
     if (!shouldTrackStreamingFollowBottom(isRunning)) return;
     scheduleStreamingScrollToBottom();
   }, [currentStage, isRunning, scheduleStreamingScrollToBottom, streamFollowSignal]);
@@ -408,8 +415,8 @@ export function AgentMessages({
     [collapsedNodeIds, messageBlocks]
   );
   const toolbarTargets = useMemo(
-    () => getAgentRoundToolbarTargets(messageBlocks, visibleMessageBlocks),
-    [messageBlocks, visibleMessageBlocks]
+    () => getAgentRoundToolbarTargets(messageBlocks, visibleMessageBlocks, { isRunning }),
+    [isRunning, messageBlocks, visibleMessageBlocks]
   );
   const toolbarTargetByAnchorId = useMemo(
     () => new Map(toolbarTargets.map((target) => [target.anchorBlockId, target])),

--- a/frontend/src/features/assistant/components/agent/display/agent-message-blocks.ts
+++ b/frontend/src/features/assistant/components/agent/display/agent-message-blocks.ts
@@ -26,6 +26,10 @@ export interface AgentRoundToolbarTarget {
   timestamp?: number;
 }
 
+interface AgentRoundToolbarOptions {
+  isRunning?: boolean;
+}
+
 interface BuildAgentMessageBlocksOptions {
   closeOpenNodeAt?: number;
 }
@@ -246,8 +250,11 @@ function getLatestAssistantToolbarTimestamp(blocks: AgentMessageBlock[]): number
 
 export function getAgentRoundToolbarTargets(
   blocks: AgentMessageBlock[],
-  visibleBlocks: AgentMessageBlock[]
+  visibleBlocks: AgentMessageBlock[],
+  options: AgentRoundToolbarOptions = {}
 ): AgentRoundToolbarTarget[] {
+  if (options.isRunning) return [];
+
   const roundOrder: string[] = [];
   const rounds = new Map<string, {
     blocks: AgentMessageBlock[];

--- a/frontend/src/features/assistant/components/agent/display/agent-message-display-items.ts
+++ b/frontend/src/features/assistant/components/agent/display/agent-message-display-items.ts
@@ -54,6 +54,14 @@ function isToolMessage(message: AgentBlockDisplayMessage): message is ToolDispla
   return message.type === "tool";
 }
 
+function hasPendingDisplayMessage(messages: AgentBlockDisplayMessage[]): boolean {
+  return messages.some((message) => Boolean(
+    message.isStreaming
+    || message.status === "running"
+    || message.status === "pending"
+  ));
+}
+
 function pushMessageItem(items: AgentDisplayItem[], message: AgentBlockDisplayMessage): void {
   items.push({
     id: `message:${items.length}`,
@@ -140,48 +148,32 @@ function pushRequestItems(
 
   const firstToolIndex = requestMessages.findIndex((message) => message.type === "tool");
   if (firstToolIndex < 0) {
+    if (items.at(-1)?.type === "exploration" && hasPendingDisplayMessage(requestMessages)) {
+      pushExplorationItem(items, requestMessages);
+      return;
+    }
     requestMessages.forEach((message) => pushMessageItem(items, message));
     return;
   }
 
-  const prefixMessages = requestMessages.slice(0, firstToolIndex);
-  let prefixEmittedOutside = false;
-  let explorationCandidate: AgentBlockDisplayMessage[] = [];
-
-  const flushExplorationCandidate = () => {
-    if (explorationCandidate.length === 0) return;
-    pushExplorationItem(items, explorationCandidate);
-    explorationCandidate = [];
-  };
-
-  const emitPrefixOutside = () => {
-    if (prefixEmittedOutside) return;
-    prefixMessages.forEach((message) => pushMessageItem(items, message));
-    prefixEmittedOutside = true;
-  };
-
-  for (let index = firstToolIndex; index < requestMessages.length; index += 1) {
-    const message = requestMessages[index];
-    if (!isToolMessage(message)) continue;
-
-    if (isReadToolMessage(message)) {
-      if (explorationCandidate.length === 0) {
-        explorationCandidate = prefixEmittedOutside ? [] : [...prefixMessages];
-        prefixEmittedOutside = true;
-      }
-      explorationCandidate.push(message);
-      continue;
-    }
-
-    flushExplorationCandidate();
-    emitPrefixOutside();
-    pushMessageItem(items, message);
+  const firstExploreToolIndex = requestMessages.findIndex(isReadToolMessage);
+  if (firstExploreToolIndex < 0) {
+    requestMessages.forEach((message) => pushMessageItem(items, message));
+    return;
   }
 
-  flushExplorationCandidate();
-  if (!prefixEmittedOutside) {
-    emitPrefixOutside();
+  const firstNonExploreToolIndex = requestMessages.findIndex(
+    (message) => isToolMessage(message) && !isReadToolMessage(message)
+  );
+  const shouldGroupExplorePrefix = firstNonExploreToolIndex < 0 || firstExploreToolIndex < firstNonExploreToolIndex;
+  if (!shouldGroupExplorePrefix) {
+    requestMessages.forEach((message) => pushMessageItem(items, message));
+    return;
   }
+
+  const explorationEndIndex = firstNonExploreToolIndex < 0 ? requestMessages.length : firstNonExploreToolIndex;
+  pushExplorationItem(items, requestMessages.slice(0, explorationEndIndex));
+  requestMessages.slice(explorationEndIndex).forEach((message) => pushMessageItem(items, message));
 }
 
 export function buildExplorationSummary(messages: AgentBlockDisplayMessage[]): ExplorationSummary {

--- a/frontend/src/features/assistant/lib/agent-transcript-state.ts
+++ b/frontend/src/features/assistant/lib/agent-transcript-state.ts
@@ -127,6 +127,20 @@ function isAssistantOutputMessage(message: AgentMessage): boolean {
   return (message.type === "text" && message.role === "assistant") || message.type === "agent_output";
 }
 
+function stopStreamingAssistantOutput(messages: AgentMessage[]): AgentMessage[] {
+  let changed = false;
+  const next = messages.map((message) => {
+    if (!isAssistantOutputMessage(message) || !(message.isStreaming || message.status === "running")) return message;
+    changed = true;
+    return {
+      ...message,
+      status: "completed" as const,
+      isStreaming: false,
+    };
+  });
+  return changed ? next : messages;
+}
+
 function isSameAssistantOutputByFallback(item: AgentMessage, message: AgentMessage): boolean {
   if (!isAssistantOutputMessage(item) || !isAssistantOutputMessage(message)) return false;
   if (!item.isStreaming && item.status !== "running") return false;
@@ -293,7 +307,7 @@ export function upsertTranscriptStreamingMessage(messages: AgentMessage[], messa
 }
 
 export function stopTranscriptStreamingMessages(messages: AgentMessage[]): AgentMessage[] {
-  return stopStreamingToolMessages(stopStreamingReasoning(messages));
+  return stopStreamingToolMessages(stopStreamingReasoning(stopStreamingAssistantOutput(messages)));
 }
 
 function completeLatestAssistantMessage(
@@ -600,7 +614,7 @@ export function applyAgentTranscriptEvent(
         state: {
           ...state,
           messages: upsertTranscriptMessage(
-            clearRetryMessages(stopStreamingReasoning(baseMessages)).filter((item) => item.type !== "question" && item.type !== "clarification"),
+            clearRetryMessages(stopStreamingReasoning(stopStreamingAssistantOutput(baseMessages))).filter((item) => item.type !== "question" && item.type !== "clarification"),
             message
           ),
           status: "waiting_answer",
@@ -613,7 +627,7 @@ export function applyAgentTranscriptEvent(
 
     if (message.type === "tool") {
       const nextMessages = upsertTranscriptStreamingMessage(
-        clearRetryMessages(stopStreamingReasoning(baseMessages)).filter((item) => item.type !== "approval" && item.type !== "tool_approval"),
+        clearRetryMessages(stopStreamingReasoning(stopStreamingAssistantOutput(baseMessages))).filter((item) => item.type !== "approval" && item.type !== "tool_approval"),
         message
       );
       return {


### PR DESCRIPTION
## PR 标题

fix(frontend): 修复 Agent 消息流式展示顺序

## 变更说明

- 问题: Agent 会话流式输出时，Explore 分组、消息顺序和底部跟随存在异常表现。
- 重要性: 这些问题会导致用户看到的 Agent 执行过程顺序错乱、toolbar 提前出现，以及自动滚动未对齐到实际底部。
- 变化: 调整 Agent 流式消息边界处理，避免后续 content 追加到上一段输出。
- 变化: 重写 Explore 分组规则，支持连续 Explore request 合并，并在运行中正确处理临时分组。
- 变化: 修复运行中 toolbar 提前显示和底部跟随未计入容器 padding 的问题。

## 关联 Issue / PR (如有)

#XXXX

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

- 流式工具边界没有结束上一段 assistant content，后续 token fallback 合并到了旧文本。
- Explore 分组在 request 边界、连续 Explore request 和流式未完成内容场景下缺少完整规则。
- toolbar 生成只判断当前 block 是否 running，没有考虑整轮会话仍在运行。
- 滚动到底部时额外调用 `scrollIntoView({ block: "end" })`，导致滚动位置回退一个容器底部 padding。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证证据：
- `pnpm type-check`
- `pnpm lint`
- 临时回归测试覆盖流式 content 分段、Explore 分组、toolbar 运行态隐藏与底部 padding 对齐，验证后已清理临时文件。
- 本次不涉及数据库变更。
