### PR TITLE
style(frontend): 调整智能体设置列表展示

### DIFF
--- a/frontend/src/features/settings/components/agent-definitions-settings.tsx
+++ b/frontend/src/features/settings/components/agent-definitions-settings.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   Checkbox,
   Flex,
+  Switch,
   ScrollArea,
   Text,
   TextArea,
@@ -87,25 +88,19 @@ function getEffectiveModelSelection(modelId: string | null): string {
 
 function buildAgentModelOptions(
   llmModelOptions: ModelIdSelectOption[],
-  defaultModelId: string,
-  lightModelId: string,
   t: (key: string) => string,
 ): ModelIdSelectOption[] {
   return [
     {
       value: SYSTEM_DEFAULT_MODEL_REFERENCE,
       id: t("settings.agentsFollowSystemSetting"),
-      name: defaultModelId
-        ? `${t("settings.agentsSystemDefaultModel")} (${defaultModelId})`
-        : t("settings.agentsSystemDefaultModel"),
+      name: t("settings.agentsSystemDefaultModel"),
       taskType: "llm",
     },
     {
       value: SYSTEM_LIGHT_MODEL_REFERENCE,
       id: t("settings.agentsFollowSystemSetting"),
-      name: lightModelId
-        ? `${t("settings.agentsSystemLightModel")} (${lightModelId})`
-        : t("settings.agentsSystemLightModel"),
+      name: t("settings.agentsSystemLightModel"),
       taskType: "llm",
     },
     ...llmModelOptions,
@@ -146,7 +141,6 @@ function AgentForm({
   const [formEnabledSkillIds, setFormEnabledSkillIds] = useState<string[]>([
     ...def.enabled_skill_ids,
   ]);
-  const [formEnabled, setFormEnabled] = useState(def.enabled);
   const [formDelegatableAgents, setFormDelegatableAgents] = useState<string[]>([
     ...def.delegatable_agents,
   ]);
@@ -175,7 +169,6 @@ function AgentForm({
       formModelId !== getEffectiveModelSelection(def.model_id) ||
       JSON.stringify(formToolCategoryKeys) !== JSON.stringify(def.tool_category_keys) ||
       JSON.stringify(formEnabledSkillIds) !== JSON.stringify(def.enabled_skill_ids) ||
-      formEnabled !== def.enabled ||
       JSON.stringify(formDelegatableAgents) !== JSON.stringify(def.delegatable_agents)
     );
   }, [
@@ -185,7 +178,6 @@ function AgentForm({
     formModelId,
     formToolCategoryKeys,
     formEnabledSkillIds,
-    formEnabled,
     formDelegatableAgents,
   ]);
 
@@ -199,7 +191,6 @@ function AgentForm({
         model_id: formModelId,
         tool_category_keys: formToolCategoryKeys,
         enabled_skill_ids: formEnabledSkillIds,
-        enabled: formEnabled,
         delegatable_agents: formDelegatableAgents,
       });
     },
@@ -420,17 +411,6 @@ function AgentForm({
         )}
       </Flex>
 
-      <Flex
-        align="center"
-        gap="2"
-      >
-        <Checkbox
-          checked={formEnabled}
-          onCheckedChange={(checked) => setFormEnabled(checked === true)}
-        />
-        <Text size="2">{t("settings.agentsEnabled")}</Text>
-      </Flex>
-
       {isPrimary && (
         <Flex
           direction="column"
@@ -649,13 +629,8 @@ export function AgentDefinitionsSettings({
   const hasLlmModels = llmModelOptions.length > 0;
   const modelOptions = useMemo(
     () =>
-      buildAgentModelOptions(
-        llmModelOptions,
-        settings?.defaultModel ?? "",
-        settings?.lightModel ?? "",
-        t,
-      ),
-    [llmModelOptions, settings?.defaultModel, settings?.lightModel, t],
+      buildAgentModelOptions(llmModelOptions, t),
+    [llmModelOptions, t],
   );
 
   const effectiveSelectedKey = useMemo(() => {
@@ -817,6 +792,40 @@ export function AgentDefinitionsSettings({
     onError: () => toast.error(t("settings.agentsDeleteFailed")),
   });
 
+  const toggleMutation = useMutation({
+    mutationFn: ({ key, enabled }: { key: string; enabled: boolean }) =>
+      updateAgentDefinition(key, { enabled }),
+    onMutate: async ({ key, enabled }) => {
+      await queryClient.cancelQueries({ queryKey: ["agent-definitions"] });
+      const previous = queryClient.getQueryData<AgentDefinitionResponse[]>(["agent-definitions"]);
+
+      if (previous) {
+        queryClient.setQueryData<AgentDefinitionResponse[]>(
+          ["agent-definitions"],
+          previous.map((item) => (item.key === key ? { ...item, enabled } : item)),
+        );
+      }
+
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(["agent-definitions"], context.previous);
+      }
+      toast.error(t("common.error"));
+    },
+    onSuccess: (updatedDef) => {
+      queryClient.setQueryData<AgentDefinitionResponse[]>(["agent-definitions"], (current) => {
+        if (!current) return current;
+        return current.map((item) => (item.key === updatedDef.key ? updatedDef : item));
+      });
+      toast.success(updatedDef.enabled ? t("worldInfo.enabled") : t("worldInfo.disabled"));
+    },
+    onSettled: () => {
+      invalidateDefs();
+    },
+  });
+
   const openMenuAt = useCallback((key: string, position: { x: number; y: number }) => {
     setMenuState({ key, position });
   }, []);
@@ -909,33 +918,72 @@ export function AgentDefinitionsSettings({
         className="agent-definition-item-content"
       >
         <Flex
-          align="center"
+          align="start"
+          justify="between"
           gap="2"
           className="agent-definition-item-row"
         >
-          <span
-            className="agent-definition-kind-icon"
-            aria-label={getAgentKindLabel(def.kind)}
-            title={getAgentKindLabel(def.kind)}
+          <Flex
+            align="center"
+            gap="2"
+            className="agent-definition-item-title-row"
           >
-            {def.kind === "primary" ? <Crown size={14} /> : <Bot size={14} />}
-          </span>
-          <Text
-            size="2"
-            truncate
-            weight={effectiveSelectedKey === def.key ? "medium" : "regular"}
-          >
-            {def.display_name}
-          </Text>
-          {def.source === "builtin" ? (
-            <Badge
-              size="1"
-              variant="soft"
-              color="green"
+            <span
+              className="agent-definition-kind-icon"
+              aria-label={getAgentKindLabel(def.kind)}
+              title={getAgentKindLabel(def.kind)}
             >
-              {t("settings.agentsBuiltin")}
-            </Badge>
-          ) : null}
+              {def.kind === "primary" ? <Crown size={14} /> : <Bot size={14} />}
+            </span>
+            <Text
+              size="2"
+              truncate
+              weight={effectiveSelectedKey === def.key ? "medium" : "regular"}
+            >
+              {def.display_name}
+            </Text>
+            {def.source === "builtin" ? (
+              <Badge
+                size="1"
+                variant="soft"
+                color="green"
+              >
+                {t("settings.agentsBuiltin")}
+              </Badge>
+            ) : null}
+          </Flex>
+
+          <Flex
+            align="center"
+            gap="1"
+            className="agent-definition-item-actions"
+          >
+            <Switch
+              size="1"
+              checked={def.enabled}
+              disabled={toggleMutation.isPending}
+              onClick={(event) => event.stopPropagation()}
+              onCheckedChange={(checked) => {
+                void toggleMutation.mutateAsync({ key: def.key, enabled: checked === true });
+              }}
+            />
+            <IconButton
+              type="button"
+              variant="ghost"
+              color="gray"
+              size="1"
+              className="agent-definition-item-menu"
+              aria-label={t("settings.agentsMenu")}
+              onClick={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                const rect = event.currentTarget.getBoundingClientRect();
+                openMenuAt(def.key, { x: rect.right, y: rect.bottom + 4 });
+              }}
+            >
+              <MoreHorizontal size={14} />
+            </IconButton>
+          </Flex>
         </Flex>
         <Text
           size="1"
@@ -945,23 +993,6 @@ export function AgentDefinitionsSettings({
           {def.description || t("settings.agentsNoDescription")}
         </Text>
       </Flex>
-
-      <IconButton
-        type="button"
-        variant="ghost"
-        color="gray"
-        size="1"
-        className="agent-definition-item-menu"
-        aria-label={t("settings.agentsMenu")}
-        onClick={(event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          const rect = event.currentTarget.getBoundingClientRect();
-          openMenuAt(def.key, { x: rect.right, y: rect.bottom + 4 });
-        }}
-      >
-        <MoreHorizontal size={14} />
-      </IconButton>
     </div>
   );
 

--- a/frontend/src/features/settings/components/settings-dialog.css
+++ b/frontend/src/features/settings/components/settings-dialog.css
@@ -224,9 +224,9 @@
 
 .agent-definition-item {
   display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 10px;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
   width: 100%;
   min-width: 0;
   padding: 10px 12px;
@@ -272,6 +272,16 @@
 .agent-definition-item-row {
   width: 100%;
   min-width: 0;
+  gap: 10px;
+}
+
+.agent-definition-item-title-row {
+  min-width: 0;
+  flex: 1;
+}
+
+.agent-definition-item-actions {
+  flex-shrink: 0;
 }
 
 .agent-definition-kind-icon {
@@ -287,6 +297,8 @@
 .agent-definition-item-description {
   display: block;
   overflow: hidden;
+  width: 100%;
+  min-width: 0;
   white-space: nowrap;
   text-overflow: ellipsis;
 }


### PR DESCRIPTION
## PR 标题

style(frontend): 调整智能体设置列表展示

## 变更说明

- 问题: 智能体设置中的启用状态只能在编辑区切换，列表项信息层级不够清晰，模型默认选项还会额外显示括号包裹的 ID。
- 重要性: 统一设置页交互方式，减少切换步骤，提升列表可读性与选择效率。
- 变化: 将智能体启用开关移到列表项右侧并支持直接切换；将列表项改为上下结构，描述独占第二行且超出单行省略；去掉系统默认模型与轻量模型选项后缀 ID。
- 验证: 已运行 `pnpm type-check`、`pnpm lint`、`pnpm build`。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [x] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

不适用；本次为设置页样式与交互整理。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 构建验证: `pnpm build`
- 当前 `frontend/package.json` 未提供测试脚本，因此未执行前端自动化测试。
