### PR TITLE
chore(status-bar): 添加索引进度展示

### DIFF
--- a/frontend/src/features/app-shell/components/status-bar.css
+++ b/frontend/src/features/app-shell/components/status-bar.css
@@ -53,3 +53,83 @@
   background: var(--green-9);
   box-shadow: 0 0 0 1px var(--green-a5);
 }
+
+.app-status-bar__index-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  border-radius: 2px;
+  color: inherit;
+  background: transparent;
+  font: inherit;
+  cursor: pointer;
+}
+
+.app-status-bar__index-button:hover {
+  color: var(--gray-12);
+}
+
+.app-status-bar__index-button:focus-visible {
+  outline: 1px solid var(--accent-8);
+  outline-offset: 2px;
+}
+
+.app-status-bar__index-progress,
+.app-status-bar__index-project-progress {
+  display: block;
+  overflow: hidden;
+  height: 5px;
+  border-radius: 999px;
+  background: var(--gray-a5);
+}
+
+.app-status-bar__index-progress {
+  width: 100px;
+}
+
+.app-status-bar__index-progress-indicator,
+.app-status-bar__index-project-progress-indicator {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--blue-9);
+  transition: width 180ms ease-out;
+}
+
+.app-status-bar__index-button[data-state="error"] .app-status-bar__index-progress-indicator {
+  background: var(--red-9);
+}
+
+.app-status-bar__index-popover {
+  width: 250px;
+}
+
+.app-status-bar__index-project-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.app-status-bar__index-project {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 4px 12px;
+}
+
+.app-status-bar__index-project-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-status-bar__index-project-progress {
+  grid-column: 1 / -1;
+  width: 100%;
+}
+
+.app-status-bar__index-error-detail {
+  margin: 0;
+}

--- a/frontend/src/features/app-shell/components/status-bar.tsx
+++ b/frontend/src/features/app-shell/components/status-bar.tsx
@@ -1,9 +1,10 @@
+import { HoverCard, Text } from "@radix-ui/themes";
 import { useMemo, useSyncExternalStore, type ReactNode } from "react";
+import { useTranslation } from "react-i18next";
 
-import {
-  getSocketConnectionStatus,
-  subscribeSocketConnectionStatus,
-} from "@/lib/socket-client";
+import { useAppShell } from "@/features/app-shell/components/app-shell-context";
+import { useOverallIndexStatus, type ProjectIndexStatus } from "@/lib/index-status";
+import { getSocketConnectionStatus, subscribeSocketConnectionStatus } from "@/lib/socket-client";
 
 import "./status-bar.css";
 
