### PR TITLE
fix(agent): 修复会话切换模型不生效

### DIFF
--- a/backend/app/agent_runtime/runner/session_runner.py
+++ b/backend/app/agent_runtime/runner/session_runner.py
@@ -73,7 +73,7 @@ class SessionRunner:
         self._validate_model_config(model_config)
         self.session_id = session_id
         self.task_id = task_id
-        self.model_config = model_config
+        self.model_config = dict(model_config)
         self.project_id = project_id
         self.agent_key = agent_key
         self._graph: CompiledStateGraph | None = None
@@ -96,6 +96,10 @@ class SessionRunner:
                 "config",
                 "model_config.max_context_tokens must be a positive int",
             )
+
+    def update_model_config(self, model_config: dict) -> None:
+        self._validate_model_config(model_config)
+        self.model_config = dict(model_config)
 
     async def _get_graph(self) -> CompiledStateGraph:
         if self._graph is None:

--- a/backend/app/api/routers/agent_runtime.py
+++ b/backend/app/api/routers/agent_runtime.py
@@ -707,9 +707,23 @@ async def send_agent_message(
             session_id=session_id,
             message="Agent 消息已排队",
             queued=True,
+            model_updated=False,
             pending_message=AgentPendingMessageResponse(**pending_message),
         )
-    if await runner.can_continue():
+    can_continue = await runner.can_continue()
+    model_updated = False
+    if body.model_id and not can_continue:
+        try:
+            runner.update_model_config(await _resolve_model_config(session, body.model_id))
+            model_updated = True
+        except NotFoundError as exc:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=str(exc),
+            ) from exc
+    if can_continue:
         coro = runner.continue_with_user_message(body.message)
     else:
         coro = runner.run(user_request=body.message)
@@ -725,6 +739,7 @@ async def send_agent_message(
         session_id=session_id,
         message="Agent 任务已启动",
         queued=False,
+        model_updated=model_updated,
         pending_message=None,
     )
 

--- a/backend/app/api/schemas/agent.py
+++ b/backend/app/api/schemas/agent.py
@@ -46,6 +46,7 @@ class AgentSendMessageRequest(BaseModel):
     """发送用户消息请求。"""
 
     message: str = Field(..., description="用户消息内容")
+    model_id: str | None = Field(default=None, description="下一轮执行使用的模型ID")
 
 
 class AgentPendingMessageResponse(BaseModel):
@@ -63,6 +64,7 @@ class AgentSendMessageResponse(BaseModel):
     session_id: str = Field(..., description="会话ID")
     message: str = Field(..., description="结果消息")
     queued: bool = Field(default=False, description="是否进入 pending 队列")
