### PR TITLE
fix(agent): 防止会话检查点泄露模型密钥

### DIFF
--- a/backend/app/agent_runtime/context/compaction/service.py
+++ b/backend/app/agent_runtime/context/compaction/service.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.context.compaction.window import CompactionWindow
 from app.agent_runtime.graph.state import AgentRuntimeState
+from app.agent_runtime.model_config import to_client_model_config
 from app.agent_runtime.persistence import compaction_repo
 from app.agent_runtime.persistence import repo as message_repo
 from app.agent_runtime.persistence.compaction_types import (
@@ -44,6 +45,7 @@ async def compact_window(
     trigger: CompactionTrigger,
     event_sink: EventSink | None = None,
     usage_sink: UsageSink | None = None,
+    model_config: Mapping[str, Any] | None = None,
 ) -> PersistedCompaction:
     session_id = str(state.get("session_id") or "")
     task_id = str(state.get("task_id") or "")
@@ -86,8 +88,10 @@ async def compact_window(
         raise error from exc
 
     try:
-        model_config = _model_config(state)
-        model = create_chat_model(ModelConfig(**model_config))
+        effective_model_config = (
+            dict(model_config) if model_config is not None else _model_config(state)
+        )
+        model = create_chat_model(ModelConfig(**to_client_model_config(effective_model_config)))
         response = await model.ainvoke(messages)
     except Exception as exc:
         logger.opt(exception=True).error("Compaction LLM request failed")

--- a/backend/app/agent_runtime/fork.py
+++ b/backend/app/agent_runtime/fork.py
@@ -12,6 +12,7 @@ from sqlmodel import col
 
 from app.agent_runtime.persistence import compaction_repo, repo as message_repo
 from app.agent_runtime.persistence.model import AgentRunMessage
+from app.agent_runtime.model_config import without_api_key
 from app.core.errors import NotFoundError
 from app.core.ids import generate_id
 from app.storage.models.revision import Revision
@@ -65,7 +66,7 @@ def _build_fork_state(
         "session_id": session_id,
         "task_id": task.id,
         "project_id": task.project_id,
-        "model_config": model_config,
+        "model_config": without_api_key(model_config),
         "active_agent": None,
         "is_completed": True,
         "error": None,

--- a/backend/app/agent_runtime/graph/orchestrator/graph.py
+++ b/backend/app/agent_runtime/graph/orchestrator/graph.py
@@ -19,6 +19,7 @@ from app.agent_runtime.graph.config import build_child_config, get_inject_queue
 from app.agent_runtime.graph.node_events import with_node_events
 from app.agent_runtime.graph.orchestrator.state import OrchestratorState
 from app.agent_runtime.graph.react_agent import create_react_agent
+from app.agent_runtime.model_config import to_client_model_config
 from app.agent_runtime.tools import ToolRegistry
 from app.agent_runtime.tools.impls.skill.skill import skill_tool_names_for_definition
 from app.agent_runtime.tools.hooks.auth import auth_hook
@@ -84,10 +85,17 @@ async def primary_node(
     config: RunnableConfig | None = None,
 ) -> dict:
     """Run the Primary Agent as the only parent graph node."""
-    model_config = ModelConfig(**state["model_config"])
+    configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
+    runtime_model_config = (
+        configurable.get("model_config") if isinstance(configurable, dict) else None
+    )
+    if not isinstance(runtime_model_config, dict):
+        raise ValueError("Agent 运行时模型配置不可用")
+    model_config = ModelConfig(**to_client_model_config(runtime_model_config))
     model = create_chat_model(model_config)
     agent_key = state.get("agent_key", "primary")
     tool_state = dict(state)
+    tool_state["model_config"] = dict(runtime_model_config)
     tool_state["active_agent"] = agent_key
 
     agent_config = ReactAgentConfig(
@@ -111,6 +119,7 @@ async def primary_node(
     )
 
     effective_state = dict(state)
+    effective_state["model_config"] = dict(runtime_model_config)
     effective_state["active_agent"] = agent_key
     await react_graph.ainvoke(
         {

--- a/backend/app/agent_runtime/graph/react_agent.py
+++ b/backend/app/agent_runtime/graph/react_agent.py
@@ -219,12 +219,13 @@ async def maybe_auto_compact(
     db_session: Any,
     event_sink: Callable[[str, dict[str, Any]], Awaitable[None] | None] | None,
     usage_sink: Callable[[dict[str, Any]], Awaitable[None] | None] | None,
+    model_config: Mapping[str, Any] | None = None,
 ) -> bool:
     del agent_name
-    model_config = state.get("model_config")
+    persisted_model_config = state.get("model_config")
     max_context_tokens = 0
-    if isinstance(model_config, Mapping):
-        raw_max_context_tokens = model_config.get("max_context_tokens")
+    if isinstance(persisted_model_config, Mapping):
+        raw_max_context_tokens = persisted_model_config.get("max_context_tokens")
         if isinstance(raw_max_context_tokens, int):
             max_context_tokens = raw_max_context_tokens
     if max_context_tokens <= 0:
@@ -289,6 +290,7 @@ async def maybe_auto_compact(
             trigger="auto",
             event_sink=tracked_event_sink if event_sink is not None else None,
             usage_sink=usage_sink,
+            model_config=model_config,
         )
     except CompactionError as exc:
         await emit_error_once(exc)
@@ -509,6 +511,9 @@ def create_react_agent(
         compaction_usage_sink = configurable.get("compaction_usage_sink")
         if not callable(compaction_usage_sink):
             compaction_usage_sink = None
+        runtime_model_config = configurable.get("model_config")
+        if not isinstance(runtime_model_config, Mapping):
+            runtime_model_config = None
         drained_injected_user_message = False
         context_parts: list[ContextMessage] | None = None
         effective_runtime_state: Mapping[str, Any] | None = None
@@ -627,6 +632,7 @@ def create_react_agent(
                 db_session=runtime_db_session,
                 event_sink=agent_event_sink,
                 usage_sink=compaction_usage_sink,
+                model_config=runtime_model_config,
             ):
                 context_parts = await build_context_parts(
                     state=cast("AgentRuntimeState", effective_runtime_state),

--- a/backend/app/agent_runtime/model_config.py
+++ b/backend/app/agent_runtime/model_config.py
@@ -1,0 +1,16 @@
+from collections.abc import Mapping
+from typing import Any
+
+
+def without_api_key(model_config: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the model configuration safe to persist in graph state."""
+    persisted_config = dict(model_config)
+    persisted_config.pop("api_key", None)
+    return persisted_config
+
+
+def to_client_model_config(model_config: Mapping[str, Any]) -> dict[str, Any]:
+    """Remove Agent runtime-only fields before constructing a model client."""
+    client_config = dict(model_config)
+    client_config.pop("model_record_id", None)
+    return client_config

--- a/backend/app/agent_runtime/runner/checkpointer.py
+++ b/backend/app/agent_runtime/runner/checkpointer.py
@@ -1,11 +1,13 @@
 import os
 import shutil
 from pathlib import Path
-
 import aiosqlite
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import Checkpoint, copy_checkpoint
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 
 import app.settings as app_settings
+from app.agent_runtime.model_config import without_api_key
 
 _checkpointer: AsyncSqliteSaver | None = None
 
@@ -53,7 +55,35 @@ async def get_checkpointer() -> AsyncSqliteSaver:
         conn = await aiosqlite.connect(db_path)
         _checkpointer = AsyncSqliteSaver(conn)
         await _checkpointer.setup()
+        await _remove_api_keys_from_existing_checkpoints(_checkpointer)
     return _checkpointer
+
+
+async def _remove_api_keys_from_existing_checkpoints(
+    checkpointer: AsyncSqliteSaver,
+) -> None:
+    """Rewrite legacy Agent checkpoints that persisted plaintext API keys."""
+    checkpoints: list[tuple[RunnableConfig, Checkpoint]] = []
+    async for item in checkpointer.alist(None):
+        channel_values = item.checkpoint.get("channel_values")
+        if not isinstance(channel_values, dict):
+            continue
+        model_config = channel_values.get("model_config")
+        if not isinstance(model_config, dict) or "api_key" not in model_config:
+            continue
+        sanitized_checkpoint = copy_checkpoint(item.checkpoint)
+        sanitized_channel_values = sanitized_checkpoint["channel_values"]
+        sanitized_channel_values["model_config"] = without_api_key(model_config)
+        sanitized_checkpoint["channel_values"] = sanitized_channel_values
+        checkpoints.append((item.config, sanitized_checkpoint))
+
+    for config, checkpoint in checkpoints:
+        await checkpointer.aput(
+            config,
+            checkpoint,
+            {},
+            checkpoint.get("channel_versions", {}),
+        )
 
 
 async def delete_checkpoints_for_thread(thread_id: str) -> int:

--- a/backend/app/agent_runtime/runner/session_runner.py
+++ b/backend/app/agent_runtime/runner/session_runner.py
@@ -21,6 +21,7 @@ from app.agent_runtime.audit.collector import AuditCollector
 from app.agent_runtime.graph.orchestrator.graph import build_orchestrator_graph
 from app.agent_runtime.graph.react_agent import _to_history_dict
 from app.agent_runtime.graph.state import AgentRuntimeState
+from app.agent_runtime.model_config import without_api_key
 from app.agent_runtime.persistence import (
     MessagePersister,
     PersistenceError,
@@ -409,6 +410,7 @@ class SessionRunner:
                 "compaction_usage_sink": self._emit_persisted_task_usage_events,
                 "inject_queue": self._inject_queue,
                 "inject_message_consumed_sink": self._mark_injected_user_message_sent,
+                "model_config": self.model_config,
             }
         }
 
@@ -569,7 +571,7 @@ class SessionRunner:
                 "session_id": self.session_id,
                 "task_id": self.task_id,
                 "project_id": self.project_id,
-                "model_config": self.model_config,
+                "model_config": without_api_key(self.model_config),
                 "active_agent": None,
                 "agent_key": self.agent_key,
                 "is_completed": False,
@@ -613,6 +615,7 @@ class SessionRunner:
                 trigger="manual",
                 event_sink=self._emit_agent_event,
                 usage_sink=self._emit_persisted_task_usage_events,
+                model_config=self.model_config,
             )
             return {
                 "compaction_id": result.id,
@@ -672,7 +675,7 @@ class SessionRunner:
                 "session_id": self.session_id,
                 "task_id": self.task_id,
                 "project_id": self.project_id,
-                "model_config": self.model_config,
+                "model_config": without_api_key(self.model_config),
                 "active_agent": None,
                 "agent_key": self.agent_key,
                 "is_completed": False,

--- a/backend/app/agent_runtime/runner/subagent_runner.py
+++ b/backend/app/agent_runtime/runner/subagent_runner.py
@@ -16,6 +16,7 @@ from app.agent_runtime.agents.definitions import (
 from app.agent_runtime.audit.collector import AuditCollector
 from app.agent_runtime.agents.tool_categories import get_tool_names_for_categories
 from app.agent_runtime.graph.react_agent import create_react_agent
+from app.agent_runtime.model_config import to_client_model_config
 from app.agent_runtime.persistence import MessagePersister
 from app.agent_runtime.persistence.child_runs import (
     claim_next_child_run_request,
@@ -341,7 +342,7 @@ class SubagentRunner:
             )
         finally:
             await _close_session(session)
-        model = create_chat_model(ModelConfig(**model_config))
+        model = create_chat_model(ModelConfig(**to_client_model_config(model_config)))
         return create_react_agent(
             agent_config,
             model=model,

--- a/backend/app/api/routers/agent_runtime.py
+++ b/backend/app/api/routers/agent_runtime.py
@@ -31,6 +31,7 @@ from app.agent_runtime.persistence.task_projection import (
 from app.agent_runtime.persistence.model import AgentChildRun
 from app.agent_runtime.revisions import rollback_revision_for_session
 from app.agent_runtime.fork import fork_agent_session_at_revision
+from app.agent_runtime.model_config import without_api_key
 from app.agent_runtime.runner.checkpointer import (
     delete_checkpoints_after_for_thread,
     delete_checkpoints_for_thread,
@@ -250,7 +251,7 @@ def _build_seed_state(
         "session_id": session_id,
         "task_id": task_id,
         "project_id": project_id,
-        "model_config": dict(model_config),
+        "model_config": without_api_key(model_config),
         "active_agent": None,
         "agent_key": agent_key,
         "is_completed": False,
@@ -365,7 +366,10 @@ async def _get_runner(session_id: str, session: AsyncSession | None = None) -> S
     restored_model_config = values.get("model_config")
     if not _is_valid_model_config(restored_model_config):
         raise NotFoundError(f"会话不存在: {session_id}")
-    runner.model_config = dict(restored_model_config)
+    model_record_id = restored_model_config.get("model_record_id")
+    if not isinstance(model_record_id, str) or not model_record_id:
+        raise NotFoundError(f"会话不存在: {session_id}")
+    runner.model_config = await _resolve_model_config(session, model_record_id)
     restored_agent_key = values.get("agent_key")
     if isinstance(restored_agent_key, str) and restored_agent_key:
         runner.agent_key = restored_agent_key
@@ -375,6 +379,7 @@ async def _get_runner(session_id: str, session: AsyncSession | None = None) -> S
 
 def _build_model_config(model, provider, api_key: str) -> dict:
     return {
+        "model_record_id": model.id,
         "provider_type": provider.provider_type,
         "base_url": provider.url,
         "api_key": api_key,

--- a/backend/tests/agent_runtime/test_checkpointer.py
+++ b/backend/tests/agent_runtime/test_checkpointer.py
@@ -6,6 +6,9 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import app.agent_runtime.runner.checkpointer as checkpointer_mod
+import aiosqlite
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+import pytest
 from app.agent_runtime.runner.checkpointer import (
     close_checkpointer,
     delete_checkpoints_after_for_thread,
@@ -14,6 +17,50 @@ from app.agent_runtime.runner.checkpointer import (
     init_checkpointer,
     reset_checkpointer,
 )
+
+
+@pytest.mark.asyncio
+async def test_get_checkpointer_removes_api_keys_from_legacy_checkpoints():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        db_path = os.path.join(tmpdir, "test_checkpoints.db")
+        os.environ["AGENT_CHECKPOINT_DB"] = db_path
+        await reset_checkpointer()
+
+        conn = await aiosqlite.connect(db_path)
+        legacy_checkpointer = AsyncSqliteSaver(conn)
+        await legacy_checkpointer.setup()
+        config = {
+            "configurable": {
+                "thread_id": "legacy-session",
+                "checkpoint_ns": "",
+            }
+        }
+        checkpoint = {
+            "v": 2,
+            "id": "legacy-checkpoint",
+            "ts": "2026-07-12T00:00:00+00:00",
+            "channel_values": {
+                "model_config": {
+                    "model_record_id": "model-1",
+                    "model_id": "gpt-test",
+                    "api_key": "legacy-secret",
+                }
+            },
+            "channel_versions": {},
+            "versions_seen": {},
+            "pending_sends": [],
+        }
+        await legacy_checkpointer.aput(config, checkpoint, {}, {})
+        await conn.close()
+
+        checkpointer = await get_checkpointer()
+        persisted = await checkpointer.aget_tuple(config)
+
+        assert persisted is not None
+        assert "api_key" not in persisted.checkpoint["channel_values"]["model_config"]
+
+        del os.environ["AGENT_CHECKPOINT_DB"]
+        await reset_checkpointer()
 
 
 async def test_get_checkpointer_creates_db():

--- a/backend/tests/agent_runtime/test_model_factory.py
+++ b/backend/tests/agent_runtime/test_model_factory.py
@@ -1,4 +1,21 @@
+from app.agent_runtime.model_config import to_client_model_config
 from app.models.clients.model_factory import create_chat_model, ModelConfig
+
+
+def test_to_client_model_config_excludes_internal_model_record_id():
+    config = to_client_model_config(
+        {
+            "model_record_id": "model-record-1",
+            "provider_type": "openai-compatible",
+            "base_url": "https://api.openai.com/v1",
+            "api_key": "sk-test",
+            "model_id": "gpt-4o",
+        }
+    )
+
+    model = create_chat_model(ModelConfig(**config))
+
+    assert model.model_name == "gpt-4o"
 
 
 def test_create_chat_model_openai_returns_chat_openai():

--- a/backend/tests/agent_runtime/test_session_runner.py
+++ b/backend/tests/agent_runtime/test_session_runner.py
@@ -29,6 +29,29 @@ def test_session_runner_inject_queue():
     assert runner._inject_queue.empty()
 
 
+def test_runtime_config_keeps_api_key_outside_persisted_state():
+    runner = SessionRunner(
+        session_id="sess_runtime_config",
+        task_id="task_runtime_config",
+        model_config={
+            "model_record_id": "model-record-1",
+            "provider_type": "openai-compatible",
+            "model_id": "gpt-4o",
+            "api_key": "sk-runtime",
+            "base_url": "",
+            "max_context_tokens": 8000,
+        },
+    )
+
+    config = runner._build_runtime_config(
+        runtime_session=MagicMock(),
+        runtime_context={},
+        audit_collector=MagicMock(),
+    )
+
+    assert config["configurable"]["model_config"]["api_key"] == "sk-runtime"
+
+
 @pytest.mark.asyncio
 async def test_session_runner_inject_message():
     runner = SessionRunner(session_id="sess_001", task_id="task_001", model_config={

--- a/backend/tests/api/test_agent.py
+++ b/backend/tests/api/test_agent.py
@@ -19,7 +19,7 @@ from app.agent_runtime.persistence.child_runs import (
     record_child_run_pending_approval,
 )
 from app.agent_runtime.revisions import begin_user_revision
-from app.agent_runtime.runner.checkpointer import reset_checkpointer
+from app.agent_runtime.runner.checkpointer import get_checkpointer, reset_checkpointer
 from app.agent_runtime.runner.run_registry import get_agent_run_registry
 from app.agent_runtime.runner.session_runner import SessionRunner
 from app.agent_runtime.streaming.replay_buffer import get_agent_event_replay_buffer
@@ -1301,6 +1301,37 @@ class TestAgentAPI:
         assert data["is_running"] is False
         assert data["state"]["model_config"]["model_id"] == "gpt-3.5-turbo"
         assert session_id in _SESSION_RUNNERS
+        assert _SESSION_RUNNERS[session_id].model_config["api_key"] == "test_api_key"
+
+    async def test_agent_checkpoint_and_session_state_do_not_contain_api_key(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={
+                "project_id": target["project_id"],
+                "model_id": target["model_id"],
+                "max_iterations": 5,
+            },
+        )
+        session_id = session_response.json()["session_id"]
+
+        checkpointer = await get_checkpointer()
+        checkpoint = await checkpointer.aget_tuple(
+            {"configurable": {"thread_id": session_id}}
+        )
+
+        assert checkpoint is not None
+        persisted_model_config = checkpoint.checkpoint["channel_values"]["model_config"]
+        assert "api_key" not in persisted_model_config
+
+        _SESSION_RUNNERS.clear()
+        response = await client.get(f"/api/v1/agent/sessions/{session_id}")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "api_key" not in response.json()["state"]["model_config"]
 
     async def test_list_subagent_sessions_returns_only_active_state_rows(
         self,


### PR DESCRIPTION
## PR 标题

fix(agent): 防止会话检查点泄露模型密钥

## 变更说明

- 问题: Agent 将解密后的 API Key 写入 LangGraph checkpoint，并可能通过会话状态接口返回。
- 重要性: checkpoint 持久化了可直接调用模型服务的凭据，存在敏感信息泄露风险。
- 变化: checkpoint 仅保存模型记录引用和非敏感参数；运行期在内存中传递完整模型配置，恢复会话时重新解析模型与密钥。
- 变化: 启动时清理旧 checkpoint 中的明文密钥，并在主 Agent、子 Agent 和压缩调用前过滤内部模型引用字段。
- 测试: 补充 checkpoint 清理、会话恢复、运行期密钥边界和模型客户端配置过滤回归测试。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [x] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

Agent 会话创建时将完整模型配置写入图状态，其中包含已解密的 `api_key`。LangGraph 会将图状态保存到 SQLite checkpoint，状态接口又直接返回该状态。为消除泄露，需要区分持久化配置与仅供当前进程调用的运行期配置。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令：

```text
uv run pytest tests/api/test_agent.py tests/agent_runtime/test_checkpointer.py tests/agent_runtime/test_model_factory.py tests/agent_runtime/test_react_agent.py tests/agent_runtime/test_session_runner.py tests/agent_runtime/runner/test_subagent_runner.py -q
119 passed in 51.23s

just lint
All checks passed!

just type-check
All checks passed!
```