@@ -15,6 +16,14 @@ interface StatusBarItem {
 
 interface StatusBarProps {
   version: string;
+}
+
+interface IndexProgressState {
+  activeProjects: ProjectIndexStatus[];
+  hasFailure: boolean;
+  indexableTotal: number;
+  indexedTotal: number;
+  progress: number;
 }
 
 function StatusBarSection({ items, side }: { items: StatusBarItem[]; side: "left" | "right" }) {
@@ -64,7 +73,145 @@ function SocketStatusItem() {
   );
 }
 
+function getIndexableChapterCount(project: ProjectIndexStatus): number {
+  return Math.max(0, project.total_chapters - project.empty_content_count);
+}
+
+function getProgressPercentage(indexed: number, total: number): number {
+  if (total === 0) return 0;
+  return Math.min(100, Math.max(0, (indexed / total) * 100));
+}
+
+function getIndexProgressState(projects: ProjectIndexStatus[]): IndexProgressState {
+  const indexableTotal = projects.reduce(
+    (total, project) => total + getIndexableChapterCount(project),
+    0,
+  );
+  const indexedTotal = projects.reduce((total, project) => total + project.indexed_count, 0);
+
+  return {
+    activeProjects: projects.filter((project) => project.in_progress_count > 0),
+    hasFailure: projects.some((project) => project.failed_count > 0),
+    indexableTotal,
+    indexedTotal,
+    progress: getProgressPercentage(indexedTotal, indexableTotal),
+  };
+}
+
+function IndexProgressStatusItem({
+  activeProjects,
+  hasFailure,
+  indexableTotal,
+  indexedTotal,
+  progress,
+}: IndexProgressState) {
+  const { t } = useTranslation();
+  const { openSettings } = useAppShell();
+  const state = hasFailure ? "error" : "indexing";
+  const progressText = t("index.progress", { indexed: indexedTotal, total: indexableTotal });
+
+  return (
+    <HoverCard.Root>
+      <HoverCard.Trigger>
+        <button
+          type="button"
+          className="app-status-bar__index-button"
+          data-state={state}
+          aria-label={t("index.statusBar.openSettings")}
+          onClick={() => openSettings({ category: "index" })}
+        >
+          <span>{hasFailure ? t("index.statusBar.error") : t("index.statusBar.indexing")}</span>
+          <span
+            className="app-status-bar__index-progress"
+            role="progressbar"
+            aria-label={progressText}
+            aria-valuemin={0}
+            aria-valuemax={indexableTotal}
+            aria-valuenow={Math.min(indexableTotal, indexedTotal)}
+            aria-valuetext={progressText}
+          >
+            <span
+              className="app-status-bar__index-progress-indicator"
+              style={{ width: `${progress}%` }}
+            />
+          </span>
+        </button>
+      </HoverCard.Trigger>
+      <HoverCard.Content
+        side="top"
+        align="end"
+        size="1"
+        className="app-status-bar__index-popover"
+      >
+        {activeProjects.length > 0 ? (
+          <div className="app-status-bar__index-project-list">
+            {activeProjects.map((project) => {
+              const total = getIndexableChapterCount(project);
+              const projectProgress = getProgressPercentage(project.indexed_count, total);
+              const projectProgressText = t("index.progress", {
+                indexed: project.indexed_count,
+                total,
+              });
+
+              return (
+                <div
+                  className="app-status-bar__index-project"
+                  key={project.project_id}
+                >
+                  <Text
+                    as="span"
+                    size="1"
+                    weight="medium"
+                    className="app-status-bar__index-project-title"
+                  >
+                    {project.title || t("index.untitledProject")}
+                  </Text>
+                  <Text
+                    as="span"
+                    size="1"
+                    color="gray"
+                  >
+                    {projectProgressText}
+                  </Text>
+                  <span
+                    className="app-status-bar__index-project-progress"
+                    role="progressbar"
+                    aria-label={projectProgressText}
+                    aria-valuemin={0}
+                    aria-valuemax={total}
+                    aria-valuenow={Math.min(total, project.indexed_count)}
+                    aria-valuetext={projectProgressText}
+                  >
+                    <span
+                      className="app-status-bar__index-project-progress-indicator"
+                      style={{ width: `${projectProgress}%` }}
+                    />
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <Text
+            as="p"
+            size="1"
+            color="red"
+            className="app-status-bar__index-error-detail"
+          >
+            {t("index.statusBar.errorDetail")}
+          </Text>
+        )}
+      </HoverCard.Content>
+    </HoverCard.Root>
+  );
+}
+
 export function StatusBar({ version }: StatusBarProps) {
+  const { data: indexStatus } = useOverallIndexStatus();
+  const indexProgressState = useMemo(
+    () => getIndexProgressState(indexStatus?.projects ?? []),
+    [indexStatus?.projects],
+  );
   const leftItems = useMemo<StatusBarItem[]>(
     () => [
       {
@@ -79,11 +226,16 @@ export function StatusBar({ version }: StatusBarProps) {
   const rightItems = useMemo<StatusBarItem[]>(
     () => [
       {
+        id: "index-progress",
+        content: <IndexProgressStatusItem {...indexProgressState} />,
+        isVisible: indexProgressState.hasFailure || indexProgressState.activeProjects.length > 0,
+      },
+      {
         id: "socket-status",
         content: <SocketStatusItem />,
       },
     ],
-    [],
+    [indexProgressState],
   );
 
   return (

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1663,6 +1663,12 @@
     "indexFailed": "Indexing failed: {{message}}",
     "indexFailedUnknown": "Unknown error",
     "progress": "Indexed {{indexed}} / {{total}} chapters",
+    "statusBar": {
+      "indexing": "Indexing",
+      "error": "Index error",
+      "errorDetail": "Indexing errors need attention in Index Settings.",
+      "openSettings": "Open Index Settings"
+    },
     "indexed": "Indexed",
     "pending": "Pending",
     "failed": "Failed",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1023,6 +1023,12 @@
     "indexFailed": "索引失败：{{message}}",
     "indexFailedUnknown": "未知错误",
     "progress": "已索引 {{indexed}} / {{total}} 章",
+    "statusBar": {
+      "indexing": "索引中",
+      "error": "索引错误",
+      "errorDetail": "存在索引错误，请在索引设置中查看并重试。",
+      "openSettings": "打开索引设置"
+    },
     "indexed": "已索引",
     "pending": "待索引",
     "failed": "失败",


### PR DESCRIPTION
## PR 标题

chore(status-bar): 添加索引进度展示

## 变更说明

- 问题: 索引任务在后台执行时，用户需要进入索引设置才能获知整体进度与异常状态。
- 重要性: 状态栏可提供持续可见的索引状态，减少切换页面查询任务进度的成本。
- 变化: 在全局状态栏展示索引中、索引错误及整体进度，并支持跳转至索引设置。
- 变化: 增加项目级进度明细弹层、进度条状态样式及中英文文案。

## 关联 Issue / PR (如有)

Refs #80

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因(如有)

索引进度与错误信息仅在索引设置页呈现，缺少全局可见的任务状态入口。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证记录：

- `pnpm lint`
- `pnpm type-check`