+    model_updated: bool = Field(default=False, description="是否已更新下一轮执行模型")
     pending_message: AgentPendingMessageResponse | None = Field(
         default=None,
         description="进入 pending 的消息负载",

--- a/backend/tests/api/test_agent.py
+++ b/backend/tests/api/test_agent.py
@@ -21,6 +21,7 @@ from app.agent_runtime.persistence.child_runs import (
 from app.agent_runtime.revisions import begin_user_revision
 from app.agent_runtime.runner.checkpointer import reset_checkpointer
 from app.agent_runtime.runner.run_registry import get_agent_run_registry
+from app.agent_runtime.runner.session_runner import SessionRunner
 from app.agent_runtime.streaming.replay_buffer import get_agent_event_replay_buffer
 from app.api.routers.agent_runtime import _SESSION_RUNNERS
 from app.socket.handlers import agent_session_room, agent_subagents_room
@@ -298,6 +299,144 @@ class TestAgentAPI:
 
         created_task = await task_service.get_task(session, data["task_id"])
         assert created_task.title == data["task_title"]
+
+    async def test_send_agent_message_uses_requested_model_for_next_run(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session.add(
+            Task(
+                id="task-model-switch",
+                project_id=target["project_id"],
+                title="模型切换",
+                mode="agent",
+                agent_session_id="session-model-switch",
+            )
+        )
+        await session.commit()
+
+        runner = SessionRunner(
+            session_id="session-model-switch",
+            task_id="task-model-switch",
+            model_config={"max_context_tokens": 8000, "model_id": "previous-model"},
+            project_id=target["project_id"],
+        )
+        runner.can_continue = AsyncMock(return_value=False)
+        runner.run = MagicMock(return_value=AsyncMock())
+        _SESSION_RUNNERS["session-model-switch"] = runner
+
+        next_model_config = {"max_context_tokens": 32000, "model_id": "next-model"}
+        with patch(
+            "app.api.routers.agent_runtime._resolve_model_config",
+            AsyncMock(return_value=next_model_config),
+        ) as resolve_model_config, patch(
+            "app.api.routers.agent_runtime._launch_task",
+            AsyncMock(),
+        ):
+            response = await client.post(
+                "/api/v1/agent/sessions/session-model-switch/message",
+                json={"message": "使用新模型继续", "model_id": "next-model-record"},
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["model_updated"] is True
+        resolve_model_config.assert_awaited_once_with(session, "next-model-record")
+        assert runner.model_config == next_model_config
+        runner.run.assert_called_once_with(user_request="使用新模型继续")
+
+    async def test_send_agent_message_keeps_interrupted_run_model(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session.add(
+            Task(
+                id="task-model-resume",
+                project_id=target["project_id"],
+                title="模型恢复",
+                mode="agent",
+                agent_session_id="session-model-resume",
+            )
+        )
+        await session.commit()
+
+        original_model_config = {"max_context_tokens": 8000, "model_id": "original-model"}
+        runner = SessionRunner(
+            session_id="session-model-resume",
+            task_id="task-model-resume",
+            model_config=original_model_config,
+            project_id=target["project_id"],
+        )
+        runner.can_continue = AsyncMock(return_value=True)
+        runner.continue_with_user_message = MagicMock(return_value=AsyncMock())
+        _SESSION_RUNNERS["session-model-resume"] = runner
+
+        with patch(
+            "app.api.routers.agent_runtime._resolve_model_config",
+            AsyncMock(),
+        ) as resolve_model_config, patch(
+            "app.api.routers.agent_runtime._launch_task",
+            AsyncMock(),
+        ):
+            response = await client.post(
+                "/api/v1/agent/sessions/session-model-resume/message",
+                json={"message": "继续原任务", "model_id": "new-model-record"},
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["model_updated"] is False
+        resolve_model_config.assert_not_awaited()
+        assert runner.model_config == original_model_config
+        runner.continue_with_user_message.assert_called_once_with("继续原任务")
+
+    async def test_send_agent_message_queues_without_updating_model(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session.add(
+            Task(
+                id="task-model-pending",
+                project_id=target["project_id"],
+                title="模型排队",
+                mode="agent",
+                agent_session_id="session-model-pending",
+            )
+        )
+        await session.commit()
+
+        runner = MagicMock()
+        runner.task_id = "task-model-pending"
+        runner.project_id = target["project_id"]
+        runner.queue_pending_user_message = AsyncMock(
+            return_value={
+                "message_id": "pending-model-message",
+                "content": "排队消息",
+                "created_at": "2026-07-12T00:00:00+00:00",
+            }
+        )
+        _SESSION_RUNNERS["session-model-pending"] = runner
+
+        with patch(
+            "app.api.routers.agent_runtime._resolve_model_config",
+            AsyncMock(),
+        ) as resolve_model_config, patch(
+            "app.api.routers.agent_runtime.get_agent_run_registry"
+        ) as get_registry:
+            get_registry.return_value.is_running = AsyncMock(return_value=True)
+            response = await client.post(
+                "/api/v1/agent/sessions/session-model-pending/message",
+                json={"message": "排队消息", "model_id": "next-model-record"},
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["model_updated"] is False
+        resolve_model_config.assert_not_awaited()
+        runner.queue_pending_user_message.assert_awaited_once_with("排队消息")
 
     async def test_create_agent_session_rejects_mode_field(self, client: AsyncClient) -> None:
         target = await _seed_agent_target(client)

--- a/frontend/src/features/assistant/hooks/use-agent-session.ts
+++ b/frontend/src/features/assistant/hooks/use-agent-session.ts
@@ -167,6 +167,7 @@ export function useAgentSession({
   const ignoredApprovalIdsRef = useRef<Set<string>>(new Set());
   const suppressSocketEventsAfterAbortRef = useRef(false);
   const sessionIdRef = useRef<string | null>(null);
+  const activeModelIdRef = useRef<string | null>(null);
   const pendingMessageRef = useRef<AgentPendingMessage | null>(null);
   const isCompactingRef = useRef(false);
   const manualCompactionPreviousStateRef = useRef<Pick<
@@ -590,6 +591,7 @@ export function useAgentSession({
 
         onSessionCreated?.(createResponse);
         sessionIdRef.current = createResponse.session_id;
+        activeModelIdRef.current = modelId;
         setSessionId(createResponse.session_id);
         queryClient.invalidateQueries({ queryKey: ["tasks", projectId], exact: false });
         attachAgentSocket(createResponse.session_id);
@@ -646,7 +648,9 @@ export function useAgentSession({
           attachAgentSocket(activeSessionId);
           await joinAgentSession(activeSessionId);
         }
-        const response = await sendAgentMessage(activeSessionId, message);
+        const nextModelId = modelId === activeModelIdRef.current ? undefined : modelId;
+        const response = await sendAgentMessage(activeSessionId, message, nextModelId);
+        if (response.model_updated && nextModelId) activeModelIdRef.current = nextModelId;
         if (response.queued && response.pending_message) {
           syncPendingMessageState(createPendingUserMessage(response.pending_message));
         }
@@ -661,7 +665,7 @@ export function useAgentSession({
         toast.error(i18n.t("assistant.sendMessageFailed"));
       }
     },
-    [attachAgentSocket, sessionId, syncPendingMessageState, updateTranscriptState],
+    [attachAgentSocket, modelId, sessionId, syncPendingMessageState, updateTranscriptState],
   );
 
   const compactSession = useCallback(async () => {
@@ -836,6 +840,7 @@ export function useAgentSession({
 
   const resetSession = useCallback(() => {
     sessionIdRef.current = null;
+    activeModelIdRef.current = null;
     suppressSocketEventsAfterAbortRef.current = false;
     transportRetryAttemptRef.current = 0;
     suppressNextErrorAfterCompactionErrorRef.current = false;
@@ -885,6 +890,7 @@ export function useAgentSession({
       } = {},
     ) => {
       sessionIdRef.current = existingSessionId;
+      activeModelIdRef.current = null;
       suppressSocketEventsAfterAbortRef.current = false;
       transportRetryAttemptRef.current = 0;
       suppressNextErrorAfterCompactionErrorRef.current = false;

--- a/frontend/src/lib/agent.types.ts
+++ b/frontend/src/lib/agent.types.ts
@@ -258,6 +258,7 @@ export interface AgentSessionStateResponse {
 
 export interface AgentSendMessageRequest {
   message: string;
+  model_id?: string;
 }
 
 export type AgentPendingMessageAction = "queued" | "cancelled" | "consumed";
@@ -273,6 +274,7 @@ export interface AgentSendMessageResponse {
   session_id: string;
   message: string;
   queued: boolean;
+  model_updated: boolean;
   pending_message: AgentPendingMessage | null;
 }
 

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -2199,6 +2199,7 @@ import type {
   AgentSessionCreateResponse,
   AgentForkResponse,
   AgentPendingMessage,
+  AgentSendMessageRequest,
   AgentSendMessageResponse,
   AgentSessionStateResponse,
   AgentRollbackResponse,
@@ -2310,14 +2311,20 @@ export async function fetchSubagentSession(childRunId: string): Promise<Subagent
 export async function sendAgentMessage(
   sessionId: string,
   message: string,
+  modelId?: string,
 ): Promise<AgentSendMessageResponse> {
-  const response = await apiClient.post(`/agent/sessions/${sessionId}/message`, { message });
+  const request: AgentSendMessageRequest = {
+    message,
+    ...(modelId ? { model_id: modelId } : {}),
+  };
+  const response = await apiClient.post(`/agent/sessions/${sessionId}/message`, request);
   const data = response.data as Record<string, unknown>;
   return {
     success: data.success === true,
     session_id: String(data.session_id ?? sessionId),
     message: String(data.message ?? ""),
     queued: data.queued === true,
+    model_updated: data.model_updated === true,
     pending_message: transformPendingAgentMessage(data.pending_message),
   };
 }


### PR DESCRIPTION
## PR 标题

fix(agent): 修复会话切换模型不生效

## 变更说明

- 问题: 已创建 Agent 会话在前端切换模型后，后续消息仍使用创建会话时的模型。
- 重要性: 模型选择器状态与实际运行模型不一致，导致用户配置无法生效。
- 变化: 新一轮 Agent 运行会接收并应用当前模型；运行中排队消息和中断恢复继续使用原模型。
- 变化: 增加模型更新结果字段与回归测试，避免重复解析未变化的模型配置。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

已有会话发送消息时，前端未传递当前 `model_id`；后端消息接口也未接收或更新运行配置，导致 `SessionRunner` 始终复用会话创建时的模型配置。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证记录：

- `uv run pytest tests/api/test_agent.py tests/agent_runtime/runner/test_session_runner_config.py -q`：42 passed
- `uv run ruff check .`
- `uv run ty check app`
- `pnpm type-check`
- `pnpm lint`
- `pnpm format:check`
