### PR TITLE
chore(agent): 限制子智能体委派与提问能力

### DIFF
--- a/backend/app/agent_runtime/runner/subagent_runner.py
+++ b/backend/app/agent_runtime/runner/subagent_runner.py
@@ -59,6 +59,9 @@ from app.storage.services import task_service
 
 SYSTEM_DEFAULT_MODEL_REFERENCE = "__system_default_model__"
 SYSTEM_LIGHT_MODEL_REFERENCE = "__system_light_model__"
+_SUBAGENT_RESTRICTED_TOOL_NAMES = frozenset(
+    ("dispatch_subagent", "notify_subagent", "recycle_subagent", "ask_user")
+)
 
 
 def build_child_messages(history: list[BaseMessage], *, content: str) -> list[BaseMessage]:
@@ -269,7 +272,11 @@ class SubagentRunner:
     ):
         if not definition.enabled or definition.kind != "subagent":
             raise ValueError(f"agent is not an enabled subagent: {definition.key}")
-        names = list(get_tool_names_for_categories(definition.enabled_tool_categories))
+        names = [
+            name
+            for name in get_tool_names_for_categories(definition.enabled_tool_categories)
+            if name not in _SUBAGENT_RESTRICTED_TOOL_NAMES
+        ]
         session = await _open_session(self.session_factory)
         try:
             names.extend(await skill_tool_names_for_definition(definition, session))

--- a/backend/app/storage/services/agent_definition_service.py
+++ b/backend/app/storage/services/agent_definition_service.py
@@ -20,6 +20,7 @@ from app.storage.repos import agent_definition_repo
 _BUILTIN_KEYS = frozenset(
     ("primary", "explorer", "composer", "auditor", "writer", "actor", "reviewer")
 )
+_SUBAGENT_RESTRICTED_TOOL_CATEGORIES = frozenset(("orchestration", "interaction"))
 
 
 def _normalize_enabled_skills(skill_ids: list[str] | None) -> list[str]:
@@ -34,6 +35,19 @@ def _normalize_enabled_skills(skill_ids: list[str] | None) -> list[str]:
         seen.add(value)
         normalized.append(value)
     return normalized
