### PR TITLE
chore(frontend): 适配角色与世界书移动端顶栏

### DIFF
--- a/frontend/src/features/characters/pages/characters-page.css
+++ b/frontend/src/features/characters/pages/characters-page.css
@@ -205,6 +205,52 @@
   overflow: hidden;
 }
 
+.characters-editor-shell--mobile {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+}
+
+.characters-page-content-fill {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.characters-page-mobile-topbar {
+  min-height: 44px;
+  border-bottom: 1px solid var(--gray-a4);
+  background: var(--color-background);
+}
+
+.characters-page-mobile-topbar-side {
+  width: 32px;
+  height: 32px;
+  flex-shrink: 0;
+}
+
+.characters-page-mobile-sidebar-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.characters-page-mobile-sidebar-sheet {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  z-index: 11;
+  height: 100%;
+  overflow: hidden;
+  border-right: 1px solid var(--gray-a4);
+  background: var(--color-background);
+  will-change: transform;
+}
+
 .characters-right-empty {
   padding: var(--space-5);
 }

--- a/frontend/src/features/characters/pages/characters-page.tsx
+++ b/frontend/src/features/characters/pages/characters-page.tsx
@@ -1,10 +1,13 @@
-import { AlertDialog, Box, Button, Dialog, Flex, Text } from "@radix-ui/themes";
+import { AlertDialog, Box, Button, Flex, IconButton, Tooltip, Text } from "@radix-ui/themes";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { List } from "lucide-react";
+import { motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Group, Panel, Separator } from "react-resizable-panels";
 import { useSearchParams } from "react-router";
 
+import { MobileAppSidebarTrigger } from "@/features/app-shell";
 import { toast } from "@/components/toast";
 import {
   batchDeleteCharacters,
@@ -29,6 +32,8 @@ import "./characters-page.css";
 
 const LAST_PROJECT_KEY = "characters.lastProjectId";
 const LAST_CHARACTER_KEY = "characters.lastCharacterId";
+const MotionBox = motion.create(Box);
+const MOBILE_SIDEBAR_WIDTH = 320;
 
 function toCharacterListItem(character: Character): CharacterListItem {
   return {
@@ -367,7 +372,56 @@ export function CharactersPage() {
         </Group>
       ) : currentProjectId ? (
         <Box className="characters-page-body characters-page-body--mobile">
-          <Box className="characters-panel characters-editor-shell">{editorContent}</Box>
+          <Box className="characters-panel characters-editor-shell characters-editor-shell--mobile">
+            <Flex
+              align="center"
+              justify="between"
+              px="3"
+              py="2"
+              className="characters-page-mobile-topbar"
+            >
+              <Flex align="center" gap="1">
+                <MobileAppSidebarTrigger />
+                <Tooltip content={t("characters.listTitle")}>
+                  <IconButton
+                    variant="ghost"
+                    size="2"
+                    aria-label={t("characters.listTitle")}
+                    onClick={() => setListOpen(!isListOpen)}
+                  >
+                    <List size={18} />
+                  </IconButton>
+                </Tooltip>
+              </Flex>
+
+              <Box className="characters-page-mobile-topbar-side" />
+            </Flex>
+
+            <Box className="characters-page-content-fill">{editorContent}</Box>
+
+            <motion.div
+              initial={false}
+              animate={{ opacity: isListOpen ? 1 : 0 }}
+              transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
+              onClick={() => setListOpen(false)}
+              className="characters-page-mobile-sidebar-backdrop"
+              style={{ pointerEvents: isListOpen ? "auto" : "none" }}
+            />
+
+            <MotionBox
+              initial={false}
+              animate={{ x: isListOpen ? 0 : -MOBILE_SIDEBAR_WIDTH }}
+              transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
+              className="characters-page-mobile-sidebar-sheet"
+              style={{
+                width: MOBILE_SIDEBAR_WIDTH,
+                minWidth: MOBILE_SIDEBAR_WIDTH,
+                pointerEvents: isListOpen ? "auto" : "none",
+              }}
+            >
+              {list}
+            </MotionBox>
+          </Box>
         </Box>
       ) : (
         <Flex
@@ -391,19 +445,6 @@ export function CharactersPage() {
           </Text>
         </Flex>
       )}
-
-      <Dialog.Root
-        open={isListOpen}
-        onOpenChange={setListOpen}
-      >
-        <Dialog.Content
-          className="characters-mobile-dialog"
-          maxWidth="360px"
-        >
-          <Dialog.Title>{t("characters.listTitle")}</Dialog.Title>
-          {list}
-        </Dialog.Content>
-      </Dialog.Root>
 
       <CharacterProfileDialog
         character={profileCharacter}

--- a/frontend/src/features/world-info/pages/world-info-page.css
+++ b/frontend/src/features/world-info/pages/world-info-page.css
@@ -26,6 +26,67 @@
   overflow-y: auto;
 }
 
+.world-info-page-mobile-layout {
+  height: 100%;
+  min-height: 0;
+  flex: 1;
+}
+
+.world-info-page-editor-shell--mobile {
+  position: relative;
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.world-info-page-content-fill {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  background: var(--color-background);
+}
+
+.world-info-page-mobile-topbar {
+  min-height: 44px;
+  border-bottom: 1px solid var(--gray-a4);
+  background: var(--color-background);
+}
+
+.world-info-page-mobile-sidebar-backdrop {
+  position: absolute;
+  inset: 0;
+  z-index: 10;
+  background: rgba(0, 0, 0, 0.5);
+}
+
+.world-info-page-mobile-sidebar-sheet {
+  position: absolute;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  z-index: 11;
+  height: 100%;
+  overflow: hidden;
+  border-right: 1px solid var(--gray-a4);
+  background: var(--color-background);
+  will-change: transform;
+}
+
+.world-info-page-mobile-assistant-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: var(--color-background);
+  visibility: visible;
+  pointer-events: none;
+  will-change: transform;
+}
+
+.world-info-page-mobile-assistant-overlay[data-open="true"] {
+  pointer-events: auto;
+}
+
 .world-info-page-separator {
   position: relative;
   width: 1px;

--- a/frontend/src/features/world-info/pages/world-info-page.tsx
+++ b/frontend/src/features/world-info/pages/world-info-page.tsx
@@ -4,8 +4,10 @@
  * 世界书主页面，按项目展示对应世界书条目与编辑器。
  */
 
-import { Box, Flex, Text, Dialog, Button, Skeleton } from "@radix-ui/themes";
+import { Box, Flex, Text, Dialog, Button, Skeleton, IconButton, Tooltip } from "@radix-ui/themes";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Bot, List } from "lucide-react";
+import { motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Panel, Group, Separator } from "react-resizable-panels";
@@ -13,6 +15,7 @@ import { useSearchParams } from "react-router";
 
 import "./world-info-page.css";
 
+import { MobileAppSidebarTrigger } from "@/features/app-shell";
 import { toast } from "@/components/toast";
 import { AssistantSidebar } from "@/features/assistant";
 import type { AssistantSidebarState } from "@/features/assistant";
@@ -42,6 +45,8 @@ import { useWorldInfoStore } from "../store/use-world-info-store";
 
 const LAST_PROJECT_KEY = "worldInfo.lastProjectId";
 const LAST_ENTRY_KEY = "worldInfo.lastEntryId";
+const MotionBox = motion.create(Box);
+const MOBILE_SIDEBAR_WIDTH = 320;
 
 function generateUniqueEntryName(baseName: string, entries: WorldInfoEntryBrief[]): string {
   const normalizedName = baseName.trim();
@@ -65,6 +70,8 @@ export function WorldInfoPage() {
     setCurrentWorldInfo,
     currentEntryId,
     setCurrentEntry,
+    sidebarOpen,
+    setSidebarOpen,
     setFromWriting,
   } = useWorldInfoStore();
 
@@ -85,6 +92,7 @@ export function WorldInfoPage() {
     isAgentRunning: false,
   });
   const [isMobile, setIsMobile] = useState(false);
+  const [isAssistantOpen, setIsAssistantOpen] = useState(false);
   const [currentProjectId, setCurrentProjectId] = useState<string | null>(null);
 
   useEffect(() => {
@@ -312,7 +320,9 @@ export function WorldInfoPage() {
     setCurrentProjectId(projectId || null);
     setCurrentEntry(null);
     setIsCreatingEntry(false);
-  }, [setCurrentEntry]);
+    setSidebarOpen(false);
+    setIsAssistantOpen(false);
+  }, [setCurrentEntry, setSidebarOpen]);
 
   /** 处理创建条目 */
   const handleCreateEntry = useCallback(() => {
@@ -328,8 +338,9 @@ export function WorldInfoPage() {
   const handleSelectEntry = useCallback(
     (entryId: string) => {
       setCurrentEntry(entryId);
+      setSidebarOpen(false);
     },
-    [setCurrentEntry],
+    [setCurrentEntry, setSidebarOpen],
   );
 
   /** 处理切换条目启用状态 */
@@ -576,6 +587,8 @@ export function WorldInfoPage() {
     <AssistantSidebar
       projectId={currentProjectId}
       onStateChange={setAssistantState}
+      onClose={() => setIsAssistantOpen(false)}
+      isMobileOverlay={isMobile}
     />
   ) : (
     <Flex
@@ -590,6 +603,67 @@ export function WorldInfoPage() {
         align="center"
       >
         {t("worldInfo.noProject")}
+      </Text>
+    </Flex>
+  );
+
+  const editorContent = isCreatingEntry ? (
+    <Box p="4">
+      <Flex
+        direction="column"
+        gap="4"
+        style={{ maxWidth: 800, margin: "0 auto" }}
+      >
+        <Skeleton width="120px" height="14px" />
+        <Skeleton width="100%" height="36px" />
+        <Flex gap="4">
+          <Skeleton style={{ flex: 1 }} height="36px" />
+          <Skeleton style={{ flex: 1 }} height="36px" />
+        </Flex>
+        <Skeleton width="100%" height="200px" />
+        <Skeleton width="100%" height="80px" />
+      </Flex>
+    </Box>
+  ) : selectedEntry ? (
+    <EntryEditor
+      key={selectedEntry.id}
+      entry={selectedEntry}
+      worldInfoId={currentWorldInfoId!}
+      entries={entries}
+      scrollToLine={scrollToLine}
+      onScrollComplete={handleScrollComplete}
+      isAgentLocked={isAgentLocked}
+    />
+  ) : currentEntryId && isEntryLoading ? (
+    <Box p="4">
+      <Flex
+        direction="column"
+        gap="4"
+        style={{ maxWidth: 800, margin: "0 auto" }}
+      >
+        <Skeleton width="120px" height="14px" />
+        <Skeleton width="100%" height="36px" />
+        <Flex gap="4">
+          <Skeleton style={{ flex: 1 }} height="36px" />
+          <Skeleton style={{ flex: 1 }} height="36px" />
+        </Flex>
+        <Skeleton width="100%" height="200px" />
+        <Skeleton width="100%" height="80px" />
+      </Flex>
+    </Box>
+  ) : (
+    <Flex
+      align="center"
+      justify="center"
+      height="100%"
+      direction="column"
+      gap="2"
+    >
+      <Text
+        size="3"
+        color="gray"
+      >
+        {t("worldInfo.selectEntry")}
       </Text>
     </Flex>
   );
@@ -640,102 +714,7 @@ export function WorldInfoPage() {
                   data-scroll-container
                   className="world-info-page-editor-shell"
                 >
-                  {isCreatingEntry ? (
-                    <Box p="4">
-                      <Flex
-                        direction="column"
-                        gap="4"
-                        style={{ maxWidth: 800, margin: "0 auto" }}
-                      >
-                        <Skeleton
-                          width="120px"
-                          height="14px"
-                        />
-                        <Skeleton
-                          width="100%"
-                          height="36px"
-                        />
-                        <Flex gap="4">
-                          <Skeleton
-                            style={{ flex: 1 }}
-                            height="36px"
-                          />
-                          <Skeleton
-                            style={{ flex: 1 }}
-                            height="36px"
-                          />
-                        </Flex>
-                        <Skeleton
-                          width="100%"
-                          height="200px"
-                        />
-                        <Skeleton
-                          width="100%"
-                          height="80px"
-                        />
-                      </Flex>
-                    </Box>
-                  ) : selectedEntry ? (
-                    <EntryEditor
-                      key={selectedEntry.id}
-                      entry={selectedEntry}
-                      worldInfoId={currentWorldInfoId!}
-                      entries={entries}
-                      scrollToLine={scrollToLine}
-                      onScrollComplete={handleScrollComplete}
-                      isAgentLocked={isAgentLocked}
-                    />
-                  ) : currentEntryId && isEntryLoading ? (
-                    <Box p="4">
-                      <Flex
-                        direction="column"
-                        gap="4"
-                        style={{ maxWidth: 800, margin: "0 auto" }}
-                      >
-                        <Skeleton
-                          width="120px"
-                          height="14px"
-                        />
-                        <Skeleton
-                          width="100%"
-                          height="36px"
-                        />
-                        <Flex gap="4">
-                          <Skeleton
-                            style={{ flex: 1 }}
-                            height="36px"
-                          />
-                          <Skeleton
-                            style={{ flex: 1 }}
-                            height="36px"
-                          />
-                        </Flex>
-                        <Skeleton
-                          width="100%"
-                          height="200px"
-                        />
-                        <Skeleton
-                          width="100%"
-                          height="80px"
-                        />
-                      </Flex>
-                    </Box>
-                  ) : (
-                    <Flex
-                      align="center"
-                      justify="center"
-                      height="100%"
-                      direction="column"
-                      gap="2"
-                    >
-                      <Text
-                        size="3"
-                        color="gray"
-                      >
-                        {t("worldInfo.selectEntry")}
-                      </Text>
-                    </Flex>
-                  )}
+                  {editorContent}
                 </Box>
               </Panel>
 
@@ -754,92 +733,70 @@ export function WorldInfoPage() {
               </Panel>
             </Group>
           ) : currentProjectId ? (
-            <Flex
-              direction="column"
-              style={{
-                flex: 1,
-                minHeight: 0,
-                background: "var(--gray-a2)",
-                overflow: "hidden",
-              }}
-            >
-              <Box
-                style={{
-                  flex: "0 0 42%",
-                  minHeight: 240,
-                  borderBottom: "1px solid var(--gray-a4)",
-                  background: "var(--color-background)",
-                  overflow: "hidden",
-                }}
-              >
-                {sidebarContent}
-              </Box>
-              <Box
-                data-scroll-container
-                style={{
-                  flex: 1,
-                  minHeight: 0,
-                  overflowY: "auto",
-                  background: "var(--color-background)",
-                }}
-              >
-                {isCreatingEntry ? (
-                  <Box p="4">
-                    <Flex
-                      direction="column"
-                      gap="4"
-                      style={{ maxWidth: 800, margin: "0 auto" }}
-                    >
-                      <Skeleton width="120px" height="14px" />
-                      <Skeleton width="100%" height="36px" />
-                      <Flex gap="4">
-                        <Skeleton style={{ flex: 1 }} height="36px" />
-                        <Skeleton style={{ flex: 1 }} height="36px" />
-                      </Flex>
-                      <Skeleton width="100%" height="200px" />
-                      <Skeleton width="100%" height="80px" />
-                    </Flex>
-                  </Box>
-                ) : selectedEntry ? (
-                  <EntryEditor
-                    key={selectedEntry.id}
-                    entry={selectedEntry}
-                    worldInfoId={currentWorldInfoId!}
-                    entries={entries}
-                    scrollToLine={scrollToLine}
-                    onScrollComplete={handleScrollComplete}
-                    isAgentLocked={isAgentLocked}
-                  />
-                ) : currentEntryId && isEntryLoading ? (
-                  <Box p="4">
-                    <Flex
-                      direction="column"
-                      gap="4"
-                      style={{ maxWidth: 800, margin: "0 auto" }}
-                    >
-                      <Skeleton width="120px" height="14px" />
-                      <Skeleton width="100%" height="36px" />
-                      <Flex gap="4">
-                        <Skeleton style={{ flex: 1 }} height="36px" />
-                        <Skeleton style={{ flex: 1 }} height="36px" />
-                      </Flex>
-                      <Skeleton width="100%" height="200px" />
-                      <Skeleton width="100%" height="80px" />
-                    </Flex>
-                  </Box>
-                ) : (
-                  <Flex
-                    align="center"
-                    justify="center"
-                    height="100%"
-                    direction="column"
-                    gap="2"
-                  >
-                    <Text size="3" color="gray">
-                      {t("worldInfo.selectEntry")}
-                    </Text>
+            <Flex className="world-info-page-mobile-layout">
+              <Box className="world-info-page-editor-shell world-info-page-editor-shell--mobile">
+                <Flex
+                  align="center"
+                  justify="between"
+                  px="3"
+                  py="2"
+                  className="world-info-page-mobile-topbar"
+                >
+                  <Flex align="center" gap="1">
+                    <MobileAppSidebarTrigger />
+                    <Tooltip content={t("worldInfo.entries")}>
+                      <IconButton
+                        variant="ghost"
+                        size="2"
+                        aria-label={t("worldInfo.entries")}
+                        onClick={() => setSidebarOpen(!sidebarOpen)}
+                      >
+                        <List size={18} />
+                      </IconButton>
+                    </Tooltip>
                   </Flex>
-                )}
+
+                  <Tooltip content={t("assistant.mobileTitle")}>
+                    <IconButton
+                      variant="ghost"
+                      size="2"
+                      aria-label={t("assistant.mobileTitle")}
+                      onClick={() => setIsAssistantOpen(true)}
+                    >
+                      <Bot size={18} />
+                    </IconButton>
+                  </Tooltip>
+                </Flex>
+
+                <Box
+                  data-scroll-container
+                  className="world-info-page-content-fill"
+                >
+                  {editorContent}
+                </Box>
+
+                <motion.div
+                  initial={false}
+                  animate={{ opacity: sidebarOpen ? 1 : 0 }}
+                  transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
+                  onClick={() => setSidebarOpen(false)}
+                  className="world-info-page-mobile-sidebar-backdrop"
+                  style={{ pointerEvents: sidebarOpen ? "auto" : "none" }}
+                />
+
+                <MotionBox
+                  initial={false}
+                  animate={{ x: sidebarOpen ? 0 : -MOBILE_SIDEBAR_WIDTH }}
+                  transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
+                  className="world-info-page-mobile-sidebar-sheet"
+                  style={{
+                    width: MOBILE_SIDEBAR_WIDTH,
+                    minWidth: MOBILE_SIDEBAR_WIDTH,
+                    pointerEvents: sidebarOpen ? "auto" : "none",
+                  }}
+                >
+                  {sidebarContent}
+                </MotionBox>
               </Box>
             </Flex>
           ) : (
@@ -860,6 +817,19 @@ export function WorldInfoPage() {
           )}
         </Flex>
       </Box>
+
+      {isMobile && currentProjectId && (
+        <MotionBox
+          initial={false}
+          animate={{ x: isAssistantOpen ? 0 : "100%" }}
+          transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
+          className="world-info-page-mobile-assistant-overlay"
+          data-open={isAssistantOpen}
+          aria-hidden={!isAssistantOpen}
+        >
+          {agentSidebarContent}
+        </MotionBox>
+      )}
 
       <ImportWorldInfoDialog
         open={importDialogOpen}


### PR DESCRIPTION
## PR 标题

chore(frontend): 适配角色与世界书移动端顶栏

## 变更说明

- 问题: 角色页和世界书页在移动端仍沿用桌面式布局，缺少与章节编辑器一致的顶栏与侧栏交互
- 重要性: 统一移动端入口结构，降低页面切换与列表访问成本，保持跨页面交互一致性
- 变化: 为角色页增加移动端顶栏和左侧滑出列表，并移除原有移动端 Dialog 列表实现
- 变化: 为世界书增加移动端顶栏、左侧条目抽屉和右侧助手覆盖层，并复用编辑区渲染逻辑
- 变化: 对齐章节编辑器移动端的动画、层级、边框与抽屉交互样式

## 关联 Issue / PR (如有)

#XXXX

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因(如有)

角色页和世界书页的移动端交互未与章节编辑器保持一致，导致同一应用内不同编辑页的入口结构和操作路径不统一。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 验证命令: `pnpm type-check`
- 验证命令: `pnpm lint`
