### PR TITLE
fix(agent): 修复会话重连后流式事件丢失

### DIFF
--- a/frontend/src/features/assistant/hooks/use-agent-session.ts
+++ b/frontend/src/features/assistant/hooks/use-agent-session.ts
@@ -646,8 +646,8 @@ export function useAgentSession({
 
         if (!socketUnsubscribeRef.current) {
           attachAgentSocket(activeSessionId);
-          await joinAgentSession(activeSessionId);
         }
+        await joinAgentSession(activeSessionId);
         const nextModelId = modelId === activeModelIdRef.current ? undefined : modelId;
         const response = await sendAgentMessage(activeSessionId, message, nextModelId);
         if (response.model_updated && nextModelId) activeModelIdRef.current = nextModelId;

--- a/frontend/src/features/assistant/lib/agent-socket.ts
+++ b/frontend/src/features/assistant/lib/agent-socket.ts
@@ -5,6 +5,8 @@ import { connectSocket, getSocket } from "@/lib/socket-client";
 import { AGENT_SOCKET_EVENTS, toAgentEvent } from "./agent-socket-events";
 import { getString, isRecord } from "./tool-result-normalization";
 
+const pendingAgentSessionJoins = new Map<string, Promise<void>>();
+
 export function subscribeAgentSessionEvents(
   sessionId: string,
   onEvent: (event: AgentEvent) => void,
@@ -12,6 +14,19 @@ export function subscribeAgentSessionEvents(
 ): () => void {
   const activeSocket = getSocket();
   const connectError = (error: Error) => onError?.(error);
+  let hasJoinedRoom = false;
+  const joinedHandler = (data: unknown) => {
+    if (!isRecord(data) || getString(data.session_id) !== sessionId) return;
+    hasJoinedRoom = true;
+  };
+  const connectHandler = () => {
+    if (!hasJoinedRoom) return;
+    void joinAgentSession(sessionId).catch((error) => {
+      onError?.(
+        error instanceof Error ? error : new Error(i18n.t("assistant.joinAgentSessionFailed")),
+      );
+    });
+  };
   const handlers = AGENT_SOCKET_EVENTS.map((eventName) => {
     const handler = (data: unknown) => {
       const event = toAgentEvent(eventName, sessionId, data);
@@ -21,9 +36,13 @@ export function subscribeAgentSessionEvents(
     return { eventName, handler };
   });
 
+  activeSocket.on("agent:joined", joinedHandler);
+  activeSocket.on("connect", connectHandler);
   activeSocket.on("connect_error", connectError);
 
   return () => {
+    activeSocket.off("agent:joined", joinedHandler);
+    activeSocket.off("connect", connectHandler);
     activeSocket.off("connect_error", connectError);
     handlers.forEach(({ eventName, handler }) => activeSocket.off(eventName, handler));
     activeSocket.emit("agent:leave", { session_id: sessionId });
@@ -31,33 +50,44 @@ export function subscribeAgentSessionEvents(
 }
 
 export async function joinAgentSession(sessionId: string): Promise<void> {
-  const activeSocket = getSocket();
-  await connectSocket();
+  const pendingJoin = pendingAgentSessionJoins.get(sessionId);
+  if (pendingJoin) return pendingJoin;
 
-  return new Promise((resolve, reject) => {
-    const cleanup = () => {
-      window.clearTimeout(timeout);
-      activeSocket.off("agent:joined", onJoined);
-      activeSocket.off("agent:error", onError);
-    };
-    const onJoined = (data: unknown) => {
-      if (!isRecord(data) || getString(data.session_id) !== sessionId) return;
-      cleanup();
-      resolve();
-    };
-    const onError = (data: unknown) => {
-      if (isRecord(data) && data.type === "invalid_session") {
+  const joinPromise = (async () => {
+    const activeSocket = getSocket();
+    await connectSocket({ force: true });
+
+    await new Promise<void>((resolve, reject) => {
+      const cleanup = () => {
+        window.clearTimeout(timeout);
+        activeSocket.off("agent:joined", onJoined);
+        activeSocket.off("agent:error", onError);
+      };
+      const onJoined = (data: unknown) => {
+        if (!isRecord(data) || getString(data.session_id) !== sessionId) return;
         cleanup();
-        reject(new Error(getString(data.reason) || i18n.t("assistant.joinAgentSessionFailed")));
-      }
-    };
+        resolve();
+      };
+      const onError = (data: unknown) => {
+        if (isRecord(data) && data.type === "invalid_session") {
+          cleanup();
+          reject(new Error(getString(data.reason) || i18n.t("assistant.joinAgentSessionFailed")));
+        }
+      };
 
-    activeSocket.on("agent:joined", onJoined);
-    activeSocket.on("agent:error", onError);
-    const timeout = window.setTimeout(() => {
-      cleanup();
-      reject(new Error(i18n.t("assistant.joinAgentSessionTimeout")));
-    }, 5000);
-    activeSocket.emit("agent:join", { session_id: sessionId });
-  });
+      activeSocket.on("agent:joined", onJoined);
+      activeSocket.on("agent:error", onError);
+      const timeout = window.setTimeout(() => {
+        cleanup();
+        reject(new Error(i18n.t("assistant.joinAgentSessionTimeout")));
+      }, 5000);
+      activeSocket.emit("agent:join", { session_id: sessionId });
+    });
+  })();
+  pendingAgentSessionJoins.set(sessionId, joinPromise);
+  void joinPromise.then(
+    () => pendingAgentSessionJoins.delete(sessionId),
+    () => pendingAgentSessionJoins.delete(sessionId),
+  );
+  return joinPromise;
 }

--- a/frontend/src/lib/socket-client.ts
+++ b/frontend/src/lib/socket-client.ts
@@ -105,11 +105,18 @@ export function getSocket(): Socket {
   return state.socket;
 }
 
-export function connectSocket(): Promise<Socket> {
+export function connectSocket({ force = false }: { force?: boolean } = {}): Promise<Socket> {
   const state = getSocketState();
   const activeSocket = getSocket();
   if (activeSocket.connected) return Promise.resolve(activeSocket);
-  if (state.connectPromise) return state.connectPromise;
+  if (state.connectPromise) {
+    if (force && activeSocket.active) {
+      // Cancel a pending automatic backoff before an explicit user action.
+      activeSocket.disconnect();
+      activeSocket.connect();
+    }
+    return state.connectPromise;
+  }
 
   state.connectPromise = new Promise<Socket>((resolve, reject) => {
     const cleanup = () => {
@@ -134,6 +141,7 @@ export function connectSocket(): Promise<Socket> {
       cleanup();
       reject(new Error("WebSocket 连接超时"));
     }, 5000);
+    if (force && activeSocket.active) activeSocket.disconnect();
     activeSocket.connect();
   }).finally(() => {
     state.connectPromise = null;


### PR DESCRIPTION
## PR 标题

fix(agent): 修复会话重连后流式事件丢失

## 变更说明

- 问题: Socket 断线后会话房间订阅失效；在自动重连退避期间继续发送消息，Agent 虽可运行但前端收不到流式事件。
- 重要性: 用户需要刷新页面才能恢复会话流式输出。
- 变化: Socket 重连后自动重新加入 Agent 会话房间，并在继续会话前确认 `agent:join` 已完成。
- 变化: 用户发送消息时主动取消自动重连退避并立即重连；合并同一会话的并发入房请求。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

Socket.IO 断线后，服务端会移除旧连接在 Agent 会话房间中的成员资格。前端保留了事件监听器，但没有在重连后重新发送 `agent:join`。此外，Socket.IO 自动重连处于退避等待时，普通 `socket.connect()` 不会立即发起新的连接尝试。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

已执行 `pnpm format:check`、`pnpm type-check`、`pnpm lint` 和 `pnpm build`。前端当前未配置测试执行器，因此未新增不可运行的测试依赖。
