### PR TITLE
fix(mobile): 修复移动端布局适配问题

### DIFF
--- a/frontend/src/components/global-loading.css
+++ b/frontend/src/components/global-loading.css
@@ -1,6 +1,9 @@
 .global-loading-shell {
   position: fixed;
-  inset: 0;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 100dvh;
   z-index: 9999;
   background:
     radial-gradient(circle at center, var(--gray-a3) 0, transparent 26%),
@@ -17,7 +20,7 @@
   height: 100%;
 }
 
-.global-loading-spinner-shell {
+.rt-Box.global-loading-spinner-shell {
   position: relative;
   display: grid;
   width: 96px;

--- a/frontend/src/features/app-shell/components/app-sidebar.tsx
+++ b/frontend/src/features/app-shell/components/app-sidebar.tsx
@@ -213,7 +213,10 @@ export function AppSidebar({ appearance, onToggleTheme }: AppSidebarProps) {
             transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
             style={{
               position: "fixed",
-              inset: 0,
+              top: 0,
+              left: 0,
+              right: 0,
+              bottom: "var(--app-status-bar-height)",
               background: "rgba(0, 0, 0, 0.36)",
               zIndex: 99,
             }}
@@ -243,6 +246,7 @@ export function AppSidebar({ appearance, onToggleTheme }: AppSidebarProps) {
               zIndex: 100,
               overflow: "hidden",
               boxShadow: isMobile ? "var(--shadow-5)" : undefined,
+              clipPath: isMobile ? "inset(0 -64px 0 0)" : undefined,
             }}
           >
             <Flex

--- a/frontend/src/features/characters/pages/characters-page.css
+++ b/frontend/src/features/characters/pages/characters-page.css
@@ -15,6 +15,11 @@
   min-height: 0;
 }
 
+.rt-Box.characters-page-body--mobile {
+  display: flex;
+  flex-direction: column;
+}
+
 .characters-panel {
   height: 100%;
   min-width: 0;
@@ -205,13 +210,14 @@
   overflow: hidden;
 }
 
-.characters-editor-shell--mobile {
+.rt-Box.characters-editor-shell--mobile {
   position: relative;
   display: flex;
+  flex: 1;
   flex-direction: column;
 }
 
-.characters-page-content-fill {
+.rt-Box.characters-page-content-fill {
   flex: 1;
   min-height: 0;
   display: flex;

--- a/frontend/src/features/world-info/pages/world-info-page.css
+++ b/frontend/src/features/world-info/pages/world-info-page.css
@@ -32,7 +32,7 @@
   flex: 1;
 }
 
-.world-info-page-editor-shell--mobile {
+.rt-Box.world-info-page-editor-shell--mobile {
   position: relative;
   display: flex;
   flex: 1;

--- a/frontend/src/features/world-info/pages/world-info-page.tsx
+++ b/frontend/src/features/world-info/pages/world-info-page.tsx
@@ -708,16 +708,18 @@ export function WorldInfoPage() {
   );
 
   return (
-    <Box
+    <Flex
+      direction="column"
       style={{
         height: "100%",
         minHeight: 0,
         overflow: "hidden",
       }}
     >
-      <Box
+      <Flex
+        direction="column"
         style={{
-          height: "100%",
+          flex: 1,
           minHeight: 0,
           overflow: "hidden",
         }}
@@ -864,7 +866,7 @@ export function WorldInfoPage() {
             </Flex>
           )}
         </Flex>
-      </Box>
+      </Flex>
 
       {isMobile && currentProjectId && (
         <MotionBox
@@ -924,6 +926,6 @@ export function WorldInfoPage() {
           </Flex>
         </Dialog.Content>
       </Dialog.Root>
-    </Box>
+    </Flex>
   );
 }


### PR DESCRIPTION
## PR 标题

fix(mobile): 修复移动端布局适配问题

## 变更说明

- 问题: 移动端下全局 loading spinner 不居中、app-shell 遮罩和阴影覆盖底部状态栏、世界书和角色页面内容区底部出现空白
- 重要性: 影响移动端首屏体验和核心页面可用性
- 变化:
  - 全局 loading spinner-shell 的 `display: grid` 被 `.rt-Box { display: block }` 覆盖，`place-items: center` 失效，spinner 偏移 36px；改用 `.rt-Box.global-loading-spinner-shell` 提高特异性
  - 世界书/角色页面多个移动端容器的 `display: flex` 被同样覆盖，子元素 `flex: 1` 无法生效，内容区高度塌缩；对受影响选择器加 `.rt-Box` 前缀，世界书页面外层 `Box` 改为 `Flex`
  - app-shell 侧边栏 backdrop 的 `inset: 0` 改为 `bottom: var(--app-status-bar-height)`，不再覆盖状态栏
  - app-shell 侧边栏添加 `clip-path: inset(0 -64px 0 0)` 裁剪 box-shadow 底部溢出，仅保留右侧阴影
  - 全局 loading shell 的 `inset: 0` 改为 `height: 100dvh`，适配移动端动态视口

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

Radix Themes 的 `.rt-Box` 类设置 `display: block`，与项目组件 CSS 中 `display: flex/grid` 的特异性相同（均为 0,1,0）。由于 Radix Themes 样式在 Vite 构建输出中排在组件 CSS 之后，`.rt-Box` 的 `display: block` 覆盖了组件 intended 的 flex/grid 布局，导致 flex 子项无法伸展、grid 居中失效。

提示词页面（prompt-chains-page.css）已用 `.rt-Box.className` 选择器（特异性 0,2,0）规避了此问题，本次修复沿用相同模式。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

通过 Playwright 以 390x844 移动端视口验证：
- spinner 中心坐标 `(195, 422)` 与视口中心完全重合，偏移量 0
- 角色页面 `.characters-page-content-fill` 高度从 44px 恢复为 773px
- 世界书页面 `.world-info-page-content-fill` 高度从 24px 恢复为 773px
- backdrop 底部（822px）与状态栏顶部（822px）无重叠
- sidebar `clip-path` 裁剪后 `backdrop-filter: blur(12px)` 仍正常工作
