### PR TITLE
fix(background): 修复服务器重启后摘要任务卡死与孤儿子项未清理

### DIFF
--- a/backend/app/background/jobs/definitions/summary_batch.py
+++ b/backend/app/background/jobs/definitions/summary_batch.py
@@ -474,6 +474,13 @@ async def _finalize_incomplete_batch_items(context: JobContext, reason: str) -> 
                 continue
             summary = await summary_service.mark_summary_failed(context.session, summary, reason)
             await summary_service.publish_chapter_summary_update(context, summary)
+            await _publish_item_terminal(
+                context,
+                item,
+                summary,
+                terminal_status="failed",
+                error_message=reason,
+            )
             continue
         if item.type != summary_service.SUMMARY_BATCH_ITEM_TYPE_LONG_TERM:
             continue
@@ -495,6 +502,13 @@ async def _finalize_incomplete_batch_items(context: JobContext, reason: str) -> 
             continue
         summary = await summary_service.mark_summary_failed(context.session, summary, reason)
         await summary_service.publish_long_term_summary_update(context, summary)
+        await _publish_item_terminal(
+            context,
+            item,
+            summary,
+            terminal_status="failed",
+            error_message=reason,
+        )
 
 
 async def _handle_summary_batch_failed(context: JobContext, reason: str) -> None:

--- a/backend/app/background/jobs/repos.py
+++ b/backend/app/background/jobs/repos.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
 from app.background.jobs.models import BackgroundJob, BackgroundJobEvent, BackgroundJobItem
-from app.background.jobs.states import JOB_STATUS_PENDING, JOB_STATUS_RUNNING
+from app.background.jobs.states import JOB_STATUS_PENDING, JOB_STATUS_RUNNING, TERMINAL_STATUSES
 
 
 async def create_job(session: AsyncSession, job: BackgroundJob) -> BackgroundJob:
@@ -130,6 +130,20 @@ async def list_expired_running_jobs(session: AsyncSession, *, limit: int = 50) -
         .where(col(BackgroundJob.lease_expires_at).is_not(None))
         .where(col(BackgroundJob.lease_expires_at) < now)
         .order_by(col(BackgroundJob.lease_expires_at).asc())
+        .limit(limit)
+    )
+    return list(result.scalars().all())
+
+
+async def list_terminal_jobs_with_active_items(
+    session: AsyncSession, *, limit: int = 50
+) -> list[BackgroundJob]:
+    result = await session.execute(
+        select(BackgroundJob)
+        .join(BackgroundJobItem)
+        .where(col(BackgroundJob.status).in_(TERMINAL_STATUSES))
+        .where(col(BackgroundJobItem.status).in_([JOB_STATUS_PENDING, JOB_STATUS_RUNNING]))
+        .group_by(BackgroundJob.id)
         .limit(limit)
     )
     return list(result.scalars().all())

--- a/backend/app/background/jobs/service.py
+++ b/backend/app/background/jobs/service.py
@@ -418,7 +418,41 @@ async def recover_stale_job(
             payload={"reason": reason, "attempt_count": job.attempt_count},
         )
         return job
+    definition = get_job_registry().get(job.type)
+    if definition is not None and definition.on_timeout is not None:
+        from app.background.runtime.context import JobContext
+
+        context = JobContext(session=session, job=job, publisher=publisher, definition=definition)
+        await definition.on_timeout(context, reason)
     return await mark_timeout(session, publisher, job, error_message=reason)
