### PR TITLE
refactor(agent): 重构 mention XML 流转链路

### DIFF
--- a/backend/app/agent_runtime/context/helpers/canonical_mentions.py
+++ b/backend/app/agent_runtime/context/helpers/canonical_mentions.py
@@ -6,12 +6,14 @@ import re
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.storage.repos.character_repo import get_by_id as get_character_by_id
 from app.storage.repos.chapter_repo import get_by_id as get_chapter_by_id
 from app.storage.repos.note_category_repo import (
     get_by_id as get_note_category_by_id,
 )
 from app.storage.repos.note_repo import get_by_id as get_note_by_id
 from app.storage.repos.volume_repo import get_by_id as get_volume_by_id
+from app.storage.repos.world_info_entry_repo import get_by_id as get_world_info_entry_by_id
 
 _MENTION_RE = re.compile(
     r"<of-mention\b(?P<attrs_self>[^<>]*?)\s*/>"
@@ -19,6 +21,15 @@ _MENTION_RE = re.compile(
     re.DOTALL,
 )
 _ATTR_RE = re.compile(r'([A-Za-z_][A-Za-z0-9_]*)="([^"]*)"')
+
+_KIND_ATTR_BY_ID_ATTR = (
+    ("volume_id", "volume"),
+    ("chapter_id", "chapter"),
+    ("note_id", "note"),
+    ("note_category_id", "note_category"),
+    ("world_info_entry_id", "world_info_entry"),
+    ("character_id", "character"),
+)
 
 
 @dataclass(frozen=True)
@@ -48,7 +59,7 @@ def parse_canonical_mentions(text: str) -> list[str | CanonicalMention]:
 def _match_to_mention(match: re.Match[str]) -> CanonicalMention:
     raw = match.group(0)
     attrs = _parse_attrs(match.group("attrs_self") or match.group("attrs_block") or "")
-    kind = attrs.get("kind", "")
+    kind = _infer_kind(attrs)
     body = match.group("body") or ""
     return CanonicalMention(
         raw=raw,
@@ -62,16 +73,32 @@ def _parse_attrs(raw_attrs: str) -> dict[str, str]:
     return {key: html.unescape(value) for key, value in _ATTR_RE.findall(raw_attrs)}
 
 
+def _infer_kind(attrs: dict[str, str]) -> str:
+    for attr_name, kind in _KIND_ATTR_BY_ID_ATTR:
+        if attrs.get(attr_name, "").strip():
+            return kind
+    return attrs.get("kind", "").strip()
+
+
+def _is_expanded_mention(mention: CanonicalMention) -> bool:
+    return bool(
+        mention.attrs.get("line_start", "").strip()
+        and mention.attrs.get("line_end", "").strip()
+    )
+
+
 class _MentionResolver:
     def __init__(self, session: AsyncSession | None) -> None:
         self._session = session
         self._volume_cache: dict[str, str | None] = {}
-        self._chapter_cache: dict[str, str | None] = {}
+        self._chapter_path_cache: dict[str, str | None] = {}
         self._note_cache: dict[str, str | None] = {}
         self._note_category_cache: dict[str, str | None] = {}
+        self._world_info_entry_cache: dict[str, str | None] = {}
+        self._character_cache: dict[str, str | None] = {}
 
-    async def display_label(self, mention: CanonicalMention) -> str:
-        fallback = mention.attrs.get("label", "").strip()
+    async def anchor_label(self, mention: CanonicalMention) -> str:
+        fallback = _fallback_label(mention)
         if self._session is None:
             return fallback
         if mention.kind == "volume":
@@ -79,10 +106,10 @@ class _MentionResolver:
             if volume_id:
                 return await self._resolve_volume_title(volume_id) or fallback
             return fallback
-        if mention.kind in {"chapter", "line_range"}:
+        if mention.kind == "chapter":
             chapter_id = mention.attrs.get("chapter_id", "").strip()
             if chapter_id:
-                return await self._resolve_chapter_title(chapter_id) or fallback
+                return await self._resolve_chapter_path(chapter_id) or fallback
             return fallback
         if mention.kind == "note":
             note_id = mention.attrs.get("note_id", "").strip()
@@ -93,6 +120,16 @@ class _MentionResolver:
             category_id = mention.attrs.get("note_category_id", "").strip()
             if category_id:
                 return await self._resolve_note_category_title(category_id) or fallback
+            return fallback
+        if mention.kind == "world_info_entry":
+            entry_id = mention.attrs.get("world_info_entry_id", "").strip()
+            if entry_id:
+                return await self._resolve_world_info_entry_title(entry_id) or fallback
+            return fallback
+        if mention.kind == "character":
+            character_id = mention.attrs.get("character_id", "").strip()
+            if character_id:
+                return await self._resolve_character_name(character_id) or fallback
             return fallback
         return fallback
 
@@ -107,16 +144,21 @@ class _MentionResolver:
         self._volume_cache[volume_id] = title
         return title
 
-    async def _resolve_chapter_title(self, chapter_id: str) -> str | None:
-        if chapter_id in self._chapter_cache:
-            return self._chapter_cache[chapter_id]
+    async def _resolve_chapter_path(self, chapter_id: str) -> str | None:
+        if chapter_id in self._chapter_path_cache:
+            return self._chapter_path_cache[chapter_id]
         session = self._session
         if session is None:
             return None
         chapter = await get_chapter_by_id(session, chapter_id)
-        title = chapter.title.strip() if chapter and chapter.title else None
-        self._chapter_cache[chapter_id] = title
-        return title
+        if chapter is None or not chapter.title:
+            self._chapter_path_cache[chapter_id] = None
+            return None
+        chapter_title = chapter.title.strip()
+        volume_title = await self._resolve_volume_title(chapter.volume_id)
+        path = f"{volume_title}/{chapter_title}" if volume_title else chapter_title
+        self._chapter_path_cache[chapter_id] = path
+        return path
 
     async def _resolve_note_title(self, note_id: str) -> str | None:
         if note_id in self._note_cache:
@@ -140,6 +182,28 @@ class _MentionResolver:
         self._note_category_cache[category_id] = title
         return title
 
+    async def _resolve_world_info_entry_title(self, entry_id: str) -> str | None:
+        if entry_id in self._world_info_entry_cache:
+            return self._world_info_entry_cache[entry_id]
+        session = self._session
+        if session is None:
+            return None
+        entry = await get_world_info_entry_by_id(session, entry_id)
+        title = entry.name.strip() if entry and entry.name else None
+        self._world_info_entry_cache[entry_id] = title
+        return title
+
+    async def _resolve_character_name(self, character_id: str) -> str | None:
+        if character_id in self._character_cache:
+            return self._character_cache[character_id]
+        session = self._session
+        if session is None:
+            return None
+        character = await get_character_by_id(session, character_id)
+        name = character.name.strip() if character and character.name else None
+        self._character_cache[character_id] = name
+        return name
+
 
 async def compile_canonical_mentions(
     text: str,
@@ -151,59 +215,68 @@ async def compile_canonical_mentions(
 
     resolver = _MentionResolver(session)
     compiled: list[str] = []
-    pending_quote_lines: list[str] = []
 
-    def _trim_trailing_inline_space() -> None:
-        if not compiled:
-            return
-        compiled[-1] = compiled[-1].rstrip(" \t")
-        if not compiled[-1]:
-            compiled.pop()
-
-    def _flush_pending_quotes(next_text: str | None = None) -> None:
-        nonlocal pending_quote_lines
-        if not pending_quote_lines:
-            return
-        _trim_trailing_inline_space()
-        if compiled and not compiled[-1].endswith("\n"):
-            compiled.append("\n")
-        compiled.append("\n".join(f"> {line}" for line in pending_quote_lines))
-        if next_text is not None and not next_text.startswith("\n"):
-            compiled.append("\n")
-        pending_quote_lines = []
-
-    for part in parts:
+    for index, part in enumerate(parts):
         if isinstance(part, str):
-            if not part.strip():
-                continue
-            _flush_pending_quotes(part)
             compiled.append(part)
             continue
-        rendered = await _compile_mention(part, resolver)
-        pending_quote_lines.append(rendered)
-    _flush_pending_quotes()
+
+        if _is_expanded_mention(part):
+            if not compiled:
+                compiled.append("\n")
+            elif not compiled[-1].endswith("\n"):
+                compiled.append("\n")
+            compiled.append(await _compile_expanded_mention(part, resolver))
+            continue
+
+        compiled.append(await _compile_compact_mention(part, resolver))
+
     return "".join(compiled)
 
 
-async def _compile_mention(
+def _fallback_label(mention: CanonicalMention) -> str:
+    if label := mention.attrs.get("label", "").strip():
+        return label
+    for attr_name, _kind in _KIND_ATTR_BY_ID_ATTR:
+        if value := mention.attrs.get(attr_name, "").strip():
+            return value
+    return mention.raw
+
+
+async def _compile_compact_mention(
     mention: CanonicalMention, resolver: _MentionResolver
 ) -> str:
-    display_label = (await resolver.display_label(mention)) or mention.raw
+    anchor = await _build_anchor(mention, resolver)
+    if anchor is None:
+        return mention.raw
+    return f" {anchor} "
 
-    if mention.kind == "volume":
-        return f"引用卷：{display_label}"
-    if mention.kind == "chapter":
-        return f"引用章节：{display_label}"
-    if mention.kind == "note":
-        return f"引用笔记：{display_label}"
-    if mention.kind == "note_category":
-        return f"引用笔记分类：{display_label}"
-    if mention.kind == "line_range":
-        start_line = mention.attrs.get("start_line", "").strip()
-        end_line = mention.attrs.get("end_line", "").strip()
-        snapshot_text = re.sub(r"\s+", " ", mention.body).strip()
-        prefix = f"引用片段：{display_label} 第{start_line}-{end_line}行"
-        if snapshot_text:
-            return f"{prefix}；原文快照：{snapshot_text}"
-        return prefix
-    return mention.raw
+
+async def _compile_expanded_mention(
+    mention: CanonicalMention, resolver: _MentionResolver
+) -> str:
+    anchor = await _build_anchor(mention, resolver, include_line_range=True)
+    if anchor is None:
+        return mention.raw
+    body = re.sub(r"\s+", " ", mention.body).strip()
+    return f"{anchor}\n```\n{body}\n```\n"
+
+
+async def _build_anchor(
+    mention: CanonicalMention,
+    resolver: _MentionResolver,
+    *,
+    include_line_range: bool = False,
+) -> str | None:
+    if not mention.kind:
+        return None
+    display_label = (await resolver.anchor_label(mention)) or _fallback_label(mention)
+    anchor = f"@{mention.kind}:{display_label}"
+    if not include_line_range:
+        return anchor
+
+    start_line = mention.attrs.get("line_start", "").strip()
+    end_line = mention.attrs.get("line_end", "").strip()
+    if not start_line or not end_line:
+        return anchor
+    return f"{anchor}:{start_line}-{end_line}"

--- a/backend/app/agent_runtime/context/parts/history.py
+++ b/backend/app/agent_runtime/context/parts/history.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.agent_runtime.context.helpers import compile_canonical_mentions
 from app.agent_runtime.context.types import ContextMessage
 
 
@@ -113,6 +114,8 @@ async def build_history(
         content = raw.get("content", "")
         if role == "tool":
             content = _compact_tool_result_content(content, tool_name=name)
+        elif role == "user" and db_session is not None and isinstance(content, str) and "<of-mention" in content:
+            content = await compile_canonical_mentions(content, db_session)
         result.append(ContextMessage(
             role=role,
             content=content,

--- a/backend/app/agent_runtime/graph/react_agent.py
+++ b/backend/app/agent_runtime/graph/react_agent.py
@@ -25,6 +25,7 @@ from langgraph.types import RetryPolicy
 
 from app.agent_runtime.types import ReactAgentConfig
 from app.agent_runtime.context import build_context, build_context_parts
+from app.agent_runtime.context.helpers import compile_canonical_mentions
 from app.agent_runtime.context.compaction.config import AUTO_TRIGGER_RATIO
 from app.agent_runtime.context.compaction.service import CompactionError, compact_window
 from app.agent_runtime.context.compaction.tokens import count_context_tokens
@@ -579,15 +580,22 @@ def create_react_agent(
                             consumed = await consumed
                         should_inject = consumed is not False
                     if should_inject:
+                        compiled_content = content
+                        if (
+                            db_session is not None
+                            and isinstance(content, str)
+                            and "<of-mention" in content
+                        ):
+                            compiled_content = await compile_canonical_mentions(content, db_session)
                         drained_injected_user_message = True
                         transient_parts.append(
                             ContextMessage(
                                 role="user",
-                                content=content,
+                                content=compiled_content,
                                 metadata={"part": "runtime"},
                             )
                         )
-                        transient_messages.append(HumanMessage(content=content))
+                        transient_messages.append(HumanMessage(content=compiled_content))
 
         if (
             termination.mode == "tool_success"

--- a/backend/app/agent_runtime/persistence/repo.py
+++ b/backend/app/agent_runtime/persistence/repo.py
@@ -5,7 +5,6 @@ from datetime import UTC, datetime
 from typing import cast
 
 from sqlalchemy import delete, func, select
-from app.agent_runtime.context.helpers import compile_canonical_mentions
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
@@ -96,9 +95,6 @@ async def insert_message(
             raise PersistenceWriteError(
                 f"insert_message failed to allocate seq for session {session_id}"
             ) from e
-        normalized_content = content
-        if role == "user" and isinstance(content, str) and "<of-mention" in content:
-            normalized_content = await compile_canonical_mentions(content, session)
         now = created_at or datetime.now(UTC)
         row = AgentRunMessage(
             id=message_id or generate_id(),
@@ -107,7 +103,7 @@ async def insert_message(
             project_id=project_id,
             role=role,
             agent_id=agent_id,
-            content=normalized_content,
+            content=content,
             reasoning=reasoning,
             reasoning_duration_ms=reasoning_duration_ms,
             tool_calls=json.dumps(tool_calls) if tool_calls is not None else None,

--- a/backend/app/agent_runtime/runner/session_runner.py
+++ b/backend/app/agent_runtime/runner/session_runner.py
@@ -651,7 +651,7 @@ class SessionRunner:
                 )
                 _user_message, revision = await self._begin_user_turn(
                     graph=graph,
-                    user_request=compiled_user_request,
+                    user_request=user_request,
                 )
                 state_user_request = compiled_user_request
             else:
@@ -791,21 +791,20 @@ class SessionRunner:
         await self._inject_queue.put((message_id, "user", content))
 
     async def queue_pending_user_message(self, content: str) -> dict[str, str]:
-        compiled_content = await self._compile_user_message_content(content)
         message_id = generate_id()
         created_at = datetime.now(UTC)
-        self._queued_user_messages[message_id] = (compiled_content, created_at)
+        self._queued_user_messages[message_id] = (content, created_at)
         created_at_iso = _format_utc_iso_datetime(created_at)
         await self._emit_pending_user_message(
-            compiled_content,
+            content,
             message_id=message_id,
             action="queued",
             created_at=created_at_iso,
         )
-        await self.inject_message(compiled_content, message_id)
+        await self.inject_message(content, message_id)
         return {
             "message_id": message_id,
-            "content": compiled_content,
+            "content": content,
             "created_at": created_at_iso,
         }
 
@@ -878,10 +877,9 @@ class SessionRunner:
         return message_id, content
 
     async def cancel_and_continue(self, new_message: str, message_id: str) -> None:
-        compiled_message = await self._compile_user_message_content(new_message)
         self._cancel_event.set()
         await self._inject_queue.put((None, "system", "[系统] 上一条回复被用户中止"))
-        await self._inject_queue.put((message_id, "user", compiled_message))
+        await self._inject_queue.put((message_id, "user", new_message))
 
     def cancel(self) -> None:
         self._cancel_event.set()
@@ -919,9 +917,9 @@ class SessionRunner:
         )
         user_message, revision = await self._begin_user_turn(
             graph=graph,
-            user_request=compiled_user_request,
+            user_request=user_request,
         )
-        await self.inject_message(compiled_user_request, user_message.id)
+        await self.inject_message(user_request, user_message.id)
 
         runtime_context: dict[str, Any] = {}
         audit_collector = AuditCollector(

--- a/backend/app/api/routers/notes.py
+++ b/backend/app/api/routers/notes.py
@@ -304,7 +304,15 @@ async def search_mention_candidates(
     query: Annotated[str, Query(description="mention 检索词")] = "",
     limit: Annotated[int, Query(ge=1, le=50, description="返回的最大候选数")] = 20,
     kind: Annotated[
-        Literal["volume", "chapter", "note", "note_category"] | None,
+        Literal[
+            "volume",
+            "chapter",
+            "note",
+            "note_category",
+            "world_info_entry",
+            "character",
+        ]
+        | None,
         Query(description="候选类型过滤"),
     ] = None,
 ) -> MentionCandidateSearchResponse:

--- a/backend/app/api/schemas/chapter.py
+++ b/backend/app/api/schemas/chapter.py
@@ -102,7 +102,14 @@ class VolumeTreeResponse(BaseModel):
 class MentionCandidateItem(BaseModel):
     """对话 mention 候选项。"""
 
-    kind: Literal["volume", "chapter", "note", "note_category"] = Field(description="候选类型")
+    kind: Literal[
+        "volume",
+        "chapter",
+        "note",
+        "note_category",
+        "world_info_entry",
+        "character",
+    ] = Field(description="候选类型")
     id: str = Field(description="卷或章节 ID")
     title: str = Field(description="候选标题")
     label: str = Field(description="插入 mention 时使用的标签")

--- a/backend/app/storage/repos/world_info_entry_repo.py
+++ b/backend/app/storage/repos/world_info_entry_repo.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 
 from sqlalchemy import delete as sql_delete
 from sqlalchemy.engine import CursorResult
-from sqlalchemy import func, select, update as sql_update
+from sqlalchemy import func, or_, select, update as sql_update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
@@ -88,6 +88,29 @@ async def list_enabled_by_world_info(
             col(WorldInfoEntry.is_enabled) == True,  # noqa: E712
         )
         .order_by(col(WorldInfoEntry.order))
+    )
+    return list(result.scalars().all())
+
+
+async def search_by_world_info(
+    session: AsyncSession,
+    world_info_id: str,
+    query: str,
+    *,
+    limit: int = 20,
+) -> list[WorldInfoEntry]:
+    pattern = f"%{query}%"
+    result = await session.execute(
+        select(WorldInfoEntry)
+        .where(col(WorldInfoEntry.world_info_id) == world_info_id)
+        .where(
+            or_(
+                col(WorldInfoEntry.name).ilike(pattern),
+                col(WorldInfoEntry.content).ilike(pattern),
+            )
+        )
+        .order_by(col(WorldInfoEntry.order))
+        .limit(limit)
     )
     return list(result.scalars().all())
 

--- a/backend/app/storage/services/mention_service.py
+++ b/backend/app/storage/services/mention_service.py
@@ -10,17 +10,27 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.errors import NotFoundError
 from app.storage.repos import (
+    character_repo,
     chapter_repo,
     note_category_repo,
     note_repo,
     project_repo,
     volume_repo,
+    world_info_entry_repo,
+    world_info_repo,
 )
 
 
 @dataclass(frozen=True)
 class MentionCandidate:
-    kind: Literal["volume", "chapter", "note", "note_category"]
+    kind: Literal[
+        "volume",
+        "chapter",
+        "note",
+        "note_category",
+        "world_info_entry",
+        "character",
+    ]
     id: str
     title: str
     label: str
@@ -50,7 +60,15 @@ async def search_all_mention_candidates(
     query: str,
     *,
     limit: int = 20,
-    kind: Literal["volume", "chapter", "note", "note_category"] | None = None,
+    kind: Literal[
+        "volume",
+        "chapter",
+        "note",
+        "note_category",
+        "world_info_entry",
+        "character",
+    ]
+    | None = None,
 ) -> list[MentionCandidate]:
     project = await project_repo.get_by_id(session, project_id)
     if project is None:
@@ -150,10 +168,64 @@ async def search_all_mention_candidates(
                 )
             )
 
+    if kind is None or kind == "world_info_entry":
+        world_info = await world_info_repo.get_by_project_id(session, project_id)
+        if world_info is not None:
+            matched_entries = await world_info_entry_repo.search_by_world_info(
+                session,
+                world_info.id,
+                normalized_query,
+                limit=clamped_limit,
+            )
+            base_index = len(scored_candidates)
+            for offset, entry in enumerate(matched_entries):
+                entry_title = _display_title(entry.name)
+                scored_candidates.append(
+                    (
+                        _match_rank(entry_title, normalized_query),
+                        base_index + offset,
+                        MentionCandidate(
+                            kind="world_info_entry",
+                            id=entry.id,
+                            title=entry_title,
+                            label=entry_title,
+                        ),
+                    )
+                )
+
+    if kind is None or kind == "character":
+        matched_characters = await character_repo.search_by_project(
+            session,
+            project_id,
+            normalized_query,
+        )
+        base_index = len(scored_candidates)
+        for offset, character in enumerate(matched_characters[:clamped_limit]):
+            character_name = _display_title(character.name)
+            scored_candidates.append(
+                (
+                    _match_rank(character_name, normalized_query),
+                    base_index + offset,
+                    MentionCandidate(
+                        kind="character",
+                        id=character.id,
+                        title=character_name,
+                        label=character_name,
+                    ),
+                )
+            )
+
     scored_candidates.sort(
         key=lambda item: (
             item[0],
-            {"volume": 0, "chapter": 1, "note": 2, "note_category": 3}.get(
+            {
+                "volume": 0,
+                "chapter": 1,
+                "note": 2,
+                "note_category": 3,
+                "world_info_entry": 4,
+                "character": 5,
+            }.get(
                 item[2].kind, 4
             ),
             item[1],

--- a/backend/tests/agent_runtime/context/parts/test_history.py
+++ b/backend/tests/agent_runtime/context/parts/test_history.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import AsyncMock, patch
 import pytest
 
 from app.agent_runtime.context.parts.history import build_history
@@ -112,12 +113,29 @@ async def test_history_preserves_extra_metadata_kind():
     assert result[0].metadata == {"part": "history", "kind": "thinking"}
 
 
-async def test_history_preserves_user_content_without_recompiling_mentions():
+async def test_history_compiles_user_mentions_for_llm_context_when_session_available():
     raw = [{
         "role": "user",
-        "content": '<of-mention kind="chapter" chapter_id="chap_1" label="旧章节" />',
+        "content": '<of-mention chapter_id="chap_1" label="旧章节" />',
+    }]
+
+    fake_session = object()
+    with patch(
+        "app.agent_runtime.context.parts.history.compile_canonical_mentions",
+        AsyncMock(return_value=" @chapter:第一卷/第一章 "),
+    ) as compile_mock:
+        result = await build_history(raw, fake_session)
+
+    compile_mock.assert_awaited_once_with(raw[0]["content"], fake_session)
+    assert result[0].content == " @chapter:第一卷/第一章 "
+
+
+async def test_history_preserves_user_xml_when_session_unavailable():
+    raw = [{
+        "role": "user",
+        "content": '<of-mention chapter_id="chap_1" label="旧章节" />',
     }]
 
     result = await build_history(raw)
 
-    assert result[0].content == '<of-mention kind="chapter" chapter_id="chap_1" label="旧章节" />'
+    assert result[0].content == raw[0]["content"]

--- a/backend/tests/agent_runtime/runner/test_session_runner_persistence.py
+++ b/backend/tests/agent_runtime/runner/test_session_runner_persistence.py
@@ -203,8 +203,8 @@ async def test_queue_pending_user_message_enqueues_without_persisting_until_cons
     factory = isolated_db
     sid = "s_x"
     emitted: list[tuple[str, dict]] = []
-    raw_follow_up = 'follow-up<of-mention kind="volume" volume_id="vol_x" label="旧卷" />'
-    compiled_follow_up = "follow-up\n> 引用卷：第一卷"
+    raw_follow_up = 'follow-up<of-mention volume_id="vol_x" label="旧卷" />'
+    persisted_follow_up = raw_follow_up
 
     async def capture_emit(name, payload=None, *_args, **_kwargs):
         emitted.append((name, payload or {}))
@@ -221,7 +221,7 @@ async def test_queue_pending_user_message_enqueues_without_persisting_until_cons
 
     pending = await runner.queue_pending_user_message(raw_follow_up)
 
-    assert pending["content"] == compiled_follow_up
+    assert pending["content"] == persisted_follow_up
     assert isinstance(pending["created_at"], str) and pending["created_at"]
 
     queued = runner._inject_queue.get_nowait()
@@ -229,7 +229,7 @@ async def test_queue_pending_user_message_enqueues_without_persisting_until_cons
     assert pending["message_id"] == queued_message_id
     assert isinstance(queued_message_id, str) and queued_message_id
     assert role == "user"
-    assert content == compiled_follow_up
+    assert content == persisted_follow_up
     assert queued_message_id in runner._queued_user_messages
 
     async with factory() as s:
@@ -251,8 +251,8 @@ async def test_cancel_pending_user_message_emits_cancel_event_and_skips_injectio
     factory = isolated_db
     sid = "s_x"
     emitted: list[tuple[str, dict]] = []
-    raw_follow_up = 'follow-up<of-mention kind="volume" volume_id="vol_x" label="旧卷" />'
-    compiled_follow_up = "follow-up\n> 引用卷：第一卷"
+    raw_follow_up = 'follow-up<of-mention volume_id="vol_x" label="旧卷" />'
+    persisted_follow_up = raw_follow_up
 
     async def capture_emit(name, payload=None, *_args, **_kwargs):
         emitted.append((name, payload or {}))
@@ -271,7 +271,7 @@ async def test_cancel_pending_user_message_emits_cancel_event_and_skips_injectio
     restored = await runner.cancel_pending_user_message(pending["message_id"])
 
     assert restored["message_id"] == pending["message_id"]
-    assert restored["content"] == compiled_follow_up
+    assert restored["content"] == persisted_follow_up
     assert pending["message_id"] not in runner._queued_user_messages
 
     runner._persister = runner._make_persister()
@@ -297,8 +297,8 @@ async def test_drain_inject_queue_emits_consumed_and_user_text_for_pending_messa
     factory = isolated_db
     sid = "s_x"
     emitted: list[tuple[str, dict]] = []
-    raw_follow_up = 'follow-up<of-mention kind="volume" volume_id="vol_x" label="旧卷" />'
-    compiled_follow_up = "follow-up\n> 引用卷：第一卷"
+    raw_follow_up = 'follow-up<of-mention volume_id="vol_x" label="旧卷" />'
+    persisted_follow_up = raw_follow_up
 
     async def capture_emit(name, payload=None, *_args, **_kwargs):
         emitted.append((name, payload or {}))
@@ -317,13 +317,13 @@ async def test_drain_inject_queue_emits_consumed_and_user_text_for_pending_messa
     runner._persister = runner._make_persister()
 
     drained = await runner._drain_inject_queue()
-    assert drained == [("user", compiled_follow_up, pending["message_id"])]
+    assert drained == [("user", persisted_follow_up, pending["message_id"])]
 
     async with factory() as s:
         items = await repo.list_by_session(s, sid)
 
     assert [(item.role, item.content, item.status) for item in items] == [
-        ("user", compiled_follow_up, "sent"),
+        ("user", persisted_follow_up, "sent"),
     ]
     queued_index = next(
         index
@@ -354,8 +354,8 @@ async def test_run_consumes_queued_follow_up_before_turn_finishes(
     monkeypatch,
 ):
     factory = isolated_db
-    raw_follow_up = 'follow-up<of-mention kind="volume" volume_id="vol_x" label="旧卷" />'
-    compiled_follow_up = "follow-up\n> 引用卷：第一卷"
+    raw_follow_up = 'follow-up<of-mention volume_id="vol_x" label="旧卷" />'
+    persisted_follow_up = raw_follow_up
 
     class _FakeModel:
         def bind_tools(self, _tools):
@@ -451,7 +451,7 @@ async def test_run_consumes_queued_follow_up_before_turn_finishes(
     ]
     assert user_messages == [
         ("user", "help", "sent"),
-        ("user", compiled_follow_up, "sent"),
+        ("user", persisted_follow_up, "sent"),
     ]
     assert not [item for item in items if item.role == "user" and item.status == "pending"]
     assert runner._queued_user_messages == {}
@@ -463,8 +463,8 @@ async def test_injected_follow_up_persists_after_assistant_reply(
     monkeypatch,
 ):
     factory = isolated_db
-    raw_follow_up = 'follow-up<of-mention kind="volume" volume_id="vol_x" label="旧卷" />'
-    compiled_follow_up = "follow-up\n> 引用卷：第一卷"
+    raw_follow_up = 'follow-up<of-mention volume_id="vol_x" label="旧卷" />'
+    persisted_follow_up = raw_follow_up
 
     async def noop_emit(*_args, **_kwargs):
         return None
@@ -499,7 +499,7 @@ async def test_injected_follow_up_persists_after_assistant_reply(
         "data": {"output": AIMessage(content="reply1")},
     })
     drained = await runner._drain_inject_queue()
-    assert drained == [("user", compiled_follow_up, queued_message_id)]
+    assert drained == [("user", persisted_follow_up, queued_message_id)]
 
     async with factory() as session:
         items = await repo.list_by_session(session, "session_x")
@@ -512,7 +512,7 @@ async def test_injected_follow_up_persists_after_assistant_reply(
     assert conversation == [
         ("user", "help"),
         ("assistant", "reply1"),
-        ("user", compiled_follow_up),
+        ("user", persisted_follow_up),
     ]
     assert queued_message_id not in runner._queued_user_messages
 

--- a/backend/tests/agent_runtime/test_mentions.py
+++ b/backend/tests/agent_runtime/test_mentions.py
@@ -5,9 +5,13 @@ from app.agent_runtime.context.helpers import (
     compile_canonical_mentions,
     parse_canonical_mentions,
 )
+from app.storage.models.character import Character
 from app.storage.models.chapter import Chapter
+from app.storage.models.note import Note
 from app.storage.models.project import Project
 from app.storage.models.volume import Volume
+from app.storage.models.world_info import WorldInfo
+from app.storage.models.world_info_entry import WorldInfoEntry
 
 
 async def _seed_story_graph(session) -> tuple[Volume, Chapter]:
@@ -35,27 +39,59 @@ async def _seed_story_graph(session) -> tuple[Volume, Chapter]:
     return volume, chapter
 
 
+async def _seed_note_world_and_character(session) -> tuple[Note, WorldInfoEntry, Character]:
+    project = Project(id="proj_mentions_extra", title="提及扩展项目")
+    note = Note(
+        id="note_mentions",
+        project_id=project.id,
+        title="角色笔记",
+        content="第一行\n第二行",
+    )
+    world_info = WorldInfo(id="wi_mentions", project_id=project.id, name="默认世界书")
+    world_entry = WorldInfoEntry(
+        id="wie_mentions",
+        world_info_id=world_info.id,
+        uid=1,
+        name="帝国设定",
+        order=1,
+        content="背景一\n背景二",
+    )
+    character = Character(
+        id="char_mentions",
+        project_id=project.id,
+        name="林夏",
+        description="角色一\n角色二",
+    )
+    session.add(project)
+    session.add(note)
+    session.add(world_info)
+    session.add(world_entry)
+    session.add(character)
+    await session.commit()
+    return note, world_entry, character
+
+
 def test_parse_canonical_mentions_keeps_text_and_tag_segments():
     parsed = parse_canonical_mentions(
-        '前文<of-mention kind="chapter" chapter_id="chap_1" label="旧章节" />后文'
+        '前文<of-mention chapter_id="chap_1" />后文'
     )
 
     assert parsed[0] == "前文"
     assert isinstance(parsed[1], CanonicalMention)
     assert parsed[1].kind == "chapter"
     assert parsed[1].attrs["chapter_id"] == "chap_1"
-    assert parsed[1].attrs["label"] == "旧章节"
     assert parsed[1].body == ""
     assert parsed[2] == "后文"
 
 
 def test_parse_canonical_mentions_decodes_escaped_attrs_and_body():
     parsed = parse_canonical_mentions(
-        '<of-mention kind="line_range" chapter_id="chap_1" label="第二章 &quot;引用&quot;">A&amp;B &lt;C&gt;</of-mention>'
+        '<of-mention chapter_id="chap_1" line_start="15" line_end="20" label="第二章 &quot;引用&quot;">A&amp;B &lt;C&gt;</of-mention>'
     )
 
     assert len(parsed) == 1
     assert isinstance(parsed[0], CanonicalMention)
+    assert parsed[0].kind == "chapter"
     assert parsed[0].attrs["label"] == '第二章 "引用"'
     assert parsed[0].body == "A&B <C>"
 
@@ -65,11 +101,11 @@ async def test_compile_canonical_mentions_renders_single_mention_as_blockquote_l
     volume, _chapter = await _seed_story_graph(session)
 
     compiled = await compile_canonical_mentions(
-        '请参考<of-mention kind="volume" volume_id="vol_mentions" label="旧卷名" />后继续',
+        '请参考<of-mention volume_id="vol_mentions" />后继续',
         session,
     )
 
-    assert compiled == f"请参考\n> 引用卷：{volume.title}\n后继续"
+    assert compiled == f"请参考 @volume:{volume.title} 后继续"
 
 
 @pytest.mark.asyncio
@@ -78,19 +114,21 @@ async def test_compile_canonical_mentions_groups_consecutive_mentions_into_block
 
     compiled = await compile_canonical_mentions(
         (
-            '请参考<of-mention kind="volume" volume_id="vol_mentions" label="旧卷名" /> \n  '
-            '<of-mention kind="chapter" chapter_id="chap_mentions" label="旧章节名" />\n'
-            '<of-mention kind="line_range" chapter_id="chap_mentions" start_line="15" '
-            'end_line="20" label="旧片段">快照正文</of-mention>后继续'
+            '请参考<of-mention volume_id="vol_mentions" />\n'
+            '<of-mention chapter_id="chap_mentions" />\n'
+            '<of-mention chapter_id="chap_mentions" line_start="15" '
+            'line_end="20">快照正文</of-mention>后继续'
         ),
         session,
     )
 
     assert compiled == (
-        "请参考\n"
-        f"> 引用卷：{volume.title}\n"
-        f"> 引用章节：{chapter.title}\n"
-        "> 引用片段：修订后第二章 第15-20行；原文快照：快照正文\n"
+        f"请参考 @volume:{volume.title} \n"
+        f" @chapter:{volume.title}/{chapter.title} \n"
+        f"@chapter:{volume.title}/{chapter.title}:15-20\n"
+        "```\n"
+        "快照正文\n"
+        "```\n"
         "后继续"
     )
 
@@ -101,29 +139,76 @@ async def test_compile_canonical_mentions_flattens_multiline_line_range_snapshot
 
     compiled = await compile_canonical_mentions(
         (
-            '<of-mention kind="line_range" chapter_id="chap_mentions" start_line="15" '
-            'end_line="20" label="旧片段">第一行\n第二行\n第三行</of-mention>'
+            '<of-mention chapter_id="chap_mentions" line_start="15" '
+            'line_end="20">第一行\n第二行\n第三行</of-mention>'
         ),
         session,
     )
 
-    assert compiled == "> 引用片段：修订后第二章 第15-20行；原文快照：第一行 第二行 第三行"
+    assert compiled == (
+        "\n"
+        "@chapter:修订后第一卷/修订后第二章:15-20\n"
+        "```\n"
+        "第一行 第二行 第三行\n"
+        "```\n"
+    )
 
 
 @pytest.mark.asyncio
 async def test_compile_canonical_mentions_falls_back_to_stored_labels_when_missing(session):
     compiled = await compile_canonical_mentions(
         (
-            '<of-mention kind="volume" volume_id="missing-volume" label="存档卷" />\n'
-            '<of-mention kind="chapter" chapter_id="missing-chapter" label="存档章节" />'
-            '<of-mention kind="line_range" chapter_id="missing-line" start_line="3" '
-            'end_line="5" label="第二章 3-5">旧快照</of-mention>'
+            '<of-mention volume_id="missing-volume" label="存档卷" />\n'
+            '<of-mention chapter_id="missing-chapter" label="存档章节" />'
+            '<of-mention chapter_id="missing-line" line_start="3" '
+            'line_end="5" label="第二章 3-5">旧快照</of-mention>'
         ),
         session,
     )
 
     assert compiled == (
-        "> 引用卷：存档卷\n"
-        "> 引用章节：存档章节\n"
-        "> 引用片段：第二章 3-5 第3-5行；原文快照：旧快照"
+        " @volume:存档卷 \n"
+        " @chapter:存档章节 \n"
+        "@chapter:第二章 3-5:3-5\n"
+        "```\n"
+        "旧快照\n"
+        "```\n"
+    )
+
+
+@pytest.mark.asyncio
+async def test_compile_canonical_mentions_supports_note_world_info_and_character(session):
+    note, world_entry, character = await _seed_note_world_and_character(session)
+
+    compiled = await compile_canonical_mentions(
+        (
+            '<of-mention note_id="note_mentions" />\n'
+            '<of-mention world_info_entry_id="wie_mentions" />\n'
+            '<of-mention character_id="char_mentions" />'
+        ),
+        session,
+    )
+
+    assert compiled == (
+        f" @note:{note.title} \n"
+        f" @world_info_entry:{world_entry.name} \n"
+        f" @character:{character.name} "
+    )
+
+
+@pytest.mark.asyncio
+async def test_compile_canonical_mentions_supports_expanded_note_content(session):
+    note, _world_entry, _character = await _seed_note_world_and_character(session)
+
+    compiled = await compile_canonical_mentions(
+        '<of-mention note_id="note_mentions" line_start="2" line_end="3">设定片段</of-mention>',
+        session,
+    )
+
+    assert compiled == (
+        "\n"
+        f"@note:{note.title}:2-3\n"
+        "```\n"
+        "设定片段\n"
+        "```\n"
     )

--- a/backend/tests/agent_runtime/test_session_runner.py
+++ b/backend/tests/agent_runtime/test_session_runner.py
@@ -305,8 +305,8 @@ async def test_continue_with_user_message_resumes_checkpoint_with_command_update
         persist_node_event=AsyncMock(),
         apply_interrupt_preview=AsyncMock(),
     )
-    raw_message = '<of-mention kind="chapter" chapter_id="chap_1" label="旧章节" />'
-    compiled_message = "> 引用章节：修订章节"
+    raw_message = '<of-mention chapter_id="chap_1" label="旧章节" />'
+    compiled_message = " @chapter:修订卷/修订章节 "
 
     with patch(
         "app.agent_runtime.runner.session_runner.compile_canonical_mentions",
@@ -348,7 +348,7 @@ async def test_continue_with_user_message_resumes_checkpoint_with_command_update
     assert captured["config"]["configurable"]["runtime_context"] == {}
     assert "context_anchor_order" not in begin_revision.await_args.kwargs
     queued = runner._inject_queue.get_nowait()
-    assert queued == ("msg_2", "user", compiled_message)
+    assert queued == ("msg_2", "user", raw_message)
 
 
 @pytest.mark.asyncio
@@ -384,8 +384,8 @@ async def test_run_compiles_user_request_for_model_and_persistence():
         persist_node_event=AsyncMock(),
     )
     persisted_message = SimpleNamespace(id="msg_mentions_001", seq=0, created_at=datetime.now(UTC))
-    raw_message = '<of-mention kind="chapter" chapter_id="chap_1" label="旧章节" />'
-    compiled_message = "> 引用章节：修订章节"
+    raw_message = '<of-mention chapter_id="chap_1" label="旧章节" />'
+    compiled_message = " @chapter:修订卷/修订章节 "
 
     with patch(
         "app.agent_runtime.runner.session_runner.compile_canonical_mentions",
@@ -400,7 +400,7 @@ async def test_run_compiles_user_request_for_model_and_persistence():
          ),          patch.object(runner, "_make_persister", MagicMock(return_value=fake_persister)):
         await runner.run(user_request=raw_message)
 
-    persist_user_message.assert_awaited_once_with(compiled_message)
+    persist_user_message.assert_awaited_once_with(raw_message)
     assert captured["state"]["user_request"] == compiled_message
 
 
@@ -419,14 +419,9 @@ async def test_cancel_and_continue_queues_compiled_user_message():
         project_id="proj_001",
     )
     fake_session = MagicMock(close=AsyncMock())
-    raw_message = '<of-mention kind="chapter" chapter_id="chap_1" label="旧章节" />'
-    compiled_message = "> 引用章节：修订章节"
+    raw_message = '<of-mention chapter_id="chap_1" label="旧章节" />'
 
     with patch(
-        "app.agent_runtime.runner.session_runner.compile_canonical_mentions",
-        AsyncMock(return_value=compiled_message),
-        create=True,
-    ), patch(
         "app.agent_runtime.runner.session_runner.create_session",
         AsyncMock(return_value=fake_session),
     ):
@@ -441,7 +436,7 @@ async def test_cancel_and_continue_queues_compiled_user_message():
     assert runner._inject_queue.get_nowait() == (
         "msg_cancel_001",
         "user",
-        compiled_message,
+        raw_message,
     )
 
 

--- a/backend/tests/api/test_notes.py
+++ b/backend/tests/api/test_notes.py
@@ -360,6 +360,67 @@ async def test_mentions_kind_filter_note_category_only(client: AsyncClient) -> N
 
 
 @pytest.mark.asyncio
+async def test_mentions_include_world_info_entry_and_character(client: AsyncClient) -> None:
+    project_id, _ = await _create_project(client)
+    world_info_resp = await client.get(f"/api/v1/projects/{project_id}/world-info")
+    assert world_info_resp.status_code == 200
+    world_info_id = world_info_resp.json()["id"]
+    entry_resp = await client.post(
+        f"/api/v1/world-info/{world_info_id}/entries",
+        json={"name": "帝国设定", "content": "背景"},
+    )
+    assert entry_resp.status_code == 201
+    character_resp = await client.post(
+        f"/api/v1/projects/{project_id}/characters",
+        data={"name": "林夏", "description": "主角"},
+    )
+    assert character_resp.status_code == 201
+
+    entry_search = await client.get(
+        f"/api/v1/projects/{project_id}/mentions",
+        params={"query": "帝国"},
+    )
+    assert entry_search.status_code == 200
+    entry_items = entry_search.json()["items"]
+    assert any(
+        item["kind"] == "world_info_entry" and item["title"] == "帝国设定"
+        for item in entry_items
+    )
+
+    character_search = await client.get(
+        f"/api/v1/projects/{project_id}/mentions",
+        params={"query": "林夏"},
+    )
+    assert character_search.status_code == 200
+    character_items = character_search.json()["items"]
+    assert any(
+        item["kind"] == "character" and item["title"] == "林夏"
+        for item in character_items
+    )
+
+
+@pytest.mark.asyncio
+async def test_mentions_kind_filter_world_info_entry_only(client: AsyncClient) -> None:
+    project_id, _ = await _create_project(client)
+    world_info_resp = await client.get(f"/api/v1/projects/{project_id}/world-info")
+    assert world_info_resp.status_code == 200
+    world_info_id = world_info_resp.json()["id"]
+    await client.post(
+        f"/api/v1/world-info/{world_info_id}/entries",
+        json={"name": "地理设定", "content": "地图"},
+    )
+
+    resp = await client.get(
+        f"/api/v1/projects/{project_id}/mentions",
+        params={"query": "设定", "kind": "world_info_entry"},
+    )
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    assert all(item["kind"] == "world_info_entry" for item in items)
+    assert any(item["title"] == "地理设定" for item in items)
+
+
+@pytest.mark.asyncio
 async def test_mentions_project_404(client: AsyncClient) -> None:
     resp = await client.get(
         "/api/v1/projects/nonexistent/mentions",

--- a/frontend/src/features/assistant/components/agent/agent-composer-editor.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-composer-editor.tsx
@@ -9,10 +9,12 @@ import type { KeyboardEvent as ReactKeyboardEvent } from "react";
 
 import type { AssistantMentionCandidate } from "@/features/assistant/lib/mention-text";
 import {
+  buildCharacterMentionTag,
   buildChapterMentionTag,
   buildNoteCategoryMentionTag,
   buildNoteMentionTag,
   buildVolumeMentionTag,
+  buildWorldInfoEntryMentionTag,
   findActiveMentionQuery,
   mentionTextToHtml,
   parseMentionText,
@@ -89,11 +91,21 @@ function createMentionNodeAttrs(
           volumeId: candidate.id,
           label: candidate.label,
         })
+      : candidate.kind === "character"
+        ? buildCharacterMentionTag({
+            characterId: candidate.id,
+            label: candidate.label,
+          })
       : candidate.kind === "note"
         ? buildNoteMentionTag({
             noteId: candidate.id,
             label: candidate.label,
           })
+        : candidate.kind === "world_info_entry"
+          ? buildWorldInfoEntryMentionTag({
+              worldInfoEntryId: candidate.id,
+              label: candidate.label,
+            })
         : candidate.kind === "note_category"
           ? buildNoteCategoryMentionTag({
               categoryId: candidate.id,
@@ -113,8 +125,10 @@ function createMentionNodeAttrs(
     chapterId: candidate.kind === "chapter" ? candidate.id : "",
     noteId: candidate.kind === "note" ? candidate.id : "",
     noteCategoryId: candidate.kind === "note_category" ? candidate.id : "",
-    startLine: "",
-    endLine: "",
+    worldInfoEntryId: candidate.kind === "world_info_entry" ? candidate.id : "",
+    characterId: candidate.kind === "character" ? candidate.id : "",
+    lineStart: "",
+    lineEnd: "",
   };
 }
 

--- a/frontend/src/features/assistant/components/agent/agent-mention-suggestions.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-mention-suggestions.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, FileText, Folder, StickyNote } from "lucide-react";
+import { BookOpen, FileText, Folder, ScrollText, StickyNote, UserRound } from "lucide-react";
 import { motion } from "motion/react";
 import { useEffect, useRef } from "react";
 import type { CSSProperties } from "react";
@@ -23,6 +23,8 @@ function getItemIcon(kind: AssistantMentionCandidate["kind"]) {
   if (kind === "volume") return <BookOpen size={12} />;
   if (kind === "note") return <StickyNote size={12} />;
   if (kind === "note_category") return <Folder size={12} />;
+  if (kind === "world_info_entry") return <ScrollText size={12} />;
+  if (kind === "character") return <UserRound size={12} />;
   return <FileText size={12} />;
 }
 
@@ -37,7 +39,11 @@ function getItemMeta(
         ? t("assistant.mentionKind.note")
         : item.kind === "note_category"
           ? t("assistant.mentionKind.noteCategory")
-          : t("assistant.mentionKind.chapter");
+          : item.kind === "world_info_entry"
+            ? t("assistant.mentionKind.worldInfoEntry")
+            : item.kind === "character"
+              ? t("assistant.mentionKind.character")
+              : t("assistant.mentionKind.chapter");
   return item.description
     ? t("assistant.mentionMetaFormat", { base, description: item.description })
     : base;

--- a/frontend/src/features/assistant/components/agent/extensions/mention-node-view.tsx
+++ b/frontend/src/features/assistant/components/agent/extensions/mention-node-view.tsx
@@ -21,8 +21,10 @@ export function MentionNodeView({ node, selected, extension }: NodeViewProps) {
       chapter_id: String(node.attrs.chapterId ?? ""),
       note_id: String(node.attrs.noteId ?? ""),
       note_category_id: String(node.attrs.noteCategoryId ?? ""),
-      start_line: String(node.attrs.startLine ?? ""),
-      end_line: String(node.attrs.endLine ?? ""),
+      world_info_entry_id: String(node.attrs.worldInfoEntryId ?? ""),
+      character_id: String(node.attrs.characterId ?? ""),
+      line_start: String(node.attrs.lineStart ?? ""),
+      line_end: String(node.attrs.lineEnd ?? ""),
     },
     body: String(node.attrs.mentionBody ?? ""),
   };

--- a/frontend/src/features/assistant/components/agent/extensions/mention-node.ts
+++ b/frontend/src/features/assistant/components/agent/extensions/mention-node.ts
@@ -12,8 +12,10 @@ export interface AssistantMentionNodeAttributes {
   chapterId: string;
   noteId: string;
   noteCategoryId: string;
-  startLine: string;
-  endLine: string;
+  worldInfoEntryId: string;
+  characterId: string;
+  lineStart: string;
+  lineEnd: string;
 }
 
 export interface AssistantMentionNodeOptions {
@@ -49,10 +51,12 @@ export const MentionNode = Node.create<AssistantMentionNodeOptions>({
       mentionBody: { default: "" },
       volumeId: { default: "" },
       chapterId: { default: "" },
-      noteId: { default: "" },
-      noteCategoryId: { default: "" },
-      startLine: { default: "" },
-      endLine: { default: "" },
+        noteId: { default: "" },
+        noteCategoryId: { default: "" },
+        worldInfoEntryId: { default: "" },
+        characterId: { default: "" },
+        lineStart: { default: "" },
+        lineEnd: { default: "" },
     };
   },
 
@@ -71,8 +75,10 @@ export const MentionNode = Node.create<AssistantMentionNodeOptions>({
             chapterId: node.dataset.mentionChapterId ?? "",
             noteId: node.dataset.mentionNoteId ?? "",
             noteCategoryId: node.dataset.mentionNoteCategoryId ?? "",
-            startLine: node.dataset.mentionStartLine ?? "",
-            endLine: node.dataset.mentionEndLine ?? "",
+            worldInfoEntryId: node.dataset.mentionWorldInfoEntryId ?? "",
+            characterId: node.dataset.mentionCharacterId ?? "",
+            lineStart: node.dataset.mentionLineStart ?? "",
+            lineEnd: node.dataset.mentionLineEnd ?? "",
           };
         },
       },
@@ -92,8 +98,10 @@ export const MentionNode = Node.create<AssistantMentionNodeOptions>({
         "data-mention-chapter-id": HTMLAttributes.chapterId || "",
         "data-mention-note-id": HTMLAttributes.noteId || "",
         "data-mention-note-category-id": HTMLAttributes.noteCategoryId || "",
-        "data-mention-start-line": HTMLAttributes.startLine || "",
-        "data-mention-end-line": HTMLAttributes.endLine || "",
+        "data-mention-world-info-entry-id": HTMLAttributes.worldInfoEntryId || "",
+        "data-mention-character-id": HTMLAttributes.characterId || "",
+        "data-mention-line-start": HTMLAttributes.lineStart || "",
+        "data-mention-line-end": HTMLAttributes.lineEnd || "",
       }),
       HTMLAttributes.mentionLabel || "",
     ];

--- a/frontend/src/features/assistant/components/agent/mention-chip.tsx
+++ b/frontend/src/features/assistant/components/agent/mention-chip.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, FileText, Folder, Quote, StickyNote } from "lucide-react";
+import { BookOpen, FileText, Folder, Quote, ScrollText, StickyNote, UserRound } from "lucide-react";
 import type { ReactNode } from "react";
 
 import type { AssistantMentionKind } from "@/features/assistant/lib/mention-text";
@@ -10,6 +10,8 @@ function getMentionIcon(kind: AssistantMentionKind): ReactNode {
   if (kind === "chapter") return <FileText size={12} />;
   if (kind === "note") return <StickyNote size={12} />;
   if (kind === "note_category") return <Folder size={12} />;
+  if (kind === "world_info_entry") return <ScrollText size={12} />;
+  if (kind === "character") return <UserRound size={12} />;
   return <Quote size={12} />;
 }
 

--- a/frontend/src/features/assistant/lib/mention-text.ts
+++ b/frontend/src/features/assistant/lib/mention-text.ts
@@ -3,7 +3,13 @@ import { pinyinMatch } from "@/lib/pinyin-search";
 
 export type { AssistantMentionCandidate } from "@/lib/mention.types";
 
-export type AssistantMentionKind = "volume" | "chapter" | "line_range" | "note" | "note_category";
+export type AssistantMentionKind =
+  | "volume"
+  | "chapter"
+  | "note"
+  | "note_category"
+  | "world_info_entry"
+  | "character";
 
 export interface AssistantMentionToken {
   raw: string;
@@ -17,6 +23,20 @@ export type AssistantMentionSegment = string | AssistantMentionToken;
 const MENTION_RE =
   /<of-mention\b(?<attrsSelf>[^<>]*?)\s*\/>|<of-mention\b(?<attrsBlock>[^<>]*?)>(?<body>.*?)<\/of-mention\s*>/gs;
 const ATTR_RE = /([A-Za-z_][A-Za-z0-9_]*)="([^"]*)"/g;
+
+function inferMentionKind(attrs: Record<string, string>): AssistantMentionKind {
+  if (attrs.volume_id?.trim()) return "volume";
+  if (attrs.chapter_id?.trim()) return "chapter";
+  if (attrs.note_id?.trim()) return "note";
+  if (attrs.note_category_id?.trim()) return "note_category";
+  if (attrs.world_info_entry_id?.trim()) return "world_info_entry";
+  if (attrs.character_id?.trim()) return "character";
+  return "chapter";
+}
+
+function isExpandedMention(token: AssistantMentionToken): boolean {
+  return Boolean(token.attrs.line_start?.trim() && token.attrs.line_end?.trim());
+}
 
 function decodeMentionEntities(text: string): string {
   return text
@@ -60,7 +80,7 @@ export function parseMentionText(text: string): AssistantMentionSegment[] {
     }
 
     const attrs = parseAttrs((match.groups?.attrsSelf ?? match.groups?.attrsBlock ?? "").trim());
-    const kind = (attrs.kind ?? "") as AssistantMentionKind;
+    const kind = inferMentionKind(attrs);
     segments.push({
       raw,
       kind,
@@ -91,14 +111,16 @@ function buildMentionHtml(token: AssistantMentionToken): string {
     ` data-mention-kind="${escapeHtmlAttr(token.kind)}"` +
     ` data-mention-raw="${escapeHtmlAttr(token.raw)}"` +
     ` data-mention-label="${escapeHtmlAttr(getMentionDisplayLabel(token))}"` +
-    ` data-mention-body="${escapeHtmlAttr(token.body)}"` +
-    ` data-mention-volume-id="${escapeHtmlAttr(token.attrs.volume_id ?? "")}"` +
-    ` data-mention-chapter-id="${escapeHtmlAttr(token.attrs.chapter_id ?? "")}"` +
-    ` data-mention-note-id="${escapeHtmlAttr(token.attrs.note_id ?? "")}"` +
-    ` data-mention-note-category-id="${escapeHtmlAttr(token.attrs.note_category_id ?? "")}"` +
-    ` data-mention-start-line="${escapeHtmlAttr(token.attrs.start_line ?? "")}"` +
-    ` data-mention-end-line="${escapeHtmlAttr(token.attrs.end_line ?? "")}"` +
-    `></span>`
+      ` data-mention-body="${escapeHtmlAttr(token.body)}"` +
+      ` data-mention-volume-id="${escapeHtmlAttr(token.attrs.volume_id ?? "")}"` +
+      ` data-mention-chapter-id="${escapeHtmlAttr(token.attrs.chapter_id ?? "")}"` +
+      ` data-mention-note-id="${escapeHtmlAttr(token.attrs.note_id ?? "")}"` +
+      ` data-mention-note-category-id="${escapeHtmlAttr(token.attrs.note_category_id ?? "")}"` +
+      ` data-mention-world-info-entry-id="${escapeHtmlAttr(token.attrs.world_info_entry_id ?? "")}"` +
+      ` data-mention-character-id="${escapeHtmlAttr(token.attrs.character_id ?? "")}"` +
+      ` data-mention-line-start="${escapeHtmlAttr(token.attrs.line_start ?? "")}"` +
+      ` data-mention-line-end="${escapeHtmlAttr(token.attrs.line_end ?? "")}"` +
+      `></span>`
   );
 }
 
@@ -138,8 +160,8 @@ function stripLineRangeSuffix(label: string): string {
 }
 
 function getLineRangeDisplayLabel(token: AssistantMentionToken): string | null {
-  const startLine = token.attrs.start_line?.trim();
-  const endLine = token.attrs.end_line?.trim();
+  const startLine = token.attrs.line_start?.trim();
+  const endLine = token.attrs.line_end?.trim();
   if (!startLine || !endLine) return null;
 
   const rangeLabel = `L${startLine}-${endLine}`;
@@ -155,7 +177,7 @@ function getLineRangeDisplayLabel(token: AssistantMentionToken): string | null {
 }
 
 export function getMentionDisplayLabel(token: AssistantMentionToken): string {
-  if (token.kind === "line_range") {
+  if (isExpandedMention(token)) {
     const lineRangeLabel = getLineRangeDisplayLabel(token);
     if (lineRangeLabel) return lineRangeLabel;
   }
@@ -163,7 +185,11 @@ export function getMentionDisplayLabel(token: AssistantMentionToken): string {
   return (
     token.attrs.label?.trim() ||
     token.attrs.chapter_id?.trim() ||
+    token.attrs.note_id?.trim() ||
     token.attrs.volume_id?.trim() ||
+    token.attrs.note_category_id?.trim() ||
+    token.attrs.world_info_entry_id?.trim() ||
+    token.attrs.character_id?.trim() ||
     token.kind
   );
 }
@@ -175,6 +201,8 @@ export function getMentionNavigationTarget(token: AssistantMentionToken): {
 } | null {
   if (token.kind === "volume") return null;
   if (token.kind === "note_category") return null;
+  if (token.kind === "world_info_entry") return null;
+  if (token.kind === "character") return null;
 
   if (token.kind === "note") {
     const noteId = token.attrs.note_id?.trim();
@@ -188,21 +216,10 @@ export function getMentionNavigationTarget(token: AssistantMentionToken): {
   const chapterId = token.attrs.chapter_id?.trim();
   if (!chapterId) return null;
 
-  if (token.kind === "chapter") {
-    return {
-      chapterId,
-      title: token.attrs.label?.trim() || chapterId,
-    };
-  }
-
-  if (token.kind === "line_range") {
-    return {
-      chapterId,
-      title: stripLineRangeSuffix(token.attrs.label?.trim() ?? "") || chapterId,
-    };
-  }
-
-  return null;
+  return {
+    chapterId,
+    title: stripLineRangeSuffix(token.attrs.label?.trim() ?? "") || chapterId,
+  };
 }
 
 export function buildVolumeMentionTag({
@@ -212,7 +229,7 @@ export function buildVolumeMentionTag({
   volumeId: string;
   label: string;
 }): string {
-  return `<of-mention kind="volume" volume_id="${escapeMentionAttribute(volumeId)}" label="${escapeMentionAttribute(label)}" />`;
+  return `<of-mention volume_id="${escapeMentionAttribute(volumeId)}" label="${escapeMentionAttribute(label)}" />`;
 }
 
 export function buildChapterMentionTag({
@@ -222,11 +239,11 @@ export function buildChapterMentionTag({
   chapterId: string;
   label: string;
 }): string {
-  return `<of-mention kind="chapter" chapter_id="${escapeMentionAttribute(chapterId)}" label="${escapeMentionAttribute(label)}" />`;
+  return `<of-mention chapter_id="${escapeMentionAttribute(chapterId)}" label="${escapeMentionAttribute(label)}" />`;
 }
 
 export function buildNoteMentionTag({ noteId, label }: { noteId: string; label: string }): string {
-  return `<of-mention kind="note" note_id="${escapeMentionAttribute(noteId)}" label="${escapeMentionAttribute(label)}" />`;
+  return `<of-mention note_id="${escapeMentionAttribute(noteId)}" label="${escapeMentionAttribute(label)}" />`;
 }
 
 export function buildNoteCategoryMentionTag({
@@ -236,7 +253,27 @@ export function buildNoteCategoryMentionTag({
   categoryId: string;
   label: string;
 }): string {
-  return `<of-mention kind="note_category" note_category_id="${escapeMentionAttribute(categoryId)}" label="${escapeMentionAttribute(label)}" />`;
+  return `<of-mention note_category_id="${escapeMentionAttribute(categoryId)}" label="${escapeMentionAttribute(label)}" />`;
+}
+
+export function buildWorldInfoEntryMentionTag({
+  worldInfoEntryId,
+  label,
+}: {
+  worldInfoEntryId: string;
+  label: string;
+}): string {
+  return `<of-mention world_info_entry_id="${escapeMentionAttribute(worldInfoEntryId)}" label="${escapeMentionAttribute(label)}" />`;
+}
+
+export function buildCharacterMentionTag({
+  characterId,
+  label,
+}: {
+  characterId: string;
+  label: string;
+}): string {
+  return `<of-mention character_id="${escapeMentionAttribute(characterId)}" label="${escapeMentionAttribute(label)}" />`;
 }
 
 export function buildLineRangeMentionTag({
@@ -253,8 +290,8 @@ export function buildLineRangeMentionTag({
   snapshotText: string;
 }): string {
   return (
-    `<of-mention kind="line_range" chapter_id="${escapeMentionAttribute(chapterId)}" start_line="${startLine}" ` +
-    `end_line="${endLine}" label="${escapeMentionAttribute(label)}">${escapeMentionEntities(snapshotText)}</of-mention>`
+    `<of-mention chapter_id="${escapeMentionAttribute(chapterId)}" line_start="${startLine}" ` +
+    `line_end="${endLine}" label="${escapeMentionAttribute(label)}">${escapeMentionEntities(snapshotText)}</of-mention>`
   );
 }
 

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1273,7 +1273,9 @@
       "volume": "Volume",
       "note": "Note",
       "noteCategory": "Note category",
-      "chapter": "Chapter"
+      "chapter": "Chapter",
+      "worldInfoEntry": "World info entry",
+      "character": "Character"
     },
     "mentionSearch": {
       "idle": "Type to search",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1329,7 +1329,9 @@
       "volume": "卷",
       "note": "笔记",
       "noteCategory": "笔记分类",
-      "chapter": "章节"
+      "chapter": "章节",
+      "worldInfoEntry": "世界书条目",
+      "character": "角色"
     },
     "mentionSearch": {
       "idle": "输入内容以检索",

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -649,7 +649,13 @@ function transformVolumeTree(raw: Record<string, unknown>): VolumeTreeResponse {
 
 function transformMentionCandidate(raw: Record<string, unknown>): AssistantMentionCandidate {
   return {
-    kind: raw.kind as "volume" | "chapter" | "note",
+    kind: raw.kind as
+      | "volume"
+      | "chapter"
+      | "note"
+      | "note_category"
+      | "world_info_entry"
+      | "character",
     id: raw.id as string,
     title: raw.title as string,
     label: raw.label as string,
@@ -669,7 +675,7 @@ export async function searchMentionCandidates(
   projectId: string,
   query: string,
   limit = 20,
-  kind?: "volume" | "chapter" | "note",
+  kind?: "volume" | "chapter" | "note" | "note_category" | "world_info_entry" | "character",
   signal?: AbortSignal,
 ): Promise<AssistantMentionCandidate[]> {
   const response = await apiClient.get<Record<string, unknown>>(`/projects/${projectId}/mentions`, {

--- a/frontend/src/lib/mention.types.ts
+++ b/frontend/src/lib/mention.types.ts
@@ -1,5 +1,5 @@
 export interface AssistantMentionCandidate {
-  kind: "volume" | "chapter" | "note" | "note_category";
+  kind: "volume" | "chapter" | "note" | "note_category" | "world_info_entry" | "character";
   id: string;
   title: string;
   label: string;


### PR DESCRIPTION
## PR 标题

refactor(agent): 重构 mention XML 流转链路

## 变更说明

- 问题: mention 在持久化阶段被提前编译为上下文文本，导致数据库内容、前端展示链路和 Agent 上下文链路不一致。
- 重要性: 该问题会造成流式消息与持久化消息显示不一致，并影响 mention-chip 的稳定渲染与后续解析。
- 变化: 统一前后端 mention 的 XML 流转格式，新增世界书条目与角色 mention 类型，并将上下文编译后移到构建上下文与运行时注入阶段。
- 变化: 补充 mention 解析、持久化、会话续跑与 API 候选搜索相关回归测试，覆盖压缩/展开两种上下文注入模式。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [x] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

原有实现将 mention 编译逻辑放在消息持久化之前，导致“存储格式”和“上下文格式”混在一起；前端无法始终基于原始 XML 渲染 mention-chip，流式阶段与持久化阶段也会出现不同显示结果。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

测试证据：
- `uv run pytest tests/agent_runtime/test_session_runner.py tests/agent_runtime/runner/test_session_runner_persistence.py tests/agent_runtime/context/parts/test_history.py tests/agent_runtime/test_mentions.py tests/background/test_background_jobs.py tests/api/test_notes.py -q`
- `pnpm type-check`
- `pnpm lint`
