### PR TITLE
feat(frontend): 添加全局状态栏

### DIFF
--- a/frontend/src/features/app-shell/components/app-layout.css
+++ b/frontend/src/features/app-shell/components/app-layout.css
@@ -1,0 +1,22 @@
+.app-layout-root {
+  --app-status-bar-height: 22px;
+
+  display: flex;
+  flex-direction: column;
+  height: 100dvh;
+  overflow: hidden;
+}
+
+.app-layout-body {
+  position: relative;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.app-layout-content {
+  height: 100%;
+  padding-left: var(--app-sidebar-width);
+  overflow: hidden;
+  transition: padding-left 0.24s cubic-bezier(0.22, 1, 0.36, 1);
+}

--- a/frontend/src/features/app-shell/components/app-layout.tsx
+++ b/frontend/src/features/app-shell/components/app-layout.tsx
@@ -1,4 +1,3 @@
-import { Box } from "@radix-ui/themes";
 import { useEffect, useMemo, useState } from "react";
 import { Outlet } from "react-router";
 
@@ -7,14 +6,17 @@ import type { SettingsDialogRoute } from "@/features/settings/lib/settings-route
 
 import { AppShellContext } from "./app-shell-context";
 import { AppSidebar } from "./app-sidebar";
+import "./app-layout.css";
+import { StatusBar } from "./status-bar";
 
 interface AppLayoutProps {
   appearance: "light" | "dark";
+  version: string;
   onAppearanceChange: (appearance: "light" | "dark") => void;
   onToggleTheme: () => void;
 }
 
-export function AppLayout({ appearance, onAppearanceChange, onToggleTheme }: AppLayoutProps) {
+export function AppLayout({ appearance, version, onAppearanceChange, onToggleTheme }: AppLayoutProps) {
   const [isMobile, setIsMobile] = useState(() => window.innerWidth < 768);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -54,27 +56,19 @@ export function AppLayout({ appearance, onAppearanceChange, onToggleTheme }: App
 
   return (
     <AppShellContext.Provider value={contextValue}>
-      <Box
-        style={{
-          height: "100dvh",
-          overflow: "hidden",
-        }}
-      >
-        <AppSidebar
-          appearance={appearance}
-          onToggleTheme={onToggleTheme}
-        />
+      <div className="app-layout-root">
+        <div className="app-layout-body">
+          <AppSidebar
+            appearance={appearance}
+            onToggleTheme={onToggleTheme}
+          />
 
-        <Box
-          style={{
-            paddingLeft: "var(--app-sidebar-width)",
-            height: "100%",
-            overflow: "hidden",
-            transition: "padding-left 0.24s cubic-bezier(0.22, 1, 0.36, 1)",
-          }}
-        >
-          <Outlet />
-        </Box>
+          <div className="app-layout-content">
+            <Outlet />
+          </div>
+        </div>
+
+        <StatusBar version={version} />
 
         <SettingsDialog
           appearance={appearance}
@@ -83,7 +77,7 @@ export function AppLayout({ appearance, onAppearanceChange, onToggleTheme }: App
           onOpenChange={setIsSettingsOpen}
           route={settingsRoute}
         />
-      </Box>
+      </div>
     </AppShellContext.Provider>
   );
 }

--- a/frontend/src/features/app-shell/components/app-sidebar.tsx
+++ b/frontend/src/features/app-shell/components/app-sidebar.tsx
@@ -229,7 +229,7 @@ export function AppSidebar({ appearance, onToggleTheme }: AppSidebarProps) {
             position="fixed"
             top="0"
             left="0"
-            bottom="0"
+            bottom="var(--app-status-bar-height)"
             initial={isMobile ? { x: -SIDEBAR_EXPANDED_WIDTH } : false}
             animate={
               isMobile ? { x: 0, width: SIDEBAR_EXPANDED_WIDTH } : { x: 0, width: sidebarWidth }

--- a/frontend/src/features/app-shell/components/status-bar.css
+++ b/frontend/src/features/app-shell/components/status-bar.css
@@ -1,0 +1,55 @@
+.app-status-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  height: var(--app-status-bar-height);
+  min-height: var(--app-status-bar-height);
+  padding: 0;
+  border-top: 1px solid var(--gray-a5);
+  color: var(--gray-11);
+  background: var(--gray-2);
+  font-size: 11px;
+  line-height: 1;
+  user-select: none;
+}
+
+.app-status-bar__section {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  height: 100%;
+}
+
+.app-status-bar__section[data-side="right"] {
+  justify-content: flex-end;
+  margin-left: auto;
+}
+
+.app-status-bar__item {
+  display: inline-flex;
+  align-items: center;
+  height: 100%;
+  min-width: 0;
+  padding: 0 8px;
+  white-space: nowrap;
+}
+
+.app-status-bar__connection {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.app-status-bar__connection-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--red-9);
+  box-shadow: 0 0 0 1px var(--red-a5);
+}
+
+.app-status-bar__connection[data-state="connected"] .app-status-bar__connection-dot {
+  background: var(--green-9);
+  box-shadow: 0 0 0 1px var(--green-a5);
+}

--- a/frontend/src/features/app-shell/components/status-bar.tsx
+++ b/frontend/src/features/app-shell/components/status-bar.tsx
@@ -1,0 +1,105 @@
+import { useMemo, useSyncExternalStore, type ReactNode } from "react";
+
+import {
+  getSocketConnectionStatus,
+  subscribeSocketConnectionStatus,
+} from "@/lib/socket-client";
+
+import "./status-bar.css";
+
+interface StatusBarItem {
+  id: string;
+  content: ReactNode;
+  isVisible?: boolean;
+}
+
+interface StatusBarProps {
+  version: string;
+}
+
+function StatusBarSection({ items, side }: { items: StatusBarItem[]; side: "left" | "right" }) {
+  const visibleItems = items.filter((item) => item.isVisible !== false);
+  if (visibleItems.length === 0) return null;
+
+  return (
+    <div
+      className="app-status-bar__section"
+      data-side={side}
+      data-slot="status-bar-section"
+    >
+      {visibleItems.map((item) => (
+        <div
+          className="app-status-bar__item"
+          data-slot="status-bar-item"
+          key={item.id}
+        >
+          {item.content}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SocketStatusItem() {
+  const status = useSyncExternalStore(
+    subscribeSocketConnectionStatus,
+    getSocketConnectionStatus,
+    getSocketConnectionStatus,
+  );
+  const isConnected = status === "connected";
+
+  return (
+    <span
+      className="app-status-bar__connection"
+      data-state={status}
+      data-slot="socket-status"
+      aria-label={isConnected ? "Socket 已连接" : "Socket 连接断开"}
+    >
+      <span
+        className="app-status-bar__connection-dot"
+        aria-hidden="true"
+      />
+      {isConnected ? "已连接" : "连接断开"}
+    </span>
+  );
+}
+
+export function StatusBar({ version }: StatusBarProps) {
+  const leftItems = useMemo<StatusBarItem[]>(
+    () => [
+      {
+        id: "version",
+        content: <span data-slot="app-version">OpenFic v{version}</span>,
+        isVisible: Boolean(version),
+      },
+    ],
+    [version],
+  );
+
+  const rightItems = useMemo<StatusBarItem[]>(
+    () => [
+      {
+        id: "socket-status",
+        content: <SocketStatusItem />,
+      },
+    ],
+    [],
+  );
+
+  return (
+    <footer
+      className="app-status-bar"
+      data-slot="status-bar"
+      aria-label="应用状态栏"
+    >
+      <StatusBarSection
+        items={leftItems}
+        side="left"
+      />
+      <StatusBarSection
+        items={rightItems}
+        side="right"
+      />
+    </footer>
+  );
+}

--- a/frontend/src/lib/socket-client.ts
+++ b/frontend/src/lib/socket-client.ts
@@ -2,9 +2,60 @@ import { io, type Socket } from "socket.io-client";
 
 import { getRuntimeConfig } from "./runtime-config";
 
-let socket: Socket | null = null;
-let socketUrl: string | undefined;
-let connectPromise: Promise<Socket> | null = null;
+export type SocketConnectionStatus = "connected" | "disconnected";
+
+interface SocketClientState {
+  socket: Socket | null;
+  socketUrl: string | undefined;
+  connectPromise: Promise<Socket> | null;
+  connectionStatus: SocketConnectionStatus;
+  statusListeners: Set<() => void>;
+  statusBoundSocket: Socket | null;
+}
+
+declare global {
+  interface Window {
+    __openficSocketClientState?: SocketClientState;
+  }
+}
+
+function getSocketState(): SocketClientState {
+  window.__openficSocketClientState ??= {
+    socket: null,
+    socketUrl: undefined,
+    connectPromise: null,
+    connectionStatus: "disconnected",
+    statusListeners: new Set<() => void>(),
+    statusBoundSocket: null,
+  };
+  return window.__openficSocketClientState;
+}
+
+function setConnectionStatus(nextStatus: SocketConnectionStatus): void {
+  const state = getSocketState();
+  if (state.connectionStatus === nextStatus) return;
+  state.connectionStatus = nextStatus;
+  state.statusListeners.forEach((listener) => listener());
+}
+
+export function getSocketConnectionStatus(): SocketConnectionStatus {
+  return getSocketState().connectionStatus;
+}
+
+export function subscribeSocketConnectionStatus(listener: () => void): () => void {
+  const state = getSocketState();
+  state.statusListeners.add(listener);
+  return () => state.statusListeners.delete(listener);
+}
+
+function bindConnectionStatus(socket: Socket): void {
+  const state = getSocketState();
+  if (state.statusBoundSocket === socket) return;
+  state.statusBoundSocket = socket;
+  socket.on("connect", () => setConnectionStatus("connected"));
+  socket.on("disconnect", () => setConnectionStatus("disconnected"));
+  socket.on("connect_error", () => setConnectionStatus("disconnected"));
+}
 
 function getSocketUrl(): string | undefined {
   const runtimeBackendUrl = getRuntimeConfig()?.backendBaseUrl;
@@ -23,15 +74,19 @@ function getSocketUrl(): string | undefined {
 }
 
 export function getSocket(): Socket {
+  const state = getSocketState();
   const nextSocketUrl = getSocketUrl();
-  if (socket && socketUrl !== nextSocketUrl) {
-    socket.disconnect();
-    socket = null;
-    connectPromise = null;
+  if (state.socket && state.socketUrl !== nextSocketUrl) {
+    state.socket.disconnect();
+    state.socket = null;
+    state.socketUrl = undefined;
+    state.connectPromise = null;
+    state.statusBoundSocket = null;
+    setConnectionStatus("disconnected");
   }
 
-  if (!socket) {
-    socket = nextSocketUrl
+  if (!state.socket) {
+    state.socket = nextSocketUrl
       ? io(nextSocketUrl, {
           path: "/socket.io",
           autoConnect: false,
@@ -42,18 +97,21 @@ export function getSocket(): Socket {
           autoConnect: false,
           transports: ["websocket", "polling"],
         });
-    socketUrl = nextSocketUrl;
+    state.socketUrl = nextSocketUrl;
+    bindConnectionStatus(state.socket);
+    setConnectionStatus(state.socket.connected ? "connected" : "disconnected");
   }
 
-  return socket;
+  return state.socket;
 }
 
 export function connectSocket(): Promise<Socket> {
+  const state = getSocketState();
   const activeSocket = getSocket();
   if (activeSocket.connected) return Promise.resolve(activeSocket);
-  if (connectPromise) return connectPromise;
+  if (state.connectPromise) return state.connectPromise;
 
-  connectPromise = new Promise<Socket>((resolve, reject) => {
+  state.connectPromise = new Promise<Socket>((resolve, reject) => {
     const cleanup = () => {
       window.clearTimeout(timeout);
       activeSocket.off("connect", onConnect);
@@ -78,15 +136,22 @@ export function connectSocket(): Promise<Socket> {
     }, 5000);
     activeSocket.connect();
   }).finally(() => {
-    connectPromise = null;
+    state.connectPromise = null;
   });
 
-  return connectPromise;
+  return state.connectPromise;
 }
 
 export function disposeSocketForHmr(): void {
-  socket?.disconnect();
-  socket = null;
-  socketUrl = undefined;
-  connectPromise = null;
+  const state = getSocketState();
+  state.socket?.disconnect();
+  state.socket = null;
+  state.socketUrl = undefined;
+  state.connectPromise = null;
+  state.statusBoundSocket = null;
+  setConnectionStatus("disconnected");
+}
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(disposeSocketForHmr);
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -18,6 +18,7 @@ import { publishDesktopAppearance } from "./lib/desktop-appearance-bridge";
 import { applyCodeFontFamily, applyFontFamily, loadConfiguredFonts } from "./lib/font-utils";
 import { getOrCreateRoot } from "./lib/get-or-create-root";
 import { loadRuntimeConfig } from "./lib/runtime-config";
+import { connectSocket } from "./lib/socket-client";
 import { preloadTiktokenEncoding } from "./lib/tiktoken-utils";
 import { registerSW } from "./pwa/register-sw";
 
@@ -46,10 +47,12 @@ const DashboardPage = lazy(() =>
 
 function AppContent({
   appearance,
+  version,
   setAppearance,
   toggleTheme,
 }: {
   appearance: "light" | "dark";
+  version: string;
   setAppearance: (appearance: "light" | "dark") => void;
   toggleTheme: () => void;
 }) {
@@ -60,6 +63,7 @@ function AppContent({
           element={
             <AppLayout
               appearance={appearance}
+              version={version}
               onAppearanceChange={setAppearance}
               onToggleTheme={toggleTheme}
             />
@@ -102,6 +106,7 @@ function AppContent({
 function Root() {
   const [appearance, setAppearance] = useState<"light" | "dark">("light");
   const [settings, setSettings] = useState<Settings | null>(null);
+  const [version, setVersion] = useState("");
   const [isReady, setIsReady] = useState(false);
   const [error, setError] = useState(false);
 
@@ -118,13 +123,14 @@ function Root() {
       try {
         await loadRuntimeConfig();
 
-        const [, settings] = await Promise.all([
+        const [health, settings] = await Promise.all([
           checkHealth(),
           queryClient.fetchQuery({
             queryKey: ["settings"],
             queryFn: fetchSettings,
           }),
           preloadTiktokenEncoding(),
+          connectSocket(),
         ]);
 
         applyFontFamily(settings.fontFamily);
@@ -133,6 +139,7 @@ function Root() {
 
         if (mounted) {
           setSettings(settings);
+          setVersion(health.version);
           setAppearance(settings.theme);
           setIsReady(true);
         }
@@ -184,6 +191,7 @@ function Root() {
             ) : (
               <AppContent
                 appearance={appearance}
+                version={version}
                 setAppearance={setAppearance}
                 toggleTheme={toggleTheme}
               />


### PR DESCRIPTION
## PR 标题

feat(frontend): 添加全局状态栏

## 变更说明

- 问题: 前端缺少全局状态栏，无法在所有页面持续展示应用版本和 socket 连接状态。
- 重要性: 状态栏可作为全局运行状态入口，帮助用户快速判断后端实时连接是否可用。
- 变化: 新增底部全局状态栏，左侧显示后端版本号，右侧显示 socket 已连接/连接断开状态。
- 变化: 将 socket 连接纳入应用初始化健康检查，并将 socket client 状态提升为浏览器全局单例，避免分包或开发环境下出现多个实例。
- 变化: 调整应用壳布局，为 22px 状态栏预留空间，侧边栏避开底部状态栏。

## 关联 Issue / PR (如有)

#XXXX

## 变更类型

- [x] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

此前 socket client 状态只保存在模块级变量中，在 preview/构建分包或开发热更新场景下可能出现状态源不一致；应用壳布局使用 Radix Box 承载 flex 根容器时也会被组件默认样式影响，导致状态栏位置异常。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

本次为前端应用壳与 socket 连接状态变更，无数据库迁移。已运行 `pnpm type-check`、`pnpm lint`、`pnpm build`。未新增测试文件。