### PR TITLE
fix(settings): 锁定运行期间的智能体配置

### DIFF
--- a/backend/app/agent_runtime/runner/checkpointer.py
+++ b/backend/app/agent_runtime/runner/checkpointer.py
@@ -4,12 +4,18 @@ from pathlib import Path
 import aiosqlite
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import Checkpoint, copy_checkpoint
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 
 import app.settings as app_settings
 from app.agent_runtime.model_config import without_api_key
 
 _checkpointer: AsyncSqliteSaver | None = None
+
+_ALLOWED_MSGPACK_MODULES = (
+    ("app.agent_runtime.tools.impls.interaction.ask_user", "Question"),
+    ("app.agent_runtime.tools.impls.interaction.ask_user", "QuestionOption"),
+)
 
 
 def _default_db_path() -> Path:
@@ -53,7 +59,12 @@ async def get_checkpointer() -> AsyncSqliteSaver:
         db_path = _get_db_path()
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         conn = await aiosqlite.connect(db_path)
-        _checkpointer = AsyncSqliteSaver(conn)
+        _checkpointer = AsyncSqliteSaver(
+            conn,
+            serde=JsonPlusSerializer(
+                allowed_msgpack_modules=_ALLOWED_MSGPACK_MODULES,
+            ),
+        )
         await _checkpointer.setup()
         await _remove_api_keys_from_existing_checkpoints(_checkpointer)
     return _checkpointer

--- a/backend/app/agent_runtime/runner/run_registry.py
+++ b/backend/app/agent_runtime/runner/run_registry.py
@@ -130,6 +130,14 @@ class AgentRunRegistry:
             session_tasks = self._tasks.get(session_id) or {}
             return any(not task.done() for task in session_tasks.values())
 
+    async def has_running_tasks(self) -> bool:
+        async with self._lock:
+            return any(
+                not task.done()
+                for session_tasks in self._tasks.values()
+                for task in session_tasks.values()
+            )
+
     async def is_parent_running(self, session_id: str) -> bool:
         async with self._lock:
             task = (self._tasks.get(session_id) or {}).get("__parent__")

--- a/backend/app/agent_runtime/session_activity.py
+++ b/backend/app/agent_runtime/session_activity.py
@@ -1,0 +1,38 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
+
+from app.agent_runtime.persistence.model import AgentChildRun
+from app.agent_runtime.runner.run_registry import get_agent_run_registry
+from app.storage.models.task import Task
+
+_ACTIVE_CHILD_RUN_STATUSES = ("queued", "running", "waiting_user")
+
+
+async def has_active_agent_sessions(session: AsyncSession) -> bool:
+    """Return whether any parent or child agent session can still resume work."""
+    if await get_agent_run_registry().has_running_tasks():
+        return True
+
+    if await _has_running_agent_task(session):
+        return True
+
+    return await _has_active_child_run(session)
+
+
+async def _has_running_agent_task(session: AsyncSession) -> bool:
+    result = await session.execute(
+        select(Task)
+        .where(col(Task.agent_session_id).is_not(None))
+        .where(col(Task.is_running).is_(True))
+        .limit(1)
+    )
+    return result.scalar_one_or_none() is not None
+async def _has_active_child_run(session: AsyncSession) -> bool:
+    result = await session.execute(
+        select(AgentChildRun)
+        .where(col(AgentChildRun.is_active).is_(True))
+        .where(col(AgentChildRun.status).in_(_ACTIVE_CHILD_RUN_STATUSES))
+        .limit(1)
+    )
+    return result.scalar_one_or_none() is not None

--- a/backend/app/api/agent_settings_lock.py
+++ b/backend/app/api/agent_settings_lock.py
@@ -1,0 +1,17 @@
+from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.agent_runtime.session_activity import has_active_agent_sessions
+
+AGENT_SETTINGS_LOCKED_DETAIL = {
+    "code": "agent_settings_locked",
+    "message": "Agent 会话运行中，无法修改相关设置",
+}
+
+
+async def require_agent_settings_unlocked(session: AsyncSession) -> None:
+    if await has_active_agent_sessions(session):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=AGENT_SETTINGS_LOCKED_DETAIL,
+        )

--- a/backend/app/api/routers/agent_definitions.py
+++ b/backend/app/api/routers/agent_definitions.py
@@ -14,6 +14,7 @@ from app.api.schemas.agent_definition import (
     AgentToolCategoryResponse,
     AgentDefinitionUpdateRequest,
 )
+from app.api.agent_settings_lock import require_agent_settings_unlocked
 from app.agent_runtime.agents.definitions import agent_definition_from_record
 from app.agent_runtime.agents.tool_categories import list_tool_categories
 from app.core.errors import NotFoundError, ValidationError
@@ -98,6 +99,7 @@ async def create_definition(
     session: AsyncSession = Depends(get_session),
 ) -> AgentDefinitionResponse:
     try:
+        await require_agent_settings_unlocked(session)
         record = await agent_definition_service.create_definition(
             session,
             key=body.key,
@@ -137,6 +139,7 @@ async def update_definition(
     session: AsyncSession = Depends(get_session),
 ) -> AgentDefinitionResponse:
     try:
+        await require_agent_settings_unlocked(session)
         record = await agent_definition_service.update_definition(
             session,
             key=key,
@@ -169,6 +172,7 @@ async def reset_definition(
     session: AsyncSession = Depends(get_session),
 ) -> AgentDefinitionResponse:
     try:
+        await require_agent_settings_unlocked(session)
         defn = await agent_definition_service.reset_definition(session, key)
     except ValidationError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
@@ -186,6 +190,7 @@ async def delete_definition(
     session: AsyncSession = Depends(get_session),
 ):
     try:
+        await require_agent_settings_unlocked(session)
         await agent_definition_service.delete_definition(session, key)
     except NotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))

--- a/backend/app/api/routers/agent_rules.py
+++ b/backend/app/api/routers/agent_rules.py
@@ -14,6 +14,7 @@ from app.api.schemas.agent_rule import (
     AgentRuleResponse,
     AgentRuleUpdate,
 )
+from app.api.agent_settings_lock import require_agent_settings_unlocked
 from app.core.errors import NotFoundError
 from app.storage.database import get_session
 from app.storage.services import agent_rule_service
