### PR TITLE
chore(backend): 迁移类型检查到 ty

### DIFF
--- a/backend/app/agent_runtime/agents/definitions.py
+++ b/backend/app/agent_runtime/agents/definitions.py
@@ -3,7 +3,7 @@
 from collections.abc import Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -182,14 +182,14 @@ def agent_definition_from_record(record: AgentDefinitionRecord) -> AgentDefiniti
         key=record.key,
         display_name=record.display_name,
         description=record.description,
-        kind=record.kind,  # type: ignore[arg-type]
+        kind=cast(Literal["primary", "subagent"], record.kind),
         prompt_agent_name=record.prompt_agent_name,
         model_id=record.model_id,
         tool_category_keys=tuple(record.tool_category_keys_json or ()),
         enabled_skill_ids=tuple(record.enabled_skill_ids_json or ()),
         metadata=MappingProxyType(dict(record.metadata_json or {})),
         enabled=record.enabled,
-        source=record.source,  # type: ignore[arg-type]
+        source=cast(Literal["builtin", "custom"], record.source),
         delegatable_agents=tuple(record.delegatable_agents or ()),
     )
 

--- a/backend/app/agent_runtime/graph/orchestrator/graph.py
+++ b/backend/app/agent_runtime/graph/orchestrator/graph.py
@@ -123,7 +123,7 @@ async def primary_node(
 
 
 def build_orchestrator_graph(checkpointer=None) -> CompiledStateGraph:
-    builder = StateGraph(OrchestratorState)
+    builder = StateGraph(cast(Any, OrchestratorState))
     primary_action = cast(
         Callable[[dict[str, Any], RunnableConfig | None], Awaitable[dict[str, Any]]],
         primary_node,
@@ -135,4 +135,4 @@ def build_orchestrator_graph(checkpointer=None) -> CompiledStateGraph:
     builder.add_node("primary", cast(Any, primary_with_events))
     builder.add_edge(START, "primary")
     builder.add_edge("primary", END)
-    return builder.compile(checkpointer=checkpointer)
+    return cast(CompiledStateGraph, builder.compile(checkpointer=checkpointer))

--- a/backend/app/agent_runtime/graph/react_agent.py
+++ b/backend/app/agent_runtime/graph/react_agent.py
@@ -110,7 +110,7 @@ def _should_retry_on(policy: RetryPolicy, exc: Exception) -> bool:
     if isinstance(retry_on, type):
         return isinstance(exc, retry_on)
     if isinstance(retry_on, Sequence):
-        return any(isinstance(exc, exc_type) for exc_type in retry_on)
+        return any(isinstance(exc, cast(type[BaseException], exc_type)) for exc_type in retry_on)
     if callable(retry_on):
         return bool(retry_on(exc))
     return False
@@ -851,7 +851,7 @@ def create_react_agent(
     # Build graph
     # ------------------------------------------------------------------
 
-    graph = StateGraph(ReactState)
+    graph = StateGraph(cast(Any, ReactState))
 
     graph.add_node(
         "llm_call",

--- a/backend/app/agent_runtime/persistence/compaction_repo.py
+++ b/backend/app/agent_runtime/persistence/compaction_repo.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from typing import cast
 from datetime import UTC, datetime
 
 from sqlalchemy import delete, select
@@ -73,7 +74,7 @@ def _row_to_dto(row: AgentContextCompaction) -> PersistedCompaction:
         start_seq=row.start_seq,
         end_seq=row.end_seq,
         summary=row.summary,
-        trigger=row.trigger,  # type: ignore[arg-type]
+        trigger=cast(CompactionTrigger, row.trigger),
         source_input_tokens=row.source_input_tokens,
         summary_tokens=row.summary_tokens,
         created_at=row.created_at,

--- a/backend/app/agent_runtime/persistence/repo.py
+++ b/backend/app/agent_runtime/persistence/repo.py
@@ -2,6 +2,7 @@
 
 import json
 from datetime import UTC, datetime
+from typing import cast
 
 from sqlalchemy import delete, func, select
 from app.agent_runtime.context.helpers import compile_canonical_mentions
@@ -29,7 +30,7 @@ def _row_to_dto(row: AgentRunMessage) -> PersistedMessage:
         session_id=row.session_id,
         task_id=row.task_id,
         project_id=row.project_id,
-        role=row.role,  # type: ignore[arg-type]
+        role=cast(Role, row.role),
         agent_id=row.agent_id,
         content=row.content,
         reasoning=row.reasoning,
@@ -37,7 +38,7 @@ def _row_to_dto(row: AgentRunMessage) -> PersistedMessage:
         tool_calls=json.loads(row.tool_calls) if row.tool_calls else None,
         tool_call_id=row.tool_call_id,
         tool_name=row.tool_name,
-        status=row.status,  # type: ignore[arg-type]
+        status=cast(Status, row.status),
         message_type=row.message_type or "message",
         display_channel=row.display_channel or "list",
         llm_visibility=row.llm_visibility or "visible",

--- a/backend/app/agent_runtime/plan/service.py
+++ b/backend/app/agent_runtime/plan/service.py
@@ -286,6 +286,7 @@ async def update_plan(
         if todo_id is None:
             replacement_rows.append(
                 PlanTodoRecord(
+                    plan_id=plan.id,
                     title=title,
                     content=content,
                     status="pending",

--- a/backend/app/agent_runtime/revisions.py
+++ b/backend/app/agent_runtime/revisions.py
@@ -672,20 +672,23 @@ async def record_agent_activity_for_change(
     if before is None and after is not None:
         operation: Literal["create", "update", "delete", "move_to_volume"] = "create"
         chapter_id = after.id
+        project_id = after.project_id
         title = after.title
     elif before is not None and after is None:
         operation = "delete"
         chapter_id = before.id
+        project_id = before.project_id
         title = before.title
     elif before is not None and after is not None:
         operation = "move_to_volume" if before.volume_id != after.volume_id else "update"
         chapter_id = after.id
+        project_id = after.project_id
         title = after.title
     else:
         return
     await writing_activity_service.record_activity(
         session,
-        project_id=(after or before).project_id,  # type: ignore[union-attr]
+        project_id=project_id,
         chapter_id=chapter_id,
         chapter_title=title,
         source="agent",

--- a/backend/app/agent_runtime/tool_call_recovery.py
+++ b/backend/app/agent_runtime/tool_call_recovery.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from hashlib import sha1
-from typing import Any
+from typing import Any, cast
 
 from json_repair import loads as repair_json_loads
 
@@ -89,7 +89,7 @@ def recover_tool_calls(
         if not isinstance(raw_tool_call, Mapping):
             continue
         recovered_tool_call = _recover_one_tool_call(
-            raw_tool_call,
+            cast(Mapping[str, Any], raw_tool_call),
             index=index,
             id_seed=id_seed,
         )

--- a/backend/app/api/middleware/access_log.py
+++ b/backend/app/api/middleware/access_log.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from http import HTTPStatus
 from inspect import getsourcelines
 from types import CodeType
-from typing import Callable, MutableMapping, cast
+from typing import MutableMapping, Protocol, TypeGuard, cast
 
 from loguru import logger
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -63,6 +63,14 @@ class EndpointLocation:
     line: int
 
 
+class LocatedCallable(Protocol):
+    __module__: str
+    __qualname__: str
+    __code__: CodeType
+
+    def __call__(self, *args: object, **kwargs: object) -> object: ...
+
+
 def format_access_log(
     method: str, path: str, status_code: int, duration_ms: float
 ) -> str:
@@ -71,9 +79,18 @@ def format_access_log(
 
 def get_endpoint_location(request: Request) -> EndpointLocation | None:
     endpoint = request.scope.get("endpoint")
-    if not callable(endpoint) or not hasattr(endpoint, "__code__"):
+    if not _is_located_callable(endpoint):
         return None
     return get_callable_location(endpoint)
+
+
+def _is_located_callable(endpoint: object) -> TypeGuard[LocatedCallable]:
+    return (
+        callable(endpoint)
+        and hasattr(endpoint, "__code__")
+        and hasattr(endpoint, "__module__")
+        and hasattr(endpoint, "__qualname__")
+    )
 
 
 def _patch_endpoint_location(
@@ -84,7 +101,7 @@ def _patch_endpoint_location(
     record["line"] = endpoint_location.line
 
 
-def get_callable_location(endpoint: Callable[..., object]) -> EndpointLocation:
+def get_callable_location(endpoint: LocatedCallable) -> EndpointLocation:
     code = _get_callable_code(endpoint)
     line = code.co_firstlineno
     try:
@@ -98,8 +115,8 @@ def get_callable_location(endpoint: Callable[..., object]) -> EndpointLocation:
     )
 
 
-def _get_callable_code(endpoint: Callable[..., object]) -> CodeType:
-    return endpoint.__code__  # type: ignore[attr-defined]
+def _get_callable_code(endpoint: LocatedCallable) -> CodeType:
+    return endpoint.__code__
 
 
 def _log_at_level(bound_logger, status_code: int, message: str) -> None:

--- a/backend/app/api/routers/agent_runtime.py
+++ b/backend/app/api/routers/agent_runtime.py
@@ -12,8 +12,7 @@ from typing import TypeGuard, cast
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from loguru import logger
-from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.agent_runtime.agents.definitions import load_agent_definition
 from app.agent_runtime.context.compaction.service import CompactionError
@@ -230,11 +229,10 @@ def _build_seed_state(
 
 
 def _is_valid_model_config(model_config: object) -> TypeGuard[dict[str, object]]:
-    return (
-        isinstance(model_config, dict)
-        and isinstance(model_config.get("max_context_tokens"), int)
-        and int(model_config["max_context_tokens"]) > 0
-    )
+    if not isinstance(model_config, dict):
+        return False
+    max_context_tokens = model_config.get("max_context_tokens")
+    return isinstance(max_context_tokens, int) and max_context_tokens > 0
 
 
 def _build_subagent_state_response(
@@ -415,6 +413,16 @@ async def _set_task_running_state(
             },
             room=background_project_room(project_id),
         )
+
+
+def _make_status_session_factory(session: AsyncSession) -> Callable[[], AsyncSession]:
+    if session.bind is None:
+        raise RuntimeError("数据库会话未绑定连接")
+    factory = async_sessionmaker(
+        session.bind,
+        expire_on_commit=False,
+    )
+    return factory
 
 
 async def _launch_task(
@@ -654,11 +662,7 @@ async def send_agent_message(
     runner = await _get_runner(session_id, session)
     registry = get_agent_run_registry()
     task = await task_service.get_task(session, runner.task_id)
-    status_session_factory = sessionmaker(  # type: ignore[call-overload]
-        session.bind,
-        class_=AsyncSession,
-        expire_on_commit=False,
-    )
+    status_session_factory = _make_status_session_factory(session)
     if _is_pending_agent_session_title(task.title):
         await enqueue_session_title_job(session, task, body.message)
         await background_service.commit_and_notify(session)
@@ -745,11 +749,7 @@ async def compact_agent_session(
     pending_message: tuple[str, str] | None = None
     compaction_error: CompactionError | None = None
     result: dict[str, int | str] | None = None
-    status_session_factory = sessionmaker(  # type: ignore[call-overload]
-        session.bind,
-        class_=AsyncSession,
-        expire_on_commit=False,
-    )
+    status_session_factory = _make_status_session_factory(session)
 
     try:
         registered = await registry.try_register_parent(session_id, current_task)
@@ -852,11 +852,7 @@ async def submit_agent_question_answer(
     session: AsyncSession = Depends(get_session),
 ) -> dict:
     runner = await _get_runner(session_id, session)
-    status_session_factory = sessionmaker(  # type: ignore[call-overload]
-        session.bind,
-        class_=AsyncSession,
-        expire_on_commit=False,
-    )
+    status_session_factory = _make_status_session_factory(session)
     payload = {
         "action_type": "clarification",
         "action_id": body.action_id,
@@ -879,11 +875,7 @@ async def submit_agent_tool_approval(
     session: AsyncSession = Depends(get_session),
 ) -> dict:
     runner = await _get_runner(session_id, session)
-    status_session_factory = sessionmaker(  # type: ignore[call-overload]
-        session.bind,
-        class_=AsyncSession,
-        expire_on_commit=False,
-    )
+    status_session_factory = _make_status_session_factory(session)
     payload = {
         "action_type": "tool_approval",
         "approval_id": body.approval_id,
@@ -1061,11 +1053,7 @@ async def rollback_agent_session(
             raise
     if result.affected_child_run_ids:
         status_publisher = SubagentRunner(
-            session_factory=sessionmaker(  # type: ignore[call-overload]
-                session.bind,
-                class_=AsyncSession,
-                expire_on_commit=False,
-            ),
+            session_factory=_make_status_session_factory(session),
             model_config=runner.model_config if runner is not None else {"max_context_tokens": 1},
             project_id=runner.project_id if runner is not None else "",
         )
@@ -1174,11 +1162,7 @@ async def cancel_agent_session(
     session: AsyncSession = Depends(get_session),
 ) -> AgentCancelResponse:
     runner = await _get_runner(session_id, session)
-    status_session_factory = sessionmaker(  # type: ignore[call-overload]
-        session.bind,
-        class_=AsyncSession,
-        expire_on_commit=False,
-    )
+    status_session_factory = _make_status_session_factory(session)
     status_publisher = SubagentRunner(
         session_factory=status_session_factory,
         model_config=runner.model_config,

--- a/backend/app/memory/chapter/summary_service.py
+++ b/backend/app/memory/chapter/summary_service.py
@@ -7,7 +7,7 @@ import unicodedata
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from difflib import SequenceMatcher
-from typing import Any, cast
+from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -728,7 +728,7 @@ async def _get_or_create_summary_batch_job(
         offset=0,
     )
     if existing:
-        return cast(BackgroundJob, existing[0]), False
+        return existing[0], False
     job = await job_service.submit_job(
         session,
         job_type=JOB_TYPE_SUMMARY_BATCH,
@@ -741,7 +741,7 @@ async def _get_or_create_summary_batch_job(
         subject_type="project",
         subject_id=project_id,
     )
-    return cast(BackgroundJob, job), True
+    return job, True
 
 
 async def _existing_batch_item_map(session: AsyncSession, batch_job_id: str) -> dict[str, BackgroundJobItem]:

--- a/backend/app/models/clients/deepseek_payload.py
+++ b/backend/app/models/clients/deepseek_payload.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Shared DeepSeek payload helpers."""
 
-from typing import Any
+from typing import Any, cast
 
 from langchain_core.messages import AIMessage
 
@@ -22,6 +22,7 @@ def patch_deepseek_reasoning_payload(input_: Any, payload: dict[str, Any]) -> No
     for source, target in zip(source_messages, payload_messages, strict=False):
         if not isinstance(source, AIMessage) or not isinstance(target, dict):
             continue
+        target = cast(dict[str, Any], target)
         reasoning_content = source.additional_kwargs.get("reasoning_content")
         if reasoning_content:
             target["reasoning_content"] = reasoning_content

--- a/backend/app/models/clients/embedding_client.py
+++ b/backend/app/models/clients/embedding_client.py
@@ -6,10 +6,11 @@ Embedding Client - Embedding模型调用客户端。
 """
 
 from dataclasses import dataclass
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 from langchain_core.embeddings import Embeddings
 from loguru import logger
+from pydantic import SecretStr
 
 
 @dataclass
@@ -82,7 +83,7 @@ class EmbeddingClient:
 
             self._embeddings = GoogleGenerativeAIEmbeddings(
                 model=config.model_id,
-                google_api_key=config.api_key,  # type: ignore[call-arg]
+                api_key=SecretStr(config.api_key),
                 base_url=config.base_url or None,
             )
         elif provider == "mistral":
@@ -90,7 +91,7 @@ class EmbeddingClient:
 
             self._embeddings = MistralAIEmbeddings(
                 model=config.model_id,
-                api_key=config.api_key,  # type: ignore[arg-type]
+                api_key=cast(Any, config.api_key),
             )
         elif provider == "ollama":
             from langchain_ollama import OllamaEmbeddings

--- a/backend/app/models/clients/llm_client.py
+++ b/backend/app/models/clients/llm_client.py
@@ -10,7 +10,7 @@ import time
 from dataclasses import dataclass
 import json
 import re
-from typing import AsyncGenerator, Any, Mapping
+from typing import AsyncGenerator, Any, Mapping, cast
 
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import (
@@ -558,6 +558,6 @@ class LLMClient:
             返回self以支持链式调用。
         """
         llm = self._get_llm()
-        self._llm_with_tools = llm.bind_tools(tools)  # type: ignore[assignment]
+        self._llm_with_tools = cast(BaseChatModel, llm.bind_tools(tools))
         logger.info(f"已绑定 {len(tools)} 个工具到LLM")
         return self

--- a/backend/app/models/repos/model_provider_repo.py
+++ b/backend/app/models/repos/model_provider_repo.py
@@ -4,8 +4,10 @@ ModelProvider Repository - 模型服务提供商数据访问层。
 """
 
 from datetime import UTC, datetime
+from typing import Any, cast
 
 from sqlalchemy import delete, select
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
@@ -138,4 +140,4 @@ async def delete_by_id(session: AsyncSession, provider_id: str) -> bool:
     result = await session.execute(
         delete(ModelProvider).where(col(ModelProvider.id) == provider_id)
     )
-    return result.rowcount > 0  # type: ignore[attr-defined]
+    return cast("CursorResult[Any]", result).rowcount > 0

--- a/backend/app/models/repos/model_repo.py
+++ b/backend/app/models/repos/model_repo.py
@@ -258,14 +258,14 @@ async def get_all_tags(session: AsyncSession) -> list[str]:
         标签列表（去重）。
     """
     result = await session.execute(select(col(Model.tags)))
-    tags_set = set()
+    tags_set: set[str] = set()
 
     for tags_json in result.scalars():
         try:
             tags_list = json.loads(tags_json)
             if isinstance(tags_list, list):
-                tags_set.update(tags_list)
+                tags_set.update(tag for tag in tags_list if isinstance(tag, str))
         except json.JSONDecodeError:
             continue
 
-    return sorted(list(tags_set))
+    return sorted(tags_set)

--- a/backend/app/models/repos/model_repo.py
+++ b/backend/app/models/repos/model_repo.py
@@ -5,8 +5,10 @@ Model Repository - 模型数据访问层。
 
 import json
 from datetime import UTC, datetime
+from typing import Any, cast
 
 from sqlalchemy import delete, select
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
@@ -242,7 +244,7 @@ async def delete_by_id(session: AsyncSession, model_id: str) -> bool:
         是否成功删除。
     """
     result = await session.execute(delete(Model).where(col(Model.id) == model_id))
-    return result.rowcount > 0  # type: ignore[attr-defined]
+    return cast("CursorResult[Any]", result).rowcount > 0
 
 
 async def get_all_tags(session: AsyncSession) -> list[str]:

--- a/backend/app/storage/repos/chapter_summary_repo.py
+++ b/backend/app/storage/repos/chapter_summary_repo.py
@@ -2,8 +2,10 @@
 """Repository helpers for structured chapter summaries."""
 
 from datetime import UTC, datetime
+from typing import Any, cast
 
 from sqlalchemy import and_, delete as sql_delete, func, or_, select
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
@@ -51,7 +53,7 @@ async def delete_by_id(session: AsyncSession, summary_id: str) -> bool:
         sql_delete(ChapterSummary).where(col(ChapterSummary.id) == summary_id)
     )
     await session.flush()
-    return result.rowcount > 0  # type: ignore[attr-defined]
+    return cast("CursorResult[Any]", result).rowcount > 0
 
 
 async def get_by_chapter_id(

--- a/backend/app/storage/repos/character_repo.py
+++ b/backend/app/storage/repos/character_repo.py
@@ -2,8 +2,10 @@
 """Character Repository - 角色数据访问层。"""
 
 from datetime import UTC, datetime
+from typing import Any, cast
 
 from sqlalchemy import delete as sql_delete
+from sqlalchemy.engine import CursorResult
 from sqlalchemy import func, or_, select
 from sqlalchemy import update as sql_update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -131,7 +133,7 @@ async def batch_update_favorite(
         .values(is_favorited=is_favorited, updated_at=datetime.now(UTC))
     )
     await session.flush()
-    return result.rowcount  # type: ignore[attr-defined]
+    return cast("CursorResult[Any]", result).rowcount
 
 
 async def batch_delete(
@@ -149,7 +151,7 @@ async def batch_delete(
         )
     )
     await session.flush()
-    return result.rowcount  # type: ignore[attr-defined]
+    return cast("CursorResult[Any]", result).rowcount
 
 
 async def delete(session: AsyncSession, character: Character) -> None:

--- a/backend/app/storage/repos/revision_repo.py
+++ b/backend/app/storage/repos/revision_repo.py
@@ -4,8 +4,10 @@ Revision Repository - 版本数据访问层。
 """
 
 from datetime import UTC, datetime
+from typing import Any, cast
 
 from sqlalchemy import func, select
+from sqlalchemy.engine import CursorResult
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
@@ -235,4 +237,4 @@ async def complete_active_revisions_by_session(
         .values(status="completed", finished_at=datetime.now(UTC), updated_at=datetime.now(UTC))
     )
     await session.flush()
-    return result.rowcount  # type: ignore[attr-defined]
+    return cast("CursorResult[Any]", result).rowcount

--- a/backend/app/storage/repos/world_info_entry_repo.py
+++ b/backend/app/storage/repos/world_info_entry_repo.py
@@ -3,7 +3,10 @@
 WorldInfoEntry Repository - 世界书条目数据访问层。
 """
 
+from typing import Any, cast
+
 from sqlalchemy import delete as sql_delete
+from sqlalchemy.engine import CursorResult
 from sqlalchemy import func, select, update as sql_update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
@@ -209,7 +212,7 @@ async def batch_toggle(
         .values(is_enabled=is_enabled)
     )
     await session.flush()
-    return result.rowcount  # type: ignore[attr-defined]
+    return cast("CursorResult[Any]", result).rowcount
 
 
 async def batch_delete(
@@ -225,7 +228,7 @@ async def batch_delete(
         )
     )
     await session.flush()
-    return result.rowcount  # type: ignore[attr-defined]
+    return cast("CursorResult[Any]", result).rowcount
 
 
 async def shift_orders(

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -77,7 +77,6 @@ openfic = "app.cli:main"
 [dependency-groups]
 dev = [
     "gradio>=5.0.0",
-    "mypy>=1.19.1",
     "pre-commit>=4.5.1",
     "pyinstaller>=6.20.0",
     "pytest>=9.0.2",
@@ -85,6 +84,7 @@ dev = [
     "pytest-cov>=7.0.0",
     "respx>=0.22.0",
     "ruff>=0.14.10",
+    "ty>=0.0.56",
     "types-nanoid>=2.0.0.20260508",
     "types-pyyaml>=6.0.12.20260510",
 ]
@@ -116,6 +116,16 @@ filterwarnings = [
     "ignore::DeprecationWarning:langchain_cohere.*",
 ]
 
-[[tool.mypy.overrides]]
-module = ["lancedb"]
-ignore_missing_imports = true
+[tool.ty.analysis]
+allowed-unresolved-imports = ["lancedb"]
+
+[tool.ty.src]
+exclude = ["app/storage/migrations/versions/legacy/**"]
+
+[tool.ty.rules]
+invalid-argument-type = "ignore"
+invalid-assignment = "ignore"
+invalid-return-type = "ignore"
+missing-argument = "ignore"
+no-matching-overload = "ignore"
+unknown-argument = "ignore"

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -121,11 +121,3 @@ allowed-unresolved-imports = ["lancedb"]
 
 [tool.ty.src]
 exclude = ["app/storage/migrations/versions/legacy/**"]
-
-[tool.ty.rules]
-invalid-argument-type = "ignore"
-invalid-assignment = "ignore"
-invalid-return-type = "ignore"
-missing-argument = "ignore"
-no-matching-overload = "ignore"
-unknown-argument = "ignore"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -217,30 +217,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ast-serialize"
-version = "0.5.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/81/9d/09e27731bd5864a9ce04e3244074e674bb8936bf62b45e0357248717adac/ast_serialize-0.5.0.tar.gz", hash = "sha256:5880091bfe6f4f986f22866375c2e884843e7a0b6343ae41aeea659613d879b6", size = 61157, upload-time = "2026-05-17T17:48:29.429Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/9e/dc2530acb3a60dc6e46d65abf27d1d9f86721694757906a148d90a6860de/ast_serialize-0.5.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:0668aa9459cfa8c9c49ddd2163ebcf43088ba045ef7492af6fe22e0098303101", size = 1191380, upload-time = "2026-05-17T17:48:03.738Z" },
-    { url = "https://files.pythonhosted.org/packages/26/0a/bd3d18a582f273d6c843d16bb9e22e9e16365ff7991e92f18f798e9f1224/ast_serialize-0.5.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:bf683d6363edf2b39eed6b6d4fe22d34b6203867a67e27134d9e2a2680c4bc4a", size = 1183879, upload-time = "2026-05-17T17:48:05.463Z" },
-    { url = "https://files.pythonhosted.org/packages/40/ae/1f919100f8620887af58fcc381c61a1f218cdf89c6e155f87b213e61010a/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cc22cf0c9be65e71cf88fda130af60d61eb4a79370ad4cfe7900d48a4aa2211", size = 1244529, upload-time = "2026-05-17T17:48:07.008Z" },
-    { url = "https://files.pythonhosted.org/packages/c6/ca/6376559dcce707cdbc1d0d9a13c8d3baaaa501e949ce0ebdc4230cd881aa/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f66173891548c9f2726bf27957b41cabce12fa679dc6da505ddbde4d4b3b31cf", size = 1240560, upload-time = "2026-05-17T17:48:08.46Z" },
-    { url = "https://files.pythonhosted.org/packages/35/b2/a620e206b5aeb7efbf2710336df57d457cffbb3991076bbcc1147ef9abd4/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e42d729ef2be96a14efbad355093284739e3670ece3e534f82cc8832790911d9", size = 1451172, upload-time = "2026-05-17T17:48:09.922Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/e0/4ad5c04c24a40481b2935ce9a0ccdb6023dc8b667167d06ae530cc3512f2/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b725026bafa801dbd7310eb13a75f0a2e370e7e51b2cb225f9d21fcfadf919ee", size = 1265072, upload-time = "2026-05-17T17:48:11.469Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/71/4d1d479aa56d0101c40e17720c3d6ac2af7269ea0487a80b18e7bfd1a5b7/ast_serialize-0.5.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b54f60c1d78767a53b67eaa663f0dfac3afe606aa07f1301572f588b73d64809", size = 1270488, upload-time = "2026-05-17T17:48:13.575Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/4f/0de1bbe06f6edef9fde4ed12ca8e7b3ec7e6e2bd4e672c5af487f7957665/ast_serialize-0.5.0-cp39-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:27d51654fc240a1e87e742d353d98eb45b75f62f129086b3596ab53df2ac2a43", size = 1260702, upload-time = "2026-05-17T17:48:15.141Z" },
-    { url = "https://files.pythonhosted.org/packages/75/61/e00872439cfdddcc3c1b6cdaa6e5d904ba8e26a18807c67c4e14409d0ca8/ast_serialize-0.5.0-cp39-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c36237c46dd1674542f2109740ea5ea485a169bf1431939ada0434e17934", size = 1311182, upload-time = "2026-05-17T17:48:16.779Z" },
-    { url = "https://files.pythonhosted.org/packages/76/8e/699a5b955f7926956c95e9e1d74132acad73c2fe7a426f94da89123c20aa/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1943db345233cc7194a470f13afa9c59772c0b123dea0c9414c4d4ca54369759", size = 1421410, upload-time = "2026-05-17T17:48:18.527Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/ae/d5b7626874478997adc7a29ab28accf21e596fb590c944290401dfd0b29e/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:df1c00022cbbcb064bfaa505aa9c9295362443ce5dacb459d1331d3da353f887", size = 1516587, upload-time = "2026-05-17T17:48:20.133Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/ce/b59e02a82d9c4244d64cde502e0b00e83e38816abe19155ceb5437402c7f/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_i686.whl", hash = "sha256:cae65289fc456fde04af979a2be09302ef5d8ab92ef23e596d6746dc267ada27", size = 1515171, upload-time = "2026-05-17T17:48:21.921Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/38/d8d90042747d05aa08d4efcf1c99035a5f670a6bf4c214d31644392afbca/ast_serialize-0.5.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:239a4c354e8d676e9d94631d1d4a64edc6b266f86ff3a5a80aedd344f342c01d", size = 1464668, upload-time = "2026-05-17T17:48:23.544Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/51/5b840c4df7334104cecffa28f23904fe81ca89ca223d2450e288de39fd3c/ast_serialize-0.5.0-cp39-abi3-win32.whl", hash = "sha256:143a4ef63285a075871908fda3672dc21864b83a8ec3ee12304aa3e4c5387b9a", size = 1068311, upload-time = "2026-05-17T17:48:25.027Z" },
-    { url = "https://files.pythonhosted.org/packages/41/11/ca5672c7d491825bc4cd6702dea106a6b60d928707712ec257c7833ae476/ast_serialize-0.5.0-cp39-abi3-win_amd64.whl", hash = "sha256:cf25572c526add400f26a4750dc6ce0c3bb93fc1f75e7ae0cad4ce4f2cd5c590", size = 1108931, upload-time = "2026-05-17T17:48:26.591Z" },
-    { url = "https://files.pythonhosted.org/packages/45/19/cc8bd127d28a43da249aa955cfd164cf8fd534e79e42cea96c4854d72fd0/ast_serialize-0.5.0-cp39-abi3-win_arm64.whl", hash = "sha256:92a31c9c20d25a076edaeec76b128a3535d74a24f340b9a8a7e96c9b86dc9642", size = 1081181, upload-time = "2026-05-17T17:48:28.122Z" },
-]
-
-[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1600,40 +1576,6 @@ wheels = [
 ]
 
 [[package]]
-name = "librt"
-version = "0.11.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/40/08/9e7f6b5d2b5bed6ad055cdd5925f192bb403a51280f86b56554d9d0699a2/librt-0.11.0.tar.gz", hash = "sha256:075dc3ef4458a278e0195cbf6ac9d38808d9b906c5a6c7f7f79c3888276a3fb1", size = 200139, upload-time = "2026-05-10T18:17:25.138Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/d0/07c77e067f0838949b43bd89232c29d72efebb9d2801a9750184eb706b71/librt-0.11.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b87504f1690a23b9a2cca841191a04f83895d4fc2dd04df91d82b1a04ca2ad46", size = 144147, upload-time = "2026-05-10T18:15:53.227Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/24/8493538fa4f62f982686398a5b8f68008138a75086abdea19ade64bf4255/librt-0.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40071fc5fe0ce8daa6de616702314a01e1250711682b0523d6ab8d4525910cb3", size = 143614, upload-time = "2026-05-10T18:15:54.657Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/1e/f8bad050810d9171f34a1648ed910e56814c2ba61639f2bd53c6377ae24b/librt-0.11.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:137e79445c896a0ea7b265f52d23954e05b64222ee1af69e2cb34219067cbb67", size = 485538, upload-time = "2026-05-10T18:15:56.117Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/fe/3594ebfbaf03084ba4b120c9ba5c3183fd938a48725e9bbe6ff0a5159ad8/librt-0.11.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:cca6644054e78746d8d4ef238681f9c34ff8b584fe6b988ecebb8db3b15e622a", size = 479623, upload-time = "2026-05-10T18:15:57.544Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/da/5d1876984b3746c85dbd219dbfcb73c85f54ee263fd32e5b2a632ec14571/librt-0.11.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d5b0eea49f5562861ee8d757a32ef7d559c1d35be2aaaa1ec28941d74c9ffc8a", size = 513082, upload-time = "2026-05-10T18:15:58.805Z" },
-    { url = "https://files.pythonhosted.org/packages/19/6e/55bdf5d5ca00c3e18430690bf2c953d8d3ffd3c337418173d33dec985dc9/librt-0.11.0-cp312-cp312-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0d1029d7e1ae1a7e647ed6fb5df8c4ce2dffefb7a9f5fd1376a4554d96dac09f", size = 508105, upload-time = "2026-05-10T18:16:00.2Z" },
-    { url = "https://files.pythonhosted.org/packages/07/10/f1f23a7c595ee90ece4d35c851e5d104b1311a887ed1b4ac4c35bbd13da8/librt-0.11.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bc3ce6b33c5828d9e80592011a5c584cb2ce86edbc4088405f70da47dc1d1b3b", size = 522268, upload-time = "2026-05-10T18:16:01.708Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/02/5720f5697a7f54b78b3aefbe20df3a48cedcff1276618c4aa481177942ed/librt-0.11.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:936c5995f3514a42111f20099397d8177c79b4d7e70961e396c6f5a0a3566766", size = 527348, upload-time = "2026-05-10T18:16:03.496Z" },
-    { url = "https://files.pythonhosted.org/packages/50/db/b4a47c6f91db4ff76348a0b3dd0cc65e090a078b765a810a62ff9434c3d3/librt-0.11.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9bc0ca6ad9381cbe8e4aa6e5726e4c80c78115a6e9723c599ed1d73e092bc49d", size = 516294, upload-time = "2026-05-10T18:16:05.173Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/58/9384b2f4eb1ed1d273d40948a7c5c4b2360213b402ef3be4641c06299f9c/librt-0.11.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:070aa8c26c0a74774317a72df8851facc7f0f012a5b406557ac56992d92e1ec8", size = 553608, upload-time = "2026-05-10T18:16:06.839Z" },
-    { url = "https://files.pythonhosted.org/packages/21/7b/5aa8848a7c6a9278c79375146da1812e695754ceec5f005e6043461a7315/librt-0.11.0-cp312-cp312-win32.whl", hash = "sha256:6bf14feb84b05ae945277395451998c89c54d0def4070eb5c08de544930b245a", size = 101879, upload-time = "2026-05-10T18:16:08.103Z" },
-    { url = "https://files.pythonhosted.org/packages/37/33/8a745436944947575b584231750a41417de1a38cf6a2e9251d1065651c09/librt-0.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:75672f0bc524ede266287d532d7923dbce94c7514ad07627bac3d0c6d92cc4d9", size = 119831, upload-time = "2026-05-10T18:16:09.174Z" },
-    { url = "https://files.pythonhosted.org/packages/59/67/a6739ac96e28b7855808bdb0370e250606104a859750d209e5a0716fe7ab/librt-0.11.0-cp312-cp312-win_arm64.whl", hash = "sha256:2f10cf143e4a9bb0f4f5af568a00df94a2d69ef41c2579584454bb0fe5cc642c", size = 103470, upload-time = "2026-05-10T18:16:10.369Z" },
-    { url = "https://files.pythonhosted.org/packages/82/61/e59168d4d0bf2bf90f4f0caf7a001bfc60254c3af4586013b04dc3ef517b/librt-0.11.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:78dc31f7fdfe9c9d0eb0e8f42d139db230e826415bbcabd9f0e9faaaee909894", size = 144119, upload-time = "2026-05-10T18:16:11.771Z" },
-    { url = "https://files.pythonhosted.org/packages/61/fd/caa1d60b12f7dd79ccea23054e06eeaebe266a5f52c40a6b651069200ce5/librt-0.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fa475675db22290c3158e1d42326d0f5a65f04f44a0e68c3630a25b53560fb9c", size = 143565, upload-time = "2026-05-10T18:16:13.334Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/a9/dc744f5c2b4978d48db970be29f22716d3413d28b14ad99740817315cf2c/librt-0.11.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:621db29691044bdeda22e789e482e1b0f3a985d90e3426c9c6d17606416205ea", size = 485395, upload-time = "2026-05-10T18:16:14.729Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/21/7f8e97a1e4dae952a5a95948f6f8507a173bc1e669f54340bba6ca1ca31b/librt-0.11.0-cp313-cp313-manylinux2014_i686.manylinux_2_17_i686.manylinux_2_28_i686.whl", hash = "sha256:a9010e2ed5b3a9e158c5fd966b3ab7e834bb3d3aacc8f66c91dd4b57a3799230", size = 479383, upload-time = "2026-05-10T18:16:16.321Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/6d/d8ee9c114bebf2c50e29ec2aa940826fccb62a645c3e4c18760987d0e16d/librt-0.11.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c39513d8b7477a2e1ed8c43fc21c524e8d5a0f8d4e8b7b074dbdbe7820a08e2", size = 513010, upload-time = "2026-05-10T18:16:17.647Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/43/0b5708af2bd30a46400e72ba6bdaa8f066f15fb9a688527e34220e8d6c06/librt-0.11.0-cp313-cp313-manylinux_2_34_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7aef3cf1d5af86e770ab04bfd993dfc4ae8b8c17f66fb77dd4a7d50de7bbb1a3", size = 508433, upload-time = "2026-05-10T18:16:19.309Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/50/356187247d09013490481033183b3532b58acf8028bcb34b2b56a375c9b2/librt-0.11.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:557183ddc36babe46b27dd60facbd5adb4492181a5be887587d57cda6e092f21", size = 522595, upload-time = "2026-05-10T18:16:20.642Z" },
-    { url = "https://files.pythonhosted.org/packages/40/e7/c6ac4240899c7f3248079d5a9900debe0dadb3fdeaf856684c987105ba47/librt-0.11.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:83d3e1f72bd42f6c5c0b7daec530c3f829bd02db42c70b8ddf0c2d90a2459930", size = 527255, upload-time = "2026-05-10T18:16:22.352Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/b5/a81322dbeedeeaf9c1ee6f001734d28a09d8383ac9e6779bc24bbd0743c6/librt-0.11.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:4ce1f21fbe589bc1afd7872dece84fb0e1144f794a288e58a10d2c54a55c43be", size = 516847, upload-time = "2026-05-10T18:16:23.627Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/66/6e6323787d592b55204a42595ff1102da5115601b53a7e9ddebc889a6da5/librt-0.11.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:970b09f7044ea2b64c9da42fd3d335666518cfd1c6e8a182c95da73d0214b41e", size = 553920, upload-time = "2026-05-10T18:16:25.025Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/21/623f8ca230857102066d9ca8c6c1734995908c4d0d1bee7bb2ef0021cb33/librt-0.11.0-cp313-cp313-win32.whl", hash = "sha256:78fddc31cd4d3caa897ad5d31f856b1faadc9474021ad6cb182b9018793e254e", size = 101898, upload-time = "2026-05-10T18:16:26.649Z" },
-    { url = "https://files.pythonhosted.org/packages/b3/1d/b4ebd44dd723f768469007515cb92251e0ae286c94c140f374801140fa74/librt-0.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:8ca8aa88751a775870b764e93bad5135385f563cb8dcee399abf034ea4d3cb47", size = 119812, upload-time = "2026-05-10T18:16:27.859Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/e4/b2f4ca7965ca373b491cdb4bc25cdb30c1649ca81a8782056a83850292a9/librt-0.11.0-cp313-cp313-win_arm64.whl", hash = "sha256:96f044bb325fd9cf1a723015638c219e9143f0dfbc0ca54c565df2b7fc748b44", size = 103448, upload-time = "2026-05-10T18:16:29.066Z" },
-]
-
-[[package]]
 name = "loguru"
 version = "0.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1651,7 +1593,7 @@ name = "macholib"
 version = "1.16.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "altgraph" },
+    { name = "altgraph", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
 wheels = [
@@ -1860,45 +1802,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy"
-version = "2.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ast-serialize" },
-    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "mypy-extensions" },
-    { name = "pathspec" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/82/15/cca9d88503549ed6fedeaa1d448cdddd542ee8a490232d732e278036fbf2/mypy-2.1.0.tar.gz", hash = "sha256:81e76ad12c2d804512e9b13240d1588316531bfba07558286078bfbce9613633", size = 3898359, upload-time = "2026-05-11T18:37:36.237Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/b1/55861beb5c339b44f9a2ba92df9e2cb1eeb4ae1eee674cdf7772c797778b/mypy-2.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:244358bf1c0da7722230bce60683d52e8e9fd030554926f15b747a84efb5b3af", size = 14874381, upload-time = "2026-05-11T18:37:31.784Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/b3/b7f770114b7d0ac92d0f76e8d93c2780844a70488a90e91821927850da86/mypy-2.1.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4ec7c57657493c7a75534df2751c8ae2cda383c16ecc55d2106c54476b1b16f6", size = 13665501, upload-time = "2026-05-11T18:34:23.063Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/f3/8ae2037967e2126689a0c11d99e2b707134a565191e92c60ca2572aec60a/mypy-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8161b6ff4392410023224f0969d17db93e1e154bc3e4ba62598e720723ae211", size = 14045750, upload-time = "2026-05-11T18:31:48.151Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/32/615eb5911859e43d054941b0d0a7d06cfa2870eba86529cf385b052b111c/mypy-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bf03e12003084a67395184d3eb8cbd6a489dc3655b5664b28c210a9e2403ab0b", size = 15061630, upload-time = "2026-05-11T18:37:06.898Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/03/4eafbfff8bfab1b87082741eae6e6a624028c984e6708b73bce2a8570c9d/mypy-2.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:20509760fd791c51579d573153407d226385ec1f8bcce55d730b354f3336bc22", size = 15288831, upload-time = "2026-05-11T18:31:18.07Z" },
-    { url = "https://files.pythonhosted.org/packages/99/ee/919661478e5891a3c96e549c036e467e64563ab85995b10c53c8358e16a3/mypy-2.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:6753d0c1fdd6b1a23b9e4f283ce80b2153b724adcb2653b20b85a8a28ac6436b", size = 11135228, upload-time = "2026-05-11T18:34:31.23Z" },
-    { url = "https://files.pythonhosted.org/packages/24/0a/6a12b9782ca0831a553192f351679f4548abc9d19a7cc93bb7feb02084c7/mypy-2.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:98ebb6589bb3b6d0c6f0c459d53ca55b8091fbc13d277c4041c885392e8195e8", size = 10040684, upload-time = "2026-05-11T18:36:48.199Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/dd/c7191469c777f07689c032a8f7326e393ea34c92d6d76eb7ce5ba57ea66d/mypy-2.1.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:35aac3bb114e03888f535d5eb51b8bafbb3266586b599da1940f9b1be3ec5bd5", size = 14852174, upload-time = "2026-05-11T18:31:38.929Z" },
-    { url = "https://files.pythonhosted.org/packages/55/8c/aed55408879043d72bb9135f4d0d19a02b886dd569631e113e3d2706cb8d/mypy-2.1.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8de55a8c861f2a49331f807be98d90caeceeef520bde13d43a160207f8af613e", size = 13651542, upload-time = "2026-05-11T18:36:04.636Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/8e/f371a824b1f1fa8ea6e3dbb8703d232977d572be2329554a3bc4d960302f/mypy-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5fdf2941a07434af755837d9880f7d7d25f1dacb1af9dcd4b9b66f2220a3024e", size = 14033929, upload-time = "2026-05-11T18:35:55.742Z" },
-    { url = "https://files.pythonhosted.org/packages/94/21/f54be870d6dd53a82c674407e0f8eed7174b05ec78d42e5abd7b42e84fd5/mypy-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e195b817c13f02352a9c124301f9f30f078405444679b6753c1b96b6eed37285", size = 15039200, upload-time = "2026-05-11T18:33:10.281Z" },
-    { url = "https://files.pythonhosted.org/packages/17/99/bf21748626a40ce59fd29a39386ab46afec88b7bd2f0fa6c3a97c995523f/mypy-2.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5431d42af987ebd92ba2f71d45c85ed41d8e6ca9f5fd209a69f68f707d2469e5", size = 15272690, upload-time = "2026-05-11T18:32:07.205Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/d7/9e90d2cf47100bea550ed2bc7b0d4de3a62181d84d5e37da0003e8462637/mypy-2.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:767fe8c66dc3e01e19e1737d4c38ebefead16125e1b8e58ad421903b376f5c65", size = 11147435, upload-time = "2026-05-11T18:33:56.477Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/46/e5c449e858798e35ffc90946282a27c62a77be743fe17480e4977374eb91/mypy-2.1.0-cp313-cp313-win_arm64.whl", hash = "sha256:ecfe70d43775ab99562ab128ce49854a362044c9f894961f68f898c23cb7429d", size = 10035052, upload-time = "2026-05-11T18:32:30.049Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/2a/13ca1f292f6db1b98ff495ef3467736b331621c5917cad984b7043e7348d/mypy-2.1.0-py3-none-any.whl", hash = "sha256:a663814603a5c563fb87a4f96fb473eeb30d1f5a4885afcf44f9db000a366289", size = 2693302, upload-time = "2026-05-11T18:31:29.246Z" },
-]
-
-[[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
-]
-
-[[package]]
 name = "nanoid"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2057,7 +1960,6 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "gradio" },
-    { name = "mypy" },
     { name = "pre-commit" },
     { name = "pyinstaller" },
     { name = "pytest" },
@@ -2065,6 +1967,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "respx" },
     { name = "ruff" },
+    { name = "ty" },
     { name = "types-nanoid" },
     { name = "types-pyyaml" },
 ]
@@ -2120,7 +2023,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "gradio", specifier = ">=5.0.0" },
-    { name = "mypy", specifier = ">=1.19.1" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pyinstaller", specifier = ">=6.20.0" },
     { name = "pytest", specifier = ">=9.0.2" },
@@ -2128,6 +2030,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "respx", specifier = ">=0.22.0" },
     { name = "ruff", specifier = ">=0.14.10" },
+    { name = "ty", specifier = ">=0.0.56" },
     { name = "types-nanoid", specifier = ">=2.0.0.20260508" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20260510" },
 ]
@@ -2254,15 +2157,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/21/ea191195e587b18cf682e97f433f81b2d0fbe341380e80a3e0d6e4403c8e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d26cbe1fcfc12e8fd900e2454163e466b2d3af84f7c75481df7683ffc073d870", size = 11350796, upload-time = "2026-05-11T18:53:32.056Z" },
     { url = "https://files.pythonhosted.org/packages/64/69/f0eaaf54939f0e8c6768fd06be9af2cef9b36048b96dfb9e1b2c685a807e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e91cec1879ada0624fc3dc9953c5cbd60208e59c0db28f540c5d6d47502422f", size = 11799741, upload-time = "2026-05-11T18:53:34.985Z" },
     { url = "https://files.pythonhosted.org/packages/45/a4/865e0e510cae5fc2194de4db28be638952de942571ba9125934fd9c01d47/pandas-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:08d789b41f87e0905880e293cedf6197ce71fe67cc081358b1e148a491b9bd13", size = 10499958, upload-time = "2026-05-11T18:53:37.857Z" },
-]
-
-[[package]]
-name = "pathspec"
-version = "1.1.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]
@@ -3279,6 +3173,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/d7/0535a28b1f5f24f6612fb3ff1e89fb1a8d160fee0f976e0aa6803862134b/tqdm-4.68.3.tar.gz", hash = "sha256:00dfa48452b6b6cfae3dd9885636c23d3422d1ec97c66d96818cbd5e0821d482", size = 170596, upload-time = "2026-06-17T07:36:52.105Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/8e/bb97bb0c71802080bfc8952937d174e49cfc50de5c951dd47b2496f0dcdb/tqdm-4.68.3-py3-none-any.whl", hash = "sha256:39832cc2def2789a6f29df83f172db7416cea70052c0907a57801c5f2fdccb03", size = 78337, upload-time = "2026-06-17T07:36:50.132Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.56"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/07/fb29aea5235b0aa8ecfc4d1cc6ddf9fba8b863d67d96c6d345694d644c43/ty-0.0.56.tar.gz", hash = "sha256:84d114dc3796361c0fc72945016eabd74d46b9ee64f198cb0e485719704681e5", size = 6050123, upload-time = "2026-07-01T16:44:56.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/48/bce79e7ca5c1cc529d3e0d37ddd1121aea4b68a4f749974ad1cc77161871/ty-0.0.56-py3-none-linux_armv6l.whl", hash = "sha256:186d4a53e15747c947e1ec3d7eec8e345d8e40a1ca10e634c585db52497e87dd", size = 11643066, upload-time = "2026-07-01T16:44:18.374Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d1/22555d8a1d719661f10050f3865d877bbf497da908961c75fe22217dd18a/ty-0.0.56-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:aae1a980fd9535da0469b7ba2b2e1b54a907743a5e0f442dd57eee9f5bfd034c", size = 11407487, upload-time = "2026-07-01T16:44:20.956Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/2d/b3b7a74ce8bc59ef48843ad80179bb0d9598bbd6cfc0d11d519bdf6b1352/ty-0.0.56-py3-none-macosx_11_0_arm64.whl", hash = "sha256:afd3058c0a6c5f241e814734f133008c93ee805f61c9cf4ce7412b8822b5d9ad", size = 10962270, upload-time = "2026-07-01T16:44:22.959Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ac/6c2fd7de0304a8a7218a756af74f7e62a5e8540fdb175e0a869e51042345/ty-0.0.56-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:058b52f7a823ac13aae3cae30809dd6b5145794b64d8478f9ef38c75d79b4483", size = 11471406, upload-time = "2026-07-01T16:44:25.327Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b6/11d861156861c03c7726b74558f9a0e0092661aff83a4fda1279df28c425/ty-0.0.56-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2c66e00c1522add1f2bbdd2e45828c953b35c306b7bef03ec9169c75a63699a0", size = 11445612, upload-time = "2026-07-01T16:44:27.531Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/ba/09df108582090f3c0770ec4bc8675affed60248f6793a78d909be16211d9/ty-0.0.56-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:40903d71c669a30691b5a5d5728056c7877a1bd6be4f233a38883a8b28cf34d7", size = 12093889, upload-time = "2026-07-01T16:44:29.548Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/f7/dbb4b4ccb69cd64c209ae55b1ab788ace8222c2bc1f6845be9e7cbedbf25/ty-0.0.56-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:63fe3947fe0c46c69a7d950e6832ee70a9ec17321fefbff3d2e3c20baf9e5bd0", size = 12666337, upload-time = "2026-07-01T16:44:31.586Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e9/73f903fe4a3d9ea02f26f57c1eb07e3b1029ec92b0e8c2364718893440e3/ty-0.0.56-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71a0c1a72f9854532e710e119b6871ffe4542c8a65146f1f65dcd78fecd885b4", size = 12280247, upload-time = "2026-07-01T16:44:33.637Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/90/cebd222495832f1a00dcd321ba25f3cab804221a4991b992c2178bec68ee/ty-0.0.56-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70d1665596494e24d8ebd198438872b5a56ec3cae5f2bcf6c673be797acc4e3c", size = 11991107, upload-time = "2026-07-01T16:44:36.122Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/07/8f7337a07250f42d975cdb6decf47fc5b421e6c7da5e3e7be1e85f63a7e5/ty-0.0.56-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:778f99e51558afc1dbbe48ee38ab6aae7b31390ed8c1a1ef1499b295e9f1e82f", size = 12298970, upload-time = "2026-07-01T16:44:38.243Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/b9/a52cd59034a48f5f18c6b155cc2cc36861d874b6d0af204b12c898024c3d/ty-0.0.56-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:867bc5708e0066bb4ff6c7db524bd5deea2676c62bfe71d3303138b3be850af0", size = 11425683, upload-time = "2026-07-01T16:44:40.473Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/2e/48e42d33357d52eefb695c0c3fcfc96879b73668a7447d1d1e0ad774fedc/ty-0.0.56-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:a6012f4189c928edb330a37deb9930f982380bd4aa7c4b8e0428eec9651c7551", size = 11469258, upload-time = "2026-07-01T16:44:42.513Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/01/ad1b4138be1e3fa97863af3925aa2134f17a593240c35dc38c3429fb5ad1/ty-0.0.56-py3-none-musllinux_1_2_i686.whl", hash = "sha256:8ee83de1a7ff4cc32837ec06134ce391d441bc5b35ecd8d3cfe053f120f3e4c1", size = 11758736, upload-time = "2026-07-01T16:44:44.567Z" },
+    { url = "https://files.pythonhosted.org/packages/09/34/9d81967ff240eaa57e9249728ef7b7790747cf6d3c9a98ec86b2cfdcc8ee/ty-0.0.56-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:62619b3b0e2c6248ef30d3f0e2f2217ae9893040585be07f32324242f197cd6f", size = 12100242, upload-time = "2026-07-01T16:44:46.584Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/36/f51d4666d2de6cf33c1f3a1fcc4bb6b70b197dd6ceaa491eef71d78fe8e8/ty-0.0.56-py3-none-win32.whl", hash = "sha256:b30687bb5cd9729d34c889a289edf32770388d9bb05243e534e723fb45e0381b", size = 11093759, upload-time = "2026-07-01T16:44:49.171Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/b4/8fb5d4acfa4afb152245b20fa263069a7547bd1f8e4bfca4eda280c897d7/ty-0.0.56-py3-none-win_amd64.whl", hash = "sha256:ad4c8c47b6f4e3f9ed3fc0b1a5d650088d229e17dd8f63c1826d6bbe94cc3235", size = 12100327, upload-time = "2026-07-01T16:44:51.26Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/fc/6a183e71edde90d0c35c2303f23f7a45b6891d1a2c45daf7b8f869831e19/ty-0.0.56-py3-none-win_arm64.whl", hash = "sha256:57538f273d444a5f1293fa7860e967178afe3917611fc5eff16b64e1204fe0d6", size = 11538780, upload-time = "2026-07-01T16:44:53.8Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## PR 标题

chore(backend): 迁移类型检查到 ty

## 变更说明

- 问题: 后端仍使用 `mypy`，且迁移到 `ty` 后默认规则暴露出多处类型边界问题。
- 重要性: 统一后端类型检查工具，减少检查依赖，并让当前代码在 `ty` 下可通过检查。
- 变化: 移除 `mypy` 开发依赖，新增 `ty`，并同步 `uv.lock`。
- 变化: 修复 `ty` 报告的类型错误，包含 `Literal` 边界、SQLAlchemy 结果类型、LangGraph 泛型、session factory、模型客户端参数类型等。
- 变化: 排除 legacy migrations 目录，避免历史迁移脚本阻塞当前类型检查。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因(如有)

`ty` 的默认诊断比原有 `mypy` 配置更严格，移除规则忽略后暴露出多个类型表达不准确的位置；其中大部分是第三方库泛型、数据库字符串到 `Literal` 的边界转换，以及异步 session factory 类型标注不精确。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令：

- `uv run ty check app --output-format concise`
- `uv run ruff check .`
- `uv run pytest tests/api/test_access_log.py tests/agent_runtime/test_agent_definitions.py tests/api/test_agent_definitions.py tests/agent_runtime/test_react_agent.py tests/agent_runtime/graph/test_react_agent_context.py tests/agent_runtime/test_agent_compaction_api.py tests/agent_runtime/tools/test_plan_tools.py tests/agent_runtime/persistence/test_plan_repo.py tests/api/test_agent.py tests/api/test_models_embedding.py tests/models/test_model_provider_service.py tests/api/test_model_providers.py tests/api/test_models.py tests/agent_runtime/test_agent_revision_rollback.py`