### PR TITLE
fix(index): 修复索引取消清理与批处理

### DIFF
--- a/backend/app/api/routers/background.py
+++ b/backend/app/api/routers/background.py
@@ -101,6 +101,8 @@ async def cancel_background_job(
     await background_service.commit_and_notify(session)
     if job.type == "summary_batch":
         get_background_supervisor().cancel_running_summary_batch(job.id)
+    elif job.type == "retrieval_chapter_index_batch":
+        get_background_supervisor().cancel_running_index_batch(job.id)
     return _to_job_response(job)
 
 

--- a/backend/app/api/routers/retrieval_index.py
+++ b/backend/app/api/routers/retrieval_index.py
@@ -114,6 +114,8 @@ async def stop_project_retrieval_index(
         )
     schedule_emit_index_status(session, project_id)
     await background_service.commit_and_notify(session)
+    for job in jobs:
+        get_background_supervisor().cancel_running_index_batch(job.id)
     return IndexStopResponse(project_id=project_id, stopped_count=len(jobs))
 
 

--- a/backend/app/background/jobs/definitions/retrieval_chapter_index_batch.py
+++ b/backend/app/background/jobs/definitions/retrieval_chapter_index_batch.py
@@ -29,7 +29,6 @@ from app.models.clients.embedding_client import EmbeddingClient, EmbeddingConfig
 from app.models.repos import model_provider_repo, model_repo
 from app.models.services.model_provider_service import ModelProviderService
 from app.retrieval.chapter_index import (
-    CHAPTER_INDEX_STATUS_FAILED,
     ChapterIndexIntegrationService,
     chapter_document_id,
     chapter_index_key,
@@ -154,52 +153,62 @@ async def _cleanup_incomplete_items(
     reason: str,
     cancelled: bool,
 ) -> None:
-    items = await job_service.list_job_items(context.session, job_id=context.job_id)
-    for item in items:
-        if item.status not in {JOB_STATUS_PENDING, JOB_STATUS_RUNNING}:
-            continue
+    running_items = await job_repo.list_items_by_status(
+        context.session,
+        job_id=context.job_id,
+        statuses={JOB_STATUS_RUNNING},
+    )
+    document_ids_by_index_key: dict[str, list[str]] = {}
+    for item in running_items:
         payload = job_service.parse_json_object(item.payload_json)
         project_id = payload.get("project_id")
         chapter_id = payload.get("chapter_id")
-        if (
-            item.status == JOB_STATUS_RUNNING
-            and isinstance(project_id, str)
-            and isinstance(chapter_id, str)
-        ):
-            try:
-                await OpenFicRetrievalService().delete_document(
-                    context.session,
-                    chapter_index_key(project_id),
-                    chapter_document_id(chapter_id),
-                )
-            except Exception as exc:
-                logger.bind(
-                    project_id=project_id,
-                    chapter_id=chapter_id,
-                    job_id=context.job_id,
-                ).warning(f"retrieval index document cleanup failed: {exc}")
-        if cancelled:
-            await _reset_state_after_cancellation(
-                context,
-                item,
-                expected_job_id=context.job_id,
-                expected_item_id=item.id,
+        if isinstance(project_id, str) and isinstance(chapter_id, str):
+            index_key = chapter_index_key(project_id)
+            document_ids_by_index_key.setdefault(index_key, []).append(
+                chapter_document_id(chapter_id)
             )
-            await _mark_item_terminal(context.session, item, JOB_STATUS_CANCELLED)
-            continue
-        await _mark_state_failed(
-            context,
-            item,
-            reason,
-            expected_job_id=context.job_id,
-            expected_item_id=item.id,
-        )
-        await _mark_item_terminal(
+
+    retrieval_service = OpenFicRetrievalService()
+    for index_key, document_ids in document_ids_by_index_key.items():
+        try:
+            await retrieval_service.delete_documents(
+                context.session,
+                index_key,
+                document_ids,
+            )
+        except Exception as exc:
+            logger.bind(
+                job_id=context.job_id,
+                index_key=index_key,
+            ).warning(f"retrieval index document cleanup failed: {exc}")
+
+    active_item_statuses = {JOB_STATUS_PENDING, JOB_STATUS_RUNNING}
+    if cancelled:
+        await retrieval_chapter_index_state_repo.reset_active_states_for_job(
             context.session,
-            item,
-            JOB_STATUS_FAILED,
-            error_message=reason,
+            job_id=context.job_id,
         )
+        await job_repo.mark_items_terminal_by_status(
+            context.session,
+            job_id=context.job_id,
+            statuses=active_item_statuses,
+            terminal_status=JOB_STATUS_CANCELLED,
+        )
+        return
+
+    await retrieval_chapter_index_state_repo.fail_active_states_for_job(
+        context.session,
+        job_id=context.job_id,
+        error_message=reason,
+    )
+    await job_repo.mark_items_terminal_by_status(
+        context.session,
+        job_id=context.job_id,
+        statuses=active_item_statuses,
+        terminal_status=JOB_STATUS_FAILED,
+        error_json=json.dumps({"message": reason}, ensure_ascii=False),
+    )
 
 
 async def handle_retrieval_chapter_index_batch(context: JobContext) -> dict[str, int]:
@@ -234,9 +243,6 @@ async def handle_retrieval_chapter_index_batch(context: JobContext) -> dict[str,
                 1 for item in items if item.status == JOB_STATUS_FAILED
             ),
         }
-
-    for item in pending_items:
-        await _mark_item_running(context.session, item)
 
     chapter_ids: list[str] = []
     item_map: dict[str, BackgroundJobItem] = {}
@@ -278,6 +284,11 @@ async def handle_retrieval_chapter_index_batch(context: JobContext) -> dict[str,
     )
     service = ChapterIndexIntegrationService()
 
+    async def mark_chapter_running(chapter_id: str) -> None:
+        item = item_map.get(chapter_id)
+        if item is not None and item.status == JOB_STATUS_PENDING:
+            await _mark_item_running(context.session, item)
+
     # 按 INDEX_BATCH_CHUNK_SIZE 拆分为子批次，每批独立提交事务并推送进度。
     # 这样前端能看到增量更新（如 10/101 → 20/101 → …），而非只在全完成时跳到 100%。
     #
@@ -293,6 +304,7 @@ async def handle_retrieval_chapter_index_batch(context: JobContext) -> dict[str,
             job_id=context.job_id,
             max_chunks_per_batch=MAX_EMBEDDING_CHUNKS_PER_REQUEST,
             check_cancelled=context.check_cancelled,
+            on_chapter_started=mark_chapter_running,
         ):
             await context.check_cancelled()
             for chapter_id in progress.completed_chapter_ids:
@@ -315,83 +327,6 @@ async def handle_retrieval_chapter_index_batch(context: JobContext) -> dict[str,
         ),
         "failed": sum(1 for item in items if item.status == JOB_STATUS_FAILED),
     }
-
-
-async def _mark_state_failed(
-    context: JobContext,
-    item: BackgroundJobItem,
-    reason: str,
-    *,
-    expected_embedding_model_ref_id: str | None = None,
-    expected_job_id: str | None = None,
-    expected_item_id: str | None = None,
-) -> None:
-    payload = job_service.parse_json_object(item.payload_json)
-    project_id = payload.get("project_id")
-    chapter_id = payload.get("chapter_id")
-    if not isinstance(project_id, str) or not isinstance(chapter_id, str):
-        return
-    state = await retrieval_chapter_index_state_repo.get_by_project_and_chapter(
-        context.session,
-        project_id=project_id,
-        chapter_id=chapter_id,
-        index_key=f"chapters:{project_id}",
-    )
-    if state is None:
-        return
-    if state.status == "needs_rebuild":
-        state.error_message = None
-        await retrieval_chapter_index_state_repo.save(context.session, state)
-        return
-    if (
-        expected_job_id is not None
-        and expected_item_id is not None
-        and (state.job_id != expected_job_id or state.item_id != expected_item_id)
-    ):
-        return
-    if expected_embedding_model_ref_id is not None:
-        setting = await setting_repo.get_by_key(
-            context.session,
-            SETTING_KEY_DEFAULT_EMBEDDING_MODEL,
-        )
-        current_model_ref_id = setting.value.strip() if setting is not None else ""
-        if current_model_ref_id != expected_embedding_model_ref_id:
-            state.status = "needs_rebuild"
-            state.job_id = None
-            state.item_id = None
-            state.error_message = None
-            await retrieval_chapter_index_state_repo.save(context.session, state)
-            return
-    state.status = CHAPTER_INDEX_STATUS_FAILED
-    state.error_message = reason
-    await retrieval_chapter_index_state_repo.save(context.session, state)
-
-
-async def _reset_state_after_cancellation(
-    context: JobContext,
-    item: BackgroundJobItem,
-    *,
-    expected_job_id: str,
-    expected_item_id: str,
-) -> None:
-    payload = job_service.parse_json_object(item.payload_json)
-    project_id = payload.get("project_id")
-    chapter_id = payload.get("chapter_id")
-    if not isinstance(project_id, str) or not isinstance(chapter_id, str):
-        return
-    state = await retrieval_chapter_index_state_repo.get_by_project_and_chapter(
-        context.session,
-        project_id=project_id,
-        chapter_id=chapter_id,
-        index_key=f"chapters:{project_id}",
-    )
-    if state is None or state.job_id != expected_job_id or state.item_id != expected_item_id:
-        return
-    state.status = "needs_rebuild"
-    state.job_id = None
-    state.item_id = None
-    state.error_message = None
-    await retrieval_chapter_index_state_repo.save(context.session, state)
 
 
 RETRIEVAL_CHAPTER_INDEX_BATCH_JOB = JobDefinition(

--- a/backend/app/background/jobs/repos.py
+++ b/backend/app/background/jobs/repos.py
@@ -187,6 +187,17 @@ async def create_item(session: AsyncSession, item: BackgroundJobItem) -> Backgro
     return item
 
 
+async def create_items(
+    session: AsyncSession,
+    items: list[BackgroundJobItem],
+) -> list[BackgroundJobItem]:
+    if not items:
+        return []
+    session.add_all(items)
+    await session.flush()
+    return items
+
+
 async def list_items(
     session: AsyncSession,
     *,
@@ -195,6 +206,21 @@ async def list_items(
     result = await session.execute(
         select(BackgroundJobItem)
         .where(col(BackgroundJobItem.job_id) == job_id)
+        .order_by(col(BackgroundJobItem.order_index).asc(), col(BackgroundJobItem.created_at).asc())
+    )
+    return list(result.scalars().all())
+
+
+async def list_items_by_status(
+    session: AsyncSession,
+    *,
+    job_id: str,
+    statuses: set[str],
+) -> list[BackgroundJobItem]:
+    result = await session.execute(
+        select(BackgroundJobItem)
+        .where(col(BackgroundJobItem.job_id) == job_id)
+        .where(col(BackgroundJobItem.status).in_(statuses))
         .order_by(col(BackgroundJobItem.order_index).asc(), col(BackgroundJobItem.created_at).asc())
     )
     return list(result.scalars().all())
@@ -219,3 +245,26 @@ async def save_item(session: AsyncSession, item: BackgroundJobItem) -> Backgroun
     await session.flush()
     await session.refresh(item)
     return item
+
+
+async def mark_items_terminal_by_status(
+    session: AsyncSession,
+    *,
+    job_id: str,
+    statuses: set[str],
+    terminal_status: str,
+    error_json: str | None = None,
+) -> None:
+    now = datetime.now(UTC)
+    await session.execute(
+        update(BackgroundJobItem)
+        .where(col(BackgroundJobItem.job_id) == job_id)
+        .where(col(BackgroundJobItem.status).in_(statuses))
+        .values(
+            status=terminal_status,
+            error_json=error_json,
+            updated_at=now,
+            finished_at=now,
+        )
+    )
+    await session.flush()

--- a/backend/app/background/jobs/service.py
+++ b/backend/app/background/jobs/service.py
@@ -494,6 +494,27 @@ async def create_item(
     )
 
 
+async def create_items(
+    session: AsyncSession,
+    *,
+    job_id: str,
+    items: list[tuple[str, str, dict[str, Any] | None, int]],
+) -> list[BackgroundJobItem]:
+    return await job_repo.create_items(
+        session,
+        [
+            BackgroundJobItem(
+                job_id=job_id,
+                item_key=item_key,
+                type=item_type,
+                payload_json=_json(payload),
+                order_index=order_index,
+            )
+            for item_key, item_type, payload, order_index in items
+        ],
+    )
+
+
 async def update_item_progress(
     session: AsyncSession,
     item: BackgroundJobItem,

--- a/backend/app/background/runtime/supervisor.py
+++ b/backend/app/background/runtime/supervisor.py
@@ -100,6 +100,9 @@ class BackgroundSupervisor:
     def cancel_running_summary_batch(self, job_id: str) -> bool:
         return any(worker.cancel_running_summary_batch(job_id) for worker in self._workers)
 
+    def cancel_running_index_batch(self, job_id: str) -> bool:
+        return any(worker.cancel_running_index_batch(job_id) for worker in self._workers)
+
     async def _run_event_bridge(self) -> None:
         assert self._transport is not None
         while not self._stop_event.is_set():

--- a/backend/app/background/runtime/worker.py
+++ b/backend/app/background/runtime/worker.py
@@ -7,7 +7,10 @@ from loguru import logger
 
 from app.background.events.publisher import BackgroundEventPublisher
 from app.background.events.types import EVENT_JOB_STARTED
-from app.background.jobs.constants import JOB_TYPE_SUMMARY_BATCH
+from app.background.jobs.constants import (
+    JOB_TYPE_RETRIEVAL_CHAPTER_INDEX_BATCH,
+    JOB_TYPE_SUMMARY_BATCH,
+)
 from app.background.jobs import repos as job_repo
 from app.background.jobs import service as job_service
 from app.background.jobs.states import JOB_STATUS_CANCEL_REQUESTED, JOB_STATUS_RUNNING
@@ -33,7 +36,9 @@ class BackgroundWorker:
         self.scan_interval_seconds = scan_interval_seconds
         self._stop_event = asyncio.Event()
         self._running_summary_batch_tasks: dict[str, asyncio.Task[dict | None]] = {}
+        self._running_index_batch_tasks: dict[str, asyncio.Task[dict | None]] = {}
         self._preempted_summary_batch_ids: set[str] = set()
+        self._preempted_index_batch_ids: set[str] = set()
 
     def stop(self) -> None:
         self._stop_event.set()
@@ -43,6 +48,14 @@ class BackgroundWorker:
         if task is None or task.done():
             return False
         self._preempted_summary_batch_ids.add(job_id)
+        task.cancel()
+        return True
+
+    def cancel_running_index_batch(self, job_id: str) -> bool:
+        task = self._running_index_batch_tasks.get(job_id)
+        if task is None or task.done():
+            return False
+        self._preempted_index_batch_ids.add(job_id)
         task.cancel()
         return True
 
@@ -110,6 +123,8 @@ class BackgroundWorker:
             )
             if job.type == JOB_TYPE_SUMMARY_BATCH:
                 self._running_summary_batch_tasks[job.id] = execution_task
+            elif job.type == JOB_TYPE_RETRIEVAL_CHAPTER_INDEX_BATCH:
+                self._running_index_batch_tasks[job.id] = execution_task
             if job.timeout_seconds is None:
                 result = await execution_task
             else:
@@ -127,13 +142,17 @@ class BackgroundWorker:
                 )
             await job_service.commit_and_notify(context.session)
         except asyncio.CancelledError:
-            if job_id not in self._preempted_summary_batch_ids:
+            is_summary_batch_cancelled = job_id in self._preempted_summary_batch_ids
+            is_index_batch_cancelled = job_id in self._preempted_index_batch_ids
+            if not is_summary_batch_cancelled and not is_index_batch_cancelled:
                 raise
+            job_name = "summary batch" if is_summary_batch_cancelled else "index batch"
+            reason = "用户停止摘要生成队列" if is_summary_batch_cancelled else "用户停止索引"
             logger.bind(job_id=job_id, worker_id=self.worker_id).info(
-                "running summary batch interrupted by cancellation request"
+                f"running {job_name} interrupted by cancellation request"
             )
             await job_service.rollback_and_discard(context.session if context else session)
-            await self._mark_cancelled_after_rollback(job_id, "用户停止摘要生成队列")
+            await self._mark_cancelled_after_rollback(job_id, reason)
         except JobCancelledError as exc:
             logger.bind(job_id=job_id, worker_id=self.worker_id).info(
                 f"background job cancelled: {exc}"
@@ -155,7 +174,9 @@ class BackgroundWorker:
         finally:
             if execution_task is not None:
                 self._running_summary_batch_tasks.pop(job_id, None)
+                self._running_index_batch_tasks.pop(job_id, None)
             self._preempted_summary_batch_ids.discard(job_id)
+            self._preempted_index_batch_ids.discard(job_id)
             with suppress(asyncio.CancelledError):
                 await self._stop_heartbeat(heartbeat_task)
             if context is not None and context.session is not session:

--- a/backend/app/retrieval/chapter_index.py
+++ b/backend/app/retrieval/chapter_index.py
@@ -570,23 +570,30 @@ async def enqueue_project_index_update(
         subject_type="project",
         subject_id=project_id,
     )
-    service = ChapterIndexIntegrationService()
-    for index, chapter in enumerate(selected):
-        item = await background_service.create_item(
-            session,
-            job_id=job.id,
-            item_key=f"chapter:{chapter.id}",
-            item_type=CHAPTER_INDEX_ITEM_TYPE,
-            payload={"project_id": project_id, "chapter_id": chapter.id},
-            order_index=index,
-        )
-        await service.mark_chapter_queued(
-            session,
-            chapter,
-            embedding_model_ref_id=model.id,
-            job_id=job.id,
-            item_id=item.id,
-        )
+    items = await background_service.create_items(
+        session,
+        job_id=job.id,
+        items=[
+            (
+                f"chapter:{chapter.id}",
+                CHAPTER_INDEX_ITEM_TYPE,
+                {"project_id": project_id, "chapter_id": chapter.id},
+                index,
+            )
+            for index, chapter in enumerate(selected)
+        ],
+    )
+    await retrieval_chapter_index_state_repo.queue_chapters_for_job(
+        session,
+        project_id=project_id,
+        index_key=index_key,
+        chapter_ids=[chapter.id for chapter in selected],
+        embedding_model_ref_id=model.id,
+        job_id=job.id,
+        item_ids_by_chapter_id={
+            chapter.id: item.id for chapter, item in zip(selected, items, strict=True)
+        },
+    )
 
     return IndexEnqueueResult(
         enqueued_count=len(selected),
@@ -1130,6 +1137,7 @@ class ChapterIndexIntegrationService:
         job_id: str,
         max_chunks_per_batch: int,
         check_cancelled: Callable[[], Awaitable[None]] | None = None,
+        on_chapter_started: Callable[[str], Awaitable[None]] | None = None,
     ) -> AsyncIterator[ChunkBatchIndexProgress]:
         """Index chapters through bounded chunk requests and yield completed chapters.
 
@@ -1237,6 +1245,8 @@ class ChapterIndexIntegrationService:
             state.embedding_model_ref_id = embedding_model.id
             state.error_message = None
             await retrieval_chapter_index_state_repo.save(session, state)
+            if on_chapter_started is not None:
+                await on_chapter_started(chapter_id)
 
             document = self.build_chapter_document(chapter)
             raw_chunks = chunker.split_text(document.text or "")

--- a/backend/app/retrieval/engine.py
+++ b/backend/app/retrieval/engine.py
@@ -200,8 +200,20 @@ class LanceDBRetrievalEngine:
         )
 
     async def delete_document(self, document_id: str) -> None:
-        table = await self._open_table()
-        await table.delete(f"document_id = '{quote_sql(document_id)}'")
+        await self.delete_documents([document_id])
+
+    async def delete_documents(self, document_ids: list[str]) -> None:
+        if not document_ids:
+            return
+        db = await self._connect()
+        names = list((await db.list_tables()).tables)
+        if self.table_name not in names:
+            return
+        table = await db.open_table(self.table_name)
+        document_id_values = ", ".join(
+            f"'{quote_sql(document_id)}'" for document_id in set(document_ids)
+        )
+        await table.delete(f"document_id IN ({document_id_values})")
 
     async def index_chunks(
         self,

--- a/backend/app/retrieval/service.py
+++ b/backend/app/retrieval/service.py
@@ -132,8 +132,18 @@ class OpenFicRetrievalService:
     async def delete_document(
         self, session: AsyncSession, index_key: str, document_id: str
     ) -> None:
+        await self.delete_documents(session, index_key, [document_id])
+
+    async def delete_documents(
+        self,
+        session: AsyncSession,
+        index_key: str,
+        document_ids: list[str],
+    ) -> None:
+        if not document_ids:
+            return
         row = await self._get_index(session, index_key)
-        await self._engine_for(row).delete_document(document_id)
+        await self._engine_for(row).delete_documents(document_ids)
 
     async def index_chunk_batch(
         self,

--- a/backend/app/storage/repos/retrieval_chapter_index_state_repo.py
+++ b/backend/app/storage/repos/retrieval_chapter_index_state_repo.py
@@ -3,7 +3,7 @@
 
 from datetime import UTC, datetime
 
-from sqlalchemy import delete, select, update
+from sqlalchemy import case, delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
@@ -40,6 +40,67 @@ async def list_by_project(
         )
     )
     return list(result.scalars().all())
+
+
+async def queue_chapters_for_job(
+    session: AsyncSession,
+    *,
+    project_id: str,
+    index_key: str,
+    chapter_ids: list[str],
+    embedding_model_ref_id: str,
+    job_id: str,
+    item_ids_by_chapter_id: dict[str, str],
+) -> None:
+    if not chapter_ids:
+        return
+    result = await session.execute(
+        select(RetrievalChapterIndexState)
+        .where(col(RetrievalChapterIndexState.project_id) == project_id)
+        .where(col(RetrievalChapterIndexState.index_key) == index_key)
+        .where(col(RetrievalChapterIndexState.chapter_id).in_(chapter_ids))
+    )
+    states = list(result.scalars().all())
+    states_by_chapter_id = {state.chapter_id: state for state in states}
+    now = datetime.now(UTC)
+    new_states = [
+        RetrievalChapterIndexState(
+            project_id=project_id,
+            chapter_id=chapter_id,
+            index_key=index_key,
+            status="queued",
+            embedding_model_ref_id=embedding_model_ref_id,
+            job_id=job_id,
+            item_id=item_ids_by_chapter_id[chapter_id],
+        )
+        for chapter_id in chapter_ids
+        if chapter_id not in states_by_chapter_id
+    ]
+    if new_states:
+        session.add_all(new_states)
+
+    existing_chapter_ids = [
+        chapter_id for chapter_id in chapter_ids if chapter_id in states_by_chapter_id
+    ]
+    if existing_chapter_ids:
+        await session.execute(
+            update(RetrievalChapterIndexState)
+            .where(col(RetrievalChapterIndexState.project_id) == project_id)
+            .where(col(RetrievalChapterIndexState.index_key) == index_key)
+            .where(col(RetrievalChapterIndexState.chapter_id).in_(existing_chapter_ids))
+            .values(
+                status="queued",
+                embedding_model_ref_id=embedding_model_ref_id,
+                job_id=job_id,
+                item_id=case(
+                    item_ids_by_chapter_id,
+                    value=col(RetrievalChapterIndexState.chapter_id),
+                ),
+                error_message=None,
+                updated_at=now,
+            )
+        )
+    await session.flush()
 
 
 async def save(
@@ -93,6 +154,41 @@ async def mark_project_needs_rebuild(
             job_id=None,
             item_id=None,
             error_message=None,
+            updated_at=datetime.now(UTC),
+        )
+    )
+    await session.flush()
+
+
+async def reset_active_states_for_job(session: AsyncSession, *, job_id: str) -> None:
+    await session.execute(
+        update(RetrievalChapterIndexState)
+        .where(col(RetrievalChapterIndexState.job_id) == job_id)
+        .where(col(RetrievalChapterIndexState.status).in_({"queued", "indexing"}))
+        .values(
+            status="needs_rebuild",
+            job_id=None,
+            item_id=None,
+            error_message=None,
+            updated_at=datetime.now(UTC),
+        )
+    )
+    await session.flush()
+
+
+async def fail_active_states_for_job(
+    session: AsyncSession,
+    *,
+    job_id: str,
+    error_message: str,
+) -> None:
+    await session.execute(
+        update(RetrievalChapterIndexState)
+        .where(col(RetrievalChapterIndexState.job_id) == job_id)
+        .where(col(RetrievalChapterIndexState.status).in_({"queued", "indexing"}))
+        .values(
+            status="failed",
+            error_message=error_message,
             updated_at=datetime.now(UTC),
         )
     )

--- a/backend/tests/api/test_retrieval_index.py
+++ b/backend/tests/api/test_retrieval_index.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.encryption import EncryptionService
 from app.background.jobs.models import BackgroundJob, BackgroundJobItem
 from app.background.jobs.states import JOB_STATUS_CANCELLED
+from app.background.runtime.supervisor import get_background_supervisor
 from app.models.repos import model_provider_repo, model_repo
 from app.storage.models.retrieval_chapter_index_state import RetrievalChapterIndexState
 from app.storage.repos import retrieval_chapter_index_state_repo, setting_repo
@@ -219,6 +220,38 @@ async def test_index_start_enqueues_outdated_chapters(
 
 
 @pytest.mark.asyncio
+async def test_index_start_batches_item_and_state_enqueue(
+    client: AsyncClient,
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app.retrieval.chapter_index as chapter_index
+    from app.background.jobs import service as background_service
+
+    await _create_embedding_model(session)
+    project_id, volume_id = await _create_project(client)
+    for index in range(3):
+        await _create_chapter(client, project_id, volume_id, title=f"第{index + 1}章")
+    await setting_repo.upsert(session, "index_mode", "all")
+    await session.commit()
+
+    async def unexpected_individual_enqueue(*_args, **_kwargs):
+        raise AssertionError("index enqueue must not create items or states individually")
+
+    monkeypatch.setattr(background_service, "create_item", unexpected_individual_enqueue)
+    monkeypatch.setattr(
+        chapter_index.ChapterIndexIntegrationService,
+        "mark_chapter_queued",
+        unexpected_individual_enqueue,
+    )
+
+    response = await client.post(f"/api/v1/projects/{project_id}/retrieval/index/start")
+
+    assert response.status_code == 200
+    assert response.json()["enqueued_count"] == 3
+
+
+@pytest.mark.asyncio
 async def test_index_stop_cancels_pending_job_and_resets_incomplete_chapters(
     client: AsyncClient,
     session: AsyncSession,
@@ -267,6 +300,65 @@ async def test_index_stop_cancels_pending_job_and_resets_incomplete_chapters(
     assert chapter_state.job_id is None
     assert chapter_state.item_id is None
     assert chapter_state.error_message is None
+
+
+@pytest.mark.asyncio
+async def test_index_stop_interrupts_running_index_job(
+    client: AsyncClient,
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    project_id, _ = await _create_project(client)
+    job = BackgroundJob(
+        type="retrieval_chapter_index_batch",
+        subject_type="project",
+        subject_id=project_id,
+        status="running",
+        payload_json='{"project_id":"test"}',
+    )
+    session.add(job)
+    await session.commit()
+
+    interrupted_job_ids: list[str] = []
+    monkeypatch.setattr(
+        get_background_supervisor(),
+        "cancel_running_index_batch",
+        interrupted_job_ids.append,
+    )
+
+    response = await client.post(f"/api/v1/projects/{project_id}/retrieval/index/stop")
+
+    assert response.status_code == 200
+    assert response.json() == {"project_id": project_id, "stopped_count": 1}
+    assert interrupted_job_ids == [job.id]
+
+
+@pytest.mark.asyncio
+async def test_background_cancel_interrupts_running_index_job(
+    client: AsyncClient,
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job = BackgroundJob(
+        type="retrieval_chapter_index_batch",
+        status="running",
+        payload_json='{"project_id":"test"}',
+    )
+    session.add(job)
+    await session.commit()
+
+    interrupted_job_ids: list[str] = []
+    monkeypatch.setattr(
+        get_background_supervisor(),
+        "cancel_running_index_batch",
+        interrupted_job_ids.append,
+    )
+
+    response = await client.post(f"/api/v1/background/jobs/{job.id}/cancel", json={})
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "cancel_requested"
+    assert interrupted_job_ids == [job.id]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/background/test_background_jobs.py
+++ b/backend/tests/background/test_background_jobs.py
@@ -19,7 +19,10 @@ from app.background.jobs.base import JobDefinition
 from app.background.jobs.definitions import register_all_background_jobs
 from app.background.jobs.definitions.chapter_summary import handle_chapter_summary
 from app.background.jobs.definitions import summary_batch as summary_batch_definition
-from app.background.jobs.constants import JOB_TYPE_SUMMARY_BATCH
+from app.background.jobs.constants import (
+    JOB_TYPE_RETRIEVAL_CHAPTER_INDEX_BATCH,
+    JOB_TYPE_SUMMARY_BATCH,
+)
 from app.background.jobs.definitions.session_title import handle_session_title
 from app.background.jobs import repos as job_repo
 from app.background.jobs import service as background_service
@@ -838,6 +841,74 @@ async def test_worker_interrupts_running_summary_batch_on_cancel_request(tmp_pat
         assert worker.cancel_running_summary_batch(job.id) is True
         await asyncio.wait_for(run_task, timeout=1)
         assert generation_cancelled.is_set()
+
+        verification_session = factory()
+        try:
+            stored_job = await job_repo.get_job(verification_session, job.id)
+            events = await job_repo.list_events(verification_session, job_id=job.id)
+        finally:
+            await verification_session.close()
+        assert stored_job is not None
+        assert stored_job.status == JOB_STATUS_CANCELLED
+        assert any(event.event_type == "cancelled_hook_ran" for event in events)
+    finally:
+        await session.close()
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_worker_interrupts_running_index_batch_on_cancel_request(tmp_path):
+    engine, factory = await _configure_file_database(tmp_path)
+    session = factory()
+    try:
+        indexing_started = asyncio.Event()
+        indexing_cancelled = asyncio.Event()
+
+        async def blocking_index_handler(_context: JobContext) -> None:
+            indexing_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                indexing_cancelled.set()
+                raise
+
+        get_job_registry()._definitions[JOB_TYPE_RETRIEVAL_CHAPTER_INDEX_BATCH] = JobDefinition(
+            type=JOB_TYPE_RETRIEVAL_CHAPTER_INDEX_BATCH,
+            name="Blocking index batch",
+            description="Blocks until cancellation for worker cancellation coverage.",
+            input_model=_NoopInput,
+            handler=blocking_index_handler,
+            on_cancelled=_cancelled_hook,
+            supports_cancel=True,
+        )
+        job = await job_repo.create_job(
+            session,
+            BackgroundJob(type=JOB_TYPE_RETRIEVAL_CHAPTER_INDEX_BATCH, payload_json='{"value":"x"}'),
+        )
+        await background_service.commit_and_notify(session)
+
+        transport = RecordingTransport()
+        worker = BackgroundWorker(worker_id="worker-1", transport=transport, scan_interval_seconds=1)
+        run_task = asyncio.create_task(worker._run_job(job.id))
+        await asyncio.wait_for(indexing_started.wait(), timeout=1)
+
+        cancel_session = factory()
+        try:
+            stored_job = await job_repo.get_job(cancel_session, job.id)
+            assert stored_job is not None
+            await background_service.request_cancel(
+                cancel_session,
+                BackgroundEventPublisher(transport),
+                stored_job,
+                reason="用户停止索引",
+            )
+            await background_service.commit_and_notify(cancel_session)
+        finally:
+            await cancel_session.close()
+
+        assert worker.cancel_running_index_batch(job.id) is True
+        await asyncio.wait_for(run_task, timeout=1)
+        assert indexing_cancelled.is_set()
 
         verification_session = factory()
         try:

--- a/backend/tests/background/test_retrieval_chapter_index_batch.py
+++ b/backend/tests/background/test_retrieval_chapter_index_batch.py
@@ -10,6 +10,7 @@ from app.background.jobs.states import (
     JOB_STATUS_CANCELLED,
     JOB_STATUS_FAILED,
     JOB_STATUS_PENDING,
+    JOB_STATUS_RUNNING,
     JOB_STATUS_SUCCEEDED,
 )
 from app.background.runtime.context import JobCancelledError, JobContext
@@ -137,8 +138,16 @@ class StateReassigningChapterIndexService:
         job_id=None,
         max_chunks_per_batch,
         check_cancelled=None,
+        on_chapter_started=None,
     ):
-        _ = (embedding_client, embedding_model, job_id, max_chunks_per_batch, check_cancelled)
+        _ = (
+            embedding_client,
+            embedding_model,
+            job_id,
+            max_chunks_per_batch,
+            check_cancelled,
+            on_chapter_started,
+        )
         if False:
             yield ChunkBatchIndexProgress([])
         from sqlalchemy import select
@@ -195,6 +204,7 @@ class MutatingFailingChapterIndexService:
         job_id=None,
         max_chunks_per_batch,
         check_cancelled=None,
+        on_chapter_started=None,
     ):
         _ = (
             chapter_ids,
@@ -203,6 +213,7 @@ class MutatingFailingChapterIndexService:
             job_id,
             max_chunks_per_batch,
             check_cancelled,
+            on_chapter_started,
         )
         if False:
             yield ChunkBatchIndexProgress([])
@@ -725,6 +736,34 @@ class CommitCheckingRetrievalService(MultiDocumentRetrievalService):
         return ChunkIndexResult(succeeded_chunk_count=len(chunks))
 
 
+class StopsAfterStartingFirstChapterIndexService:
+    async def stream_index_chapters(
+        self,
+        session,
+        *,
+        chapter_ids,
+        embedding_client,
+        embedding_model,
+        job_id,
+        max_chunks_per_batch,
+        check_cancelled=None,
+        on_chapter_started=None,
+    ):
+        _ = (
+            session,
+            embedding_client,
+            embedding_model,
+            job_id,
+            max_chunks_per_batch,
+            check_cancelled,
+        )
+        if False:
+            yield ChunkBatchIndexProgress([])
+        assert on_chapter_started is not None
+        await on_chapter_started(chapter_ids[0])
+        raise JobCancelledError("用户停止索引")
+
+
 async def _seed_multi_chapter_job(
     session: AsyncSession, *, chapter_count: int
 ):
@@ -966,9 +1005,9 @@ async def test_batch_cancellation_preserves_completed_chapters_and_resets_incomp
     deleted_document_ids: list[str] = []
 
     class CleanupRetrievalService:
-        async def delete_document(self, session, index_key, document_id):
+        async def delete_documents(self, session, index_key, document_ids):
             _ = (session, index_key)
-            deleted_document_ids.append(document_id)
+            deleted_document_ids.extend(document_ids)
 
     monkeypatch.setattr(definition, "OpenFicRetrievalService", CleanupRetrievalService)
 
@@ -1010,8 +1049,78 @@ async def test_batch_cancellation_preserves_completed_chapters_and_resets_incomp
     assert states[1].job_id is None
     assert states[1].item_id is None
     assert states[1].error_message is None
-    assert deleted_document_ids == ["chapter:chapter-multi-1"]
+    assert deleted_document_ids == []
     assert emit_count == 2
+
+
+@pytest.mark.asyncio
+async def test_batch_cancellation_batches_pending_items_and_cleans_only_running_chapter(
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    job, items, states = await _seed_multi_chapter_job(session, chapter_count=3)
+    monkeypatch.setattr(
+        definition,
+        "_build_embedding_client",
+        lambda session, model_ref_id: FakeEmbeddingClient(),
+    )
+    monkeypatch.setattr(
+        definition,
+        "ChapterIndexIntegrationService",
+        StopsAfterStartingFirstChapterIndexService,
+    )
+
+    context = JobContext(
+        session=session,
+        job=job,
+        publisher=BackgroundEventPublisher(),
+    )
+    context.check_cancelled = _noop_check_cancelled  # type: ignore[method-assign]
+
+    with pytest.raises(JobCancelledError, match="用户停止索引"):
+        await definition.handle_retrieval_chapter_index_batch(context)
+
+    await session.refresh(items[0])
+    await session.refresh(items[1])
+    await session.refresh(items[2])
+    assert items[0].status == JOB_STATUS_RUNNING
+    assert items[1].status == JOB_STATUS_PENDING
+    assert items[2].status == JOB_STATUS_PENDING
+
+    deleted_document_ids: list[str] = []
+
+    class CleanupRetrievalService:
+        async def delete_documents(self, session, index_key, document_ids):
+            _ = (session, index_key)
+            deleted_document_ids.extend(document_ids)
+
+    monkeypatch.setattr(definition, "OpenFicRetrievalService", CleanupRetrievalService)
+    monkeypatch.setattr(
+        definition.retrieval_chapter_index_state_repo,
+        "get_by_project_and_chapter",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("cancellation cleanup must not query chapter states individually")
+        ),
+    )
+    monkeypatch.setattr(
+        definition.job_repo,
+        "save_item",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("cancellation cleanup must not save items individually")
+        ),
+    )
+
+    await definition._handle_cancelled(context, "用户停止索引")
+
+    assert deleted_document_ids == ["chapter:chapter-multi-0"]
+    for item in items:
+        await session.refresh(item)
+        assert item.status == JOB_STATUS_CANCELLED
+    for state in states:
+        await session.refresh(state)
+        assert state.status == "needs_rebuild"
+        assert state.job_id is None
+        assert state.item_id is None
 
 
 

--- a/backend/tests/retrieval/test_service.py
+++ b/backend/tests/retrieval/test_service.py
@@ -704,6 +704,18 @@ async def test_delete_document_removes_rows(
 
 
 @pytest.mark.asyncio
+async def test_delete_document_ignores_missing_table(
+    session: AsyncSession, tmp_path: Path
+) -> None:
+    model = await _create_embedding_model(session)
+    service = OpenFicRetrievalService(base_dir=tmp_path / "lancedb")
+
+    await service.register_index(session, "chapters", _make_contract(model.id))
+
+    await service.delete_document(session, "chapters", "chapter-1")
+
+
+@pytest.mark.asyncio
 async def test_rebuild_replaces_table_contents(
     session: AsyncSession, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## PR 标题

fix(index): 修复索引取消清理与批处理

## 变更说明

- 问题: 运行中的索引任务只能在下一次协作检查时停止；取消清理会逐章处理，索引表缺失时会重复输出警告。
- 重要性: 大项目取消索引会产生大量无效数据库与 LanceDB 操作，且无法立即停止正在执行的 embedding 请求。
- 变化: 跟踪并抢占取消运行中的索引任务；仅清理真正开始处理的章节；将索引入队和取消收尾改为批量写入。
- 变化: LanceDB 表不存在时，文档删除按幂等无操作处理，避免取消清理重复告警。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

索引任务未复用摘要生成的 `asyncio.Task.cancel()` 抢占取消机制；任务启动时提前将所有章节 item 标记为 `running`，导致取消钩子无法区分未开始章节；取消和入队流程还逐项执行数据库写入与刷新。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证记录：

- `uv run ruff check .`
- `uv run ty check app`
- `uv run pytest`，1019 passed
