### PR TITLE
fix(backend): 去重会话标题后台任务

### DIFF
--- a/backend/app/background/jobs/session_title_jobs.py
+++ b/backend/app/background/jobs/session_title_jobs.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.background.jobs import service as background_service
 from app.background.jobs.constants import JOB_TYPE_SESSION_TITLE
+from app.background.jobs.states import JOB_STATUS_PENDING, JOB_STATUS_RUNNING
 from app.storage.models.task import Task
 
 
@@ -14,6 +15,16 @@ async def enqueue_session_title_job(
 ) -> None:
     seed = seed_message.strip()
     if not seed:
+        return
+    active_jobs = await background_service.list_jobs(
+        session,
+        subject_type="task",
+        subject_id=task.id,
+        statuses={JOB_STATUS_PENDING, JOB_STATUS_RUNNING},
+        job_type=JOB_TYPE_SESSION_TITLE,
+        limit=1,
+    )
+    if active_jobs:
         return
     await background_service.submit_job(
         session,

--- a/backend/tests/background/test_session_title_jobs.py
+++ b/backend/tests/background/test_session_title_jobs.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 from sqlalchemy import select
+from sqlmodel import col
 
 from app.background.jobs.models import BackgroundJob
 from app.background.jobs.session_title_jobs import enqueue_session_title_job
@@ -53,7 +54,9 @@ async def test_enqueue_session_title_job_keeps_raw_seed_message(session):
     )
     await session.commit()
 
-    result = await session.execute(select(BackgroundJob).where(BackgroundJob.subject_id == task.id))
+    result = await session.execute(
+        select(BackgroundJob).where(col(BackgroundJob.subject_id) == task.id)
+    )
     job = result.scalar_one()
     payload = json.loads(job.payload_json)
 
@@ -62,3 +65,28 @@ async def test_enqueue_session_title_job_keeps_raw_seed_message(session):
         '和<of-mention kind="line_range" chapter_id="chap_title_mentions" start_line="4" '
         'end_line="9" label="旧片段">保留快照</of-mention>命名'
     )
+
+
+async def test_enqueue_session_title_job_reuses_active_job_for_same_task(session):
+    project = Project(id="proj_title_dedup", title="标题去重项目")
+    task = Task(
+        id="task_title_dedup",
+        project_id=project.id,
+        title="Agent Session",
+        mode="agent",
+    )
+    session.add(project)
+    session.add(task)
+    await session.commit()
+
+    await enqueue_session_title_job(session, task, "第一条消息")
+    await enqueue_session_title_job(session, task, "第二条消息")
+    await session.commit()
+
+    result = await session.execute(
+        select(BackgroundJob).where(col(BackgroundJob.subject_id) == task.id)
+    )
+    jobs = list(result.scalars())
+
+    assert len(jobs) == 1
+    assert json.loads(jobs[0].payload_json)["seed_message"] == "第一条消息"


### PR DESCRIPTION
## PR 标题

fix(backend): 去重会话标题后台任务

## 变更说明

- 问题: 同一会话在标题生成完成前发送后续消息时，会重复创建会话标题后台任务。
- 重要性: 重复任务会造成额外的 LLM 调用，且多个任务可能竞争写入同一会话标题。
- 变化: 同一 Task 存在 `pending` 或 `running` 的标题任务时复用现有任务，不再创建新任务。
- 变化: 新增回归测试，确保连续入队仅保留首条消息对应的一个标题任务。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [x] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

标题任务入队入口未查询同一 Task 已存在的 `pending` 或 `running` 标题任务，因此在默认标题尚未被异步生成结果替换前，后续消息会重复入队。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 验证命令: `uv run pytest tests/background/test_background_jobs.py tests/background/test_session_title_jobs.py`
- 验证结果: 38 passed。
- 静态检查: `uv run ruff check app/background/jobs/session_title_jobs.py tests/background/test_session_title_jobs.py`、`uv run ty check app/background/jobs/session_title_jobs.py tests/background/test_session_title_jobs.py`。