@@ -37,6 +38,7 @@ async def create_rule(
     data: AgentRuleCreate,
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> AgentRuleResponse:
+    await require_agent_settings_unlocked(session)
     logger.info("创建 AgentRule")
     rule = await agent_rule_service.create_rule(
         session,
@@ -79,6 +81,7 @@ async def update_rule(
     data: AgentRuleUpdate,
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> AgentRuleResponse:
+    await require_agent_settings_unlocked(session)
     try:
         rule = await agent_rule_service.update_rule(
             session,
@@ -96,6 +99,7 @@ async def reorder_rules(
     data: AgentRuleReorder,
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> list[AgentRuleResponse]:
+    await require_agent_settings_unlocked(session)
     rules = await agent_rule_service.reorder_rules(session, data.rule_ids)
     return [_to_response(rule) for rule in rules]
 
@@ -105,6 +109,7 @@ async def delete_rule(
     rule_id: str,
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> None:
+    await require_agent_settings_unlocked(session)
     try:
         await agent_rule_service.delete_rule(session, rule_id)
     except NotFoundError as exc:

--- a/backend/app/api/routers/agent_runtime.py
+++ b/backend/app/api/routers/agent_runtime.py
@@ -29,7 +29,7 @@ from app.agent_runtime.persistence.task_projection import (
     load_task_messages_for_agent_session,
 )
 from app.agent_runtime.persistence.model import AgentChildRun
-from app.agent_runtime.revisions import rollback_revision_for_session
+from app.agent_runtime.revisions import finalize_revision_status, rollback_revision_for_session
 from app.agent_runtime.fork import fork_agent_session_at_revision
 from app.agent_runtime.model_config import without_api_key
 from app.agent_runtime.runner.checkpointer import (
@@ -73,6 +73,7 @@ from app.socket import emit
 from app.socket.handlers import agent_session_room, background_project_room
 from app.storage.database import get_session
 from app.storage.models.chapter import Chapter
+from app.storage.repos import revision_repo
 from app.storage.services import task_service
 
 router = APIRouter(tags=["Agent"])
@@ -367,9 +368,18 @@ async def _get_runner(session_id: str, session: AsyncSession | None = None) -> S
     if not _is_valid_model_config(restored_model_config):
         raise NotFoundError(f"会话不存在: {session_id}")
     model_record_id = restored_model_config.get("model_record_id")
-    if not isinstance(model_record_id, str) or not model_record_id:
-        raise NotFoundError(f"会话不存在: {session_id}")
-    runner.model_config = await _resolve_model_config(session, model_record_id)
+    if isinstance(model_record_id, str) and model_record_id:
+        runner.model_config = await _resolve_model_config(session, model_record_id)
+    else:
+        runner.model_config = await _resolve_legacy_model_config(
+            session,
+            restored_model_config,
+        )
+        await graph.aupdate_state(
+            {"configurable": {"thread_id": session_id}},
+            {"model_config": without_api_key(runner.model_config)},
+            as_node="primary",
+        )
     restored_agent_key = values.get("agent_key")
     if isinstance(restored_agent_key, str) and restored_agent_key:
         runner.agent_key = restored_agent_key
@@ -412,6 +422,34 @@ async def _resolve_model_config(session: AsyncSession, model_id: str) -> dict:
         raise ValueError("API密钥解密失败") from exc
 
     return _build_model_config(model, provider, api_key)
+
+
+async def _resolve_legacy_model_config(
+    session: AsyncSession,
+    legacy_model_config: dict[str, object],
+) -> dict:
+    model_id = legacy_model_config.get("model_id")
+    provider_type = legacy_model_config.get("provider_type")
+    base_url = legacy_model_config.get("base_url")
+    if (
+        not isinstance(model_id, str)
+        or not model_id
+        or not isinstance(provider_type, str)
+        or not provider_type
+        or not isinstance(base_url, str)
+        or not base_url
+    ):
+        raise NotFoundError("会话模型配置无法恢复")
+
+    model = await model_repo.get_by_legacy_agent_config(
+        session,
+        model_id=model_id,
+        provider_type=provider_type,
+        base_url=base_url,
+    )
+    if model is None:
+        raise NotFoundError("会话模型配置无法恢复")
+    return await _resolve_model_config(session, model.id)
 
 
 async def _set_task_running_state(
@@ -1228,6 +1266,16 @@ async def cancel_agent_session(
         root_session_id=session_id,
         status_publisher=status_publisher,
     )
+    task = await task_service.get_task_by_agent_session_id(session, session_id)
+    revision = (
+        await revision_repo.get_by_id(session, task.current_revision_id)
+        if task.current_revision_id
+        else None
+    )
+    if revision is not None and revision.status in {"active", "interrupted"}:
+        await finalize_revision_status(session, revision.id, "cancelled")
+    await task_service.update_task(session, task.id, is_running=False)
+    await session.commit()
     return AgentCancelResponse(
         success=True,
         session_id=session_id,

--- a/backend/app/api/routers/model_providers.py
+++ b/backend/app/api/routers/model_providers.py
@@ -23,6 +23,7 @@ from app.api.schemas.model_provider import (
     ModelProviderValidateRequest,
     ModelProviderValidateResponse,
 )
+from app.api.agent_settings_lock import require_agent_settings_unlocked
 from app.models.catalog import ModelProviderCatalogService
 from app.core.encryption import EncryptionService
 from app.core.errors import NotFoundError
@@ -161,6 +162,7 @@ async def create_provider(
     Returns:
         创建的提供商信息。
     """
+    await require_agent_settings_unlocked(session)
     logger.info(f"创建提供商: {provider_type}")
 
     provider = await service.create_provider(
@@ -206,6 +208,7 @@ async def update_provider(
     Raises:
         HTTPException: 如果提供商不存在。
     """
+    await require_agent_settings_unlocked(session)
     logger.info(f"更新提供商: {provider_id}")
 
     try:
@@ -246,6 +249,7 @@ async def delete_provider(
     Raises:
         HTTPException: 如果提供商不存在。
     """
+    await require_agent_settings_unlocked(session)
     logger.info(f"删除提供商: {provider_id}")
 
     try:

--- a/backend/app/api/routers/models.py
+++ b/backend/app/api/routers/models.py
@@ -17,6 +17,7 @@ from app.api.schemas.model import (
     TaskType,
     TagsResponse,
 )
+from app.api.agent_settings_lock import require_agent_settings_unlocked
 from app.core.errors import NotFoundError
 from app.storage.database import get_session
 from app.models.services import ModelService
@@ -176,6 +177,7 @@ async def create_model(
     Returns:
         创建的模型信息。
     """
+    await require_agent_settings_unlocked(session)
     logger.info(f"创建模型: {request.name}")
 
     model = await service.create_model(
@@ -230,6 +232,7 @@ async def update_model(
     Raises:
         HTTPException: 如果模型不存在。
     """
+    await require_agent_settings_unlocked(session)
     logger.info(f"更新模型: {model_id}")
 
     try:
@@ -285,6 +288,7 @@ async def delete_model(
     Raises:
         HTTPException: 如果模型不存在。
     """
+    await require_agent_settings_unlocked(session)
     logger.info(f"删除模型: {model_id}")
 
     try:

--- a/backend/app/api/routers/retrieval_index.py
+++ b/backend/app/api/routers/retrieval_index.py
@@ -12,6 +12,7 @@ from app.api.schemas.retrieval_index import (
     IndexStartResponse,
     IndexStopResponse,
 )
+from app.api.agent_settings_lock import require_agent_settings_unlocked
 from app.background.jobs import service as background_service
 from app.background.jobs.constants import JOB_TYPE_RETRIEVAL_CHAPTER_INDEX_BATCH
 from app.background.jobs.states import JOB_STATUS_PENDING, JOB_STATUS_RUNNING
@@ -68,6 +69,7 @@ async def start_project_retrieval_index(
     project_id: str,
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> IndexStartResponse:
+    await require_agent_settings_unlocked(session)
     await _require_project(session, project_id)
     config = await get_index_settings(session)
     if not is_project_index_enabled(config, project_id):
@@ -96,6 +98,7 @@ async def stop_project_retrieval_index(
     project_id: str,
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> IndexStopResponse:
+    await require_agent_settings_unlocked(session)
     await _require_project(session, project_id)
     publisher = get_background_supervisor().create_event_publisher()
     jobs = await background_service.list_jobs(

--- a/backend/app/api/routers/settings.py
+++ b/backend/app/api/routers/settings.py
@@ -15,7 +15,10 @@ from app.agent_runtime.tools.permission_metadata import (
     SETTING_KEY_AGENT_TOOL_PERMISSIONS,
     get_default_agent_tool_permissions,
 )
+from app.agent_runtime.session_activity import has_active_agent_sessions
+from app.api.agent_settings_lock import require_agent_settings_unlocked
 from app.api.schemas.setting import (
+    AgentSettingsLockResponse,
     AgentToolPermissionItem,
     SettingsResponse,
     SettingsUpdateRequest,
@@ -76,6 +79,19 @@ DEFAULT_SETTINGS = {
     SETTING_KEY_AGENT_BYPASS_TOOL_APPROVAL: "false",
     SETTING_KEY_AGENT_TOOL_PERMISSIONS: "[]",
 }
+
+
+@router.get(
+    "/agent-session-lock",
+    response_model=AgentSettingsLockResponse,
+    summary="获取 Agent 会话设置锁定状态",
+)
+async def get_agent_settings_lock(
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> AgentSettingsLockResponse:
+    return AgentSettingsLockResponse(
+        is_locked=await has_active_agent_sessions(session),
+    )
 
 
 def _parse_agent_tool_permissions(raw_value: str) -> list[AgentToolPermissionItem]:
@@ -301,6 +317,24 @@ async def update_settings(
     Returns:
         更新后的设置。
     """
+    is_restricted_update = any(
+        value is not None
+        for value in (
+            request.default_model,
+            request.light_model,
+            request.default_embedding_model,
+            request.index_mode,
+            request.index_enabled_projects,
+            request.index_chunk_size,
+            request.index_chunk_overlap,
+            request.index_auto_strategy,
+            request.index_rerank_enabled,
+            request.default_rerank_model,
+        )
+    )
+    if is_restricted_update:
+        await require_agent_settings_unlocked(session)
+
     logger.info(f"更新设置: {request}")
 
     settings_list = await setting_repo.get_all(session)

--- a/backend/app/api/routers/skill_reference_docs.py
+++ b/backend/app/api/routers/skill_reference_docs.py
@@ -12,6 +12,7 @@ from app.api.schemas.skill_reference_doc import (
     SkillReferenceDocResponse,
     SkillReferenceDocUpdate,
 )
+from app.api.agent_settings_lock import require_agent_settings_unlocked
 from app.core.errors import NotFoundError
 from app.storage.database import get_session
 from app.storage.services import skill_reference_doc_service
@@ -41,6 +42,7 @@ async def create_reference_doc(
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> SkillReferenceDocResponse:
     try:
+        await require_agent_settings_unlocked(session)
         logger.info(f"创建参考文档: skill_db_id={skill_db_id}")
         doc = await skill_reference_doc_service.create_reference_doc(
             session,
@@ -79,6 +81,7 @@ async def update_reference_doc(
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> SkillReferenceDocResponse:
     try:
+        await require_agent_settings_unlocked(session)
         doc = await skill_reference_doc_service.update_reference_doc(
             session,
             skill_db_id,
@@ -101,6 +104,7 @@ async def delete_reference_doc(
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> None:
     try:
+        await require_agent_settings_unlocked(session)
         await skill_reference_doc_service.delete_reference_doc(session, skill_db_id, doc_id)
     except NotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))

--- a/backend/app/api/routers/skills.py
+++ b/backend/app/api/routers/skills.py
@@ -14,6 +14,7 @@ from app.api.schemas.skill import (
     SkillResponse,
     SkillUpdate,
 )
+from app.api.agent_settings_lock import require_agent_settings_unlocked
 from app.api.schemas.skill_reference_doc import SkillReferenceDocResponse
 from app.core.errors import NotFoundError
 from app.storage.database import get_session
@@ -52,6 +53,7 @@ async def create_skill(
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> SkillResponse:
     try:
+        await require_agent_settings_unlocked(session)
         logger.info(f"创建 Skill: name={data.name}")
         skill = await skill_service.create_skill(
             session,
@@ -90,6 +92,7 @@ async def import_skill(
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> SkillImportResponse:
     try:
+        await require_agent_settings_unlocked(session)
         uploaded = [
             skill_import_service.UploadedFile(
                 filename=f.filename or "",
@@ -129,6 +132,7 @@ async def update_skill(
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> SkillResponse:
     try:
+        await require_agent_settings_unlocked(session)
         skill = await skill_service.update_skill(
             session,
             skill_db_id,
@@ -150,6 +154,7 @@ async def toggle_skill(
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> SkillResponse:
     try:
+        await require_agent_settings_unlocked(session)
         skill = await skill_service.toggle_skill(session, skill_db_id)
         return _to_response(skill)
     except NotFoundError as exc:
@@ -164,6 +169,7 @@ async def delete_skill(
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> None:
     try:
+        await require_agent_settings_unlocked(session)
         await skill_service.delete_skill(session, skill_db_id)
     except NotFoundError as exc:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))

--- a/backend/app/api/schemas/setting.py
+++ b/backend/app/api/schemas/setting.py
@@ -13,6 +13,12 @@ class AgentToolPermissionItem(BaseModel):
     mode: str = Field(..., description="权限模式：allow / ask / deny")
 
 
+class AgentSettingsLockResponse(BaseModel):
+    """Agent 会话是否正在锁定相关设置。"""
+
+    is_locked: bool = Field(..., description="是否存在未结束的 Agent 或子智能体会话")
+
+
 class SettingsResponse(BaseModel):
     """设置响应。"""
 

--- a/backend/app/models/repos/model_repo.py
+++ b/backend/app/models/repos/model_repo.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
 from app.models.entities.model import Model
+from app.models.entities.model_provider import ModelProvider
 
 
 async def get_all(session: AsyncSession) -> list[Model]:
@@ -59,6 +60,27 @@ async def get_by_id(session: AsyncSession, model_id: str) -> Model | None:
     """
     result = await session.execute(select(Model).where(col(Model.id) == model_id))
     return result.scalar_one_or_none()
+
+
+async def get_by_legacy_agent_config(
+    session: AsyncSession,
+    *,
+    model_id: str,
+    provider_type: str,
+    base_url: str,
+) -> Model | None:
+    """Find the unique current model matching a checkpoint created before model IDs persisted."""
+    result = await session.execute(
+        select(Model)
+        .join(ModelProvider, col(Model.provider_id) == col(ModelProvider.id))
+        .where(
+            col(Model.model_id) == model_id,
+            col(ModelProvider.provider_type) == provider_type,
+            col(ModelProvider.url) == base_url,
+        )
+    )
+    matches = list(result.scalars().all())
+    return matches[0] if len(matches) == 1 else None
 
 
 async def create(

--- a/backend/tests/agent_runtime/test_checkpointer.py
+++ b/backend/tests/agent_runtime/test_checkpointer.py
@@ -17,6 +17,56 @@ from app.agent_runtime.runner.checkpointer import (
     init_checkpointer,
     reset_checkpointer,
 )
+from app.agent_runtime.tools.impls.interaction.ask_user import Question, QuestionOption
+
+
+@pytest.mark.asyncio
+async def test_get_checkpointer_restores_legacy_question_checkpoint(monkeypatch, tmp_path):
+    db_path = tmp_path / "test_checkpoints.db"
+    monkeypatch.setenv("AGENT_CHECKPOINT_DB", str(db_path))
+    await reset_checkpointer()
+
+    try:
+        conn = await aiosqlite.connect(db_path)
+        legacy_checkpointer = AsyncSqliteSaver(conn)
+        await legacy_checkpointer.setup()
+        config = {
+            "configurable": {
+                "thread_id": "legacy-question-session",
+                "checkpoint_ns": "",
+            }
+        }
+        checkpoint = {
+            "v": 2,
+            "id": "legacy-question-checkpoint",
+            "ts": "2026-07-12T00:00:00+00:00",
+            "channel_values": {
+                "pending_question": Question(
+                    title="继续方式",
+                    description="请选择后续处理方式。",
+                    options=[
+                        QuestionOption(label="继续", description="继续执行"),
+                        QuestionOption(label="暂停", description="暂停执行"),
+                    ],
+                )
+            },
+            "channel_versions": {},
+            "versions_seen": {},
+            "pending_sends": [],
+        }
+        await legacy_checkpointer.aput(config, checkpoint, {}, {})
+        await conn.close()
+
+        checkpointer = await get_checkpointer()
+        persisted = await checkpointer.aget_tuple(config)
+
+        assert persisted is not None
+        question = persisted.checkpoint["channel_values"]["pending_question"]
+        assert isinstance(question, Question)
+        assert question.title == "继续方式"
+        assert isinstance(question.options[0], QuestionOption)
+    finally:
+        await reset_checkpointer()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_agent.py
+++ b/backend/tests/api/test_agent.py
@@ -2,6 +2,7 @@
 """Agent API 测试。"""
 
 import asyncio
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -35,7 +36,8 @@ from app.storage.services import task_service
 
 
 @pytest_asyncio.fixture(autouse=True)
-async def reset_agent_runtime_globals():
+async def reset_agent_runtime_globals(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("AGENT_CHECKPOINT_DB", str(tmp_path / "checkpoints.db"))
     await get_agent_run_registry().cancel_all()
     _SESSION_RUNNERS.clear()
     await reset_checkpointer()
@@ -1302,6 +1304,37 @@ class TestAgentAPI:
         assert data["state"]["model_config"]["model_id"] == "gpt-3.5-turbo"
         assert session_id in _SESSION_RUNNERS
         assert _SESSION_RUNNERS[session_id].model_config["api_key"] == "test_api_key"
+
+    async def test_get_session_state_rehydrates_legacy_model_config_without_record_id(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={
+                "project_id": target["project_id"],
+                "model_id": target["model_id"],
+                "max_iterations": 5,
+            },
+        )
+        session_id = session_response.json()["session_id"]
+        runner = _SESSION_RUNNERS[session_id]
+        graph = await runner._get_graph()
+        state = await graph.aget_state({"configurable": {"thread_id": session_id}})
+        legacy_model_config = dict(state.values["model_config"])
+        legacy_model_config.pop("model_record_id")
+        await graph.aupdate_state(
+            {"configurable": {"thread_id": session_id}},
+            {"model_config": legacy_model_config},
+            as_node="primary",
+        )
+        _SESSION_RUNNERS.clear()
+
+        response = await client.get(f"/api/v1/agent/sessions/{session_id}")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["state"]["model_config"]["model_record_id"] == target["model_id"]
 
     async def test_agent_checkpoint_and_session_state_do_not_contain_api_key(
         self,

--- a/backend/tests/api/test_agent_settings_lock.py
+++ b/backend/tests/api/test_agent_settings_lock.py
@@ -1,0 +1,229 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from unittest.mock import MagicMock
+
+from app.agent_runtime.persistence.child_runs import create_child_run
+from app.api.routers.agent_runtime import _SESSION_RUNNERS
+from app.storage.models.revision import Revision
+from app.storage.models.task import Task
+
+
+async def _create_agent_task(
+    client: AsyncClient,
+    session: AsyncSession,
+    *,
+    is_running: bool = False,
+) -> Task:
+    project_response = await client.post("/api/v1/projects", data={"title": "锁定设置测试"})
+    assert project_response.status_code == 201
+
+    task = Task(
+        project_id=project_response.json()["id"],
+        title="Agent settings lock",
+        mode="agent",
+        agent_session_id="agent-settings-lock-test",
+        is_running=is_running,
+    )
+    session.add(task)
+    await session.commit()
+    await session.refresh(task)
+    return task
+
+
+@pytest.mark.asyncio
+async def test_agent_settings_lock_reports_running_agent_task(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    await _create_agent_task(client, session, is_running=True)
+
+    response = await client.get("/api/v1/settings/agent-session-lock")
+
+    assert response.status_code == 200
+    assert response.json() == {"is_locked": True}
+
+
+@pytest.mark.asyncio
+async def test_agent_settings_lock_ignores_interrupted_parent_session(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    task = await _create_agent_task(client, session)
+    revision = Revision(
+        project_id=task.project_id,
+        task_id=task.id,
+        message="已暂停的会话不应锁定设置",
+        agent_session_id=task.agent_session_id,
+        revision_type="agent",
+        status="interrupted",
+        is_checkpoint=True,
+        project_snapshot_title="锁定设置测试",
+        project_snapshot_word_count=0,
+        project_snapshot_chapter_count=0,
+    )
+    session.add(revision)
+    await session.flush()
+    task.current_revision_id = revision.id
+    session.add(task)
+    await session.commit()
+
+    response = await client.get("/api/v1/settings/agent-session-lock")
+
+    assert response.status_code == 200
+    assert response.json() == {"is_locked": False}
+
+
+@pytest.mark.asyncio
+async def test_agent_settings_lock_reports_waiting_subagent(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    task = await _create_agent_task(client, session)
+    await create_child_run(
+        session,
+        parent_session_id=task.agent_session_id or "",
+        parent_task_id=task.id,
+        parent_thread_id=task.agent_session_id or "",
+        child_thread_id="agent-settings-lock-test:child",
+        agent_key="writer",
+        dispatch_id="dispatch-settings-lock",
+        tool_call_id="tool-call-settings-lock",
+        request={"task": "等待工具审批"},
+        status="waiting_user",
+    )
+
+    response = await client.get("/api/v1/settings/agent-session-lock")
+
+    assert response.status_code == 200
+    assert response.json() == {"is_locked": True}
+
+
+@pytest.mark.asyncio
+async def test_agent_settings_lock_is_clear_without_active_session(client: AsyncClient) -> None:
+    response = await client.get("/api/v1/settings/agent-session-lock")
+
+    assert response.status_code == 200
+    assert response.json() == {"is_locked": False}
+
+
+@pytest.mark.asyncio
+async def test_agent_settings_lock_rejects_restricted_writes(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    await _create_agent_task(client, session, is_running=True)
+
+    restricted_response = await client.put(
+        "/api/v1/settings",
+        json={"index_mode": "all"},
+    )
+    provider_response = await client.post(
+        "/api/v1/model-providers",
+        data={
+            "name": "Locked provider",
+            "url": "https://api.example.com",
+            "api_key": "test-key",
+            "provider_type": "openai",
+        },
+    )
+    model_response = await client.post(
+        "/api/v1/models",
+        json={
+            "name": "Locked model",
+            "provider_id": "provider-id",
+            "model_id": "locked-model",
+        },
+    )
+    rule_response = await client.post(
+        "/api/v1/agent-rules",
+        json={"title": "Locked rule", "content": "Blocked while running"},
+    )
+    skill_response = await client.post(
+        "/api/v1/skills",
+        json={"name": "Locked skill", "summary": "", "content": ""},
+    )
+    definition_response = await client.post(
+        "/api/v1/agent-definitions",
+        json={
+            "key": "locked-agent",
+            "display_name": "Locked Agent",
+            "kind": "subagent",
+            "prompt_agent_name": "locked-agent",
+            "enabled_tool_categories": [],
+            "enabled_skills": [],
+        },
+    )
+
+    for response in (
+        restricted_response,
+        provider_response,
+        model_response,
+        rule_response,
+        skill_response,
+        definition_response,
+    ):
+        assert response.status_code == 409
+        assert response.json()["detail"] == {
+            "code": "agent_settings_locked",
+            "message": "Agent 会话运行中，无法修改相关设置",
+        }
+
+
+@pytest.mark.asyncio
+async def test_agent_settings_lock_allows_unrestricted_settings_update(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    await _create_agent_task(client, session, is_running=True)
+
+    response = await client.put("/api/v1/settings", json={"theme": "dark"})
+
+    assert response.status_code == 200
+    assert response.json()["theme"] == "dark"
+
+
+@pytest.mark.asyncio
+async def test_cancelling_waiting_agent_session_releases_settings_lock(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    task = await _create_agent_task(client, session)
+    revision = Revision(
+        project_id=task.project_id,
+        task_id=task.id,
+        message="等待用户回答",
+        agent_session_id=task.agent_session_id,
+        revision_type="agent",
+        status="interrupted",
+        is_checkpoint=True,
+        project_snapshot_title="锁定设置测试",
+        project_snapshot_word_count=0,
+        project_snapshot_chapter_count=0,
+    )
+    session.add(revision)
+    await session.flush()
+    task.current_revision_id = revision.id
+    session.add(task)
+    await session.commit()
+
+    runner = MagicMock(project_id=task.project_id, model_config={})
+    _SESSION_RUNNERS[task.agent_session_id or ""] = runner
+    try:
+        cancel_response = await client.post(
+            f"/api/v1/agent/sessions/{task.agent_session_id}/cancel",
+        )
+        lock_response = await client.get("/api/v1/settings/agent-session-lock")
+    finally:
+        _SESSION_RUNNERS.pop(task.agent_session_id or "", None)
+
+    assert cancel_response.status_code == 200
+    runner.cancel.assert_called_once_with()
+    assert lock_response.json() == {"is_locked": False}
+    await session.refresh(task)
+    await session.refresh(revision)
+    assert task.is_running is False
+    assert revision.status == "cancelled"

--- a/backend/tests/api/test_models.py
+++ b/backend/tests/api/test_models.py
@@ -83,6 +83,58 @@ async def test_get_all_models(client: AsyncClient, session: AsyncSession):
 
 
 @pytest.mark.asyncio
+async def test_find_legacy_agent_model_requires_a_unique_match(
+    client: AsyncClient,
+    session: AsyncSession,
+):
+    from app.core.encryption import EncryptionService
+    from app.settings import settings
+
+    encrypted_key = EncryptionService(settings.encryption_key).encrypt("test-key")
+    provider = await model_provider_repo.create(
+        session=session,
+        name="Legacy Provider",
+        url="https://api.example.com",
+        api_key_encrypted=encrypted_key,
+        provider_type="openai-compatible",
+    )
+    first_model = await model_repo.create(
+        session=session,
+        name="Legacy Model 1",
+        provider_id=provider.id,
+        model_id="legacy-model",
+    )
+    await session.commit()
+
+    matched = await model_repo.get_by_legacy_agent_config(
+        session,
+        model_id="legacy-model",
+        provider_type="openai-compatible",
+        base_url="https://api.example.com",
+    )
+
+    assert matched is not None
+    assert matched.id == first_model.id
+
+    await model_repo.create(
+        session=session,
+        name="Legacy Model 2",
+        provider_id=provider.id,
+        model_id="legacy-model",
+    )
+    await session.commit()
+
+    ambiguous_match = await model_repo.get_by_legacy_agent_config(
+        session,
+        model_id="legacy-model",
+        provider_type="openai-compatible",
+        base_url="https://api.example.com",
+    )
+
+    assert ambiguous_match is None
+
+
+@pytest.mark.asyncio
 async def test_get_models_by_provider(client: AsyncClient, session: AsyncSession):
     """测试根据提供商 ID 获取模型。"""
     from app.core.encryption import EncryptionService

--- a/frontend/src/features/settings/components/agent-definitions-settings.tsx
+++ b/frontend/src/features/settings/components/agent-definitions-settings.tsx
@@ -60,6 +60,7 @@ import {
   SYSTEM_LIGHT_MODEL_REFERENCE,
 } from "../lib/agent-definitions.types";
 import { fetchSettings } from "../lib/settings-api";
+import { AgentSettingsLockNotice } from "./agent-settings-lock-notice";
 
 const LIST_WIDTH = 280;
 const SUBAGENT_RESTRICTED_TOOL_CATEGORIES = new Set(["orchestration", "interaction"]);
@@ -125,6 +126,7 @@ interface AgentFormProps {
   skills: Skill[];
   onCloseSettings?: () => void;
   onUpdated: () => void;
+  isAgentSettingsLocked: boolean;
 }
 
 function AgentForm({
@@ -136,6 +138,7 @@ function AgentForm({
   skills,
   onCloseSettings,
   onUpdated,
+  isAgentSettingsLocked,
 }: AgentFormProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -278,6 +281,7 @@ function AgentForm({
           value={formDisplayName}
           onChange={(e) => setFormDisplayName(e.target.value)}
           placeholder={t("settings.agentsDisplayNamePlaceholder")}
+          disabled={isAgentSettingsLocked}
         />
       </Flex>
 
@@ -297,6 +301,7 @@ function AgentForm({
           onChange={(event) => setFormDescription(event.target.value)}
           rows={3}
           placeholder={t("settings.agentsDescriptionPlaceholder")}
+          disabled={isAgentSettingsLocked}
         />
       </Flex>
 
@@ -317,7 +322,7 @@ function AgentForm({
           onChange={setFormModelId}
           editable={false}
           allowCustomValue={false}
-          disabled={!hasLlmModels}
+          disabled={isAgentSettingsLocked || !hasLlmModels}
           triggerStyle={{ width: "100%" }}
         />
       </Flex>
@@ -355,12 +360,13 @@ function AgentForm({
                   padding: "4px 10px",
                   borderRadius: 6,
                   border: "1px solid var(--gray-a5)",
-                  cursor: "pointer",
+                  cursor: isAgentSettingsLocked ? "not-allowed" : "pointer",
                   fontSize: 13,
                 }}
               >
                 <Checkbox
                   checked={formEnabledToolCategories.includes(opt.key)}
+                  disabled={isAgentSettingsLocked}
                   onCheckedChange={() => handleToggleToolCategory(opt.key)}
                   style={{ margin: 0 }}
                 />
@@ -395,7 +401,7 @@ function AgentForm({
             gap="2"
           >
             {selectableSkills.map((skill) => {
-              const disabled = !skill.isEnabled || !skill.isComplete;
+              const disabled = isAgentSettingsLocked || !skill.isEnabled || !skill.isComplete;
               return (
                 <label
                   key={skill.id}
@@ -460,12 +466,13 @@ function AgentForm({
                     padding: "4px 10px",
                     borderRadius: 6,
                     border: "1px solid var(--gray-a5)",
-                    cursor: "pointer",
+                    cursor: isAgentSettingsLocked ? "not-allowed" : "pointer",
                     fontSize: 13,
                   }}
                 >
                   <Checkbox
                     checked={formDelegatableAgents.includes(opt.value)}
+                    disabled={isAgentSettingsLocked}
                     onCheckedChange={() => handleToggleDelegatable(opt.value)}
                     style={{ margin: 0 }}
                   />
@@ -533,7 +540,7 @@ function AgentForm({
       >
         <Button
           size="2"
-          disabled={!hasFormChanges || updateMutation.isPending}
+          disabled={isAgentSettingsLocked || !hasFormChanges || updateMutation.isPending}
           onClick={() => updateMutation.mutate()}
           style={{ alignSelf: "flex-start" }}
         >
@@ -561,6 +568,8 @@ interface AgentDefinitionsSettingsProps {
   mobileDirection?: 1 | -1;
   onMobileDetailTitleChange?: (title: string | null) => void;
   onMobilePageChange?: (page: "list" | "detail") => void;
+  isAgentSettingsLocked: boolean;
+  isAgentSettingsLockLoading: boolean;
 }
 
 export function AgentDefinitionsSettings({
@@ -569,6 +578,8 @@ export function AgentDefinitionsSettings({
   mobileDirection: controlledMobileDirection,
   onMobileDetailTitleChange,
   onMobilePageChange,
+  isAgentSettingsLocked,
+  isAgentSettingsLockLoading,
 }: AgentDefinitionsSettingsProps) {
   const { t } = useTranslation();
   const agentKindOptions = getAgentKindOptions();
@@ -682,6 +693,7 @@ export function AgentDefinitionsSettings({
     isSettingsLoading ||
     isSettingsFetching ||
     isModelOptionsLoading ||
+    isAgentSettingsLockLoading ||
     !settings;
 
   useEffect(() => {
@@ -726,7 +738,16 @@ export function AgentDefinitionsSettings({
     setNewDescription("");
   }, []);
 
+  useEffect(() => {
+    if (!isAgentSettingsLocked) return;
+    closeCreateDialog();
+    setMenuState(null);
+    setConfirmResetKey(null);
+    setConfirmDeleteKey(null);
+  }, [closeCreateDialog, isAgentSettingsLocked]);
+
   const openCreateDialog = useCallback(() => {
+    if (isAgentSettingsLocked) return;
     setCreateMode("create");
     setCopySource(null);
     setNewKind("primary");
@@ -734,10 +755,11 @@ export function AgentDefinitionsSettings({
     setNewDisplayName("");
     setNewDescription("");
     setIsCreating(true);
-  }, []);
+  }, [isAgentSettingsLocked]);
 
   const openCopyDialog = useCallback(
     (def: AgentDefinitionResponse) => {
+      if (isAgentSettingsLocked) return;
       setCreateMode("copy");
       setCopySource(def);
       setNewKind(def.kind);
@@ -746,7 +768,7 @@ export function AgentDefinitionsSettings({
       setNewDescription(def.description);
       setIsCreating(true);
     },
-    [t],
+    [isAgentSettingsLocked, t],
   );
 
   const createMutation = useMutation({
@@ -843,16 +865,20 @@ export function AgentDefinitionsSettings({
     },
   });
 
-  const openMenuAt = useCallback((key: string, position: { x: number; y: number }) => {
-    setMenuState({ key, position });
-  }, []);
+  const openMenuAt = useCallback(
+    (key: string, position: { x: number; y: number }) => {
+      if (isAgentSettingsLocked) return;
+      setMenuState({ key, position });
+    },
+    [isAgentSettingsLocked],
+  );
 
   const closeMenu = useCallback(() => {
     setMenuState(null);
   }, []);
 
   const menuItems = useMemo<ContextMenuItem[]>(() => {
-    if (!menuTarget) return [];
+    if (!menuTarget || isAgentSettingsLocked) return [];
 
     const actions = getAgentDefinitionMenuActions(menuTarget);
     const items: ContextMenuItem[] = [];
@@ -905,6 +931,7 @@ export function AgentDefinitionsSettings({
     setConfirmResetKey,
     setSelectedKey,
     t,
+    isAgentSettingsLocked,
   ]);
 
   const renderAgentListItem = (def: AgentDefinitionResponse) => (
@@ -978,7 +1005,7 @@ export function AgentDefinitionsSettings({
             <Switch
               size="1"
               checked={def.enabled}
-              disabled={toggleMutation.isPending}
+              disabled={isAgentSettingsLocked || toggleMutation.isPending}
               onClick={(event) => event.stopPropagation()}
               onCheckedChange={(checked) => {
                 void toggleMutation.mutateAsync({ key: def.key, enabled: checked === true });
@@ -997,6 +1024,7 @@ export function AgentDefinitionsSettings({
                 const rect = event.currentTarget.getBoundingClientRect();
                 openMenuAt(def.key, { x: rect.right, y: rect.bottom + 4 });
               }}
+              disabled={isAgentSettingsLocked}
             >
               <MoreHorizontal size={14} />
             </IconButton>
@@ -1043,6 +1071,7 @@ export function AgentDefinitionsSettings({
               color="gray"
               aria-label={t("settings.agentsNewAgent")}
               onClick={openCreateDialog}
+              disabled={isAgentSettingsLocked}
             >
               <Plus size={14} />
             </IconButton>
@@ -1135,6 +1164,7 @@ export function AgentDefinitionsSettings({
       skills={skills}
       onCloseSettings={onCloseSettings}
       onUpdated={invalidateDefs}
+      isAgentSettingsLocked={isAgentSettingsLocked}
     />
   );
 
@@ -1151,53 +1181,62 @@ export function AgentDefinitionsSettings({
       ) : isMobile ? (
         <Flex
           direction="column"
-          className="agent-definitions-layout agent-definitions-layout--mobile"
+          className="agent-definitions-settings-content"
         >
-          <Box className="settings-dialog-mobile-page-stack">
-            <AnimatePresence
-              initial={false}
-              custom={currentMobileDirection}
-              mode="sync"
-            >
-              {currentMobilePage === "list" ? (
-                <MotionBox
-                  key="agents-mobile-list"
-                  custom={currentMobileDirection}
-                  variants={mobilePageVariants}
-                  initial="enter"
-                  animate="center"
-                  exit="exit"
-                  transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
-                  className="settings-dialog-mobile-page"
-                >
-                  <Box className="settings-dialog-mobile-page-padding">
-                    <Box className="settings-dialog-mobile-page-content">{listContent}</Box>
-                  </Box>
-                </MotionBox>
-              ) : (
-                <MotionBox
-                  key="agents-mobile-detail"
-                  custom={currentMobileDirection}
-                  variants={mobilePageVariants}
-                  initial="enter"
-                  animate="center"
-                  exit="exit"
-                  transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
-                  className="settings-dialog-mobile-page"
-                >
-                  <Box className="agent-definitions-detail-panel agent-definitions-detail-panel--mobile">
-                    {detailContent}
-                  </Box>
-                </MotionBox>
-              )}
-            </AnimatePresence>
-          </Box>
+          <AgentSettingsLockNotice isLocked={isAgentSettingsLocked} />
+          <Flex className="agent-definitions-layout agent-definitions-layout--mobile">
+            <Box className="settings-dialog-mobile-page-stack">
+              <AnimatePresence
+                initial={false}
+                custom={currentMobileDirection}
+                mode="sync"
+              >
+                {currentMobilePage === "list" ? (
+                  <MotionBox
+                    key="agents-mobile-list"
+                    custom={currentMobileDirection}
+                    variants={mobilePageVariants}
+                    initial="enter"
+                    animate="center"
+                    exit="exit"
+                    transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
+                    className="settings-dialog-mobile-page"
+                  >
+                    <Box className="settings-dialog-mobile-page-padding">
+                      <Box className="settings-dialog-mobile-page-content">{listContent}</Box>
+                    </Box>
+                  </MotionBox>
+                ) : (
+                  <MotionBox
+                    key="agents-mobile-detail"
+                    custom={currentMobileDirection}
+                    variants={mobilePageVariants}
+                    initial="enter"
+                    animate="center"
+                    exit="exit"
+                    transition={{ duration: 0.22, ease: [0.22, 1, 0.36, 1] }}
+                    className="settings-dialog-mobile-page"
+                  >
+                    <Box className="agent-definitions-detail-panel agent-definitions-detail-panel--mobile">
+                      {detailContent}
+                    </Box>
+                  </MotionBox>
+                )}
+              </AnimatePresence>
+            </Box>
+          </Flex>
         </Flex>
       ) : (
-        <Flex className="agent-definitions-layout">
-          {listContent}
+        <Flex
+          direction="column"
+          className="agent-definitions-settings-content"
+        >
+          <AgentSettingsLockNotice isLocked={isAgentSettingsLocked} />
+          <Flex className="agent-definitions-layout">
+            {listContent}
 
-          <Box className="agent-definitions-detail-panel">{detailContent}</Box>
+            <Box className="agent-definitions-detail-panel">{detailContent}</Box>
+          </Flex>
         </Flex>
       )}
 
@@ -1236,6 +1275,7 @@ export function AgentDefinitionsSettings({
                   setNewKey(event.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ""))
                 }
                 placeholder={t("settings.agentsKeyPlaceholder")}
+                disabled={isAgentSettingsLocked}
               />
             </Flex>
 
@@ -1253,6 +1293,7 @@ export function AgentDefinitionsSettings({
                 value={newDisplayName}
                 onChange={(event) => setNewDisplayName(event.target.value)}
                 placeholder={t("settings.agentsDisplayNamePlaceholder")}
+                disabled={isAgentSettingsLocked}
               />
             </Flex>
 
@@ -1271,6 +1312,7 @@ export function AgentDefinitionsSettings({
                 onChange={(event) => setNewDescription(event.target.value)}
                 rows={3}
                 placeholder={t("settings.agentsDescriptionPlaceholder")}
+                disabled={isAgentSettingsLocked}
               />
             </Flex>
 
@@ -1287,6 +1329,7 @@ export function AgentDefinitionsSettings({
               <Select.Root
                 value={newKind}
                 onValueChange={(value) => setNewKind(value as "primary" | "subagent")}
+                disabled={isAgentSettingsLocked}
               >
                 <Select.Trigger style={{ width: "100%" }} />
                 <Select.Content>
@@ -1316,7 +1359,12 @@ export function AgentDefinitionsSettings({
               {t("common.cancel")}
             </Button>
             <Button
-              disabled={!newKey.trim() || !newDisplayName.trim() || createMutation.isPending}
+              disabled={
+                isAgentSettingsLocked ||
+                !newKey.trim() ||
+                !newDisplayName.trim() ||
+                createMutation.isPending
+              }
               onClick={() => createMutation.mutate()}
             >
               {createMutation.isPending

--- a/frontend/src/features/settings/components/agent-settings-lock-notice.tsx
+++ b/frontend/src/features/settings/components/agent-settings-lock-notice.tsx
@@ -1,0 +1,35 @@
+import { Flex, Text } from "@radix-ui/themes";
+import { AlertTriangle } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface AgentSettingsLockNoticeProps {
+  isLocked: boolean;
+}
+
+export function AgentSettingsLockNotice({ isLocked }: AgentSettingsLockNoticeProps) {
+  const { t } = useTranslation();
+
+  if (!isLocked) return null;
+
+  return (
+    <Flex
+      align="start"
+      gap="3"
+      role="status"
+      className="settings-dialog-lock-notice"
+    >
+      <AlertTriangle
+        size={17}
+        strokeWidth={2}
+        className="settings-dialog-lock-notice-icon"
+        aria-hidden="true"
+      />
+      <Text
+        size="2"
+        className="settings-dialog-lock-notice-copy"
+      >
+        {t("settings.agentSettingsLocked")} {t("settings.agentSettingsLockHint")}
+      </Text>
+    </Flex>
+  );
+}

--- a/frontend/src/features/settings/components/connection-form-dialog.tsx
+++ b/frontend/src/features/settings/components/connection-form-dialog.tsx
@@ -45,6 +45,7 @@ interface ConnectionFormDialogProps {
   isCatalogLoading?: boolean;
   onSubmit: (data: FormData) => Promise<void>;
   isSubmitting: boolean;
+  isAgentSettingsLocked: boolean;
 }
 
 export function ConnectionFormDialog({
@@ -55,6 +56,7 @@ export function ConnectionFormDialog({
   isCatalogLoading = false,
   onSubmit,
   isSubmitting,
+  isAgentSettingsLocked,
 }: ConnectionFormDialogProps) {
   const { t } = useTranslation();
   const isEditing = !!connection;
@@ -300,6 +302,7 @@ export function ConnectionFormDialog({
                       <TextField.Root
                         {...field}
                         placeholder={t("connections.namePlaceholder")}
+                        disabled={isAgentSettingsLocked}
                       />
                     )}
                   />
@@ -332,7 +335,7 @@ export function ConnectionFormDialog({
                         onChange={field.onChange}
                         providers={catalogProviders ?? []}
                         placeholder={t("connections.providerTypePlaceholder")}
-                        disabled={isEditing}
+                        disabled={isAgentSettingsLocked || isEditing}
                       />
                     )}
                   />
@@ -382,6 +385,7 @@ export function ConnectionFormDialog({
                     <TextField.Root
                       {...field}
                       placeholder={t("connections.urlPlaceholder")}
+                      disabled={isAgentSettingsLocked}
                     />
                   )}
                 />
@@ -432,6 +436,7 @@ export function ConnectionFormDialog({
                     placeholder={
                       apiKey ? t("connections.apiKeyPlaceholderEdit") : "••••••••••••••••"
                     }
+                    disabled={isAgentSettingsLocked}
                   />
                   <Text
                     size="1"
@@ -450,6 +455,7 @@ export function ConnectionFormDialog({
                       {...field}
                       type="password"
                       placeholder={t("connections.apiKeyPlaceholder")}
+                      disabled={isAgentSettingsLocked}
                     />
                   )}
                 />
@@ -474,7 +480,9 @@ export function ConnectionFormDialog({
                 type="button"
                 variant="soft"
                 onClick={handleValidate}
-                disabled={!canValidate || validationStatus === "validating"}
+                disabled={
+                  isAgentSettingsLocked || !canValidate || validationStatus === "validating"
+                }
                 style={{
                   backgroundColor:
                     validationStatus === "success"
@@ -515,7 +523,11 @@ export function ConnectionFormDialog({
                 </Dialog.Close>
                 <Button
                   type="submit"
-                  disabled={isSubmitting || (!isEditing && validationStatus !== "success")}
+                  disabled={
+                    isAgentSettingsLocked ||
+                    isSubmitting ||
+                    (!isEditing && validationStatus !== "success")
+                  }
                 >
                   {isSubmitting ? <Spinner size={18} /> : null}
                   {isEditing ? t("common.save") : t("common.create")}

--- a/frontend/src/features/settings/components/connections-settings.tsx
+++ b/frontend/src/features/settings/components/connections-settings.tsx
@@ -7,7 +7,7 @@
 import { Box, Flex, Text, Button, IconButton } from "@radix-ui/themes";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Plus, Trash2, Edit } from "lucide-react";
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Spinner } from "@/components";
@@ -24,15 +24,31 @@ import {
 } from "../lib/model-api";
 import { ProviderIcon } from "../lib/provider-icons";
 import { getProviderDisplayName, resolveProviderDisplayName } from "../lib/provider-utils";
+import { AgentSettingsLockNotice } from "./agent-settings-lock-notice";
 import { ConnectionFormDialog } from "./connection-form-dialog";
 
-export function ConnectionsSettings() {
+interface ConnectionsSettingsProps {
+  isAgentSettingsLocked: boolean;
+  isAgentSettingsLockLoading: boolean;
+}
+
+export function ConnectionsSettings({
+  isAgentSettingsLocked,
+  isAgentSettingsLockLoading,
+}: ConnectionsSettingsProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
 
   const [formOpen, setFormOpen] = useState(false);
   const [editingConnection, setEditingConnection] = useState<ModelProvider | null>(null);
   const [deletingConnection, setDeletingConnection] = useState<ModelProvider | null>(null);
+
+  useEffect(() => {
+    if (!isAgentSettingsLocked) return;
+    setFormOpen(false);
+    setEditingConnection(null);
+    setDeletingConnection(null);
+  }, [isAgentSettingsLocked]);
 
   // 获取所有连接
   const {
@@ -134,7 +150,10 @@ export function ConnectionsSettings() {
   }, [deletingConnection, deleteMutation]);
 
   const isContentLoading =
-    isConnectionsLoading || isConnectionsFetching || isCatalogProvidersLoading;
+    isConnectionsLoading ||
+    isConnectionsFetching ||
+    isCatalogProvidersLoading ||
+    isAgentSettingsLockLoading;
 
   if (isContentLoading) {
     return (
@@ -150,6 +169,7 @@ export function ConnectionsSettings() {
 
   return (
     <Box>
+      <AgentSettingsLockNotice isLocked={isAgentSettingsLocked} />
       <Flex
         direction="column"
         gap="4"
@@ -164,7 +184,10 @@ export function ConnectionsSettings() {
 
         {/* 新建按钮 */}
         <Flex>
-          <Button onClick={handleCreate}>
+          <Button
+            onClick={handleCreate}
+            disabled={isAgentSettingsLocked}
+          >
             <Plus size={16} />
             {t("connections.newConnection")}
           </Button>
@@ -266,6 +289,7 @@ export function ConnectionsSettings() {
                       variant="ghost"
                       color="gray"
                       onClick={() => handleEdit(connection)}
+                      disabled={isAgentSettingsLocked}
                     >
                       <Edit size={16} />
                     </IconButton>
@@ -273,6 +297,7 @@ export function ConnectionsSettings() {
                       variant="ghost"
                       color="red"
                       onClick={() => handleDelete(connection)}
+                      disabled={isAgentSettingsLocked}
                     >
                       <Trash2 size={16} />
                     </IconButton>
@@ -318,6 +343,7 @@ export function ConnectionsSettings() {
         isCatalogLoading={isCatalogProvidersLoading}
         onSubmit={handleSubmit}
         isSubmitting={createMutation.isPending || updateMutation.isPending}
+        isAgentSettingsLocked={isAgentSettingsLocked}
       />
 
       {/* 删除确认对话框 */}

--- a/frontend/src/features/settings/components/import-skill-dialog.tsx
+++ b/frontend/src/features/settings/components/import-skill-dialog.tsx
@@ -13,11 +13,17 @@ interface ImportSkillDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onImported: (skill: Skill) => void;
+  disabled?: boolean;
 }
 
 type Step = "select" | "complete";
 
-export function ImportSkillDialog({ open, onOpenChange, onImported }: ImportSkillDialogProps) {
+export function ImportSkillDialog({
+  open,
+  onOpenChange,
+  onImported,
+  disabled = false,
+}: ImportSkillDialogProps) {
   const { t } = useTranslation();
   const [step, setStep] = useState<Step>("select");
   const [loading, setLoading] = useState(false);
@@ -42,6 +48,7 @@ export function ImportSkillDialog({ open, onOpenChange, onImported }: ImportSkil
 
   const handleFileSelect = useCallback(
     async (selectedFile: File) => {
+      if (disabled) return;
       const lower = selectedFile.name.toLowerCase();
       if (!lower.endsWith(".md") && !lower.endsWith(".zip")) {
         setError(t("settingsExtra.skills.importDialog.invalidFileType"));
@@ -60,16 +67,17 @@ export function ImportSkillDialog({ open, onOpenChange, onImported }: ImportSkil
         setLoading(false);
       }
     },
-    [onImported, t],
+    [disabled, onImported, t],
   );
 
   const handleDrop = useCallback(
     (event: React.DragEvent) => {
+      if (disabled) return;
       event.preventDefault();
       const droppedFile = event.dataTransfer.files[0];
       if (droppedFile) handleFileSelect(droppedFile);
     },
-    [handleFileSelect],
+    [disabled, handleFileSelect],
   );
 
   const renderSelectStep = () => (
@@ -79,6 +87,7 @@ export function ImportSkillDialog({ open, onOpenChange, onImported }: ImportSkil
         ref={fileInputRef}
         type="file"
         accept=".md,.zip"
+        disabled={disabled}
         onChange={(event) => {
           const selectedFile = event.target.files?.[0];
           if (selectedFile) handleFileSelect(selectedFile);
@@ -87,9 +96,14 @@ export function ImportSkillDialog({ open, onOpenChange, onImported }: ImportSkil
       />
       <Box
         className="import-skill-dropzone"
-        onDragOver={(event) => event.preventDefault()}
+        onDragOver={(event) => {
+          if (!disabled) event.preventDefault();
+        }}
         onDrop={handleDrop}
-        onClick={() => fileInputRef.current?.click()}
+        onClick={() => {
+          if (!disabled) fileInputRef.current?.click();
+        }}
+        data-disabled={disabled ? "true" : "false"}
       >
         <Upload
           size={48}

--- a/frontend/src/features/settings/components/index-settings-global-config.tsx
+++ b/frontend/src/features/settings/components/index-settings-global-config.tsx
@@ -35,6 +35,7 @@ interface IndexSettingsGlobalConfigProps {
   onEnabledProjectsChange: (projectIds: string[]) => void;
   onChunkSizeChange: (value: string) => void;
   onChunkOverlapChange: (value: string) => void;
+  isAgentSettingsLocked: boolean;
 }
 
 export function IndexSettingsGlobalConfig({
@@ -53,6 +54,7 @@ export function IndexSettingsGlobalConfig({
   onEnabledProjectsChange,
   onChunkSizeChange,
   onChunkOverlapChange,
+  isAgentSettingsLocked,
 }: IndexSettingsGlobalConfigProps) {
   const { t } = useTranslation();
 
@@ -84,6 +86,7 @@ export function IndexSettingsGlobalConfig({
               allowCustomValue={false}
               emptyOptionLabel={t("index.disabled")}
               triggerStyle={FIELD_WIDTH}
+              disabled={isAgentSettingsLocked}
             />
           </Flex>
 
@@ -107,6 +110,7 @@ export function IndexSettingsGlobalConfig({
               allowCustomValue={false}
               emptyOptionLabel={t("index.disabled")}
               triggerStyle={FIELD_WIDTH}
+              disabled={isAgentSettingsLocked}
             />
           </Flex>
 
@@ -120,6 +124,7 @@ export function IndexSettingsGlobalConfig({
             labelWeight="regular"
             labelColor="gray"
             gap="1"
+            disabled={isAgentSettingsLocked}
           />
 
           <LabeledSelect
@@ -132,6 +137,7 @@ export function IndexSettingsGlobalConfig({
             labelWeight="regular"
             labelColor="gray"
             gap="1"
+            disabled={isAgentSettingsLocked}
           />
 
           {settings.indexMode === "selected" ? (
@@ -147,6 +153,7 @@ export function IndexSettingsGlobalConfig({
                 labelWeight="regular"
                 labelColor="gray"
                 onChange={onEnabledProjectsChange}
+                disabled={isAgentSettingsLocked}
               />
             </Box>
           ) : null}
@@ -157,6 +164,7 @@ export function IndexSettingsGlobalConfig({
             min={1}
             unit={t("index.unitCharacters")}
             onChange={onChunkSizeChange}
+            disabled={isAgentSettingsLocked}
           />
           <LabeledNumberInput
             label={t("index.chunkOverlap")}
@@ -164,6 +172,7 @@ export function IndexSettingsGlobalConfig({
             min={0}
             unit={t("index.unitCharacters")}
             onChange={onChunkOverlapChange}
+            disabled={isAgentSettingsLocked}
           />
         </Box>
       </Flex>
@@ -177,12 +186,14 @@ function LabeledNumberInput({
   min,
   unit,
   onChange,
+  disabled,
 }: {
   label: string;
   value: string;
   min: number;
   unit: string;
   onChange: (value: string) => void;
+  disabled: boolean;
 }) {
   return (
     <Flex
@@ -202,6 +213,7 @@ function LabeledNumberInput({
         min={min}
         unit={unit}
         unitSide="right"
+        disabled={disabled}
       />
     </Flex>
   );

--- a/frontend/src/features/settings/components/index-settings.tsx
+++ b/frontend/src/features/settings/components/index-settings.tsx
@@ -27,6 +27,7 @@ import { fetchModels, fetchProviders } from "../lib/model-api";
 import { resolveProviderIconPath } from "../lib/provider-utils";
 import { fetchSettings, updateSettings } from "../lib/settings-api";
 import type { Settings, SettingsUpdateRequest } from "../lib/settings.types";
+import { AgentSettingsLockNotice } from "./agent-settings-lock-notice";
 import { IndexSettingsGlobalConfig } from "./index-settings-global-config";
 import { IndexSettingsOverview } from "./index-settings-overview";
 import {
@@ -168,7 +169,15 @@ function patchOverallIndexStatus(
   };
 }
 
-export function IndexSettings() {
+interface IndexSettingsProps {
+  isAgentSettingsLocked: boolean;
+  isAgentSettingsLockLoading: boolean;
+}
+
+export function IndexSettings({
+  isAgentSettingsLocked,
+  isAgentSettingsLockLoading,
+}: IndexSettingsProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
 
@@ -345,12 +354,13 @@ export function IndexSettings() {
 
   const handleRerankModelChange = useCallback(
     (value: string) => {
+      if (isAgentSettingsLocked) return;
       updateSettingsMutation.mutate({
         default_rerank_model: value,
         index_rerank_enabled: value !== "",
       });
     },
-    [updateSettingsMutation],
+    [isAgentSettingsLocked, updateSettingsMutation],
   );
 
   // 当服务端分块参数变化时（如被其他端修改），同步本地输入。
@@ -382,6 +392,7 @@ export function IndexSettings() {
   }, []);
 
   const scheduleChunkSave = useCallback(() => {
+    if (isAgentSettingsLocked) return;
     if (chunkSaveTimerRef.current !== null) {
       clearTimeout(chunkSaveTimerRef.current);
     }
@@ -400,10 +411,22 @@ export function IndexSettings() {
   }, [
     chunkSize,
     chunkOverlap,
+    isAgentSettingsLocked,
     settings?.indexChunkSize,
     settings?.indexChunkOverlap,
     updateSettingsMutation,
   ]);
+
+  useEffect(() => {
+    if (!isAgentSettingsLocked) return;
+    if (chunkSaveTimerRef.current !== null) {
+      clearTimeout(chunkSaveTimerRef.current);
+      chunkSaveTimerRef.current = null;
+    }
+    setPendingEmbeddingModelId(null);
+    setChunkSize(String(settings?.indexChunkSize ?? 800));
+    setChunkOverlap(String(settings?.indexChunkOverlap ?? 100));
+  }, [isAgentSettingsLocked, settings?.indexChunkOverlap, settings?.indexChunkSize]);
 
   const modeOptions = useMemo(
     () => [
@@ -424,13 +447,15 @@ export function IndexSettings() {
 
   const handleModeChange = useCallback(
     (mode: IndexMode) => {
+      if (isAgentSettingsLocked) return;
       updateSettingsMutation.mutate({ index_mode: mode });
     },
-    [updateSettingsMutation],
+    [isAgentSettingsLocked, updateSettingsMutation],
   );
 
   const handleEmbeddingModelChange = useCallback(
     (value: string) => {
+      if (isAgentSettingsLocked) return;
       const current = settings?.defaultEmbeddingModel || "";
       if (current && value !== current) {
         setPendingEmbeddingModelId(value);
@@ -438,22 +463,24 @@ export function IndexSettings() {
       }
       updateSettingsMutation.mutate({ default_embedding_model: value });
     },
-    [settings?.defaultEmbeddingModel, updateSettingsMutation],
+    [isAgentSettingsLocked, settings?.defaultEmbeddingModel, updateSettingsMutation],
   );
 
   const confirmEmbeddingModelChange = useCallback(() => {
+    if (isAgentSettingsLocked) return;
     if (pendingEmbeddingModelId === null) return;
     updateSettingsMutation.mutate({ default_embedding_model: pendingEmbeddingModelId });
     setPendingEmbeddingModelId(null);
-  }, [pendingEmbeddingModelId, updateSettingsMutation]);
+  }, [isAgentSettingsLocked, pendingEmbeddingModelId, updateSettingsMutation]);
 
   const handleAutoStrategyChange = useCallback(
     (strategy: IndexAutoStrategy) => {
+      if (isAgentSettingsLocked) return;
       updateSettingsMutation.mutate({
         index_auto_strategy: strategy,
       });
     },
-    [updateSettingsMutation],
+    [isAgentSettingsLocked, updateSettingsMutation],
   );
 
   const isContentLoading =
@@ -464,6 +491,7 @@ export function IndexSettings() {
     !models ||
     isProjectsLoading ||
     !projectsData ||
+    isAgentSettingsLockLoading ||
     (Boolean(settings) && overall.isLoading && !overall.data);
 
   if (isContentLoading) {
@@ -487,6 +515,7 @@ export function IndexSettings() {
 
   return (
     <Box>
+      <AgentSettingsLockNotice isLocked={isAgentSettingsLocked} />
       <Flex
         direction="column"
         gap="5"
@@ -514,19 +543,26 @@ export function IndexSettings() {
           onModeChange={handleModeChange}
           onAutoStrategyChange={handleAutoStrategyChange}
           onEnabledProjectsChange={(projectIds) => {
+            if (isAgentSettingsLocked) return;
             updateSettingsMutation.mutate({ index_enabled_projects: projectIds });
           }}
           onChunkSizeChange={(value) => {
+            if (isAgentSettingsLocked) return;
             setChunkSize(value);
             scheduleChunkSave();
           }}
           onChunkOverlapChange={(value) => {
+            if (isAgentSettingsLocked) return;
             setChunkOverlap(value);
             scheduleChunkSave();
           }}
+          isAgentSettingsLocked={isAgentSettingsLocked}
         />
 
-        <ProjectIndexList groups={projectGroups} />
+        <ProjectIndexList
+          groups={projectGroups}
+          isAgentSettingsLocked={isAgentSettingsLocked}
+        />
       </Flex>
 
       <ConfirmDialog

--- a/frontend/src/features/settings/components/model-form-dialog.tsx
+++ b/frontend/src/features/settings/components/model-form-dialog.tsx
@@ -64,6 +64,7 @@ interface ModelFormDialogProps {
   model?: Model;
   onSubmit: (data: ModelCreateRequest | ModelUpdateRequest) => Promise<void>;
   isSubmitting: boolean;
+  isAgentSettingsLocked: boolean;
 }
 
 export function ModelFormDialog({
@@ -72,6 +73,7 @@ export function ModelFormDialog({
   model,
   onSubmit,
   isSubmitting,
+  isAgentSettingsLocked,
 }: ModelFormDialogProps) {
   const { t } = useTranslation();
   const isEditing = !!model;
@@ -451,6 +453,7 @@ export function ModelFormDialog({
                     <TextField.Root
                       {...field}
                       placeholder={t("models.namePlaceholder")}
+                      disabled={isAgentSettingsLocked}
                     />
                   )}
                 />
@@ -496,6 +499,7 @@ export function ModelFormDialog({
                       onChange={field.onChange}
                       triggerStyle={{ width: "100%" }}
                       placeholder={t("models.taskTypePlaceholder")}
+                      disabled={isAgentSettingsLocked}
                     />
                   )}
                 />
@@ -540,6 +544,7 @@ export function ModelFormDialog({
                       onChange={field.onChange}
                       triggerStyle={{ width: "100%" }}
                       placeholder={t("models.providerPlaceholder")}
+                      disabled={isAgentSettingsLocked}
                     />
                   )}
                 />
@@ -592,7 +597,7 @@ export function ModelFormDialog({
                       models={availableModels}
                       isLoading={loadingModels}
                       placeholder={t("models.modelIdPlaceholder")}
-                      disabled={isModelSelectionDisabled}
+                      disabled={isAgentSettingsLocked || isModelSelectionDisabled}
                       taskType={taskType as TaskType}
                       error={modelsError}
                       showRefreshButton
@@ -648,6 +653,7 @@ export function ModelFormDialog({
                           field.onChange(val === "" ? null : Number(val));
                         }}
                         placeholder={t("models.dimensionsPlaceholder")}
+                        disabled={isAgentSettingsLocked}
                       />
                     )}
                   />
@@ -688,6 +694,7 @@ export function ModelFormDialog({
                       {...field}
                       placeholder={t("models.remarkPlaceholder")}
                       rows={2}
+                      disabled={isAgentSettingsLocked}
                     />
                   )}
                 />
@@ -707,6 +714,7 @@ export function ModelFormDialog({
                     existingTagsLabel={
                       existingTags && existingTags.length > 0 ? t("models.existingTags") : undefined
                     }
+                    disabled={isAgentSettingsLocked}
                   />
                 )}
               />
@@ -743,7 +751,7 @@ export function ModelFormDialog({
                 </Dialog.Close>
                 <Button
                   type="submit"
-                  disabled={isSubmitting}
+                  disabled={isAgentSettingsLocked || isSubmitting}
                 >
                   {isSubmitting ? <Spinner size={18} /> : null}
                   {isEditing ? t("common.save") : t("common.create")}

--- a/frontend/src/features/settings/components/models-settings.tsx
+++ b/frontend/src/features/settings/components/models-settings.tsx
@@ -7,7 +7,7 @@
 import { Box, Flex, Text, Button, IconButton, Badge, Tabs, Tooltip } from "@radix-ui/themes";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Plus, Trash2, Edit } from "lucide-react";
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import { Spinner } from "@/components";
@@ -38,23 +38,35 @@ import {
 } from "../lib/provider-utils";
 import { fetchSettings, updateSettings } from "../lib/settings-api";
 import { DEFAULT_MODEL_SETTINGS_TAB, type ModelSettingsTab } from "../lib/settings-route";
+import { AgentSettingsLockNotice } from "./agent-settings-lock-notice";
 import { ModelFormDialog } from "./model-form-dialog";
 
 interface ModelsSettingsProps {
   activeTab?: ModelSettingsTab;
   onActiveTabChange?: (tab: ModelSettingsTab) => void;
+  isAgentSettingsLocked: boolean;
+  isAgentSettingsLockLoading: boolean;
 }
 
 export function ModelsSettings({
   activeTab = DEFAULT_MODEL_SETTINGS_TAB,
   onActiveTabChange,
-}: ModelsSettingsProps = {}) {
+  isAgentSettingsLocked,
+  isAgentSettingsLockLoading,
+}: ModelsSettingsProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
 
   const [formOpen, setFormOpen] = useState(false);
   const [editingModel, setEditingModel] = useState<Model | null>(null);
   const [deletingModel, setDeletingModel] = useState<Model | null>(null);
+
+  useEffect(() => {
+    if (!isAgentSettingsLocked) return;
+    setFormOpen(false);
+    setEditingModel(null);
+    setDeletingModel(null);
+  }, [isAgentSettingsLocked]);
 
   // 获取所有模型
   const {
@@ -284,6 +296,7 @@ export function ModelsSettings({
     isProvidersFetching ||
     isSettingsLoading ||
     isSettingsFetching ||
+    isAgentSettingsLockLoading ||
     (llmCatalogProviderTypes.length > 0 &&
       (isLlmCatalogMetadataLoading || isLlmCatalogMetadataFetching));
 
@@ -308,6 +321,7 @@ export function ModelsSettings({
 
   return (
     <Box>
+      <AgentSettingsLockNotice isLocked={isAgentSettingsLocked} />
       <Flex
         direction="column"
         gap="4"
@@ -352,7 +366,7 @@ export function ModelsSettings({
               }
               editable={false}
               allowCustomValue={false}
-              disabled={!hasLlmModels}
+              disabled={isAgentSettingsLocked || !hasLlmModels}
               emptyOptionLabel={`（${t("models.selectModelPlaceholder")}）`}
             />
           </Flex>
@@ -384,7 +398,7 @@ export function ModelsSettings({
               }
               editable={false}
               allowCustomValue={false}
-              disabled={!hasLlmModels}
+              disabled={isAgentSettingsLocked || !hasLlmModels}
               emptyOptionLabel={`（${t("models.selectModelPlaceholder")}）`}
             />
           </Flex>
@@ -396,7 +410,7 @@ export function ModelsSettings({
             <span>
               <Button
                 onClick={handleCreate}
-                disabled={!hasProviders}
+                disabled={isAgentSettingsLocked || !hasProviders}
               >
                 <Plus size={16} />
                 {t("models.newModel")}
@@ -527,6 +541,7 @@ export function ModelsSettings({
                             variant="ghost"
                             color="gray"
                             onClick={() => handleEdit(model)}
+                            disabled={isAgentSettingsLocked}
                           >
                             <Edit size={16} />
                           </IconButton>
@@ -534,6 +549,7 @@ export function ModelsSettings({
                             variant="ghost"
                             color="red"
                             onClick={() => handleDelete(model)}
+                            disabled={isAgentSettingsLocked}
                           >
                             <Trash2 size={16} />
                           </IconButton>
@@ -598,6 +614,7 @@ export function ModelsSettings({
         model={editingModel || undefined}
         onSubmit={handleSubmit}
         isSubmitting={createMutation.isPending || updateMutation.isPending}
+        isAgentSettingsLocked={isAgentSettingsLocked}
       />
 
       {/* 删除确认对话框 */}

--- a/frontend/src/features/settings/components/project-index-list.tsx
+++ b/frontend/src/features/settings/components/project-index-list.tsx
@@ -32,6 +32,7 @@ export interface ProjectIndexGroup {
 
 interface ProjectIndexListProps {
   groups: ProjectIndexGroup[];
+  isAgentSettingsLocked: boolean;
 }
 
 const EXPAND_TRANSITION = {
@@ -39,7 +40,7 @@ const EXPAND_TRANSITION = {
   opacity: { duration: 0.18, ease: "easeOut" },
 } as const;
 
-export function ProjectIndexList({ groups }: ProjectIndexListProps) {
+export function ProjectIndexList({ groups, isAgentSettingsLocked }: ProjectIndexListProps) {
   const { t } = useTranslation();
 
   return (
@@ -58,6 +59,7 @@ export function ProjectIndexList({ groups }: ProjectIndexListProps) {
               <ProjectIndexAccordionItem
                 key={group.projectId}
                 group={group}
+                isAgentSettingsLocked={isAgentSettingsLocked}
               />
             ))}
           </Flex>
@@ -74,7 +76,13 @@ export function ProjectIndexList({ groups }: ProjectIndexListProps) {
   );
 }
 
-function ProjectIndexAccordionItem({ group }: { group: ProjectIndexGroup }) {
+function ProjectIndexAccordionItem({
+  group,
+  isAgentSettingsLocked,
+}: {
+  group: ProjectIndexGroup;
+  isAgentSettingsLocked: boolean;
+}) {
   const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(false);
   const bodyId = useId();
@@ -140,6 +148,7 @@ function ProjectIndexAccordionItem({ group }: { group: ProjectIndexGroup }) {
                 projectId={group.projectId}
                 enabled={group.enabled}
                 unit={unit}
+                isAgentSettingsLocked={isAgentSettingsLocked}
               />
             ))}
           </motion.div>
@@ -153,10 +162,12 @@ function IndexUnitRow({
   projectId,
   enabled,
   unit,
+  isAgentSettingsLocked,
 }: {
   projectId: string;
   enabled: boolean;
   unit: IndexUnitStatus;
+  isAgentSettingsLocked: boolean;
 }) {
   const { t } = useTranslation();
   const startMutation = useStartProjectIndex(projectId);
@@ -195,7 +206,9 @@ function IndexUnitRow({
               }
               startMutation.mutate();
             }}
-            disabled={isIndexing ? isSubmitting : !canStart || isSubmitting}
+            disabled={
+              isAgentSettingsLocked || (isIndexing ? isSubmitting : !canStart || isSubmitting)
+            }
           >
             {isIndexing ? (
               <Square

--- a/frontend/src/features/settings/components/rules-settings.tsx
+++ b/frontend/src/features/settings/components/rules-settings.tsx
@@ -31,6 +31,8 @@ import {
   updateAgentRule,
 } from "@/lib/api-client";
 
+import { AgentSettingsLockNotice } from "./agent-settings-lock-notice";
+
 import "./skills-settings.css";
 
 const MotionBox = motion.create(Box);
@@ -52,6 +54,8 @@ interface RulesSettingsProps {
   mobileDirection?: 1 | -1;
   onMobileDetailTitleChange?: (title: string | null) => void;
   onMobilePageChange?: (page: "list" | "detail") => void;
+  isAgentSettingsLocked: boolean;
+  isAgentSettingsLockLoading: boolean;
 }
 
 interface RuleFormState {
@@ -77,6 +81,8 @@ export function RulesSettings({
   mobileDirection: controlledMobileDirection,
   onMobileDetailTitleChange,
   onMobilePageChange,
+  isAgentSettingsLocked,
+  isAgentSettingsLockLoading,
 }: RulesSettingsProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -95,6 +101,13 @@ export function RulesSettings({
     window.addEventListener("resize", checkMobile);
     return () => window.removeEventListener("resize", checkMobile);
   }, []);
+
+  useEffect(() => {
+    if (!isAgentSettingsLocked) return;
+    setDeleteDialogOpen(false);
+    setContextMenuPos(null);
+    setContextMenuRuleId(null);
+  }, [isAgentSettingsLocked]);
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["agent-rules"],
@@ -216,7 +229,7 @@ export function RulesSettings({
   }, []);
 
   const contextMenuItems = useMemo<ContextMenuItem[]>(() => {
-    if (!contextMenuRuleId) return [];
+    if (!contextMenuRuleId || isAgentSettingsLocked) return [];
     return [
       {
         id: "delete",
@@ -230,7 +243,7 @@ export function RulesSettings({
         },
       },
     ];
-  }, [contextMenuRuleId, handleCloseContextMenu, t]);
+  }, [contextMenuRuleId, handleCloseContextMenu, isAgentSettingsLocked, t]);
 
   const listContent = (
     <div className="skills-settings-list-container">
@@ -277,7 +290,7 @@ export function RulesSettings({
                 color="gray"
                 aria-label={t("settingsExtra.rules.newRule")}
                 onClick={handleCreate}
-                disabled={createMutation.isPending}
+                disabled={isAgentSettingsLocked || createMutation.isPending}
               >
                 <Plus size={14} />
               </IconButton>
@@ -321,6 +334,7 @@ export function RulesSettings({
                   if (isMobile) handleMobilePageChange("detail");
                 }}
                 onContextMenu={(position) => handleContextMenu(rule.id, position)}
+                isAgentSettingsLocked={isAgentSettingsLocked}
               />
             ))}
           </Flex>
@@ -329,7 +343,7 @@ export function RulesSettings({
     </div>
   );
 
-  if (isLoading) {
+  if (isLoading || isAgentSettingsLockLoading) {
     return (
       <Flex
         align="center"
@@ -367,6 +381,7 @@ export function RulesSettings({
       key={selectedRule.id}
       rule={selectedRule}
       onSave={handleSave}
+      isAgentSettingsLocked={isAgentSettingsLocked}
     />
   );
 
@@ -376,6 +391,7 @@ export function RulesSettings({
         direction="column"
         className="skills-settings skills-settings--settings"
       >
+        <AgentSettingsLockNotice isLocked={isAgentSettingsLocked} />
         <Box className="settings-dialog-mobile-page-stack">
           <AnimatePresence
             initial={false}
@@ -448,6 +464,7 @@ export function RulesSettings({
               </Button>
               <Button
                 color="red"
+                disabled={isAgentSettingsLocked}
                 onClick={() => {
                   if (effectiveSelectedRuleId) deleteMutation.mutate(effectiveSelectedRuleId);
                 }}
@@ -466,6 +483,7 @@ export function RulesSettings({
       direction="column"
       className="skills-settings skills-settings--settings"
     >
+      <AgentSettingsLockNotice isLocked={isAgentSettingsLocked} />
       <Flex className="skills-settings-layout skills-settings-layout--settings">
         <Box
           display={{ initial: "none", md: "block" }}
@@ -511,6 +529,7 @@ export function RulesSettings({
             </Button>
             <Button
               color="red"
+              disabled={isAgentSettingsLocked}
               onClick={() => {
                 if (effectiveSelectedRuleId) deleteMutation.mutate(effectiveSelectedRuleId);
               }}
@@ -530,6 +549,7 @@ interface RuleListItemProps {
   isMenuOpen: boolean;
   onSelect: () => void;
   onContextMenu: (position: ContextMenuPosition) => void;
+  isAgentSettingsLocked: boolean;
 }
 
 function RuleListItem({
@@ -538,14 +558,16 @@ function RuleListItem({
   isMenuOpen,
   onSelect,
   onContextMenu,
+  isAgentSettingsLocked,
 }: RuleListItemProps) {
   const { t } = useTranslation();
   const handleContextMenu = useCallback(
     (event: React.MouseEvent) => {
+      if (isAgentSettingsLocked) return;
       event.preventDefault();
       onContextMenu({ x: event.clientX, y: event.clientY });
     },
-    [onContextMenu],
+    [isAgentSettingsLocked, onContextMenu],
   );
 
   return (
@@ -599,6 +621,7 @@ function RuleListItem({
               const rect = event.currentTarget.getBoundingClientRect();
               onContextMenu({ x: rect.right, y: rect.bottom + 4 });
             }}
+            disabled={isAgentSettingsLocked}
           >
             <MoreHorizontal size={14} />
           </IconButton>
@@ -611,15 +634,17 @@ function RuleListItem({
 interface RuleEditorProps {
   rule: AgentRule;
   onSave: (ruleId: string, payload: RuleFormState) => Promise<unknown>;
+  isAgentSettingsLocked: boolean;
 }
 
-function RuleEditor({ rule, onSave }: RuleEditorProps) {
+function RuleEditor({ rule, onSave, isAgentSettingsLocked }: RuleEditorProps) {
   const { t } = useTranslation();
   const [form, setForm] = useState<RuleFormState>(() => toFormState(rule));
   const [lastSaved, setLastSaved] = useState<string>(() => JSON.stringify(toFormState(rule)));
   const [isSaving, setIsSaving] = useState(false);
   const hasUnsavedChanges = JSON.stringify(form) !== lastSaved;
-  const canSave = hasUnsavedChanges && !isSaving && Boolean(form.title.trim());
+  const canSave =
+    !isAgentSettingsLocked && hasUnsavedChanges && !isSaving && Boolean(form.title.trim());
 
   const handleSave = useCallback(async () => {
     if (!canSave) return;
@@ -656,6 +681,7 @@ function RuleEditor({ rule, onSave }: RuleEditorProps) {
                 setForm((prev) => ({ ...prev, title: event.target.value }));
               }}
               placeholder={t("settingsExtra.rules.titlePlaceholder")}
+              disabled={isAgentSettingsLocked}
             />
           </Box>
 
@@ -668,6 +694,7 @@ function RuleEditor({ rule, onSave }: RuleEditorProps) {
               }}
               placeholder={t("settingsExtra.rules.contentPlaceholder")}
               rows={18}
+              disabled={isAgentSettingsLocked}
             />
           </Box>
         </Flex>

--- a/frontend/src/features/settings/components/settings-content.tsx
+++ b/frontend/src/features/settings/components/settings-content.tsx
@@ -23,6 +23,7 @@ import { ModelsSettings } from "../components/models-settings";
 import { RulesSettings } from "../components/rules-settings";
 import { SettingsSidebar } from "../components/settings-sidebar";
 import { SkillsSettings } from "../components/skills-settings";
+import { useAgentSettingsLock } from "../lib/agent-settings-lock";
 import { fetchAgentTools, fetchSettings, updateSettings } from "../lib/settings-api";
 import { SETTINGS_CATEGORY_ITEMS, type SettingsCategory } from "../lib/settings-categories";
 import {
@@ -97,6 +98,8 @@ export function SettingsContent({
     queryKey: ["settings"],
     queryFn: fetchSettings,
   });
+  const { data: isAgentSettingsLocked = false, isLoading: isAgentSettingsLockLoading } =
+    useAgentSettingsLock();
 
   const {
     data: agentTools = [],
@@ -346,14 +349,26 @@ export function SettingsContent({
                 onSettingsChange={handleSettingsChange}
               />
             ) : null}
-            {activeCategory === "connections" ? <ConnectionsSettings /> : null}
+            {activeCategory === "connections" ? (
+              <ConnectionsSettings
+                isAgentSettingsLocked={isAgentSettingsLocked}
+                isAgentSettingsLockLoading={isAgentSettingsLockLoading}
+              />
+            ) : null}
             {activeCategory === "models" ? (
               <ModelsSettings
                 activeTab={activeModelTab}
                 onActiveTabChange={setActiveModelTab}
+                isAgentSettingsLocked={isAgentSettingsLocked}
+                isAgentSettingsLockLoading={isAgentSettingsLockLoading}
               />
             ) : null}
-            {activeCategory === "index" ? <IndexSettings /> : null}
+            {activeCategory === "index" ? (
+              <IndexSettings
+                isAgentSettingsLocked={isAgentSettingsLocked}
+                isAgentSettingsLockLoading={isAgentSettingsLockLoading}
+              />
+            ) : null}
             {activeCategory === "agent-tools" ? (
               <AgentToolsSettings
                 settings={displaySettings}
@@ -369,6 +384,8 @@ export function SettingsContent({
                 mobileDirection={mobileDirection}
                 onMobileDetailTitleChange={setMobileSubpageTitle}
                 onMobilePageChange={handleMobileSubpageChange}
+                isAgentSettingsLocked={isAgentSettingsLocked}
+                isAgentSettingsLockLoading={isAgentSettingsLockLoading}
               />
             ) : null}
             {activeCategory === "skills" ? (
@@ -380,6 +397,8 @@ export function SettingsContent({
                 onMobileDetailTitleChange={setMobileSubpageTitle}
                 onMobilePageChange={handleMobileSubpageChange}
                 onMobileRefDocEditChange={handleMobileRefDocEditChange}
+                isAgentSettingsLocked={isAgentSettingsLocked}
+                isAgentSettingsLockLoading={isAgentSettingsLockLoading}
               />
             ) : null}
             {activeCategory === "agents" ? (
@@ -389,6 +408,8 @@ export function SettingsContent({
                 mobileDirection={mobileDirection}
                 onMobileDetailTitleChange={setMobileSubpageTitle}
                 onMobilePageChange={handleMobileSubpageChange}
+                isAgentSettingsLocked={isAgentSettingsLocked}
+                isAgentSettingsLockLoading={isAgentSettingsLockLoading}
               />
             ) : null}
           </>

--- a/frontend/src/features/settings/components/settings-dialog.css
+++ b/frontend/src/features/settings/components/settings-dialog.css
@@ -147,11 +147,42 @@
   overflow: hidden;
 }
 
+.settings-dialog-lock-notice {
+  width: 100%;
+  margin: 0 0 20px;
+  padding: 12px 14px;
+  border: 1px solid var(--amber-a6);
+  border-radius: 10px;
+  background: var(--amber-a3);
+  color: var(--amber-11);
+  box-sizing: border-box;
+}
+
+.settings-dialog-lock-notice-icon {
+  flex: 0 0 auto;
+  margin-top: 1px;
+}
+
+.settings-dialog-lock-notice-copy {
+  min-width: 0;
+  line-height: 1.55;
+}
+
 .agent-definitions-layout {
   flex: 1 1 auto;
   min-height: 0;
   height: 100%;
   overflow: hidden;
+}
+
+.agent-definitions-settings-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  height: 100%;
+}
+
+.agent-definitions-settings-content > .agent-definitions-layout {
+  height: auto;
 }
 
 .rt-Box.agent-definitions-list-panel {
@@ -456,6 +487,10 @@
 
   .settings-dialog-content-scroll.settings-dialog-content-scroll--agents {
     padding: 0;
+  }
+
+  .settings-dialog-lock-notice {
+    margin-bottom: 16px;
   }
 
   .settings-dialog-savebar {

--- a/frontend/src/features/settings/components/skills-settings.tsx
+++ b/frontend/src/features/settings/components/skills-settings.tsx
@@ -42,6 +42,7 @@ import type { Skill, SkillCreate, SkillListResponse } from "@/lib/skill.types";
 import { countTokens } from "@/lib/tiktoken-utils";
 
 import { fetchAgentDefinitions } from "../lib/agent-definitions-api";
+import { AgentSettingsLockNotice } from "./agent-settings-lock-notice";
 import { ImportSkillDialog } from "./import-skill-dialog";
 
 import "./skills-settings.css";
@@ -60,6 +61,8 @@ interface SkillsSettingsProps {
   onMobileDetailTitleChange?: (title: string | null) => void;
   onMobilePageChange?: (page: "list" | "detail") => void;
   onMobileRefDocEditChange?: (active: boolean) => void;
+  isAgentSettingsLocked?: boolean;
+  isAgentSettingsLockLoading?: boolean;
 }
 
 const MotionBox = motion.create(Box);
@@ -99,6 +102,8 @@ export function SkillsSettings({
   onMobileDetailTitleChange,
   onMobilePageChange,
   onMobileRefDocEditChange,
+  isAgentSettingsLocked = false,
+  isAgentSettingsLockLoading = false,
 }: SkillsSettingsProps) {
   const { t } = useTranslation();
   const queryClient = useQueryClient();
@@ -219,6 +224,17 @@ export function SkillsSettings({
     setRenamingRefDocId(null);
     setDeletingRefDoc(null);
   }, [effectiveSelectedSkillId]);
+
+  useEffect(() => {
+    if (!isAgentSettingsLocked) return;
+    setDeleteDialogOpen(false);
+    setImportDialogOpen(false);
+    setEditingRefDoc(null);
+    setRenamingRefDocId(null);
+    setDeletingRefDoc(null);
+    setContextMenuPos(null);
+    setContextMenuSkillId(null);
+  }, [isAgentSettingsLocked]);
 
   const createMutation = useMutation({
     mutationFn: (payload: SkillCreate) => createSkill(payload),
@@ -400,6 +416,7 @@ export function SkillsSettings({
   });
 
   const handleCreate = () => {
+    if (isAgentSettingsLocked) return;
     const defaultPayload: SkillCreate = {
       name: t("settingsExtra.skills.newSkill"),
       summary: "",
@@ -427,7 +444,7 @@ export function SkillsSettings({
   }, []);
 
   const contextMenuItems = useMemo<ContextMenuItem[]>(() => {
-    if (!contextMenuSkillId) return [];
+    if (!contextMenuSkillId || isAgentSettingsLocked) return [];
     const skill = skills.find((s) => s.id === contextMenuSkillId);
     if (!skill) return [];
 
@@ -444,19 +461,24 @@ export function SkillsSettings({
         },
       },
     ];
-  }, [contextMenuSkillId, skills, handleCloseContextMenu, t]);
+  }, [contextMenuSkillId, skills, handleCloseContextMenu, isAgentSettingsLocked, t]);
 
   const handleCreateRefDoc = useCallback(() => {
+    if (isAgentSettingsLocked) return;
     if (!effectiveSelectedSkillId) return;
     createRefDocMutation.mutate({
       skillDbId: effectiveSelectedSkillId,
       payload: { title: t("settingsExtra.skills.newReferenceDoc"), content: "" },
     });
-  }, [createRefDocMutation, effectiveSelectedSkillId, t]);
+  }, [createRefDocMutation, effectiveSelectedSkillId, isAgentSettingsLocked, t]);
 
-  const handleStartRenameRefDoc = useCallback((doc: SkillReferenceDoc) => {
-    setRenamingRefDocId(doc.id);
-  }, []);
+  const handleStartRenameRefDoc = useCallback(
+    (doc: SkillReferenceDoc) => {
+      if (isAgentSettingsLocked) return;
+      setRenamingRefDocId(doc.id);
+    },
+    [isAgentSettingsLocked],
+  );
 
   const handleConfirmRenameRefDoc = useCallback(
     (newTitle: string) => {
@@ -481,6 +503,7 @@ export function SkillsSettings({
 
   const handleEditRefDoc = useCallback(
     (doc: SkillReferenceDoc) => {
+      if (isAgentSettingsLocked) return;
       setEditingRefDoc(doc);
       if (isMobile) {
         setInternalMobileRefDocEdit(true);
@@ -488,12 +511,16 @@ export function SkillsSettings({
         onMobileDetailTitleChange?.(doc.title || t("settingsExtra.skills.untitledReferenceDoc"));
       }
     },
-    [isMobile, onMobileRefDocEditChange, onMobileDetailTitleChange, t],
+    [isAgentSettingsLocked, isMobile, onMobileRefDocEditChange, onMobileDetailTitleChange, t],
   );
 
-  const handleDeleteRefDoc = useCallback((doc: SkillReferenceDoc) => {
-    setDeletingRefDoc(doc);
-  }, []);
+  const handleDeleteRefDoc = useCallback(
+    (doc: SkillReferenceDoc) => {
+      if (isAgentSettingsLocked) return;
+      setDeletingRefDoc(doc);
+    },
+    [isAgentSettingsLocked],
+  );
 
   const handleSaveRefDocContent = useCallback(
     async (content: string) => {
@@ -574,7 +601,7 @@ export function SkillsSettings({
                 color="gray"
                 aria-label={t("settingsExtra.skills.newSkill")}
                 onClick={handleCreate}
-                disabled={createMutation.isPending}
+                disabled={isAgentSettingsLocked || createMutation.isPending}
               >
                 <Plus size={14} />
               </IconButton>
@@ -587,7 +614,7 @@ export function SkillsSettings({
                 color="gray"
                 aria-label={t("settingsExtra.skills.importSkill")}
                 onClick={() => setImportDialogOpen(true)}
-                disabled={createMutation.isPending}
+                disabled={isAgentSettingsLocked || createMutation.isPending}
               >
                 <Import size={14} />
               </IconButton>
@@ -638,6 +665,7 @@ export function SkillsSettings({
                   })
                 }
                 onContextMenu={(pos) => handleContextMenu(skill.id, pos)}
+                isAgentSettingsLocked={isAgentSettingsLocked}
               />
             ))}
           </Flex>
@@ -646,7 +674,7 @@ export function SkillsSettings({
     </div>
   );
 
-  if (isLoading) {
+  if (isLoading || isAgentSettingsLockLoading) {
     return (
       <Flex
         align="center"
@@ -694,6 +722,7 @@ export function SkillsSettings({
       onDeleteRefDoc={handleDeleteRefDoc}
       isCreatingRefDoc={createRefDocMutation.isPending}
       isRenamingRefDoc={renameRefDocMutation.isPending}
+      isAgentSettingsLocked={isAgentSettingsLocked}
     />
   );
 
@@ -705,6 +734,7 @@ export function SkillsSettings({
         onOpenChange={(o) => !o && setEditingRefDoc(null)}
         onSave={handleSaveRefDocContent}
         isSaving={editRefDocContentMutation.isPending}
+        isAgentSettingsLocked={isAgentSettingsLocked}
       />
       <SkillReferenceDocDeleteDialog
         doc={deletingRefDoc}
@@ -712,6 +742,7 @@ export function SkillsSettings({
         onOpenChange={(o) => !o && setDeletingRefDoc(null)}
         onConfirm={handleConfirmDeleteRefDoc}
         isSaving={deleteRefDocMutation.isPending}
+        isAgentSettingsLocked={isAgentSettingsLocked}
       />
     </>
   );
@@ -726,6 +757,7 @@ export function SkillsSettings({
         direction="column"
         className={`skills-settings${isSettingsVariant ? " skills-settings--settings" : ""}`}
       >
+        {isSettingsVariant ? <AgentSettingsLockNotice isLocked={isAgentSettingsLocked} /> : null}
         <Box className="settings-dialog-mobile-page-stack">
           <AnimatePresence
             initial={false}
@@ -780,6 +812,7 @@ export function SkillsSettings({
                             onSave={handleSaveRefDocContent}
                             onDone={handleExitRefDocEdit}
                             isSaving={editRefDocContentMutation.isPending}
+                            isAgentSettingsLocked={isAgentSettingsLocked}
                           />
                         </Flex>
                       </div>
@@ -840,6 +873,7 @@ export function SkillsSettings({
               </Button>
               <Button
                 color="red"
+                disabled={isAgentSettingsLocked}
                 onClick={() =>
                   effectiveSelectedSkillId && deleteMutation.mutate(effectiveSelectedSkillId)
                 }
@@ -856,6 +890,7 @@ export function SkillsSettings({
           open={importDialogOpen}
           onOpenChange={setImportDialogOpen}
           onImported={handleImported}
+          disabled={isAgentSettingsLocked}
         />
       </Flex>
     );
@@ -866,6 +901,7 @@ export function SkillsSettings({
       direction="column"
       className={`skills-settings${isSettingsVariant ? " skills-settings--settings" : ""}`}
     >
+      {isSettingsVariant ? <AgentSettingsLockNotice isLocked={isAgentSettingsLocked} /> : null}
       <Flex
         className={`skills-settings-layout${isSettingsVariant ? " skills-settings-layout--settings" : ""}`}
       >
@@ -915,6 +951,7 @@ export function SkillsSettings({
             </Button>
             <Button
               color="red"
+              disabled={isAgentSettingsLocked}
               onClick={() =>
                 effectiveSelectedSkillId && deleteMutation.mutate(effectiveSelectedSkillId)
               }
@@ -931,6 +968,7 @@ export function SkillsSettings({
         open={importDialogOpen}
         onOpenChange={setImportDialogOpen}
         onImported={handleImported}
+        disabled={isAgentSettingsLocked}
       />
     </Flex>
   );
@@ -944,6 +982,7 @@ interface SkillListItemProps {
   onSelect: () => void;
   onToggle: () => void;
   onContextMenu: (position: ContextMenuPosition) => void;
+  isAgentSettingsLocked: boolean;
 }
 
 function SkillListItem({
@@ -954,14 +993,16 @@ function SkillListItem({
   onSelect,
   onToggle,
   onContextMenu,
+  isAgentSettingsLocked,
 }: SkillListItemProps) {
   const { t } = useTranslation();
   const handleContextMenu = useCallback(
     (e: React.MouseEvent) => {
+      if (isAgentSettingsLocked) return;
       e.preventDefault();
       onContextMenu({ x: e.clientX, y: e.clientY });
     },
-    [onContextMenu],
+    [isAgentSettingsLocked, onContextMenu],
   );
 
   return (
@@ -1036,7 +1077,7 @@ function SkillListItem({
             <Switch
               size="1"
               checked={skill.isEnabled}
-              disabled={!skill.isComplete}
+              disabled={isAgentSettingsLocked || !skill.isComplete}
               onClick={(e) => e.stopPropagation()}
               onCheckedChange={onToggle}
             />
@@ -1053,6 +1094,7 @@ function SkillListItem({
                 const rect = event.currentTarget.getBoundingClientRect();
                 onContextMenu({ x: rect.right, y: rect.bottom + 4 });
               }}
+              disabled={isAgentSettingsLocked}
             >
               <MoreHorizontal size={14} />
             </IconButton>
@@ -1083,6 +1125,7 @@ interface SkillEditorProps {
   onDeleteRefDoc: (doc: SkillReferenceDoc) => void;
   isCreatingRefDoc: boolean;
   isRenamingRefDoc: boolean;
+  isAgentSettingsLocked: boolean;
 }
 
 function SkillEditor({
@@ -1098,6 +1141,7 @@ function SkillEditor({
   onDeleteRefDoc,
   isCreatingRefDoc,
   isRenamingRefDoc,
+  isAgentSettingsLocked,
 }: SkillEditorProps) {
   const { t } = useTranslation();
   const [form, setForm] = useState<SkillFormState>(() => toFormState(skill));
@@ -1141,6 +1185,7 @@ function SkillEditor({
               value={form.name}
               onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
               placeholder={t("settingsExtra.skills.namePlaceholder")}
+              disabled={isAgentSettingsLocked}
             />
           </Box>
 
@@ -1158,6 +1203,7 @@ function SkillEditor({
               onChange={(e) => setForm((prev) => ({ ...prev, summary: e.target.value }))}
               placeholder={t("settingsExtra.skills.summaryPlaceholder")}
               rows={3}
+              disabled={isAgentSettingsLocked}
             />
           </Box>
 
@@ -1186,6 +1232,7 @@ function SkillEditor({
               onChange={(e) => setForm((prev) => ({ ...prev, content: e.target.value }))}
               placeholder={t("settingsExtra.skills.contentPlaceholder")}
               rows={12}
+              disabled={isAgentSettingsLocked}
             />
           </Box>
 
@@ -1200,6 +1247,7 @@ function SkillEditor({
             onDelete={onDeleteRefDoc}
             isCreating={isCreatingRefDoc}
             isRenaming={isRenamingRefDoc}
+            isAgentSettingsLocked={isAgentSettingsLocked}
           />
         </Flex>
       </div>
@@ -1207,7 +1255,7 @@ function SkillEditor({
       <div className="skills-settings-editor-footer">
         <Button
           onClick={() => void handleSave()}
-          disabled={!canSave}
+          disabled={isAgentSettingsLocked || !canSave}
         >
           {isSaving ? t("settingsExtra.skills.saving") : t("common.save")}
         </Button>
@@ -1227,6 +1275,7 @@ interface SkillReferenceDocsSectionProps {
   onDelete: (doc: SkillReferenceDoc) => void;
   isCreating: boolean;
   isRenaming: boolean;
+  isAgentSettingsLocked: boolean;
 }
 
 function SkillReferenceDocsSection({
@@ -1240,6 +1289,7 @@ function SkillReferenceDocsSection({
   onDelete,
   isCreating,
   isRenaming,
+  isAgentSettingsLocked,
 }: SkillReferenceDocsSectionProps) {
   const { t } = useTranslation();
 
@@ -1262,7 +1312,7 @@ function SkillReferenceDocsSection({
           variant="ghost"
           color="gray"
           onClick={onCreate}
-          disabled={isCreating}
+          disabled={isAgentSettingsLocked || isCreating}
         >
           <Plus size={14} />
           {t("settingsExtra.skills.newReferenceDocButton")}
@@ -1300,6 +1350,7 @@ function SkillReferenceDocsSection({
                     initialValue={doc.title}
                     onConfirm={onConfirmRename}
                     onCancel={onCancelRename}
+                    disabled={isAgentSettingsLocked}
                   />
                 ) : (
                   <Text
@@ -1330,7 +1381,7 @@ function SkillReferenceDocsSection({
                       variant="ghost"
                       color="gray"
                       aria-label={t("common.rename")}
-                      disabled={isRenaming}
+                      disabled={isAgentSettingsLocked || isRenaming}
                       onClick={() => onStartRename(doc)}
                     >
                       <PenLine size={14} />
@@ -1343,6 +1394,7 @@ function SkillReferenceDocsSection({
                       color="gray"
                       aria-label={t("common.edit")}
                       onClick={() => onEdit(doc)}
+                      disabled={isAgentSettingsLocked}
                     >
                       <FilePen size={14} />
                     </IconButton>
@@ -1354,6 +1406,7 @@ function SkillReferenceDocsSection({
                       color="red"
                       aria-label={t("common.delete")}
                       onClick={() => onDelete(doc)}
+                      disabled={isAgentSettingsLocked}
                     >
                       <Trash2 size={14} />
                     </IconButton>
@@ -1372,9 +1425,15 @@ interface RefDocRenameInputProps {
   initialValue: string;
   onConfirm: (newTitle: string) => void;
   onCancel: () => void;
+  disabled: boolean;
 }
 
-function RefDocRenameInput({ initialValue, onConfirm, onCancel }: RefDocRenameInputProps) {
+function RefDocRenameInput({
+  initialValue,
+  onConfirm,
+  onCancel,
+  disabled,
+}: RefDocRenameInputProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [value, setValue] = useState(initialValue);
 
@@ -1417,6 +1476,7 @@ function RefDocRenameInput({ initialValue, onConfirm, onCancel }: RefDocRenameIn
       onKeyDown={handleKeyDown}
       onClick={(event) => event.stopPropagation()}
       className="skills-settings-refdocs-item-rename-input"
+      disabled={disabled}
     />
   );
 }
@@ -1426,9 +1486,16 @@ interface ReferenceDocEditorProps {
   onSave: (content: string) => Promise<void>;
   onDone: () => void;
   isSaving: boolean;
+  isAgentSettingsLocked: boolean;
 }
 
-function ReferenceDocEditor({ doc, onSave, onDone, isSaving }: ReferenceDocEditorProps) {
+function ReferenceDocEditor({
+  doc,
+  onSave,
+  onDone,
+  isSaving,
+  isAgentSettingsLocked,
+}: ReferenceDocEditorProps) {
   const { t } = useTranslation();
   const [content, setContent] = useState(doc.content);
   const hasChanges = content !== doc.content;
@@ -1452,6 +1519,7 @@ function ReferenceDocEditor({ doc, onSave, onDone, isSaving }: ReferenceDocEdito
         onChange={(e) => setContent(e.target.value)}
         placeholder={t("settingsExtra.skills.referenceDocContentPlaceholder")}
         rows={12}
+        disabled={isAgentSettingsLocked}
       />
       <Flex
         gap="3"
@@ -1467,7 +1535,7 @@ function ReferenceDocEditor({ doc, onSave, onDone, isSaving }: ReferenceDocEdito
         </Button>
         <Button
           onClick={() => void handleSave()}
-          disabled={isSaving || !hasChanges}
+          disabled={isAgentSettingsLocked || isSaving || !hasChanges}
         >
           {isSaving ? <Spinner size={18} /> : null}
           {t("common.save")}
@@ -1483,6 +1551,7 @@ interface SkillReferenceDocEditDialogProps {
   onOpenChange: (open: boolean) => void;
   onSave: (content: string) => Promise<void>;
   isSaving: boolean;
+  isAgentSettingsLocked: boolean;
 }
 
 function SkillReferenceDocEditDialog({
@@ -1491,6 +1560,7 @@ function SkillReferenceDocEditDialog({
   onOpenChange,
   onSave,
   isSaving,
+  isAgentSettingsLocked,
 }: SkillReferenceDocEditDialogProps) {
   const { t } = useTranslation();
 
@@ -1508,6 +1578,7 @@ function SkillReferenceDocEditDialog({
               onSave={onSave}
               onDone={() => onOpenChange(false)}
               isSaving={isSaving}
+              isAgentSettingsLocked={isAgentSettingsLocked}
             />
           </Box>
         ) : null}
@@ -1522,6 +1593,7 @@ interface SkillReferenceDocDeleteDialogProps {
   onOpenChange: (open: boolean) => void;
   onConfirm: () => void;
   isSaving: boolean;
+  isAgentSettingsLocked: boolean;
 }
 
 function SkillReferenceDocDeleteDialog({
@@ -1529,6 +1601,7 @@ function SkillReferenceDocDeleteDialog({
   onOpenChange,
   onConfirm,
   isSaving,
+  isAgentSettingsLocked,
 }: SkillReferenceDocDeleteDialogProps) {
   const { t } = useTranslation();
 
@@ -1554,14 +1627,14 @@ function SkillReferenceDocDeleteDialog({
             variant="soft"
             color="gray"
             onClick={() => onOpenChange(false)}
-            disabled={isSaving}
+            disabled={isAgentSettingsLocked || isSaving}
           >
             {t("common.cancel")}
           </Button>
           <Button
             color="red"
             onClick={onConfirm}
-            disabled={isSaving}
+            disabled={isAgentSettingsLocked || isSaving}
           >
             {t("common.delete")}
           </Button>

--- a/frontend/src/features/settings/lib/agent-settings-lock.ts
+++ b/frontend/src/features/settings/lib/agent-settings-lock.ts
@@ -1,0 +1,32 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+import { apiClient } from "@/lib/api-client";
+
+export const AGENT_SETTINGS_LOCK_QUERY_KEY = ["agent-settings-lock"] as const;
+
+interface AgentSettingsLockResponse {
+  is_locked: boolean;
+}
+
+interface AgentSettingsLockErrorDetail {
+  code?: string;
+}
+
+export async function fetchAgentSettingsLock(): Promise<boolean> {
+  const response = await apiClient.get<AgentSettingsLockResponse>("/settings/agent-session-lock");
+  return response.data.is_locked === true;
+}
+
+export function useAgentSettingsLock() {
+  return useQuery({
+    queryKey: AGENT_SETTINGS_LOCK_QUERY_KEY,
+    queryFn: fetchAgentSettingsLock,
+  });
+}
+
+export function isAgentSettingsLockedError(error: unknown): boolean {
+  if (!axios.isAxiosError(error) || error.response?.status !== 409) return false;
+  const detail = error.response.data?.detail as AgentSettingsLockErrorDetail | undefined;
+  return detail?.code === "agent_settings_locked";
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -541,6 +541,8 @@
     "batchToggled": "{{count}} entries updated"
   },
   "settings": {
+    "agentSettingsLocked": "An Agent session is running, so related settings are read-only.",
+    "agentSettingsLockHint": "Wait for all sessions to finish before making changes.",
     "title": "Settings",
     "general": "General",
     "connections": "Providers",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -534,6 +534,8 @@
     "batchToggled": "已更新 {{count}} 个条目"
   },
   "settings": {
+    "agentSettingsLocked": "Agent 会话运行中，相关设置暂不可修改。",
+    "agentSettingsLockHint": "请等待所有会话结束后再修改。",
     "title": "设置",
     "general": "通用",
     "connections": "提供商",


### PR DESCRIPTION
## PR 标题

fix(settings): 锁定运行期间的智能体配置

## 变更说明

- 问题: Agent 或子智能体运行时仍可修改模型、索引、规则、技能和智能体配置，可能导致会话运行上下文与配置不一致。
- 重要性: 防止运行中的 Agent 使用被中途变更或删除的配置，并确保设置页与后端写入接口的行为一致。
- 变化: 新增全局锁定状态接口和后端写入守卫，覆盖提供商、模型、索引、规则、技能、参考文档与智能体定义的写操作。
- 变化: 设置页在分类数据和锁定状态均完成加载后显示只读内容及警告卡片；通用设置和工具权限不受影响。
- 变化: 支持恢复历史 checkpoint 中的提问对象和旧模型配置；取消会话仅终结 active 或 interrupted revision，并清理运行标记。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [x] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

运行中的会话与设置修改之间没有统一的状态判定和写入防线；部分历史中断会话的 checkpoint 无法按当前协议恢复或取消。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证结果：

- 后端：`uv run pytest -q`，`1050 passed, 1 warning`；`uv run ruff check app tests`；`uv run ty check app`
- 前端：`pnpm type-check`；`pnpm lint`；`pnpm format:check`；`pnpm build`