+
+
+_ORPHAN_HOOK_BY_STATUS = {
+    JOB_STATUS_TIMEOUT: "on_timeout",
+    JOB_STATUS_FAILED: "on_failed",
+    JOB_STATUS_CANCELLED: "on_cancelled",
+}
+
+
+async def finalize_orphan_job_items(
+    session: AsyncSession,
+    publisher: BackgroundEventPublisher,
+    job: BackgroundJob,
+) -> None:
+    """Re-run the terminal lifecycle hook for a job that reached a terminal state
+    while some of its items were still pending or running (e.g. after an unclean
+    restart before the watchdog timeout-hook fix)."""
+    definition = get_job_registry().get(job.type)
+    if definition is None:
+        return
+    hook_name = _ORPHAN_HOOK_BY_STATUS.get(job.status, "on_failed")
+    hook = getattr(definition, hook_name, None) or definition.on_failed
+    if hook is None:
+        return
+    from app.background.runtime.context import JobContext
+
+    context = JobContext(session=session, job=job, publisher=publisher, definition=definition)
+    await hook(context, f"启动恢复：任务已 {job.status} 但仍存在未完成的子项")
 
 
 async def mark_skipped(

--- a/backend/app/background/runtime/supervisor.py
+++ b/backend/app/background/runtime/supervisor.py
@@ -8,6 +8,8 @@ from typing import Any
 from loguru import logger
 
 from app.background.events.publisher import BackgroundEventPublisher
+from app.background.jobs import repos as job_repo
+from app.background.jobs import service as job_service
 from app.background.runtime.worker import BackgroundWorker
 from app.background.runtime.watchdog import BackgroundWatchdog, get_watchdog_interval_seconds
 from app.background.transport.messages import BackgroundEventMessage, JobNotification
@@ -15,6 +17,7 @@ from app.background.transport.zmq import ZmqBackgroundTransport
 from app.socket import emit
 from app.socket.handlers import agent_session_room, background_project_room
 from app.settings import settings
+from app.storage.database import create_session
 
 
 class BackgroundSupervisor:
@@ -111,6 +114,26 @@ class BackgroundSupervisor:
         count = await watchdog.run_once()
         if count:
             logger.warning(f"recovered {count} stale background jobs")
+        orphan_count = await self._finalize_orphan_job_items()
+        if orphan_count:
+            logger.warning(f"finalized orphan items for {orphan_count} terminal background jobs")
+
+    async def _finalize_orphan_job_items(self) -> int:
+        assert self._transport is not None
+        session = await create_session()
+        publisher = BackgroundEventPublisher(self._transport)
+        try:
+            jobs = await job_repo.list_terminal_jobs_with_active_items(session)
+            for job in jobs:
+                await job_service.finalize_orphan_job_items(session, publisher, job)
+            await job_service.commit_and_notify(session)
+            return len(jobs)
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            with suppress(Exception):
+                await session.close()
 
     def _resolve_project_id(self, message: BackgroundEventMessage) -> str | None:
         project_id = message.payload.get("project_id")

--- a/backend/tests/background/test_background_jobs.py
+++ b/backend/tests/background/test_background_jobs.py
@@ -1730,3 +1730,200 @@ async def test_watchdog_times_out_exhausted_expired_running_job(session):
     assert recovered_count == 1
     assert stored is not None
     assert stored.status == JOB_STATUS_TIMEOUT
+
+
+@pytest.mark.asyncio
+async def test_watchdog_times_out_expired_summary_batch_and_finalizes_running_items(tmp_path):
+    engine, factory = await _configure_file_database(tmp_path)
+    session = factory()
+    try:
+        project = Project(title="项目", description="")
+        chapter = Chapter(
+            project_id=project.id,
+            volume_id=_default_volume_id(project),
+            title="第一章",
+            content="正文" * 400,
+            word_count=800,
+            order=1,
+        )
+        session.add(project)
+        session.add(_default_volume(project))
+        session.add(chapter)
+        await session.commit()
+
+        now = datetime.now(UTC)
+        job = await background_service.submit_job(
+            session,
+            job_type=JOB_TYPE_SUMMARY_BATCH,
+            payload={"project_id": project.id},
+            context={"project_id": project.id, "model_policy": "light_model"},
+            subject_type="project",
+            subject_id=project.id,
+            max_attempts=1,
+        )
+        job.status = JOB_STATUS_RUNNING
+        job.attempt_count = 1
+        job.locked_by = "worker-before-restart"
+        job.locked_at = now - timedelta(minutes=10)
+        job.heartbeat_at = now - timedelta(minutes=10)
+        job.lease_expires_at = now - timedelta(minutes=5)
+        item = await background_service.create_item(
+            session,
+            job_id=job.id,
+            item_key=f"chapter:{chapter.id}",
+            item_type=summary_service.SUMMARY_BATCH_ITEM_TYPE_CHAPTER,
+            payload={"project_id": project.id, "chapter_id": chapter.id},
+        )
+        item.status = JOB_STATUS_RUNNING
+        summary = ChapterSummary(
+            project_id=project.id,
+            summary_type="chapter",
+            status=SUMMARY_STATUS_RUNNING,
+            chapter_id=chapter.id,
+            chapter_order=chapter.order,
+            start_order=chapter.order,
+            end_order=chapter.order,
+            job_id=item.id,
+        )
+        session.add(summary)
+        await session.commit()
+
+        transport = RecordingTransport()
+        watchdog = BackgroundWatchdog(transport=transport, interval_seconds=1)
+        assert await watchdog.run_once() == 1
+
+        verification_session = factory()
+        try:
+            stored_job = await job_repo.get_job(verification_session, job.id)
+            stored_item = await verification_session.get(BackgroundJobItem, item.id)
+            stored_summary = await verification_session.get(ChapterSummary, summary.id)
+        finally:
+            await verification_session.close()
+        assert stored_job is not None
+        assert stored_item is not None
+        assert stored_summary is not None
+        assert stored_job.status == JOB_STATUS_TIMEOUT
+        assert stored_item.status == JOB_STATUS_FAILED
+        assert stored_summary.status == SUMMARY_STATUS_FAILED
+        assert stored_summary.error_message == "后台任务 worker lease 已过期"
+        item_events = [event for event in transport.events if event.type == "background_item_failed"]
+        assert len(item_events) == 1
+        assert item_events[0].item_id == item.id
+    finally:
+        await session.close()
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_startup_finalizes_orphan_items_of_terminal_summary_batch(tmp_path):
+    engine, factory = await _configure_file_database(tmp_path)
+    session = factory()
+    try:
+        project = Project(title="项目", description="")
+        chapter_one = Chapter(
+            project_id=project.id,
+            volume_id=_default_volume_id(project),
+            title="第一章",
+            content="正文" * 400,
+            word_count=800,
+            order=1,
+        )
+        chapter_two = Chapter(
+            project_id=project.id,
+            volume_id=_default_volume_id(project),
+            title="第二章",
+            content="正文" * 400,
+            word_count=800,
+            order=2,
+        )
+        session.add(project)
+        session.add(_default_volume(project, chapter_count=2))
+        session.add(chapter_one)
+        session.add(chapter_two)
+        await session.commit()
+
+        job = await background_service.submit_job(
+            session,
+            job_type=JOB_TYPE_SUMMARY_BATCH,
+            payload={"project_id": project.id},
+            context={"project_id": project.id, "model_policy": "light_model"},
+            subject_type="project",
+            subject_id=project.id,
+            max_attempts=1,
+        )
+        job.status = JOB_STATUS_TIMEOUT
+        job.attempt_count = 1
+        job.finished_at = datetime.now(UTC)
+
+        pending_item = await background_service.create_item(
+            session,
+            job_id=job.id,
+            item_key=f"chapter:{chapter_one.id}",
+            item_type=summary_service.SUMMARY_BATCH_ITEM_TYPE_CHAPTER,
+            payload={"project_id": project.id, "chapter_id": chapter_one.id},
+            order_index=0,
+        )
+        running_item = await background_service.create_item(
+            session,
+            job_id=job.id,
+            item_key=f"chapter:{chapter_two.id}",
+            item_type=summary_service.SUMMARY_BATCH_ITEM_TYPE_CHAPTER,
+            payload={"project_id": project.id, "chapter_id": chapter_two.id},
+            order_index=1,
+        )
+        running_item.status = JOB_STATUS_RUNNING
+
+        pending_summary = ChapterSummary(
+            project_id=project.id,
+            summary_type="chapter",
+            status=SUMMARY_STATUS_QUEUED,
+            chapter_id=chapter_one.id,
+            chapter_order=chapter_one.order,
+            start_order=chapter_one.order,
+            end_order=chapter_one.order,
+            job_id=pending_item.id,
+        )
+        running_summary = ChapterSummary(
+            project_id=project.id,
+            summary_type="chapter",
+            status=SUMMARY_STATUS_RUNNING,
+            chapter_id=chapter_two.id,
+            chapter_order=chapter_two.order,
+            start_order=chapter_two.order,
+            end_order=chapter_two.order,
+            job_id=running_item.id,
+        )
+        session.add(pending_summary)
+        session.add(running_summary)
+        await session.commit()
+
+        transport = RecordingTransport()
+        publisher = BackgroundEventPublisher(transport)
+        orphan_jobs = await job_repo.list_terminal_jobs_with_active_items(session)
+        assert len(orphan_jobs) == 1
+        assert orphan_jobs[0].id == job.id
+
+        await background_service.finalize_orphan_job_items(session, publisher, orphan_jobs[0])
+        await background_service.commit_and_notify(session)
+
+        verification_session = factory()
+        try:
+            stored_pending_item = await verification_session.get(BackgroundJobItem, pending_item.id)
+            stored_running_item = await verification_session.get(BackgroundJobItem, running_item.id)
+            stored_pending_summary = await verification_session.get(ChapterSummary, pending_summary.id)
+            stored_running_summary = await verification_session.get(ChapterSummary, running_summary.id)
+        finally:
+            await verification_session.close()
+        assert stored_pending_item is not None
+        assert stored_running_item is not None
+        assert stored_pending_item.status == JOB_STATUS_FAILED
+        assert stored_running_item.status == JOB_STATUS_FAILED
+        assert stored_pending_summary is not None
+        assert stored_running_summary is not None
+        assert stored_pending_summary.status == SUMMARY_STATUS_FAILED
+        assert stored_running_summary.status == SUMMARY_STATUS_FAILED
+        item_events = [event for event in transport.events if event.type == "background_item_failed"]
+        assert len(item_events) == 2
+    finally:
+        await session.close()
+        await engine.dispose()


### PR DESCRIPTION
## PR 标题

fix(background): 修复服务器重启后摘要任务卡死与孤儿子项未清理

## 变更说明

- 问题: 服务器重启后，正在生成中的章节摘要批次任务及其子项卡在 running/pending 状态，永远无法恢复
- 重要性: 用户在前端看到摘要状态为"生成中"，但后台任务已不存在，且无法通过 UI 重新触发
- 变化: Watchdog 超时恢复时执行 on_timeout 钩子清理遗留子项；启动恢复时扫描已终态 job 中的孤儿子项并重新执行 lifecycle hook 完成清理

## 关联 Issue / PR (如有)

N/A

## 变更类型

- [x] 错误修复 (fix)

## 问题原因

**问题1：Watchdog 超时恢复不执行 lifecycle hook**

`recover_stale_job` 在重试耗尽进入 timeout 分支时，直接调用 `mark_timeout` 标记任务终态，未调用 `JobDefinition.on_timeout` 钩子。而 `summary_batch` 的 `on_timeout` → `_finalize_incomplete_batch_items` 负责将遗留的 pending/running items 和对应 ChapterSummary 标记为 failed。钩子未触发导致这些子项永久卡在运行中状态。

**问题2：启动恢复不清理已终态 job 的孤儿子项**

`_recover_stale_jobs` 仅调用 `watchdog.run_once()`，而 watchdog 只查询 `status=running` 且 `lease_expires_at` 已过期的 job。对于已处于 timeout/failed/cancelled 终态但仍有 pending/running 子项的 job（历史遗留数据），启动时没有任何清理机制。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

### 修复细节

1. **recover_stale_job（service.py）**：timeout 分支增加 `on_timeout` 钩子调用，与 worker 的 `_mark_timeout_after_rollback` 保持一致
2. **_finalize_incomplete_batch_items（summary_batch.py）**：补发 `background_item_failed` 事件，确保前端通过 SSE 即时收到失败状态
3. **list_terminal_jobs_with_active_items（repos.py）**：通过 join 查询已终态 job 中仍有 pending/running 子项的记录
4. **finalize_orphan_job_items（service.py）**：按 job 终态类型映射到对应 lifecycle hook（on_timeout/on_failed/on_cancelled）并重新执行，复用已有的 `_finalize_incomplete_batch_items` 幂等清理逻辑
5. **supervisor.py**：启动恢复在 watchdog 之后追加孤儿清理步骤

### 测试

- `test_watchdog_times_out_expired_summary_batch_and_finalizes_running_items`：验证 watchdog 超时后 items/summary 转为 failed 且发布终态事件
- `test_startup_finalizes_orphan_items_of_terminal_summary_batch`：验证启动恢复清理 timeout job 的 pending/running 孤儿子项

```
ruff check .          → All checks passed!
ty check app          → All checks passed!
pytest (1006 items)   → 1006 passed
```