+
+
+def _normalize_enabled_tool_categories(
+    kind: str,
+    category_keys: list[str],
+) -> list[str]:
+    if kind != "subagent":
+        return category_keys
+    return [
+        category_key
+        for category_key in category_keys
+        if category_key not in _SUBAGENT_RESTRICTED_TOOL_CATEGORIES
+    ]
 
 
 async def list_definitions(
@@ -76,6 +90,10 @@ async def create_definition(
         raise ValidationError(f"智能体 {key} 已存在")
 
     normalized_enabled_skills = _normalize_enabled_skills(enabled_skills)
+    normalized_tool_categories = _normalize_enabled_tool_categories(
+        kind,
+        enabled_tool_categories,
+    )
 
     record = AgentDefinitionRecord(
         key=key,
@@ -84,7 +102,7 @@ async def create_definition(
         kind=kind,
         prompt_agent_name=prompt_agent_name,
         model_id=model_id,
-        enabled_tool_categories=enabled_tool_categories,
+        enabled_tool_categories=normalized_tool_categories,
         enabled_skills=normalized_enabled_skills,
         metadata_json=metadata or {},
         enabled=True,
@@ -147,7 +165,10 @@ async def update_definition(
     if model_id is not None:
         record.model_id = model_id
     if enabled_tool_categories is not None:
-        record.enabled_tool_categories = enabled_tool_categories
+        record.enabled_tool_categories = _normalize_enabled_tool_categories(
+            record.kind,
+            enabled_tool_categories,
+        )
     if enabled_skills is not None:
         record.enabled_skills = _normalize_enabled_skills(enabled_skills)
     if metadata is not None:
@@ -156,6 +177,11 @@ async def update_definition(
         record.enabled = enabled
     if delegatable_agents is not None:
         record.delegatable_agents = delegatable_agents
+
+    record.enabled_tool_categories = _normalize_enabled_tool_categories(
+        record.kind,
+        record.enabled_tool_categories or [],
+    )
 
     return await agent_definition_repo.update(session, record)
 

--- a/backend/tests/agent_runtime/runner/test_subagent_runner.py
+++ b/backend/tests/agent_runtime/runner/test_subagent_runner.py
@@ -166,6 +166,58 @@ async def test_resolve_agent_model_config_falls_back_to_inherited_when_unconfigu
 
 
 @pytest.mark.asyncio
+async def test_subagent_runner_excludes_restricted_tools_from_definition(
+    db_session_factory,
+    monkeypatch,
+):
+    from app.agent_runtime.agents.definitions import AgentDefinition
+    from app.agent_runtime.runner.subagent_runner import SubagentRunner
+
+    captured: dict[str, list[str]] = {}
+
+    def fake_get_tools(*, names, **_kwargs):
+        captured["names"] = names
+        return []
+
+    async def fake_skill_tool_names(*_args, **_kwargs):
+        return ()
+
+    monkeypatch.setattr(
+        "app.agent_runtime.runner.subagent_runner.ToolRegistry.get_tools",
+        fake_get_tools,
+    )
+    monkeypatch.setattr(
+        "app.agent_runtime.runner.subagent_runner.skill_tool_names_for_definition",
+        fake_skill_tool_names,
+    )
+
+    runner = SubagentRunner(
+        session_factory=db_session_factory,
+        model_config={},
+        project_id="project-1",
+    )
+    definition = AgentDefinition(
+        key="restricted-subagent",
+        display_name="Restricted Subagent",
+        description="",
+        kind="subagent",
+        prompt_agent_name="restricted-subagent",
+        model_id=None,
+        enabled_tool_categories=("orchestration", "interaction", "chapter_read"),
+        enabled_skills=(),
+        metadata={},
+    )
+
+    await runner._build_tools(definition, {})
+
+    assert "dispatch_subagent" not in captured["names"]
+    assert "notify_subagent" not in captured["names"]
+    assert "recycle_subagent" not in captured["names"]
+    assert "ask_user" not in captured["names"]
+    assert "read_chapter" in captured["names"]
+
+
+@pytest.mark.asyncio
 async def test_subagent_runner_uses_child_thread_history_and_parent_task(
     db_session_factory,
     monkeypatch,

--- a/backend/tests/storage/test_agent_definition_service.py
+++ b/backend/tests/storage/test_agent_definition_service.py
@@ -69,6 +69,37 @@ async def test_create_custom_definition():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("restricted_category", ["orchestration", "interaction"])
+async def test_create_subagent_excludes_restricted_tool_category(restricted_category: str):
+    from app.storage.services import agent_definition_service
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    try:
+        async with factory() as session:
+            record = await agent_definition_service.create_definition(
+                session,
+                key="restricted-custom-bot",
+                display_name="Restricted Custom Bot",
+                description="",
+                kind="subagent",
+                prompt_agent_name="restricted-custom-bot",
+                model_id=None,
+                enabled_tool_categories=["chapter_read", restricted_category],
+                enabled_skills=[],
+                metadata={},
+                delegatable_agents=[],
+            )
+
+        assert record.enabled_tool_categories == ["chapter_read"]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
 async def test_create_duplicate_raises_validation_error():
     from app.storage.services import agent_definition_service
 
@@ -152,6 +183,81 @@ async def test_update_custom_definition():
             assert record.description == "After update"
             assert record.enabled_skills == ["skill-c"]
             assert record.delegatable_agents == ["explorer", "writer"]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("restricted_category", ["orchestration", "interaction"])
+async def test_update_subagent_excludes_restricted_tool_category(restricted_category: str):
+    from app.storage.services import agent_definition_service
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    try:
+        async with factory() as session:
+            await agent_definition_service.create_definition(
+                session,
+                key="restricted-edit-bot",
+                display_name="Restricted Edit Bot",
+                description="",
+                kind="subagent",
+                prompt_agent_name="restricted-edit-bot",
+                model_id=None,
+                enabled_tool_categories=["chapter_read"],
+                enabled_skills=[],
+                metadata={},
+                delegatable_agents=[],
+            )
+            await session.commit()
+
+            record = await agent_definition_service.update_definition(
+                session,
+                key="restricted-edit-bot",
+                enabled_tool_categories=["chapter_read", restricted_category],
+            )
+
+        assert record.enabled_tool_categories == ["chapter_read"]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_update_definition_excludes_restricted_categories_when_becoming_subagent():
+    from app.storage.services import agent_definition_service
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    factory = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+
+    try:
+        async with factory() as session:
+            await agent_definition_service.create_definition(
+                session,
+                key="primary-to-subagent",
+                display_name="Primary To Subagent",
+                description="",
+                kind="primary",
+                prompt_agent_name="primary-to-subagent",
+                model_id=None,
+                enabled_tool_categories=["orchestration", "interaction", "chapter_read"],
+                enabled_skills=[],
+                metadata={},
+                delegatable_agents=[],
+            )
+            await session.commit()
+
+            record = await agent_definition_service.update_definition(
+                session,
+                key="primary-to-subagent",
+                kind="subagent",
+            )
+
+        assert record.enabled_tool_categories == ["chapter_read"]
     finally:
         await engine.dispose()
 

--- a/frontend/src/features/settings/components/agent-definitions-settings.tsx
+++ b/frontend/src/features/settings/components/agent-definitions-settings.tsx
@@ -62,6 +62,7 @@ import {
 import { fetchSettings } from "../lib/settings-api";
 
 const LIST_WIDTH = 280;
+const SUBAGENT_RESTRICTED_TOOL_CATEGORIES = new Set(["orchestration", "interaction"]);
 const MotionBox = motion.create(Box);
 
 const mobilePageVariants = {
@@ -84,6 +85,14 @@ interface AgentListMenuState {
 function getEffectiveModelSelection(modelId: string | null): string {
   if (!modelId) return SYSTEM_DEFAULT_MODEL_REFERENCE;
   return modelId;
+}
+
+function getEnabledToolCategoriesForAgent(
+  kind: "primary" | "subagent",
+  categories: string[],
+): string[] {
+  if (kind !== "subagent") return categories;
+  return categories.filter((category) => !SUBAGENT_RESTRICTED_TOOL_CATEGORIES.has(category));
 }
 
 function buildAgentModelOptions(
@@ -136,7 +145,7 @@ function AgentForm({
   const [formDescription, setFormDescription] = useState(def.description);
   const [formModelId, setFormModelId] = useState(getEffectiveModelSelection(def.model_id));
   const [formEnabledToolCategories, setFormEnabledToolCategories] = useState<string[]>([
-    ...def.enabled_tool_categories,
+    ...getEnabledToolCategoriesForAgent(def.kind, def.enabled_tool_categories),
   ]);
   const [formEnabledSkills, setFormEnabledSkills] = useState<string[]>([...def.enabled_skills]);
   const [formDelegatableAgents, setFormDelegatableAgents] = useState<string[]>([
@@ -165,7 +174,8 @@ function AgentForm({
       formDisplayName !== def.display_name ||
       formDescription !== def.description ||
       formModelId !== getEffectiveModelSelection(def.model_id) ||
-      JSON.stringify(formEnabledToolCategories) !== JSON.stringify(def.enabled_tool_categories) ||
+      JSON.stringify(formEnabledToolCategories) !==
+        JSON.stringify(getEnabledToolCategoriesForAgent(def.kind, def.enabled_tool_categories)) ||
       JSON.stringify(formEnabledSkills) !== JSON.stringify(def.enabled_skills) ||
       JSON.stringify(formDelegatableAgents) !== JSON.stringify(def.delegatable_agents)
     );
@@ -180,6 +190,13 @@ function AgentForm({
   ]);
 
   const isPrimary = def.kind === "primary";
+  const selectableToolCategoryOptions = useMemo(
+    () =>
+      toolCategoryOptions.filter(
+        (option) => def.kind !== "subagent" || !SUBAGENT_RESTRICTED_TOOL_CATEGORIES.has(option.key),
+      ),
+    [def.kind, toolCategoryOptions],
+  );
 
   const updateMutation = useMutation({
     mutationFn: async () => {
@@ -316,7 +333,7 @@ function AgentForm({
         >
           {t("settings.agentsToolCategories")}
         </Text>
-        {toolCategoryOptions.length === 0 ? (
+        {selectableToolCategoryOptions.length === 0 ? (
           <Text
             size="2"
             color="gray"
@@ -328,7 +345,7 @@ function AgentForm({
             wrap="wrap"
             gap="2"
           >
-            {toolCategoryOptions.map((opt) => (
+            {selectableToolCategoryOptions.map((opt) => (
               <label
                 key={opt.key}
                 style={{
@@ -742,7 +759,10 @@ export function AgentDefinitionsSettings({
         kind: newKind,
         prompt_agent_name: newKey.trim(),
         model_id: sourceDefinition?.model_id ?? SYSTEM_DEFAULT_MODEL_REFERENCE,
-        enabled_tool_categories: sourceDefinition?.enabled_tool_categories ?? [],
+        enabled_tool_categories: getEnabledToolCategoriesForAgent(
+          newKind,
+          sourceDefinition?.enabled_tool_categories ?? [],
+        ),
         enabled_skills: sourceDefinition?.enabled_skills ?? [],
         metadata: sourceDefinition?.metadata ?? {},
         delegatable_agents: sourceDefinition?.delegatable_agents ?? [],


### PR DESCRIPTION
## PR 标题

chore(agent): 限制子智能体委派与提问能力

## 变更说明

- 问题: 子智能体配置可启用委派子任务和提问能力，且异常配置会被带入运行时工具集。
- 重要性: 子智能体不应继续委派或直接向用户提问，避免工具权限与执行边界被绕过。
- 变化: 子智能体设置面板隐藏两项能力；创建、更新和类型切换时清除受限分类；运行时额外过滤对应工具。
- 测试: 增加创建、更新、类型切换及运行时过滤的回归测试。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因(如有)

智能体定义服务未按 `kind` 限制工具分类，子智能体运行时也直接使用定义中配置的工具类别。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令：

- `just check`
- `pnpm lint`
- `pnpm type-check`
- `pnpm format:check`
