### PR TITLE
chore(backend): 添加 justfile 命令封装

### DIFF
--- a/backend/justfile
+++ b/backend/justfile
@@ -1,0 +1,26 @@
+# List available backend commands.
+help:
+    just --list
+
+# Run lint, type checks, and tests.
+check: lint type-check test
+
+# Run Ruff lint checks.
+lint:
+    uv run ruff check .
+
+# Run ty type checks.
+type-check:
+    uv run ty check app
+
+# Run the backend test suite, or a specific pytest target.
+test target="":
+    uv run pytest {{target}}
+
+# Build source and wheel distributions.
+build:
+    uv build
+
+# Run the backend development server.
+dev:
+    uv run uvicorn app.main:app --reload --host 127.0.0.1 --port 8000


### PR DESCRIPTION
## PR 标题

chore(backend): 添加 justfile 命令封装

## 变更说明

- 问题: 后端常用开发命令需要手动输入完整 `uv` 命令，不够统一。
- 重要性: 为后端检查、测试、构建和开发启动提供统一入口，降低本地开发命令成本。
- 变化: 新增 `backend/justfile`，包含 `lint`、`type-check`、`test`、`check`、`build` 和 `dev`。
- 变化: `test` 支持可选 pytest target，可运行单个文件或单个用例。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因(如有)

无。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令：

- `just --list`
- `just lint`
- `just type-check`
- `just test tests/api/test_volumes.py`

`dev` 为长驻开发服务器命令，未在验证中实际启动。
