### PR TITLE
feat(desktop): 支持应用内自动更新

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -228,27 +228,32 @@ jobs:
 
   # ---------------------------------------------------------------- desktop
   desktop:
-    needs: [context, build-frontend]
+    needs: [context, build-frontend, pypi]
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: windows-latest
             electron_args: '--win --x64'
+            publish_update: true
             artifact_name: desktop-win-x64
           - os: ubuntu-latest
             electron_args: '--linux --x64'
+            publish_update: false
             artifact_name: desktop-linux-x64
           - os: ubuntu-24.04-arm
             electron_args: '--linux --arm64'
+            publish_update: false
             artifact_name: desktop-linux-arm64
           - os: macos-14
             electron_args: '--mac --arm64'
+            publish_update: false
             artifact_name: desktop-mac-arm64
     runs-on: ${{ matrix.os }}
     env:
       ELECTRON_CACHE: ${{ github.workspace }}/.electron-cache
       ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.electron-builder-cache
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
@@ -292,9 +297,28 @@ jobs:
         run: pnpm build
       - name: 构建 Electron 安装包
         working-directory: desktop
-        run: pnpm exec electron-builder --config electron-builder.yml ${{ matrix.electron_args }}
+        run: pnpm exec electron-builder --config electron-builder.yml ${{ matrix.electron_args }} --publish never
+      - name: 构建 Windows ARM64 安装包
+        if: ${{ matrix.publish_update }}
+        working-directory: desktop
+        run: pnpm exec electron-builder --config electron-builder.yml --win --arm64 --publish never
+      - name: 整理 Windows 自动更新产物
+        if: ${{ matrix.publish_update }}
+        working-directory: desktop
+        run: node scripts/prepare-windows-update.mjs
+      - name: 发布 Windows 自动更新产物
+        if: ${{ matrix.publish_update }}
+        shell: bash
+        run: |
+          gh release upload "${{ needs.context.outputs.release_tag }}" \
+            desktop/dist-electron/OpenFic-*-win-setup.exe \
+            desktop/dist-electron/OpenFic-*-win-setup.exe.blockmap \
+            desktop/dist-electron/OpenFic-*-win.zip \
+            desktop/dist-electron/latest.yml \
+            --clobber
 
       - uses: actions/upload-artifact@v7
+        if: ${{ !matrix.publish_update }}
         with:
           name: ${{ matrix.artifact_name }}
           path: |
@@ -303,7 +327,6 @@ jobs:
             desktop/dist-electron/*.tar.gz
             desktop/dist-electron/*.zip
             desktop/dist-electron/*.dmg
-            desktop/dist-electron/*.blockmap
       - uses: actions/cache/save@v5
         if: ${{ steps.pnpm-cache.outputs.cache-hit != 'true' }}
         with:
@@ -320,7 +343,7 @@ jobs:
   # ---------------------------------------------------------------- release
   publish-release:
     needs: [context, desktop]
-    if: always() && needs.desktop.result != 'failure'
+    if: ${{ always() && needs.desktop.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8

--- a/desktop/electron-builder.local-update.yml
+++ b/desktop/electron-builder.local-update.yml
@@ -1,0 +1,34 @@
+appId: com.openfic.app
+productName: OpenFic
+
+directories:
+  output: dist-electron
+
+files:
+  - dist/**/*
+  - package.json
+
+extraResources:
+  - from: ../frontend/dist
+    to: frontend-dist
+    filter:
+      - "**/*"
+
+win:
+  artifactName: OpenFic-${version}-${arch}-win.${ext}
+  target:
+    - target: nsis
+      arch:
+        - x64
+        - arm64
+
+nsis:
+  oneClick: false
+  allowToChangeInstallationDirectory: true
+  artifactName: OpenFic-${version}-${arch}-win-setup.${ext}
+
+publish:
+  provider: generic
+  url: http://127.0.0.1:4567
+  updaterCacheDirName: openfic-desktop-updater
+  useMultipleRangeRequest: false

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -4,6 +4,12 @@ productName: OpenFic
 directories:
   output: dist-electron
 
+publish:
+  provider: github
+  owner: syrizelink
+  repo: OpenFic
+  releaseType: release
+
 files:
   - dist/**/*
   - package.json
@@ -15,20 +21,24 @@ extraResources:
       - "**/*"
 
 win:
+  artifactName: OpenFic-${version}-${arch}-win.${ext}
   target:
     - target: nsis
       arch:
         - x64
+        - arm64
     - target: zip
       arch:
         - x64
+        - arm64
 
 nsis:
   oneClick: false
   allowToChangeInstallationDirectory: true
-  artifactName: OpenFic-${version}-win-setup.${ext}
+  artifactName: OpenFic-${version}-${arch}-win-setup.${ext}
 
 mac:
+  artifactName: OpenFic-${version}-${arch}-mac.${ext}
   target:
     - target: dmg
       arch:
@@ -40,6 +50,7 @@ mac:
   identity: null
 
 linux:
+  artifactName: OpenFic-${version}-${arch}-linux.${ext}
   target:
     - target: AppImage
       arch:

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -12,23 +12,27 @@
     "build:setup": "vp build",
     "type-check": "tsc -p tsconfig.main.json --noEmit && tsc -p tsconfig.renderer.json --noEmit",
     "lint": "eslint . --ext .js,.jsx,.mjs,.ts,.tsx,.mts",
-    "package": "electron-builder --config electron-builder.yml"
+    "package": "electron-builder --config electron-builder.yml",
+    "package:local-update": "node scripts/package-local-update.mjs",
+    "serve:local-update": "node scripts/serve-local-update.mjs"
   },
   "dependencies": {
     "@radix-ui/themes": "^3.3.0",
+    "electron-updater": "^6.8.9",
     "lucide-react": "^1.22.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
+    "react-markdown": "^10.1.0",
     "scheduler": "^0.27.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
-    "@vitejs/plugin-react": "^6.0.3",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@typescript-eslint/eslint-plugin": "^8.59.2",
     "@typescript-eslint/parser": "^8.59.2",
+    "@vitejs/plugin-react": "^6.0.3",
     "electron": "^33.2.0",
     "electron-builder": "^25.1.8",
     "eslint": "^9.39.4",

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@radix-ui/themes':
         specifier: ^3.3.0
         version: 3.3.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      electron-updater:
+        specifier: ^6.8.9
+        version: 6.8.9
       lucide-react:
         specifier: ^1.22.0
         version: 1.22.0(react@19.2.7)
@@ -20,6 +23,9 @@ importers:
       react-dom:
         specifier: ^19.2.6
         version: 19.2.7(react@19.2.7)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
       scheduler:
         specifier: ^0.27.0
         version: 0.27.0
@@ -1382,11 +1388,17 @@ packages:
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/fs-extra@9.0.13':
     resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
+
+  '@types/hast@3.0.5':
+    resolution: {integrity: sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==}
 
   '@types/http-cache-semantics@4.2.0':
     resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
@@ -1405,6 +1417,9 @@ packages:
 
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -1428,6 +1443,12 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@types/verror@1.10.11':
     resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
@@ -1499,6 +1520,9 @@ packages:
   '@typescript-eslint/visitor-keys@8.62.0':
     resolution: {integrity: sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@ungap/structured-clone@1.3.3':
+    resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
   '@vitejs/plugin-react@6.0.3':
     resolution: {integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==}
@@ -1792,6 +1816,9 @@ packages:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.0:
     resolution: {integrity: sha512-9Y0g0Q8rmSt+H33DfKv7FOc3v+iRI+o1lbzt8jGcIosYW37IIW/2XVYq5NPdmaD5NQ59Nk26Kl/vZbwW9Fr8vg==}
 
@@ -1838,6 +1865,10 @@ packages:
     resolution: {integrity: sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==}
     engines: {node: '>=12.0.0'}
 
+  builder-util-runtime@9.7.0:
+    resolution: {integrity: sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==}
+    engines: {node: '>=12.0.0'}
+
   builder-util@25.1.7:
     resolution: {integrity: sha512-7jPjzBwEGRbwNcep0gGNpLXG9P94VA3CPAZQCzxkFXiV2GMQKlziMbY//rXPI7WKfhsvGgFXjTcXdBEwgXw9ww==}
 
@@ -1865,6 +1896,9 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -1872,6 +1906,18 @@ packages:
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
@@ -1927,6 +1973,9 @@ packages:
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   commander@5.0.0:
     resolution: {integrity: sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ==}
@@ -1989,6 +2038,9 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
     engines: {node: '>=10'}
@@ -2031,6 +2083,9 @@ packages:
 
   detect-node@2.1.0:
     resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   dir-compare@4.2.0:
     resolution: {integrity: sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==}
@@ -2077,6 +2132,9 @@ packages:
 
   electron-publish@25.1.7:
     resolution: {integrity: sha512-+jbTkR9m39eDBMP4gfbqglDd6UvBC7RLh5Y0MhFSsc6UkGHj9Vj9TWobxevHYMMqmoujL11ZLjfPpMX+Pt6YEg==}
+
+  electron-updater@6.8.9:
+    resolution: {integrity: sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==}
 
   electron@33.2.0:
     resolution: {integrity: sha512-PVw1ICAQDPsnnsmpNFX/b1i/49h67pbSPxuIENd9K9WpGO1tsRaQt+K2bmXqTuoMJsbzIc75Ce8zqtuwBPqawA==}
@@ -2177,6 +2235,9 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
 
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
@@ -2378,9 +2439,18 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -2454,13 +2524,25 @@ packages:
     resolution: {integrity: sha512-VUA7WAWNCWfm6/8f9kAb8Y6iGBWnmCfgFS5dTrv2C38LLm1KUmpY388mCVCJCsMKQomvOQ1oW8/edXdChd9ZXQ==}
     deprecated: Please update to ini >=1.3.6 to avoid a prototype pollution issue
 
+  inline-style-parser@0.1.1:
+    resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
+
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
     engines: {node: '>= 12'}
 
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
   is-ci@3.0.1:
     resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
     hasBin: true
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
@@ -2474,12 +2556,19 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
 
   is-lambda@1.0.1:
     resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
@@ -2639,8 +2728,15 @@ packages:
   lodash.difference@4.5.0:
     resolution: {integrity: sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==}
 
+  lodash.escaperegexp@4.1.2:
+    resolution: {integrity: sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==}
+
   lodash.flatten@4.4.0:
     resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isplainobject@4.0.6:
     resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
@@ -2657,6 +2753,9 @@ packages:
   log-symbols@4.1.0:
     resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
     engines: {node: '>=10'}
+
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
   lowercase-keys@2.0.0:
     resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
@@ -2698,6 +2797,93 @@ packages:
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.0.0:
+    resolution: {integrity: sha512-Ov3aWCYpb31/SkHNRlREvSZsF9ETBW/rXw4PooawZO8qy2MviDq4TI6kxX6zFmGa/zUX36STKIC/IpASQk596w==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  micromark-core-commonmark@2.0.0:
+    resolution: {integrity: sha512-jThOz/pVmAYUtkroV3D5c1osFXAMv9e0ypGDOIZuCeAe91/sD6BoE2Sjzt30yuXtwOYUmySOhMas/PVyh02itA==}
+
+  micromark-factory-destination@2.0.0:
+    resolution: {integrity: sha512-j9DGrQLm/Uhl2tCzcbLhy5kXsgkHUrjJHg4fFAeoMRwJmJerT9aw4FEhIbZStWN8A3qMwOp1uzHr4UL8AInxtA==}
+
+  micromark-factory-label@2.0.0:
+    resolution: {integrity: sha512-RR3i96ohZGde//4WSe/dJsxOX6vxIg9TimLAS3i4EhBAFx8Sm5SmqVfR8E87DPSR31nEAjZfbt91OMZWcNgdZw==}
+
+  micromark-factory-space@2.0.0:
+    resolution: {integrity: sha512-TKr+LIDX2pkBJXFLzpyPyljzYK3MtmllMUMODTQJIUfDGncESaqB90db9IAUcz4AZAJFdd8U9zOp9ty1458rxg==}
+
+  micromark-factory-title@2.0.0:
+    resolution: {integrity: sha512-jY8CSxmpWLOxS+t8W+FG3Xigc0RDQA9bKMY/EwILvsesiRniiVMejYTE4wumNc2f4UbAa4WsHqe3J1QS1sli+A==}
+
+  micromark-factory-whitespace@2.0.0:
+    resolution: {integrity: sha512-28kbwaBjc5yAI1XadbdPYHX/eDnqaUFVikLwrO7FDnKG7lpgxnvk/XGRhX/PN0mOZ+dBSZ+LgunHS+6tYQAzhA==}
+
+  micromark-util-character@2.0.0:
+    resolution: {integrity: sha512-DtHHqgTRz32ylwiGSZwoK+BTx4gaq//ig71g20pwBwRLxo3CfInyD+NyTrriLOhPz5WQOfAOSLLbKOaaGXWz9Q==}
+
+  micromark-util-chunked@2.0.0:
+    resolution: {integrity: sha512-anK8SWmNphkXdaKgz5hJvGa7l00qmcaUQoMYsBwDlSKFKjc6gjGXPDw3FNL3Nbwq5L8gE+RCbGqTw49FK5Qyvg==}
+
+  micromark-util-classify-character@2.0.0:
+    resolution: {integrity: sha512-S0ze2R9GH+fu41FA7pbSqNWObo/kzwf8rN/+IGlW/4tC6oACOs8B++bh+i9bVyNnwCcuksbFwsBme5OCKXCwIw==}
+
+  micromark-util-combine-extensions@2.0.0:
+    resolution: {integrity: sha512-vZZio48k7ON0fVS3CUgFatWHoKbbLTK/rT7pzpJ4Bjp5JjkZeasRfrS9wsBdDJK2cJLHMckXZdzPSSr1B8a4oQ==}
+
+  micromark-util-decode-numeric-character-reference@2.0.0:
+    resolution: {integrity: sha512-pIgcsGxpHEtTG/rPJRz/HOLSqp5VTuIIjXlPI+6JSDlK2oljApusG6KzpS8AF0ENUMCHlC/IBb5B9xdFiVlm5Q==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.0:
+    resolution: {integrity: sha512-pS+ROfCXAGLWCOc8egcBvT0kf27GoWMqtdarNfDcjb6YLuV5cM3ioG45Ys2qOVqeqSbjaKg72vU+Wby3eddPsA==}
+
+  micromark-util-html-tag-name@2.0.0:
+    resolution: {integrity: sha512-xNn4Pqkj2puRhKdKTm8t1YHC/BAjx6CEwRFXntTaRf/x16aqka6ouVoutm+QdkISTlT7e2zU7U4ZdlDLJd2Mcw==}
+
+  micromark-util-normalize-identifier@2.0.0:
+    resolution: {integrity: sha512-2xhYT0sfo85FMrUPtHcPo2rrp1lwbDEEzpx7jiH2xXJLqBuy4H0GgXk5ToU8IEwoROtXuL8ND0ttVa4rNqYK3w==}
+
+  micromark-util-resolve-all@2.0.0:
+    resolution: {integrity: sha512-6KU6qO7DZ7GJkaCgwBNtplXCvGkJToU86ybBAUdavvgsCiG8lSSvYxr9MhwmQ+udpzywHsl4RpGJsYWG1pDOcA==}
+
+  micromark-util-sanitize-uri@2.0.0:
+    resolution: {integrity: sha512-WhYv5UEcZrbAtlsnPuChHUAsu/iBPOVaEVsntLBIdpibO0ddy8OzavZz3iL2xVvBZOpolujSliP65Kq0/7KIYw==}
+
+  micromark-util-subtokenize@2.0.0:
+    resolution: {integrity: sha512-vc93L1t+gpR3p8jxeVdaYlbV2jTYteDje19rNSS/H5dlhxUYll5Fy6vJ2cDwP8RnsXi818yGty1ayP55y3W6fg==}
+
+  micromark-util-symbol@2.0.0:
+    resolution: {integrity: sha512-8JZt9ElZ5kyTnO94muPxIGS8oyElRJaiJO8EzV6ZSyGQ1Is8xwl4Q45qU5UOg+bGH4AikWziz0iN4sFLWs8PGw==}
+
+  micromark-util-types@2.0.0:
+    resolution: {integrity: sha512-oNh6S2WMHWRZrmutsRmDDfkzKtxF+bc2VxLC9dvtrDIRFln627VsFP6fLMgTryGDljgLPjkrzQSDcPrjPyDJ5w==}
+
+  micromark@4.0.0:
+    resolution: {integrity: sha512-o/sd0nMof8kYff+TqcDx3VSrgBTcZpSvYcAHIfHhv5VAuNmisCxjhx6YmxS8PFEpb9z5WKWKPdzf0jM23ro3RQ==}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -2930,6 +3116,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3010,6 +3199,9 @@ packages:
     resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
     engines: {node: '>=10'}
 
+  property-information@7.2.0:
+    resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
+
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
@@ -3044,6 +3236,12 @@ packages:
 
   react-is@17.0.1:
     resolution: {integrity: sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==}
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -3092,6 +3290,12 @@ packages:
 
   readdir-glob@1.0.0:
     resolution: {integrity: sha512-km0DIcwQVZ1ZUhXhMWpF74/Wm5aFEd5/jDiVWF1Hkw2myPQovG8vCQ8+FQO2KXE9npQQvCnAMZhhWuUee4WcCQ==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
@@ -3164,6 +3368,11 @@ packages:
     resolution: {integrity: sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==}
     hasBin: true
 
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -3229,6 +3438,9 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
   sprintf-js@1.1.3:
     resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
 
@@ -3264,6 +3476,9 @@ packages:
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
 
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-ansi@6.0.0:
     resolution: {integrity: sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==}
     engines: {node: '>=8'}
@@ -3279,6 +3494,12 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  style-to-js@1.0.0:
+    resolution: {integrity: sha512-OiaJVLD+ybcul+6oAdwTOKLFewvYapPLG4H3JiYBYUS0yoi29Ag1IiqprbVARaxiAXvkk+4B8aNcG7lyEDKebg==}
+
+  style-to-object@0.3.0:
+    resolution: {integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==}
 
   sumchecker@3.0.1:
     resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
@@ -3298,6 +3519,9 @@ packages:
 
   temp-file@3.4.0:
     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
+
+  tiny-typed-emitter@2.1.0:
+    resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -3328,6 +3552,12 @@ packages:
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
@@ -3371,11 +3601,29 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  unified@11.0.0:
+    resolution: {integrity: sha512-65zgPyv0vyXnJpw4fbGmoXjP0/6cBmnnesl4lSPGU2tYuzLWtuicRBFcaV6kgzitGrBHj6pgXYomMw1VQe/cQg==}
+
   unique-filename@1.1.1:
     resolution: {integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==}
 
   unique-slug@2.0.0:
     resolution: {integrity: sha512-vjbzP5tKJ/zJl4hv0YGa8AzHBiwgenSFw9iTjE0xhYZU1bf7vKb9z+C7Hl01vfi6/dEmm7JpeVOxpNQybe0sbg==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
 
   universalify@0.1.2:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
@@ -3421,6 +3669,12 @@ packages:
   verror@1.10.1:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
     engines: {node: '>=0.6.0'}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite-plus@0.2.4:
     resolution: {integrity: sha512-gaBBjOXIq9lLRU44oAYdIr99p+JBLX1kxs+l/6LqGgSXwcVKAdDa1boSrOTELqYCkQQ0fpppXUGWi9o6JDT5zw==}
@@ -3596,6 +3850,9 @@ packages:
   zip-stream@4.1.0:
     resolution: {integrity: sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==}
     engines: {node: '>= 10'}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -4842,11 +5099,19 @@ snapshots:
 
   '@types/deep-eql@4.0.2': {}
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
+
   '@types/estree@1.0.9': {}
 
   '@types/fs-extra@9.0.13':
     dependencies:
       '@types/node': 24.13.2
+
+  '@types/hast@3.0.5':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/http-cache-semantics@4.2.0': {}
 
@@ -4865,6 +5130,10 @@ snapshots:
   '@types/keyv@3.1.4':
     dependencies:
       '@types/node': 24.13.2
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
 
   '@types/ms@2.1.0': {}
 
@@ -4893,6 +5162,10 @@ snapshots:
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 24.13.2
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@types/verror@1.10.11':
     optional: true
@@ -4998,6 +5271,8 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.62.0
       eslint-visitor-keys: 5.0.1
+
+  '@ungap/structured-clone@1.3.3': {}
 
   '@vitejs/plugin-react@6.0.3(vite@8.1.4(@types/node@24.13.2))':
     dependencies:
@@ -5273,6 +5548,8 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.0: {}
 
   balanced-match@4.0.4: {}
@@ -5317,6 +5594,13 @@ snapshots:
       ieee754: 1.2.1
 
   builder-util-runtime@9.2.10:
+    dependencies:
+      debug: 4.4.3
+      sax: 1.6.0
+    transitivePeerDependencies:
+      - supports-color
+
+  builder-util-runtime@9.7.0:
     dependencies:
       debug: 4.4.3
       sax: 1.6.0
@@ -5396,12 +5680,22 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  ccount@2.0.1: {}
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chownr@2.0.0: {}
 
@@ -5448,6 +5742,8 @@ snapshots:
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
+
+  comma-separated-tokens@2.0.3: {}
 
   commander@5.0.0: {}
 
@@ -5506,6 +5802,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
@@ -5544,6 +5844,10 @@ snapshots:
 
   detect-node@2.1.0:
     optional: true
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   dir-compare@4.2.0:
     dependencies:
@@ -5634,6 +5938,19 @@ snapshots:
       fs-extra: 10.1.0
       lazy-val: 1.0.5
       mime: 2.6.0
+    transitivePeerDependencies:
+      - supports-color
+
+  electron-updater@6.8.9:
+    dependencies:
+      builder-util-runtime: 9.7.0
+      fs-extra: 10.1.0
+      js-yaml: 4.3.0
+      lazy-val: 1.0.5
+      lodash.escaperegexp: 4.1.2
+      lodash.isequal: 4.5.0
+      semver: 7.7.4
+      tiny-typed-emitter: 2.1.0
     transitivePeerDependencies:
       - supports-color
 
@@ -5755,6 +6072,8 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
@@ -5786,9 +6105,9 @@ snapshots:
     dependencies:
       pend: 1.2.0
 
-  fdir@6.5.0(picomatch@4.0.4):
+  fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -6007,9 +6326,35 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.0.0
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
+
+  html-url-attributes@3.0.1: {}
 
   http-cache-semantics@4.2.0: {}
 
@@ -6088,11 +6433,22 @@ snapshots:
   ini@1.3.4:
     optional: true
 
+  inline-style-parser@0.1.1: {}
+
   ip-address@10.2.0: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
 
   is-ci@3.0.1:
     dependencies:
       ci-info: 3.2.0
+
+  is-decimal@2.0.1: {}
 
   is-extglob@2.1.1: {}
 
@@ -6102,9 +6458,13 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-hexadecimal@2.0.1: {}
+
   is-interactive@1.0.0: {}
 
   is-lambda@1.0.1: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-unicode-supported@0.1.0: {}
 
@@ -6232,7 +6592,11 @@ snapshots:
 
   lodash.difference@4.5.0: {}
 
+  lodash.escaperegexp@4.1.2: {}
+
   lodash.flatten@4.4.0: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash.isplainobject@4.0.6: {}
 
@@ -6246,6 +6610,8 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       is-unicode-supported: 0.1.0
+
+  longest-streak@3.1.0: {}
 
   lowercase-keys@2.0.0: {}
 
@@ -6295,6 +6661,227 @@ snapshots:
     optional: true
 
   math-intrinsics@1.1.0: {}
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.0
+      micromark-util-decode-numeric-character-reference: 2.0.0
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.0.0
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.3
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.0
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
+  micromark-core-commonmark@2.0.0:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.0
+      micromark-factory-label: 2.0.0
+      micromark-factory-space: 2.0.0
+      micromark-factory-title: 2.0.0
+      micromark-factory-whitespace: 2.0.0
+      micromark-util-character: 2.0.0
+      micromark-util-chunked: 2.0.0
+      micromark-util-classify-character: 2.0.0
+      micromark-util-html-tag-name: 2.0.0
+      micromark-util-normalize-identifier: 2.0.0
+      micromark-util-resolve-all: 2.0.0
+      micromark-util-subtokenize: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
+  micromark-factory-destination@2.0.0:
+    dependencies:
+      micromark-util-character: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
+  micromark-factory-label@2.0.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
+  micromark-factory-space@2.0.0:
+    dependencies:
+      micromark-util-character: 2.0.0
+      micromark-util-types: 2.0.0
+
+  micromark-factory-title@2.0.0:
+    dependencies:
+      micromark-factory-space: 2.0.0
+      micromark-util-character: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
+  micromark-factory-whitespace@2.0.0:
+    dependencies:
+      micromark-factory-space: 2.0.0
+      micromark-util-character: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
+  micromark-util-character@2.0.0:
+    dependencies:
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
+  micromark-util-chunked@2.0.0:
+    dependencies:
+      micromark-util-symbol: 2.0.0
+
+  micromark-util-classify-character@2.0.0:
+    dependencies:
+      micromark-util-character: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
+  micromark-util-combine-extensions@2.0.0:
+    dependencies:
+      micromark-util-chunked: 2.0.0
+      micromark-util-types: 2.0.0
+
+  micromark-util-decode-numeric-character-reference@2.0.0:
+    dependencies:
+      micromark-util-symbol: 2.0.0
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.0.0
+      micromark-util-decode-numeric-character-reference: 2.0.0
+      micromark-util-symbol: 2.0.0
+
+  micromark-util-encode@2.0.0: {}
+
+  micromark-util-html-tag-name@2.0.0: {}
+
+  micromark-util-normalize-identifier@2.0.0:
+    dependencies:
+      micromark-util-symbol: 2.0.0
+
+  micromark-util-resolve-all@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.0
+
+  micromark-util-sanitize-uri@2.0.0:
+    dependencies:
+      micromark-util-character: 2.0.0
+      micromark-util-encode: 2.0.0
+      micromark-util-symbol: 2.0.0
+
+  micromark-util-subtokenize@2.0.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+
+  micromark-util-symbol@2.0.0: {}
+
+  micromark-util-types@2.0.0: {}
+
+  micromark@4.0.0:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.0
+      micromark-factory-space: 2.0.0
+      micromark-util-character: 2.0.0
+      micromark-util-chunked: 2.0.0
+      micromark-util-combine-extensions: 2.0.0
+      micromark-util-decode-numeric-character-reference: 2.0.0
+      micromark-util-encode: 2.0.0
+      micromark-util-normalize-identifier: 2.0.0
+      micromark-util-resolve-all: 2.0.0
+      micromark-util-sanitize-uri: 2.0.0
+      micromark-util-subtokenize: 2.0.0
+      micromark-util-symbol: 2.0.0
+      micromark-util-types: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   mime-db@1.52.0: {}
 
@@ -6548,6 +7135,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -6607,6 +7204,8 @@ snapshots:
     dependencies:
       err-code: 2.0.3
       retry: 0.12.0
+
+  property-information@7.2.0: {}
 
   proto-list@1.2.4:
     optional: true
@@ -6690,6 +7289,24 @@ snapshots:
 
   react-is@17.0.1: {}
 
+  react-markdown@10.1.0(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.17
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.7
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   react-remove-scroll-bar@2.3.8(@types/react@19.2.17)(react@19.2.7):
     dependencies:
       react: 19.2.7
@@ -6744,6 +7361,23 @@ snapshots:
   readdir-glob@1.0.0:
     dependencies:
       minimatch: 3.1.5
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.0
+      unified: 11.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.0
+      vfile: 6.0.3
 
   require-directory@2.1.1: {}
 
@@ -6824,6 +7458,8 @@ snapshots:
 
   semver@6.2.0: {}
 
+  semver@7.7.4: {}
+
   semver@7.8.5: {}
 
   serialize-error@7.0.1:
@@ -6886,6 +7522,8 @@ snapshots:
 
   source-map@0.6.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
   sprintf-js@1.1.3:
     optional: true
 
@@ -6925,6 +7563,11 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-ansi@6.0.0:
     dependencies:
       ansi-regex: 5.0.1
@@ -6938,6 +7581,14 @@ snapshots:
       ansi-regex: 6.2.2
 
   strip-json-comments@3.1.1: {}
+
+  style-to-js@1.0.0:
+    dependencies:
+      style-to-object: 0.3.0
+
+  style-to-object@0.3.0:
+    dependencies:
+      inline-style-parser: 0.1.1
 
   sumchecker@3.0.1:
     dependencies:
@@ -6971,14 +7622,16 @@ snapshots:
       async-exit-hook: 2.0.1
       fs-extra: 10.1.0
 
+  tiny-typed-emitter@2.1.0: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@1.2.4: {}
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinypool@2.1.0: {}
 
@@ -6991,6 +7644,10 @@ snapshots:
   tmp@0.2.7: {}
 
   totalist@3.0.1: {}
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
 
   truncate-utf8-bytes@1.0.2:
     dependencies:
@@ -7029,6 +7686,16 @@ snapshots:
 
   undici-types@7.18.2: {}
 
+  unified@11.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.3.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
   unique-filename@1.1.1:
     dependencies:
       unique-slug: 2.0.0
@@ -7036,6 +7703,29 @@ snapshots:
   unique-slug@2.0.0:
     dependencies:
       imurmurhash: 0.1.4
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
 
   universalify@0.1.2: {}
 
@@ -7072,6 +7762,16 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.4.1
     optional: true
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite-plus@0.2.4(@types/node@24.13.2)(typescript@5.9.3)(vite@8.1.4(@types/node@24.13.2)):
     dependencies:
@@ -7239,3 +7939,5 @@ snapshots:
       archiver-utils: 2.1.0
       compress-commons: 4.1.0
       readable-stream: 3.6.2
+
+  zwitch@2.0.4: {}

--- a/desktop/scripts/package-local-update.mjs
+++ b/desktop/scripts/package-local-update.mjs
@@ -1,0 +1,59 @@
+import { spawn } from "node:child_process";
+
+const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+const version = process.env.OPENFIC_UPDATE_VERSION;
+
+if (version && !/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/.test(version)) {
+  throw new Error(`OPENFIC_UPDATE_VERSION is not a valid semantic version: ${version}`);
+}
+
+function run(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(pnpm, args, { shell: process.platform === "win32", stdio: "inherit" });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${pnpm} ${args.join(" ")} exited with code ${code}`));
+    });
+  });
+}
+
+function runNode(args) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, args, { stdio: "inherit" });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`node ${args.join(" ")} exited with code ${code}`));
+    });
+  });
+}
+
+const versionConfig = version ? [`--config.extraMetadata.version=${version}`] : [];
+
+await run(["build"]);
+await run([
+  "exec",
+  "electron-builder",
+  "--config",
+  "electron-builder.local-update.yml",
+  "--win",
+  "nsis",
+  "--x64",
+  "--publish",
+  "never",
+  ...versionConfig,
+]);
+await run([
+  "exec",
+  "electron-builder",
+  "--config",
+  "electron-builder.local-update.yml",
+  "--win",
+  "nsis",
+  "--arm64",
+  "--publish",
+  "never",
+  ...versionConfig,
+]);
+await runNode(["scripts/prepare-windows-update.mjs"]);

--- a/desktop/scripts/prepare-windows-update.mjs
+++ b/desktop/scripts/prepare-windows-update.mjs
@@ -1,0 +1,50 @@
+import { createHash } from "node:crypto";
+import { access, readFile, rm, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const outputDirectory = path.resolve(process.argv[2] ?? "dist-electron");
+const packageJson = JSON.parse(await readFile(path.resolve("package.json"), "utf8"));
+const version = packageJson.version;
+const architectures = ["x64", "arm64"];
+
+async function exists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function getFileInfo(fileName) {
+  const filePath = path.join(outputDirectory, fileName);
+  const contents = await readFile(filePath);
+  const fileStats = await stat(filePath);
+  return {
+    fileName,
+    sha512: createHash("sha512").update(contents).digest("base64"),
+    size: fileStats.size,
+  };
+}
+
+const universalInstaller = `OpenFic-${version}-win-setup.exe`;
+for (const fileName of [universalInstaller, `${universalInstaller}.blockmap`]) {
+  const filePath = path.join(outputDirectory, fileName);
+  if (await exists(filePath)) await rm(filePath);
+}
+
+const files = await Promise.all(
+  architectures.map((arch) => getFileInfo(`OpenFic-${version}-${arch}-win-setup.exe`)),
+);
+const primaryFile = files[0];
+const latestYml = [
+  `version: ${version}`,
+  "files:",
+  ...files.flatMap((file) => [`  - url: ${file.fileName}`, `    sha512: ${file.sha512}`, `    size: ${file.size}`]),
+  `path: ${primaryFile.fileName}`,
+  `sha512: ${primaryFile.sha512}`,
+  `releaseDate: '${new Date().toISOString()}'`,
+  "",
+].join("\n");
+
+await writeFile(path.join(outputDirectory, "latest.yml"), latestYml, "utf8");

--- a/desktop/scripts/serve-local-update.mjs
+++ b/desktop/scripts/serve-local-update.mjs
@@ -1,0 +1,101 @@
+import { createReadStream, existsSync } from "node:fs";
+import { stat } from "node:fs/promises";
+import { createServer } from "node:http";
+import path from "node:path";
+
+const port = Number(process.env.OPENFIC_UPDATE_PORT ?? "4567");
+const updateDirectory = path.resolve(process.argv[2] ?? "dist-electron");
+const contentTypes = new Map([
+  [".exe", "application/vnd.microsoft.portable-executable"],
+  [".yml", "text/yaml; charset=utf-8"],
+  [".blockmap", "application/octet-stream"],
+]);
+
+if (!Number.isInteger(port) || port < 1 || port > 65535) {
+  throw new Error("OPENFIC_UPDATE_PORT must be an integer between 1 and 65535.");
+}
+
+if (!existsSync(updateDirectory)) {
+  throw new Error(`Update directory does not exist: ${updateDirectory}`);
+}
+
+function resolveRequestPath(requestUrl) {
+  const pathname = decodeURIComponent(new URL(requestUrl ?? "/", "http://localhost").pathname);
+  const filePath = path.resolve(updateDirectory, `.${pathname}`);
+  if (filePath !== updateDirectory && !filePath.startsWith(`${updateDirectory}${path.sep}`)) return null;
+  return filePath;
+}
+
+function getByteRange(rangeHeader, size) {
+  if (!rangeHeader) return { start: 0, end: size - 1, partial: false };
+  const match = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader);
+  if (!match) return null;
+
+  const [, startText, endText] = match;
+  if (!startText && !endText) return null;
+  if (!startText) {
+    const suffixLength = Number(endText);
+    if (!Number.isSafeInteger(suffixLength) || suffixLength < 1) return null;
+    return { start: Math.max(0, size - suffixLength), end: size - 1, partial: true };
+  }
+
+  const start = Number(startText);
+  const end = endText ? Number(endText) : size - 1;
+  if (!Number.isSafeInteger(start) || !Number.isSafeInteger(end) || start > end || start >= size) return null;
+  return { start, end: Math.min(end, size - 1), partial: true };
+}
+
+const server = createServer(async (request, response) => {
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    response.writeHead(405, { Allow: "GET, HEAD" });
+    response.end();
+    return;
+  }
+
+  let filePath;
+  try {
+    filePath = resolveRequestPath(request.url);
+  } catch {
+    response.writeHead(400);
+    response.end();
+    return;
+  }
+
+  if (!filePath) {
+    response.writeHead(403);
+    response.end();
+    return;
+  }
+
+  try {
+    const fileInfo = await stat(filePath);
+    if (!fileInfo.isFile()) throw new Error("Not a file");
+    const byteRange = getByteRange(request.headers.range, fileInfo.size);
+    if (!byteRange) {
+      response.writeHead(416, { "Content-Range": `bytes */${fileInfo.size}` });
+      response.end();
+      return;
+    }
+
+    response.writeHead(byteRange.partial ? 206 : 200, {
+      "Accept-Ranges": "bytes",
+      "Content-Length": byteRange.end - byteRange.start + 1,
+      "Content-Type": contentTypes.get(path.extname(filePath)) ?? "application/octet-stream",
+      "Cache-Control": "no-store",
+      ...(byteRange.partial ? { "Content-Range": `bytes ${byteRange.start}-${byteRange.end}/${fileInfo.size}` } : {}),
+    });
+    if (request.method === "HEAD") {
+      response.end();
+      return;
+    }
+    createReadStream(filePath, { start: byteRange.start, end: byteRange.end }).pipe(response);
+  } catch {
+    response.writeHead(404);
+    response.end();
+  }
+});
+
+server.listen(port, "127.0.0.1", () => {
+  console.log(`Serving local update files from ${updateDirectory}`);
+  console.log(`Update URL: http://127.0.0.1:${port}`);
+});

--- a/desktop/src/main/health.ts
+++ b/desktop/src/main/health.ts
@@ -1,36 +1,101 @@
+import { net } from "electron";
 import type { ChildProcess } from "node:child_process";
 
 const DEFAULT_TIMEOUT_MS = 60_000;
+
+export interface BackendHealth {
+  status: "healthy";
+  version: string | null;
+}
 
 interface WaitForBackendOptions {
   process?: ChildProcess;
   timeoutMs?: number;
 }
 
-export async function waitForBackend(baseUrl: string, options: WaitForBackendOptions | number = DEFAULT_TIMEOUT_MS): Promise<void> {
+export function parseBackendHealth(value: unknown): BackendHealth | null {
+  if (!value || typeof value !== "object") return null;
+  const candidate = value as { status?: unknown; version?: unknown };
+  if (candidate.status !== "healthy") return null;
+  if (candidate.version !== undefined && typeof candidate.version !== "string") return null;
+  return { status: "healthy", version: candidate.version ?? null };
+}
+
+function createBackendExitError(healthUrl: string, code: number | null, signal: NodeJS.Signals | null): Error {
+  if (signal) return new Error(`backend process exited before health check: ${healthUrl} (signal ${signal})`);
+  return new Error(`backend process exited before health check: ${healthUrl} (code ${code ?? "unknown"})`);
+}
+
+function isLoopbackUrl(url: string): boolean {
+  try {
+    const { hostname } = new URL(url);
+    return hostname === "localhost" || hostname === "::1" || hostname === "[::1]" || hostname.startsWith("127.");
+  } catch {
+    return false;
+  }
+}
+
+export async function waitForBackend(
+  baseUrl: string,
+  options: WaitForBackendOptions | number = DEFAULT_TIMEOUT_MS,
+): Promise<BackendHealth> {
   const timeoutMs = typeof options === "number" ? options : (options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
   const backendProcess = typeof options === "number" ? undefined : options.process;
-  const startedAt = Date.now();
   const healthUrl = `${baseUrl.replace(/\/+$/, "")}/api/v1/health`;
+  const controller = new AbortController();
+  let processError: Error | null = null;
 
-  while (Date.now() - startedAt < timeoutMs) {
-    if (backendProcess && backendProcess.exitCode !== null) {
-      throw new Error(`backend process exited before health check: ${healthUrl} (code ${backendProcess.exitCode})`);
-    }
+  const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+    processError = createBackendExitError(healthUrl, code, signal);
+    controller.abort();
+  };
+  const onError = (error: Error) => {
+    processError = new Error(`backend process failed before health check: ${healthUrl} (${error.message})`);
+    controller.abort();
+  };
 
-    try {
-      const response = await fetch(healthUrl);
-      if (response.ok) return;
-    } catch {
-      // Retry until timeout.
-    }
-
-    if (backendProcess && backendProcess.signalCode) {
-      throw new Error(`backend process exited before health check: ${healthUrl} (signal ${backendProcess.signalCode})`);
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 500));
+  if (backendProcess && backendProcess.exitCode !== null) {
+    throw createBackendExitError(healthUrl, backendProcess.exitCode, backendProcess.signalCode);
   }
 
-  throw new Error(`backend health check timeout: ${healthUrl}`);
+  backendProcess?.once("exit", onExit);
+  backendProcess?.once("error", onError);
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    while (!controller.signal.aborted) {
+      try {
+        // Node's HTTP stack is deliberately used for the local backend so its
+        // health checks never depend on Chromium's system proxy configuration.
+        const response = isLoopbackUrl(healthUrl)
+          ? await fetch(healthUrl, { signal: controller.signal })
+          : await net.fetch(healthUrl, { signal: controller.signal });
+        const health = parseBackendHealth(await response.json().catch(() => null));
+        if (response.ok && health) return health;
+      } catch {
+        if (processError) throw processError;
+      }
+
+      if (processError) throw processError;
+
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, 500);
+        controller.signal.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(timer);
+            resolve();
+          },
+          { once: true },
+        );
+      });
+    }
+
+    if (processError) throw processError;
+    throw new Error(`backend health check timeout: ${healthUrl}`);
+  } finally {
+    clearTimeout(timeout);
+    backendProcess?.off("exit", onExit);
+    backendProcess?.off("error", onError);
+  }
 }

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -1,12 +1,11 @@
 import { dialog, ipcMain, type BrowserWindow } from "electron";
-import { readdir, stat } from "node:fs/promises";
 import {
   IpcChannels,
-  type CheckDirectoryEmptyRequest,
-  type CheckDirectoryEmptyResult,
   type CheckRemoteRequest,
   type EnsureInstanceSessionRequest,
   type InitializeAppResult,
+  type InspectLocalRuntimeRequest,
+  type InspectLocalRuntimeResult,
   type InstallRuntimeRequest,
   type PingInstanceRequest,
   type PingInstanceResult,
@@ -17,8 +16,11 @@ import {
 import { readDesktopConfig, writeDesktopConfig } from "./config.js";
 import { waitForBackend } from "./health.js";
 import { ensureAppProtocolForPartition } from "./protocol.js";
-import { installLocalRuntime, startLocalBackendFromInstall } from "./runtime/setup-runner.js";
+import { findLocalInstanceByInstallDir, normalizeInstallDir } from "./local-instance.js";
+import { inspectLocalRuntime, installLocalRuntime, startLocalBackendFromInstall } from "./runtime/setup-runner.js";
 import { getDefaultInstallDir } from "./runtime/python.js";
+import { cancelUpdateDownload, checkForUpdates, downloadUpdate, getUpdateState, installUpdate, openUpdateRelease } from "./updater.js";
+import { createStartupProgressTracker, getStartupProgress } from "./startup-progress.js";
 import type { BackendProcessHandle } from "./process.js";
 import type { DesktopConfig, DesktopInstance } from "../shared/config.js";
 
@@ -32,19 +34,8 @@ export interface IpcContext {
   onConfigSaved: (config: DesktopConfig) => void;
 }
 
-async function isDirectoryEmpty(dirPath: string): Promise<CheckDirectoryEmptyResult> {
-  try {
-    const info = await stat(dirPath);
-    if (!info.isDirectory()) return { exists: false, empty: false };
-  } catch {
-    return { exists: false, empty: false };
-  }
-  try {
-    const entries = await readdir(dirPath);
-    return { exists: true, empty: entries.length === 0 };
-  } catch {
-    return { exists: true, empty: false };
-  }
+function createInstanceId(): string {
+  return `instance-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
 export function registerIpc(context: IpcContext): void {
@@ -56,15 +47,43 @@ export function registerIpc(context: IpcContext): void {
   });
 
   ipcMain.handle(IpcChannels.initializeApp, () => context.initializeApp());
+  ipcMain.handle(IpcChannels.getStartupProgress, () => getStartupProgress());
+  ipcMain.handle(IpcChannels.getUpdateState, () => getUpdateState());
+  ipcMain.handle(IpcChannels.checkForUpdate, () => checkForUpdates());
+  ipcMain.handle(IpcChannels.downloadUpdate, () => downloadUpdate());
+  ipcMain.handle(IpcChannels.cancelUpdateDownload, () => cancelUpdateDownload());
+  ipcMain.handle(IpcChannels.installUpdate, () => installUpdate());
+  ipcMain.handle(IpcChannels.openUpdateRelease, () => openUpdateRelease());
 
   ipcMain.handle(IpcChannels.ensureInstanceSession, (_event, request: EnsureInstanceSessionRequest) => {
-    ensureAppProtocolForPartition(request.partition);
+    return ensureAppProtocolForPartition(request.partition);
   });
 
   ipcMain.handle(IpcChannels.getDefaultInstallDir, () => getDefaultInstallDir());
 
   ipcMain.handle(IpcChannels.checkRemote, async (_event, request: CheckRemoteRequest) => {
-    await waitForBackend(request.url, 10_000);
+    const startupProgress = createStartupProgressTracker((progress) => {
+      _event.sender.send(IpcChannels.startupProgress, progress);
+    });
+    startupProgress.begin({
+      step: "connect-remote",
+      title: "连接 OpenFic 服务",
+      message: `正在连接 ${request.url}`,
+      progress: 0.3,
+    });
+    try {
+      await waitForBackend(request.url, 10_000);
+      startupProgress.begin({
+        step: "verify-remote",
+        title: "验证服务状态",
+        message: "远程服务已响应",
+        progress: 0.7,
+      });
+      startupProgress.complete();
+    } catch (error) {
+      startupProgress.fail(error);
+      throw error;
+    }
   });
 
   ipcMain.handle(IpcChannels.switchInstance, (_event, request: SwitchInstanceRequest) =>
@@ -88,8 +107,15 @@ export function registerIpc(context: IpcContext): void {
     return result.filePaths[0];
   });
 
-  ipcMain.handle(IpcChannels.checkDirectoryEmpty, async (_event, request: CheckDirectoryEmptyRequest) =>
-    isDirectoryEmpty(request.path),
+  ipcMain.handle(
+    IpcChannels.inspectLocalRuntime,
+    async (_event, request: InspectLocalRuntimeRequest): Promise<InspectLocalRuntimeResult> => {
+      const [runtime, config] = await Promise.all([inspectLocalRuntime(request.installDir), readDesktopConfig()]);
+      return {
+        ...runtime,
+        configuredInstance: findLocalInstanceByInstallDir(config, request.installDir),
+      };
+    },
   );
 
   ipcMain.handle(IpcChannels.installRuntime, async (_event, request: InstallRuntimeRequest) => {
@@ -99,9 +125,51 @@ export function registerIpc(context: IpcContext): void {
   });
 
   ipcMain.handle(IpcChannels.startLocalBackend, async (_event, request: StartLocalBackendRequest) => {
-    const backend = await startLocalBackendFromInstall(request.installDir);
-    context.setBackend(backend);
-    context.setBackendBaseUrl(backend.baseUrl);
+    const window = context.shellWindow();
+    if (!window) throw new Error("shell window is not available");
+    const startupProgress = createStartupProgressTracker((progress) => {
+      window.webContents.send(IpcChannels.startupProgress, progress);
+    });
+    try {
+      const backend = await startLocalBackendFromInstall(request.installDir, startupProgress);
+      context.setBackend(backend);
+      context.setBackendBaseUrl(backend.baseUrl);
+      const previousConfig = await readDesktopConfig();
+      const existingInstance = findLocalInstanceByInstallDir(previousConfig, request.installDir);
+      const instance: DesktopInstance = existingInstance ?? {
+        id: createInstanceId(),
+        name: "Local",
+        mode: "local",
+        remoteUrl: null,
+        autoStartLocal: true,
+        installDir: request.installDir,
+      };
+      const normalizedInstallDir = normalizeInstallDir(request.installDir);
+      const nextConfig: DesktopConfig = {
+        activeInstanceId: instance.id,
+        instances: [
+          ...(previousConfig?.instances ?? []).filter(
+            (candidate) =>
+              candidate.mode !== "local" ||
+              candidate.installDir === null ||
+              normalizeInstallDir(candidate.installDir) !== normalizedInstallDir,
+          ),
+          instance,
+        ],
+      };
+      await writeDesktopConfig(nextConfig);
+      context.onConfigSaved(nextConfig);
+      startupProgress.begin({
+        step: "ready",
+        title: "服务已就绪",
+        message: "OpenFic 已准备完成",
+        progress: 1,
+      });
+      startupProgress.complete();
+    } catch (error) {
+      startupProgress.fail(error);
+      throw error;
+    }
   });
 
   ipcMain.handle(IpcChannels.closeSetup, async () => undefined);

--- a/desktop/src/main/local-instance.ts
+++ b/desktop/src/main/local-instance.ts
@@ -1,0 +1,20 @@
+import path from "node:path";
+import type { DesktopConfig, DesktopInstance } from "../shared/config.js";
+
+export function normalizeInstallDir(installDir: string): string {
+  const resolved = path.resolve(installDir);
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+export function findLocalInstanceByInstallDir(config: DesktopConfig | null, installDir: string): DesktopInstance | null {
+  if (!config) return null;
+  const normalizedInstallDir = normalizeInstallDir(installDir);
+  return (
+    config.instances.find(
+      (instance) =>
+        instance.mode === "local" &&
+        instance.installDir !== null &&
+        normalizeInstallDir(instance.installDir) === normalizedInstallDir,
+    ) ?? null
+  );
+}

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -9,6 +9,10 @@ import { waitForBackend } from "./health.js";
 import { ensurePortablePython, resolveRuntimeDir } from "./runtime/python.js";
 import { ensureOpenFicRuntime, startLocalOpenFicBackend } from "./runtime/openfic.js";
 import { stopBackendProcess, type BackendProcessHandle } from "./process.js";
+import { initializeUpdater } from "./updater.js";
+import { configureDefaultSystemProxy } from "./proxy.js";
+import { createStartupProgressTracker, type StartupProgressTracker } from "./startup-progress.js";
+import { IpcChannels } from "../shared/ipc.js";
 import type { InitializeAppResult } from "../shared/ipc.js";
 import type { DesktopConfig, DesktopInstance } from "../shared/config.js";
 
@@ -75,11 +79,71 @@ function openMainWindow(): void {
   attachWindowLifecycle(mainWindow);
 }
 
-async function startLocalBackend(installDir: string | null): Promise<void> {
+function createStartupProgress(): StartupProgressTracker {
+  return createStartupProgressTracker((progress) => {
+    mainWindow?.webContents.send(IpcChannels.startupProgress, progress);
+  });
+}
+
+async function startLocalBackend(installDir: string | null, startupProgress: StartupProgressTracker): Promise<void> {
   const runtimeDir = resolveRuntimeDir(installDir);
-  const python = await ensurePortablePython(runtimeDir, () => undefined, () => undefined);
-  const runtime = await ensureOpenFicRuntime(python, runtimeDir, () => undefined);
-  const backend = await startLocalOpenFicBackend(runtime.venvPythonPath);
+  startupProgress.begin({
+    step: "check-runtime",
+    title: "检查运行环境",
+    message: "正在检查 Python 与 OpenFic 运行环境",
+    progress: 0.15,
+  });
+  let pythonWasUpdated = false;
+  const python = await ensurePortablePython(
+    runtimeDir,
+    (phase, message) => {
+      pythonWasUpdated = true;
+      startupProgress.begin({
+        step: "update-python",
+        title: phase === "download" ? "更新 Python 运行环境" : "修复 Python 运行环境",
+        message,
+        progress: phase === "download" ? 0.22 : 0.32,
+      });
+    },
+    ({ received, total }) => {
+      const fraction = total > 0 ? received / total : 0;
+      startupProgress.update({
+        step: "update-python",
+        title: "更新 Python 运行环境",
+        message: total > 0 ? `正在下载 Python · ${Math.round(fraction * 100)}%` : "正在下载 Python",
+        progress: 0.22 + fraction * 0.1,
+      });
+    },
+  );
+  if (!pythonWasUpdated) {
+    startupProgress.update({
+      step: "check-runtime",
+      title: "检查运行环境",
+      message: "Python 运行环境已就绪",
+      progress: 0.3,
+    });
+  }
+
+  let runtimeWasUpdated = false;
+  const runtime = await ensureOpenFicRuntime(python, runtimeDir, app.getVersion(), (step, message) => {
+    runtimeWasUpdated = true;
+    startupProgress.begin({
+      step: "update-openfic",
+      title: step === "install-openfic" ? "更新 OpenFic 后端" : "更新本地运行环境",
+      message,
+      progress: step === "install-openfic" ? 0.45 : 0.38,
+    });
+  });
+  if (!runtimeWasUpdated) {
+    startupProgress.update({
+      step: "check-runtime",
+      title: "检查运行环境",
+      message: "运行环境已就绪",
+      progress: 0.5,
+    });
+  }
+
+  const backend = await startLocalOpenFicBackend(runtime.venvPythonPath, app.getVersion(), startupProgress);
   setBackend(backend);
   setBackendBaseUrl(backend.baseUrl);
 }
@@ -88,28 +152,76 @@ function getActiveInstance(config: DesktopConfig): DesktopInstance | null {
   return config.instances.find((instance) => instance.id === config.activeInstanceId) ?? config.instances[0] ?? null;
 }
 
-async function activateInstance(config: DesktopConfig, instance: DesktopInstance): Promise<void> {
+async function activateInstance(
+  config: DesktopConfig,
+  instance: DesktopInstance,
+  startupProgress: StartupProgressTracker,
+): Promise<string | null> {
   activeInstanceId = instance.id;
   if (instance.mode === "remote") {
     if (!instance.remoteUrl) throw new Error("远程实例缺少后端地址");
-    await waitForBackend(instance.remoteUrl, 10_000);
+    startupProgress.begin({
+      step: "connect-remote",
+      title: "连接 OpenFic 服务",
+      message: `正在连接 ${instance.remoteUrl}`,
+      progress: 0.3,
+    });
+    const health = await waitForBackend(instance.remoteUrl, 10_000);
+    startupProgress.begin({
+      step: "verify-remote",
+      title: "验证服务状态",
+      message: "远程服务已响应，正在验证版本",
+      progress: 0.7,
+    });
     clearBackend();
     setBackendBaseUrl(instance.remoteUrl);
-    return;
+    startupProgress.begin({
+      step: "check-compatibility",
+      title: "检查版本兼容性",
+      message: "正在比较桌面端与后端版本",
+      progress: 0.85,
+    });
+    if (health.version === app.getVersion()) return null;
+    return `远程实例版本为 ${health.version ?? "未知"}，桌面端版本为 ${app.getVersion()}，部分功能可能不兼容。`;
   }
 
-  await startLocalBackend(instance.installDir);
+  await startLocalBackend(instance.installDir, startupProgress);
+  return null;
 }
 
 async function switchInstance(instanceId: string): Promise<InitializeAppResult> {
-  const config = await readDesktopConfig();
-  if (!config) return { status: "needs-setup" };
-  const instance = config.instances.find((item) => item.id === instanceId);
-  if (!instance) throw new Error("实例不存在");
-
-  await activateInstance(config, instance);
-  await writeDesktopConfig({ ...config, activeInstanceId: instance.id });
-  return { status: "ready", activeInstanceId: instance.id };
+  const startupProgress = createStartupProgress();
+  startupProgress.begin({
+    step: "load-config",
+    title: "读取实例配置",
+    message: "正在查找目标 OpenFic 实例",
+    progress: 0.1,
+  });
+  try {
+    const config = await readDesktopConfig();
+    if (!config) throw new Error("未找到 OpenFic 实例配置");
+    const instance = config.instances.find((item) => item.id === instanceId);
+    if (!instance) throw new Error("实例不存在");
+    startupProgress.update({
+      step: "load-config",
+      title: "读取实例配置",
+      message: `正在切换到 ${instance.name}`,
+      progress: 0.1,
+    });
+    const compatibilityWarning = await activateInstance(config, instance, startupProgress);
+    await writeDesktopConfig({ ...config, activeInstanceId: instance.id });
+    startupProgress.begin({
+      step: "ready",
+      title: "服务已就绪",
+      message: "OpenFic 已准备完成",
+      progress: 1,
+    });
+    startupProgress.complete();
+    return { status: "ready", activeInstanceId: instance.id, compatibilityWarning: compatibilityWarning ?? undefined };
+  } catch (error) {
+    startupProgress.fail(error);
+    throw error;
+  }
 }
 
 async function pingInstance(instance: DesktopInstance): Promise<number> {
@@ -130,27 +242,43 @@ function installMenu(): void {
 }
 
 async function initializeApp(): Promise<InitializeAppResult> {
-  const config = await readDesktopConfig();
-  writeStartupLog(`config loaded: ${config ? `${config.instances.length} instances` : "none"}`);
-
-  if (!config || config.instances.length === 0) {
-    return { status: "needs-setup" };
-  }
-
-  const instance = getActiveInstance(config);
-  if (!instance) return { status: "needs-setup" };
-
+  const startupProgress = createStartupProgress();
+  startupProgress.begin({
+    step: "load-config",
+    title: "读取本地配置",
+    message: "正在查找已有 OpenFic 实例",
+    progress: 0.05,
+  });
   try {
-    await activateInstance(config, instance);
+    const config = await readDesktopConfig();
+    writeStartupLog(`config loaded: ${config ? `${config.instances.length} instances` : "none"}`);
+    if (!config || config.instances.length === 0) {
+      startupProgress.complete("尚未配置 OpenFic 实例");
+      return { status: "needs-setup" };
+    }
+    const instance = getActiveInstance(config);
+    if (!instance) {
+      startupProgress.complete("尚未找到活动实例");
+      return { status: "needs-setup" };
+    }
+    const compatibilityWarning = await activateInstance(config, instance, startupProgress);
     if (config.activeInstanceId !== instance.id) {
       await writeDesktopConfig({ ...config, activeInstanceId: instance.id });
     }
-    return { status: "ready", activeInstanceId: instance.id };
+    startupProgress.begin({
+      step: "ready",
+      title: "服务已就绪",
+      message: "OpenFic 已准备完成",
+      progress: 1,
+    });
+    startupProgress.complete();
+    return { status: "ready", activeInstanceId: instance.id, compatibilityWarning: compatibilityWarning ?? undefined };
   } catch (err) {
     writeStartupLog(`backend failed: ${err instanceof Error ? err.message : String(err)}`);
+    startupProgress.fail(err);
     return {
       status: "needs-setup",
-      activeInstanceId: instance.id,
+      activeInstanceId: null,
       message: err instanceof Error ? err.message : String(err),
     };
   }
@@ -158,6 +286,8 @@ async function initializeApp(): Promise<InitializeAppResult> {
 
 async function bootstrap(): Promise<void> {
   writeStartupLog("bootstrap start");
+  await configureDefaultSystemProxy();
+  writeStartupLog("system proxy configured");
   handleAppProtocol();
   writeStartupLog("protocol handler installed");
   installMenu();
@@ -174,6 +304,7 @@ async function bootstrap(): Promise<void> {
 
   writeStartupLog("opening shell window");
   openMainWindow();
+  if (mainWindow) await initializeUpdater(mainWindow);
 }
 
 const gotLock = app.requestSingleInstanceLock();

--- a/desktop/src/main/process.ts
+++ b/desktop/src/main/process.ts
@@ -14,12 +14,31 @@ export interface StartBackendOptions {
   args: string[];
   port: number;
   dataDir?: string;
+  environment?: NodeJS.ProcessEnv;
+  onOutputLine?: (line: string) => void;
 }
 
 export function getBackendLogPath(): string {
   const logsDir = path.join(app.getPath("userData"), "logs");
   mkdirSync(logsDir, { recursive: true });
   return path.join(logsDir, "backend.log");
+}
+
+function observeOutputLines(stream: NodeJS.ReadableStream, onLine: (line: string) => void): void {
+  let buffer = "";
+  stream.on("data", (chunk: Buffer | string) => {
+    buffer += (typeof chunk === "string" ? chunk : chunk.toString("utf8")).replace(/\r/g, "\n");
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      const text = line.trim();
+      if (text) onLine(text);
+    }
+  });
+  stream.on("end", () => {
+    const text = buffer.trim();
+    if (text) onLine(text);
+  });
 }
 
 export function startBackendProcess(options: StartBackendOptions): BackendProcessHandle {
@@ -34,12 +53,17 @@ export function startBackendProcess(options: StartBackendOptions): BackendProces
       OPENFIC_SERVER_HOST: "127.0.0.1",
       OPENFIC_SERVER_PORT: String(options.port),
       OPENFIC_DATA_DIR: dataDir,
+      ...options.environment,
     },
     windowsHide: true,
   });
 
   child.stdout.pipe(logStream);
   child.stderr.pipe(logStream);
+  if (options.onOutputLine) {
+    observeOutputLines(child.stdout, options.onOutputLine);
+    observeOutputLines(child.stderr, options.onOutputLine);
+  }
 
   return {
     process: child,

--- a/desktop/src/main/protocol.ts
+++ b/desktop/src/main/protocol.ts
@@ -3,9 +3,10 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { RuntimeConfigResponse } from "../shared/config.js";
+import { configureSystemProxy } from "./proxy.js";
 
 let runtimeConfig: RuntimeConfigResponse | null = null;
-const registeredPartitions = new Set<string>();
+const registeredPartitions = new Map<string, Promise<void>>();
 
 export function setRuntimeConfig(config: RuntimeConfigResponse): void {
   runtimeConfig = config;
@@ -73,8 +74,15 @@ export function handleAppProtocol(): void {
   protocol.handle("app", handleAppRequest);
 }
 
-export function ensureAppProtocolForPartition(partition: string): void {
-  if (!partition || registeredPartitions.has(partition)) return;
-  session.fromPartition(partition).protocol.handle("app", handleAppRequest);
-  registeredPartitions.add(partition);
+export function ensureAppProtocolForPartition(partition: string): Promise<void> {
+  if (!partition) return Promise.resolve();
+  const registered = registeredPartitions.get(partition);
+  if (registered) return registered;
+
+  const targetSession = session.fromPartition(partition);
+  const registration = configureSystemProxy(targetSession).then(() => {
+    targetSession.protocol.handle("app", handleAppRequest);
+  });
+  registeredPartitions.set(partition, registration);
+  return registration;
 }

--- a/desktop/src/main/proxy.ts
+++ b/desktop/src/main/proxy.ts
@@ -1,0 +1,67 @@
+import { session, type Session } from "electron";
+
+const configuredSessions = new WeakMap<Session, Promise<void>>();
+const LOCAL_BYPASS_HOSTS = ["localhost", "127.0.0.1"];
+const INVALID_NO_PROXY_HOSTS = new Set(["::1", "[::1]"]);
+
+export function configureSystemProxy(targetSession: Session): Promise<void> {
+  const configured = configuredSessions.get(targetSession);
+  if (configured) return configured;
+
+  const configuration = targetSession.setProxy({ mode: "system" }).catch((error: unknown) => {
+    console.warn("Unable to configure the system proxy:", error);
+  });
+  configuredSessions.set(targetSession, configuration);
+  return configuration;
+}
+
+export function configureDefaultSystemProxy(): Promise<void> {
+  return configureSystemProxy(session.defaultSession);
+}
+
+function getProxyUrl(proxyRules: string): string | null {
+  for (const rule of proxyRules.split(";")) {
+    const match = rule.trim().match(/^(PROXY|HTTPS|SOCKS|SOCKS4|SOCKS5)\s+(.+)$/i);
+    if (!match) continue;
+
+    const [, scheme, address] = match;
+    const normalizedScheme = scheme.toUpperCase();
+    const protocol = normalizedScheme === "HTTPS" ? "https" : normalizedScheme.startsWith("SOCKS") ? normalizedScheme.toLowerCase() : "http";
+    return `${protocol}://${address.trim()}`;
+  }
+  return null;
+}
+
+function withLocalBypass(currentValue: string | undefined): string {
+  const hosts =
+    currentValue
+      ?.split(",")
+      .map((host) => host.trim())
+      .filter((host) => host && !INVALID_NO_PROXY_HOSTS.has(host)) ?? [];
+  for (const host of LOCAL_BYPASS_HOSTS) {
+    if (!hosts.includes(host)) hosts.push(host);
+  }
+  return hosts.join(",");
+}
+
+/**
+ * Child processes do not use Chromium's proxy service. Resolve the active system
+ * proxy and expose it through the conventional variables they understand.
+ */
+export async function getSystemProxyEnvironment(url: string): Promise<NodeJS.ProcessEnv> {
+  await configureDefaultSystemProxy();
+  const proxyUrl = getProxyUrl(await session.defaultSession.resolveProxy(url));
+  const noProxy = withLocalBypass(process.env.NO_PROXY ?? process.env.no_proxy);
+  if (!proxyUrl) return { NO_PROXY: noProxy, no_proxy: noProxy };
+
+  return {
+    HTTP_PROXY: proxyUrl,
+    HTTPS_PROXY: proxyUrl,
+    ALL_PROXY: proxyUrl,
+    http_proxy: proxyUrl,
+    https_proxy: proxyUrl,
+    all_proxy: proxyUrl,
+    NO_PROXY: noProxy,
+    no_proxy: noProxy,
+  };
+}

--- a/desktop/src/main/runtime/archive.ts
+++ b/desktop/src/main/runtime/archive.ts
@@ -1,3 +1,4 @@
+import { net } from "electron";
 import { createWriteStream } from "node:fs";
 import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
@@ -11,7 +12,7 @@ export async function downloadFile(
   onProgress?: (received: number, total: number) => void,
 ): Promise<void> {
   await mkdir(path.dirname(outputPath), { recursive: true });
-  const response = await fetch(url);
+  const response = await net.fetch(url);
   if (!response.ok || !response.body) {
     throw new Error(`failed to download ${url}: ${response.status}`);
   }

--- a/desktop/src/main/runtime/openfic-commands.ts
+++ b/desktop/src/main/runtime/openfic-commands.ts
@@ -3,27 +3,31 @@ interface SpawnCommand {
   args: string[];
 }
 
-function getOpenFicCliPath(venvPythonPath: string): string {
+export function resolveOpenFicCliPath(venvPythonPath: string): string {
   return process.platform === "win32"
     ? venvPythonPath.replace(/python\.exe$/i, "openfic.exe")
     : venvPythonPath.replace(/python$/i, "openfic");
 }
-export function createOpenFicProbeCommand(venvPythonPath: string): SpawnCommand {
+export function createOpenFicVersionCommand(venvPythonPath: string): SpawnCommand {
   return {
     command: venvPythonPath,
-    args: ["-m", "pip", "show", "openfic"],
+    args: ["-c", 'from importlib.metadata import version; print(version("openfic"))'],
   };
 }
 
-export function createOpenFicInstallCommand(venvPythonPath: string): Omit<SpawnCommand, "command"> {
+export function createOpenFicInstallCommand(
+  venvPythonPath: string,
+  version: string,
+  forceReinstall = false,
+): Omit<SpawnCommand, "command"> {
   return {
-    args: ["pip", "install", "--python", venvPythonPath, "openfic"],
+    args: ["pip", "install", "--python", venvPythonPath, ...(forceReinstall ? ["--reinstall"] : []), `openfic==${version}`],
   };
 }
 
 export function createOpenFicServeCommand(venvPythonPath: string, port: number): SpawnCommand {
   return {
-    command: getOpenFicCliPath(venvPythonPath),
+    command: resolveOpenFicCliPath(venvPythonPath),
     args: ["serve", "--host", "127.0.0.1", "--port", String(port)],
   };
 }

--- a/desktop/src/main/runtime/openfic.ts
+++ b/desktop/src/main/runtime/openfic.ts
@@ -1,11 +1,18 @@
 import { spawn } from "node:child_process";
-import { access, mkdir } from "node:fs/promises";
+import { access, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { findFreePort } from "../ports.js";
-import { startBackendProcess, type BackendProcessHandle } from "../process.js";
+import { startBackendProcess, stopBackendProcess, type BackendProcessHandle } from "../process.js";
+import { getSystemProxyEnvironment } from "../proxy.js";
 import { waitForBackend } from "../health.js";
-import type { PortablePython } from "./python.js";
-import { createOpenFicInstallCommand, createOpenFicProbeCommand, createOpenFicServeCommand } from "./openfic-commands.js";
+import type { PortablePython, RuntimeIntegrityCheck } from "./python.js";
+import {
+  createOpenFicInstallCommand,
+  createOpenFicServeCommand,
+  createOpenFicVersionCommand,
+  resolveOpenFicCliPath,
+} from "./openfic-commands.js";
+import type { StartupProgressTracker } from "../startup-progress.js";
 
 export type OpenFicRuntimeStep = "create-venv" | "install-uv" | "install-openfic";
 
@@ -73,10 +80,17 @@ function stripAnsi(value: string): string {
   return value.replace(ANSI_ESCAPE_SEQUENCE, "");
 }
 
-function run(command: string, args: string[], cwd: string, onStdoutLine?: (line: string) => void): Promise<void> {
+function run(
+  command: string,
+  args: string[],
+  cwd: string,
+  onStdoutLine?: (line: string) => void,
+  environment?: NodeJS.ProcessEnv,
+): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       cwd,
+      env: { ...process.env, ...environment },
       windowsHide: true,
       stdio: ["ignore", "pipe", "pipe"],
     });
@@ -93,6 +107,22 @@ function run(command: string, args: string[], cwd: string, onStdoutLine?: (line:
   });
 }
 
+function readOutput(command: string, args: string[], cwd: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, {
+      cwd,
+      windowsHide: true,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    let output = "";
+    child.stdout.on("data", (chunk: Buffer | string) => {
+      output += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    });
+    child.on("error", () => resolve(null));
+    child.on("exit", (code) => resolve(code === 0 ? output.trim() || null : null));
+  });
+}
+
 function succeeds(command: string, args: string[], cwd: string): Promise<boolean> {
   return new Promise((resolve) => {
     const child = spawn(command, args, {
@@ -105,9 +135,43 @@ function succeeds(command: string, args: string[], cwd: string): Promise<boolean
   });
 }
 
+export async function inspectOpenFicRuntime(
+  runtimeDir: string,
+  expectedVersion: string,
+): Promise<RuntimeIntegrityCheck> {
+  const venvPythonPath = getVenvPythonPath(runtimeDir);
+  if (!(await pathExists(venvPythonPath))) {
+    return { complete: false, message: "未找到 Python 虚拟环境" };
+  }
+  if (!(await readOutput(venvPythonPath, ["--version"], runtimeDir))) {
+    return { complete: false, message: "Python 虚拟环境不可用" };
+  }
+
+  const uvPath = getUvPath(runtimeDir);
+  if (!(await pathExists(uvPath)) || !(await readOutput(uvPath, ["--version"], runtimeDir))) {
+    return { complete: false, message: "uv 不存在或不可用" };
+  }
+
+  const versionCommand = createOpenFicVersionCommand(venvPythonPath);
+  const installedVersion = await readOutput(versionCommand.command, versionCommand.args, runtimeDir);
+  if (installedVersion !== expectedVersion) {
+    return {
+      complete: false,
+      message: installedVersion ? "OpenFic 后端版本不匹配" : "未找到 OpenFic 后端",
+    };
+  }
+  const openFicCliPath = resolveOpenFicCliPath(venvPythonPath);
+  if (!(await pathExists(openFicCliPath)) || !(await succeeds(openFicCliPath, ["--help"], runtimeDir))) {
+    return { complete: false, message: "OpenFic 命令行程序缺失或不可用" };
+  }
+
+  return { complete: true, message: "OpenFic 运行环境已完整安装" };
+}
+
 export async function ensureOpenFicRuntime(
   python: PortablePython,
   runtimeDir: string,
+  expectedVersion: string,
   onProgress: (step: OpenFicRuntimeStep, message: string) => void,
 ): Promise<{ uvPath: string; venvPythonPath: string }> {
   const venvDir = getVenvDir(runtimeDir);
@@ -116,34 +180,145 @@ export async function ensureOpenFicRuntime(
 
   await mkdir(runtimeDir, { recursive: true });
 
-  if (!(await pathExists(venvPythonPath))) {
+  if (python.wasReplaced) await rm(venvDir, { recursive: true, force: true });
+
+  const venvIsUsable =
+    (await pathExists(venvPythonPath)) && Boolean(await readOutput(venvPythonPath, ["--version"], runtimeDir));
+  if (!venvIsUsable) {
+    await rm(venvDir, { recursive: true, force: true });
     onProgress("create-venv", "创建 OpenFic 运行环境");
     await run(python.pythonPath, ["-m", "venv", venvDir], runtimeDir);
   }
 
-  if (!(await pathExists(uvPath))) {
+  const uvIsUsable = (await pathExists(uvPath)) && Boolean(await readOutput(uvPath, ["--version"], runtimeDir));
+  if (!uvIsUsable) {
     onProgress("install-uv", "安装 uv");
-    await run(venvPythonPath, ["-m", "pip", "install", "uv"], runtimeDir, (message) => onProgress("install-uv", message));
+    const proxyEnvironment = await getSystemProxyEnvironment("https://pypi.org/");
+    await run(
+      venvPythonPath,
+      ["-m", "pip", "install", "--force-reinstall", "uv"],
+      runtimeDir,
+      (message) => onProgress("install-uv", message),
+      proxyEnvironment,
+    );
   }
 
-  const probeCommand = createOpenFicProbeCommand(venvPythonPath);
-  if (!(await succeeds(probeCommand.command, probeCommand.args, runtimeDir))) {
-    onProgress("install-openfic", "安装 OpenFic 后端");
-    const installCommand = createOpenFicInstallCommand(venvPythonPath);
-    await run(uvPath, installCommand.args, runtimeDir, (message) => onProgress("install-openfic", message));
+  const versionCommand = createOpenFicVersionCommand(venvPythonPath);
+  const installedVersion = await readOutput(versionCommand.command, versionCommand.args, runtimeDir);
+  const openFicCliPath = resolveOpenFicCliPath(venvPythonPath);
+  const openFicCliIsUsable =
+    (await pathExists(openFicCliPath)) && (await succeeds(openFicCliPath, ["--help"], runtimeDir));
+  if (installedVersion !== expectedVersion || !openFicCliIsUsable) {
+    onProgress("install-openfic", installedVersion ? "更新 OpenFic 后端" : "安装 OpenFic 后端");
+    const proxyEnvironment = await getSystemProxyEnvironment("https://pypi.org/");
+    const installCommand = createOpenFicInstallCommand(
+      venvPythonPath,
+      expectedVersion,
+      installedVersion === expectedVersion && !openFicCliIsUsable,
+    );
+    await run(
+      uvPath,
+      installCommand.args,
+      runtimeDir,
+      (message) => onProgress("install-openfic", message),
+      proxyEnvironment,
+    );
   }
 
   return { uvPath, venvPythonPath };
 }
 
-export async function startLocalOpenFicBackend(venvPythonPath: string): Promise<BackendProcessHandle> {
+const STARTUP_LOG_MILESTONES = [
+  {
+    text: "Starting OpenFic",
+    step: "initialize-backend",
+    title: "初始化应用服务",
+    message: "正在加载 OpenFic 服务",
+    progress: 0.7,
+  },
+  {
+    text: "Database initialization or migration completed",
+    step: "initialize-database",
+    title: "初始化数据库",
+    message: "数据库初始化或迁移已完成",
+    progress: 0.82,
+  },
+  {
+    text: "Application startup complete",
+    step: "complete-backend-startup",
+    title: "完成应用启动",
+    message: "应用服务已完成初始化",
+    progress: 0.92,
+  },
+] as const;
+
+export async function startLocalOpenFicBackend(
+  venvPythonPath: string,
+  expectedVersion: string,
+  startupProgress?: StartupProgressTracker,
+): Promise<BackendProcessHandle> {
+  startupProgress?.begin({
+    step: "start-backend",
+    title: "启动 OpenFic 服务",
+    message: "正在分配本地服务端口",
+    progress: 0.6,
+  });
   const port = await findFreePort();
   const command = createOpenFicServeCommand(venvPythonPath, port);
+  const proxyEnvironment = await getSystemProxyEnvironment("https://pypi.org/");
+  let healthFallbackStarted = false;
+  let healthFallbackTimer: NodeJS.Timeout | null = null;
+
+  const beginHealthFallback = () => {
+    if (healthFallbackStarted) return;
+    healthFallbackStarted = true;
+    startupProgress?.begin({
+      step: "check-health",
+      title: "检查服务状态",
+      message: "启动阶段停留较久，正在主动检查服务响应",
+      progress: 0.96,
+    });
+  };
+
+  const scheduleHealthFallback = () => {
+    if (healthFallbackStarted) return;
+    if (healthFallbackTimer) clearTimeout(healthFallbackTimer);
+    healthFallbackTimer = setTimeout(beginHealthFallback, 5_000);
+  };
+
   const handle = startBackendProcess({
     command: command.command,
     args: command.args,
     port,
+    environment: proxyEnvironment,
+    onOutputLine: (line) => {
+      if (healthFallbackStarted) return;
+      const milestone = STARTUP_LOG_MILESTONES.find((candidate) => line.includes(candidate.text));
+      if (!milestone) return;
+      startupProgress?.begin(milestone);
+      scheduleHealthFallback();
+    },
   });
-  await waitForBackend(handle.baseUrl, { process: handle.process });
-  return handle;
+
+  scheduleHealthFallback();
+  try {
+    const health = await waitForBackend(handle.baseUrl, { process: handle.process });
+    if (healthFallbackTimer) clearTimeout(healthFallbackTimer);
+    startupProgress?.begin({
+      step: "check-health",
+      title: "检查服务状态",
+      message: "服务已响应，正在验证版本",
+      progress: 0.98,
+    });
+    if (health.version !== expectedVersion) {
+      stopBackendProcess(handle);
+      throw new Error(`本地后端版本不匹配：期望 ${expectedVersion}，实际 ${health.version ?? "未知"}`);
+    }
+    return handle;
+  } catch (error) {
+    if (healthFallbackTimer) clearTimeout(healthFallbackTimer);
+    stopBackendProcess(handle);
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`${message}。日志路径：${handle.logPath}`);
+  }
 }

--- a/desktop/src/main/runtime/python-version.ts
+++ b/desktop/src/main/runtime/python-version.ts
@@ -1,0 +1,4 @@
+export function matchesPortablePythonVersion(output: string, expectedVersion: string): boolean {
+  const match = output.match(/\bPython\s+(\d+\.\d+\.\d+)\b/);
+  return match?.[1] === expectedVersion;
+}

--- a/desktop/src/main/runtime/python.ts
+++ b/desktop/src/main/runtime/python.ts
@@ -1,17 +1,25 @@
 import { app } from "electron";
+import { spawn } from "node:child_process";
 import { access, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { downloadFile, extractTarGz } from "./archive.js";
 import { resolvePythonAsset } from "./python-assets.js";
+import { matchesPortablePythonVersion } from "./python-version.js";
 
 export interface PortablePython {
   pythonPath: string;
   rootDir: string;
+  wasReplaced: boolean;
 }
 
 export interface DownloadProgress {
   received: number;
   total: number;
+}
+
+export interface RuntimeIntegrityCheck {
+  complete: boolean;
+  message: string;
 }
 
 export function getDefaultInstallDir(): string {
@@ -49,6 +57,37 @@ function formatBytes(bytes: number): string {
   return `${value.toFixed(value >= 100 ? 0 : 1)} ${unit}`;
 }
 
+function readPythonVersion(pythonPath: string): Promise<string | null> {
+  return new Promise((resolve) => {
+    const child = spawn(pythonPath, ["--version"], {
+      windowsHide: true,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    const appendOutput = (chunk: Buffer | string) => {
+      output += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    };
+    child.stdout.on("data", appendOutput);
+    child.stderr.on("data", appendOutput);
+    child.on("error", () => resolve(null));
+    child.on("exit", (code) => resolve(code === 0 ? output.trim() || null : null));
+  });
+}
+
+export async function inspectPortablePython(runtimeDir: string): Promise<RuntimeIntegrityCheck> {
+  const pythonPath = getPortablePythonPath(getPortablePythonRoot(runtimeDir));
+  if (!(await pathExists(pythonPath))) {
+    return { complete: false, message: "未找到便携式 Python" };
+  }
+
+  const installedVersion = await readPythonVersion(pythonPath);
+  if (!installedVersion || !matchesPortablePythonVersion(installedVersion, resolvePythonAsset().version)) {
+    return { complete: false, message: "便携式 Python 不可用或版本不匹配" };
+  }
+
+  return { complete: true, message: "便携式 Python 已就绪" };
+}
+
 export async function ensurePortablePython(
   runtimeDir: string,
   onPhase: (phase: "download" | "extract", message: string) => void,
@@ -56,9 +95,18 @@ export async function ensurePortablePython(
 ): Promise<PortablePython> {
   const rootDir = getPortablePythonRoot(runtimeDir);
   const pythonPath = getPortablePythonPath(rootDir);
-  if (await pathExists(pythonPath)) return { pythonPath, rootDir };
-
   const asset = resolvePythonAsset();
+  if (await pathExists(pythonPath)) {
+    const installedVersion = await readPythonVersion(pythonPath);
+    if (installedVersion && matchesPortablePythonVersion(installedVersion, asset.version)) {
+      return { pythonPath, rootDir, wasReplaced: false };
+    }
+    await rm(rootDir, { recursive: true, force: true });
+  }
+
+  // A partial extraction may not contain the Python executable at all.
+  await rm(rootDir, { recursive: true, force: true });
+
   const archivePath = path.join(runtimeDir, `python-${asset.version}-${asset.target}.tar.gz`);
   await mkdir(runtimeDir, { recursive: true });
 
@@ -74,7 +122,7 @@ export async function ensurePortablePython(
 
   await rm(archivePath, { force: true });
 
-  return { pythonPath, rootDir };
+  return { pythonPath, rootDir, wasReplaced: true };
 }
 
 export function describeDownloadProgress(progress: DownloadProgress): string {

--- a/desktop/src/main/runtime/setup-runner.ts
+++ b/desktop/src/main/runtime/setup-runner.ts
@@ -1,8 +1,15 @@
-import type { WebContents } from "electron";
+import { app, type WebContents } from "electron";
+import { stat } from "node:fs/promises";
 import { IpcChannels, type SetupProgressEvent } from "../../shared/ipc.js";
-import { describeDownloadProgress, ensurePortablePython, resolveRuntimeDir } from "./python.js";
-import { ensureOpenFicRuntime, resolveVenvPythonPath, startLocalOpenFicBackend } from "./openfic.js";
+import { describeDownloadProgress, ensurePortablePython, inspectPortablePython, resolveRuntimeDir } from "./python.js";
+import {
+  ensureOpenFicRuntime,
+  inspectOpenFicRuntime,
+  resolveVenvPythonPath,
+  startLocalOpenFicBackend,
+} from "./openfic.js";
 import type { BackendProcessHandle } from "../process.js";
+import type { StartupProgressTracker } from "../startup-progress.js";
 
 function emitProgress(webContents: WebContents, event: SetupProgressEvent): void {
   webContents.send(IpcChannels.setupProgress, event);
@@ -44,14 +51,45 @@ export async function installLocalRuntime(webContents: WebContents, installDir: 
     },
   );
 
-  await ensureOpenFicRuntime(python, runtimeDir, (step, message) => beginStep(step, message));
+  await ensureOpenFicRuntime(python, runtimeDir, app.getVersion(), (step, message) => beginStep(step, message));
 
   if (currentStep) markDone(webContents, currentStep);
 
   return runtimeDir;
 }
 
-export async function startLocalBackendFromInstall(installDir: string): Promise<BackendProcessHandle> {
+export interface LocalRuntimeInspection {
+  status: "missing" | "incomplete" | "ready";
+  message: string;
+}
+
+export async function inspectLocalRuntime(installDir: string): Promise<LocalRuntimeInspection> {
   const runtimeDir = resolveRuntimeDir(installDir);
-  return startLocalOpenFicBackend(resolveVenvPythonPath(runtimeDir));
+  try {
+    if (!(await stat(runtimeDir)).isDirectory()) {
+      return { status: "incomplete", message: "运行环境路径不是目录" };
+    }
+  } catch {
+    return { status: "missing", message: "尚未安装本地运行环境" };
+  }
+
+  const python = await inspectPortablePython(runtimeDir);
+  if (!python.complete) return { status: "incomplete", message: python.message };
+
+  const openfic = await inspectOpenFicRuntime(runtimeDir, app.getVersion());
+  if (!openfic.complete) return { status: "incomplete", message: openfic.message };
+
+  return { status: "ready", message: openfic.message };
+}
+
+export async function startLocalBackendFromInstall(
+  installDir: string,
+  startupProgress?: StartupProgressTracker,
+): Promise<BackendProcessHandle> {
+  const inspection = await inspectLocalRuntime(installDir);
+  if (inspection.status !== "ready") {
+    throw new Error(`本地运行环境不完整：${inspection.message}。请先修复运行环境。`);
+  }
+  const runtimeDir = resolveRuntimeDir(installDir);
+  return startLocalOpenFicBackend(resolveVenvPythonPath(runtimeDir), app.getVersion(), startupProgress);
 }

--- a/desktop/src/main/startup-progress.ts
+++ b/desktop/src/main/startup-progress.ts
@@ -1,0 +1,57 @@
+import type { StartupProgressEvent } from "../shared/ipc.js";
+
+type ProgressUpdate = Pick<StartupProgressEvent, "step" | "title" | "message" | "progress">;
+
+export interface StartupProgressTracker {
+  begin(update: ProgressUpdate): void;
+  update(update: ProgressUpdate): void;
+  complete(message?: string): void;
+  fail(error: unknown): void;
+}
+
+let latestStartupProgress: StartupProgressEvent | null = null;
+
+export function getStartupProgress(): StartupProgressEvent | null {
+  return latestStartupProgress;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function createStartupProgressTracker(
+  emit: (event: StartupProgressEvent) => void,
+): StartupProgressTracker {
+  let current: ProgressUpdate | null = null;
+
+  const publish = (event: StartupProgressEvent) => {
+    latestStartupProgress = event;
+    emit(event);
+  };
+
+  const update = (next: ProgressUpdate) => {
+    current = next;
+    publish({ ...next, status: "running" });
+  };
+
+  return {
+    begin(next) {
+      if (current && current.step !== next.step) {
+        publish({ ...current, status: "done" });
+      }
+      update(next);
+    },
+    update(next) {
+      update(next);
+    },
+    complete(message) {
+      if (!current) return;
+      publish({ ...current, message: message ?? current.message, status: "done" });
+      current = null;
+    },
+    fail(error) {
+      if (!current) return;
+      publish({ ...current, message: errorMessage(error), status: "failed" });
+    },
+  };
+}

--- a/desktop/src/main/update-support.ts
+++ b/desktop/src/main/update-support.ts
@@ -1,0 +1,8 @@
+export interface UpdateSupportEnvironment {
+  platform: NodeJS.Platform;
+  arch: string;
+}
+
+export function isAutoUpdateSupported(environment: UpdateSupportEnvironment): boolean {
+  return environment.platform === "win32" && (environment.arch === "x64" || environment.arch === "arm64");
+}

--- a/desktop/src/main/updater.ts
+++ b/desktop/src/main/updater.ts
@@ -1,0 +1,150 @@
+import { app, shell, type BrowserWindow } from "electron";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import electronUpdater, { CancellationToken, NsisUpdater, type ProgressInfo, type UpdateInfo } from "electron-updater";
+import { IpcChannels, type UpdateState } from "../shared/ipc.js";
+import { isAutoUpdateSupported } from "./update-support.js";
+import { configureSystemProxy } from "./proxy.js";
+
+const { autoUpdater } = electronUpdater;
+
+let shellWindow: BrowserWindow | null = null;
+let updateState: UpdateState = { status: "idle" };
+let initialized = false;
+let downloadCancellationToken: CancellationToken | null = null;
+
+function publishState(nextState: UpdateState): void {
+  updateState = nextState;
+  shellWindow?.webContents.send(IpcChannels.updateState, nextState);
+}
+
+function describeError(error: Error): string {
+  return error.message || "更新服务暂时不可用";
+}
+
+function getReleaseNotes(info: UpdateInfo): string | undefined {
+  if (typeof info.releaseNotes === "string") return info.releaseNotes.trim() || undefined;
+  if (!Array.isArray(info.releaseNotes)) return undefined;
+  const notes = info.releaseNotes
+    .map((item) => item.note?.trim())
+    .filter((item): item is string => Boolean(item));
+  return notes.length ? notes.join("\n\n") : undefined;
+}
+
+function onUpdateAvailable(info: UpdateInfo): void {
+  publishState({ status: "available", version: info.version, releaseNotes: getReleaseNotes(info) });
+}
+
+function onDownloadProgress(progress: ProgressInfo): void {
+  publishState({
+    ...updateState,
+    status: "downloading",
+    progress: progress.percent / 100,
+    transferred: progress.transferred,
+    total: progress.total,
+    bytesPerSecond: progress.bytesPerSecond,
+  });
+}
+
+function onUpdateCancelled(info: UpdateInfo): void {
+  publishState({ status: "available", version: info.version, releaseNotes: getReleaseNotes(info) });
+}
+
+function canUseAutoUpdater(): boolean {
+  if (!app.isPackaged) return false;
+  return isAutoUpdateSupported({
+    platform: process.platform,
+    arch: process.arch,
+  });
+}
+
+function configurePortableInstallDirectory(): void {
+  const installDirectory = path.dirname(app.getPath("exe"));
+  const uninstallerPath = path.join(installDirectory, "Uninstall OpenFic.exe");
+  if (!existsSync(uninstallerPath) && autoUpdater instanceof NsisUpdater) {
+    autoUpdater.installDirectory = installDirectory;
+  }
+}
+
+export async function initializeUpdater(window: BrowserWindow): Promise<void> {
+  shellWindow = window;
+  await configureSystemProxy(autoUpdater.netSession);
+  if (initialized) {
+    window.webContents.send(IpcChannels.updateState, updateState);
+    return;
+  }
+
+  initialized = true;
+  if (!canUseAutoUpdater()) {
+    publishState({ status: "unsupported" });
+    return;
+  }
+
+  autoUpdater.autoDownload = false;
+  autoUpdater.autoInstallOnAppQuit = false;
+  configurePortableInstallDirectory();
+  autoUpdater.on("checking-for-update", () => publishState({ status: "checking" }));
+  autoUpdater.on("update-available", onUpdateAvailable);
+  autoUpdater.on("update-not-available", () => publishState({ status: "not-available" }));
+  autoUpdater.on("download-progress", onDownloadProgress);
+  autoUpdater.on("update-cancelled", onUpdateCancelled);
+  autoUpdater.on("update-downloaded", (info) => publishState({ status: "downloaded", version: info.version, releaseNotes: getReleaseNotes(info) }));
+  autoUpdater.on("error", (error) => publishState({ status: "error", message: describeError(error) }));
+  publishState({ status: "idle" });
+}
+
+export function getUpdateState(): UpdateState {
+  return updateState;
+}
+
+export async function checkForUpdates(): Promise<void> {
+  if (!canUseAutoUpdater()) {
+    publishState({ status: "unsupported" });
+    return;
+  }
+
+  publishState({ status: "checking" });
+  try {
+    await autoUpdater.checkForUpdates();
+  } catch (error) {
+    publishState({ status: "error", message: describeError(error instanceof Error ? error : new Error(String(error))) });
+  }
+}
+
+export async function downloadUpdate(): Promise<void> {
+  if (updateState.status !== "available") return;
+
+  publishState({
+    status: "downloading",
+    version: updateState.version,
+    releaseNotes: updateState.releaseNotes,
+    progress: 0,
+    transferred: 0,
+  });
+  const cancellationToken = new CancellationToken();
+  downloadCancellationToken = cancellationToken;
+  try {
+    await autoUpdater.downloadUpdate(cancellationToken);
+  } catch (error) {
+    if (!cancellationToken.cancelled) {
+      publishState({ status: "error", message: describeError(error instanceof Error ? error : new Error(String(error))) });
+    }
+  } finally {
+    if (downloadCancellationToken === cancellationToken) downloadCancellationToken = null;
+  }
+}
+
+export function cancelUpdateDownload(): void {
+  if (updateState.status !== "downloading") return;
+  downloadCancellationToken?.cancel();
+}
+
+export function installUpdate(): void {
+  if (updateState.status !== "downloaded") return;
+  autoUpdater.quitAndInstall(true, true);
+}
+
+export async function openUpdateRelease(): Promise<void> {
+  if (!updateState.version) return;
+  await shell.openExternal(`https://github.com/syrizelink/OpenFic/releases/tag/v${encodeURIComponent(updateState.version)}`);
+}

--- a/desktop/src/preload/preload.mts
+++ b/desktop/src/preload/preload.mts
@@ -2,18 +2,20 @@ import { contextBridge, ipcRenderer } from "electron";
 import { fileURLToPath } from "node:url";
 import {
   IpcChannels,
-  type CheckDirectoryEmptyRequest,
-  type CheckDirectoryEmptyResult,
   type CheckRemoteRequest,
   type EnsureInstanceSessionRequest,
   type InitializeAppResult,
+  type InspectLocalRuntimeRequest,
+  type InspectLocalRuntimeResult,
   type InstallRuntimeRequest,
   type PingInstanceRequest,
   type PingInstanceResult,
   type SaveConfigRequest,
   type SetupProgressEvent,
+  type StartupProgressEvent,
   type StartLocalBackendRequest,
   type SwitchInstanceRequest,
+  type UpdateState,
 } from "../shared/ipc.js";
 import type { DesktopConfig, DesktopInstance } from "../shared/config.js";
 
@@ -36,18 +38,35 @@ const desktopApi = {
   pingInstance: (instance: DesktopInstance): Promise<PingInstanceResult> =>
     ipcRenderer.invoke(IpcChannels.pingInstance, { instance } satisfies PingInstanceRequest),
   selectDirectory: (): Promise<string | null> => ipcRenderer.invoke(IpcChannels.selectDirectory),
-  checkDirectoryEmpty: (dirPath: string): Promise<CheckDirectoryEmptyResult> =>
-    ipcRenderer.invoke(IpcChannels.checkDirectoryEmpty, { path: dirPath } satisfies CheckDirectoryEmptyRequest),
+  inspectLocalRuntime: (installDir: string): Promise<InspectLocalRuntimeResult> =>
+    ipcRenderer.invoke(IpcChannels.inspectLocalRuntime, { installDir } satisfies InspectLocalRuntimeRequest),
   closeSetup: (): Promise<void> => ipcRenderer.invoke(IpcChannels.closeSetup),
   showSetup: (): Promise<void> => ipcRenderer.invoke(IpcChannels.showSetup),
   frontendHostPreloadPath: fileURLToPath(new URL("./frontend-host-preload.mjs", import.meta.url)),
   minimizeWindow: (): Promise<void> => ipcRenderer.invoke(IpcChannels.minimizeWindow),
   toggleMaximizeWindow: (): Promise<void> => ipcRenderer.invoke(IpcChannels.toggleMaximizeWindow),
   closeWindow: (): Promise<void> => ipcRenderer.invoke(IpcChannels.closeWindow),
+  getUpdateState: (): Promise<UpdateState> => ipcRenderer.invoke(IpcChannels.getUpdateState),
+  getStartupProgress: (): Promise<StartupProgressEvent | null> => ipcRenderer.invoke(IpcChannels.getStartupProgress),
+  checkForUpdate: (): Promise<void> => ipcRenderer.invoke(IpcChannels.checkForUpdate),
+  downloadUpdate: (): Promise<void> => ipcRenderer.invoke(IpcChannels.downloadUpdate),
+  cancelUpdateDownload: (): Promise<void> => ipcRenderer.invoke(IpcChannels.cancelUpdateDownload),
+  installUpdate: (): Promise<void> => ipcRenderer.invoke(IpcChannels.installUpdate),
+  openUpdateRelease: (): Promise<void> => ipcRenderer.invoke(IpcChannels.openUpdateRelease),
   onSetupProgress: (handler: (event: SetupProgressEvent) => void): (() => void) => {
     const listener = (_event: Electron.IpcRendererEvent, payload: SetupProgressEvent) => handler(payload);
     ipcRenderer.on(IpcChannels.setupProgress, listener);
     return () => ipcRenderer.off(IpcChannels.setupProgress, listener);
+  },
+  onStartupProgress: (handler: (event: StartupProgressEvent) => void): (() => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, payload: StartupProgressEvent) => handler(payload);
+    ipcRenderer.on(IpcChannels.startupProgress, listener);
+    return () => ipcRenderer.off(IpcChannels.startupProgress, listener);
+  },
+  onUpdateState: (handler: (state: UpdateState) => void): (() => void) => {
+    const listener = (_event: Electron.IpcRendererEvent, payload: UpdateState) => handler(payload);
+    ipcRenderer.on(IpcChannels.updateState, listener);
+    return () => ipcRenderer.off(IpcChannels.updateState, listener);
   },
 };
 

--- a/desktop/src/shared/ipc.ts
+++ b/desktop/src/shared/ipc.ts
@@ -12,13 +12,22 @@ export const IpcChannels = {
   switchInstance: "instance:switch",
   pingInstance: "instance:ping",
   selectDirectory: "dialog:select-directory",
-  checkDirectoryEmpty: "directory:check-empty",
+  inspectLocalRuntime: "setup:inspect-local-runtime",
   setupProgress: "setup:progress",
+  getStartupProgress: "app:get-startup-progress",
+  startupProgress: "app:startup-progress",
   closeSetup: "setup:close",
   showSetup: "shell:show-setup",
   minimizeWindow: "window:minimize",
   toggleMaximizeWindow: "window:toggle-maximize",
   closeWindow: "window:close",
+  getUpdateState: "update:get-state",
+  checkForUpdate: "update:check",
+  downloadUpdate: "update:download",
+  cancelUpdateDownload: "update:cancel-download",
+  installUpdate: "update:install",
+  openUpdateRelease: "update:open-release",
+  updateState: "update:state",
 } as const;
 
 export type SetupStep =
@@ -68,17 +77,56 @@ export interface StartLocalBackendRequest {
   installDir: string;
 }
 
-export interface CheckDirectoryEmptyRequest {
-  path: string;
+export interface InspectLocalRuntimeRequest {
+  installDir: string;
 }
 
-export interface CheckDirectoryEmptyResult {
-  exists: boolean;
-  empty: boolean;
+export interface InspectLocalRuntimeResult {
+  status: "missing" | "incomplete" | "ready";
+  message: string;
+  configuredInstance: DesktopInstance | null;
 }
 
 export interface InitializeAppResult {
   status: "ready" | "needs-setup";
   activeInstanceId?: string | null;
+  message?: string;
+  compatibilityWarning?: string;
+}
+
+export type StartupStep =
+  | "load-config"
+  | "check-runtime"
+  | "update-python"
+  | "update-openfic"
+  | "start-backend"
+  | "initialize-backend"
+  | "initialize-database"
+  | "complete-backend-startup"
+  | "check-health"
+  | "connect-remote"
+  | "verify-remote"
+  | "check-compatibility"
+  | "ready";
+
+export interface StartupProgressEvent {
+  step: StartupStep;
+  status: "running" | "done" | "failed";
+  title: string;
+  message: string;
+  /** Overall startup progress as a 0..1 fraction. */
+  progress: number;
+}
+
+export type UpdateStatus = "unsupported" | "idle" | "checking" | "available" | "downloading" | "downloaded" | "not-available" | "error";
+
+export interface UpdateState {
+  status: UpdateStatus;
+  version?: string;
+  releaseNotes?: string;
+  progress?: number;
+  transferred?: number;
+  total?: number;
+  bytesPerSecond?: number;
   message?: string;
 }

--- a/desktop/src/ui/app.tsx
+++ b/desktop/src/ui/app.tsx
@@ -1,13 +1,15 @@
 import { useEffect, useRef, useState, type CSSProperties } from "react";
 import { DesktopHeader } from "./components/header";
+import { DesktopNotices } from "./components/desktop-notices";
 import { BootPage } from "./pages/boot/page";
 import { FrontendPage } from "./pages/frontend/page";
 import { SetupPage } from "./pages/setup/page";
 import type { DesktopConfig } from "../shared/config";
+import type { StartupProgressEvent, UpdateState } from "../shared/ipc";
 
 type ShellState = "booting" | "setup" | "frontend";
 type Appearance = "light" | "dark";
-type SetupInitialStep = "mode" | "remote";
+type SetupInitialStep = "mode" | "remote" | "local-directory" | "local-success";
 
 interface DesktopAppearancePayload {
   appearance?: Appearance;
@@ -36,6 +38,31 @@ function isDesktopAppearancePayload(value: unknown): value is DesktopAppearanceP
   );
 }
 
+function normalizeRemoteUrl(url: string): string {
+  const trimmed = url.trim().replace(/\/+$/, "");
+  try {
+    const parsed = new URL(trimmed);
+    parsed.protocol = parsed.protocol.toLowerCase();
+    parsed.hostname = parsed.hostname.toLowerCase();
+    parsed.pathname = parsed.pathname.replace(/\/+$/, "");
+    return parsed.toString().replace(/\/+$/, "");
+  } catch {
+    return trimmed;
+  }
+}
+
+function getRemoteInstanceName(url: string): string {
+  try {
+    return new URL(url).host || "Remote";
+  } catch {
+    return url || "Remote";
+  }
+}
+
+function createInstanceId(): string {
+  return `instance-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
 export function App() {
   const [error, setError] = useState<string | null>(null);
   const [shellState, setShellState] = useState<ShellState>("booting");
@@ -43,21 +70,39 @@ export function App() {
   const [config, setConfig] = useState<DesktopConfig | null>(null);
   const [activeInstanceId, setActiveInstanceId] = useState<string | null>(null);
   const [setupInitialStep, setSetupInitialStep] = useState<SetupInitialStep>("mode");
+  const [setupInitialInstallDir, setSetupInitialInstallDir] = useState<string | null>(null);
+  const [setupInitialRemoteUrl, setSetupInitialRemoteUrl] = useState<string | null>(null);
   const [frontendReadyPartition, setFrontendReadyPartition] = useState<string | null>(null);
   const [shellAppearance, setShellAppearance] = useState<ShellAppearance>({ appearance: "light" });
+  const [compatibilityWarning, setCompatibilityWarning] = useState<string | null>(null);
+  const [updateState, setUpdateState] = useState<UpdateState>({ status: "idle" });
+  const [updateDialogOpen, setUpdateDialogOpen] = useState(false);
+  const [instancePanelOpen, setInstancePanelOpen] = useState(false);
+  const [startupProgress, setStartupProgress] = useState<StartupProgressEvent | null>(null);
   const frontendWebviewRef = useRef<HTMLElement | null>(null);
+  const lastAutoUpdateCheck = useRef<string | null>(null);
+  const automaticallyOpenedUpdate = useRef<string | null>(null);
+  const activeInstance = config?.instances.find((instance) => instance.id === activeInstanceId) ?? null;
+  const frontendPartition = activeInstanceId ? `persist:openfic-${activeInstanceId}` : "persist:openfic";
+  const canCheckForUpdates = shellState === "frontend" && activeInstance !== null && updateState.status !== "unsupported";
 
   useEffect(() => {
     let cancelled = false;
+    const dispose = window.openficDesktop.onStartupProgress((progress) => {
+      if (!cancelled) setStartupProgress(progress);
+    });
 
     const initialize = async () => {
       try {
+        const currentProgress = await window.openficDesktop.getStartupProgress();
+        if (!cancelled) setStartupProgress(currentProgress);
         const result = await window.openficDesktop.initializeApp();
         const nextConfig = await window.openficDesktop.getConfig();
         if (cancelled) return;
         setConfig(nextConfig);
         setActiveInstanceId(result.activeInstanceId ?? nextConfig?.activeInstanceId ?? null);
         setError(result.message ?? null);
+        setCompatibilityWarning(result.compatibilityWarning ?? null);
         setShellState(result.status === "ready" ? "frontend" : "setup");
       } catch (err) {
         if (cancelled) return;
@@ -70,6 +115,27 @@ export function App() {
 
     return () => {
       cancelled = true;
+      dispose();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!canCheckForUpdates || !activeInstanceId) return;
+    const runtimeKey = `${activeInstanceId}:${webviewKey}`;
+    if (lastAutoUpdateCheck.current === runtimeKey) return;
+    lastAutoUpdateCheck.current = runtimeKey;
+    void window.openficDesktop.checkForUpdate();
+  }, [activeInstanceId, canCheckForUpdates, webviewKey]);
+
+  useEffect(() => {
+    let cancelled = false;
+    void window.openficDesktop.getUpdateState().then((state) => {
+      if (!cancelled) setUpdateState(state);
+    });
+    const dispose = window.openficDesktop.onUpdateState(setUpdateState);
+    return () => {
+      cancelled = true;
+      dispose();
     };
   }, []);
 
@@ -111,9 +177,10 @@ export function App() {
     return nextConfig;
   };
 
-  const showFrontend = async () => {
+  const showFrontend = async (result?: { compatibilityWarning?: string }) => {
     const nextConfig = await refreshConfig();
     setError(null);
+    setCompatibilityWarning(result?.compatibilityWarning ?? null);
     setWebviewKey((key) => key + 1);
     setActiveInstanceId(nextConfig?.activeInstanceId ?? null);
     setShellState("frontend");
@@ -122,6 +189,8 @@ export function App() {
   const handleShowSetup = (target: SetupInitialStep = "mode") => {
     setError(null);
     setSetupInitialStep(target);
+    setSetupInitialInstallDir(null);
+    setSetupInitialRemoteUrl(null);
     setShellState("setup");
   };
 
@@ -132,11 +201,75 @@ export function App() {
 
   const handleSwitchInstance = async (instanceId: string) => {
     setError(null);
-    const result = await window.openficDesktop.switchInstance(instanceId);
-    const nextConfig = await refreshConfig();
-    setActiveInstanceId(result.activeInstanceId ?? nextConfig?.activeInstanceId ?? instanceId);
-    setWebviewKey((key) => key + 1);
-    setShellState(result.status === "ready" ? "frontend" : "setup");
+    setCompatibilityWarning(null);
+    setUpdateDialogOpen(false);
+    setStartupProgress(null);
+    setShellState("booting");
+    try {
+      const result = await window.openficDesktop.switchInstance(instanceId);
+      const nextConfig = await refreshConfig();
+      setActiveInstanceId(result.activeInstanceId ?? nextConfig?.activeInstanceId ?? instanceId);
+      setCompatibilityWarning(result.compatibilityWarning ?? null);
+      setWebviewKey((key) => key + 1);
+      setShellState(result.status === "ready" ? "frontend" : "setup");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "切换实例失败");
+      setShellState("setup");
+    }
+  };
+
+  const handleConnectRemote = async (url: string) => {
+    const normalizedUrl = normalizeRemoteUrl(url);
+    setError(null);
+    setCompatibilityWarning(null);
+    setUpdateDialogOpen(false);
+    setSetupInitialRemoteUrl(normalizedUrl);
+    setStartupProgress(null);
+    setShellState("booting");
+    try {
+      const previousConfig = await window.openficDesktop.getConfig();
+      const existingInstance = previousConfig?.instances.find(
+        (instance) => instance.mode === "remote" && instance.remoteUrl && normalizeRemoteUrl(instance.remoteUrl) === normalizedUrl,
+      );
+      const instance = existingInstance ?? {
+        id: createInstanceId(),
+        name: getRemoteInstanceName(normalizedUrl),
+        mode: "remote" as const,
+        remoteUrl: normalizedUrl,
+        autoStartLocal: false,
+        installDir: null,
+      };
+      const nextConfig: DesktopConfig = {
+        activeInstanceId: instance.id,
+        instances: existingInstance
+          ? previousConfig?.instances ?? [instance]
+          : [...(previousConfig?.instances ?? []), instance],
+      };
+      await window.openficDesktop.saveConfig(nextConfig);
+      const result = await window.openficDesktop.switchInstance(instance.id);
+      await showFrontend(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "无法连接到该地址");
+      setSetupInitialStep("remote");
+      setShellState("setup");
+    }
+  };
+
+  const handleStartLocal = async (installDir: string) => {
+    setError(null);
+    setCompatibilityWarning(null);
+    setUpdateDialogOpen(false);
+    setSetupInitialInstallDir(installDir);
+    setStartupProgress(null);
+    setShellState("booting");
+    try {
+      await window.openficDesktop.startLocalBackend(installDir);
+      await showFrontend();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "启动后端失败");
+      setSetupInitialStep("local-directory");
+      setShellState("setup");
+    }
   };
 
   const handleSaveConfig = async (nextConfig: DesktopConfig) => {
@@ -145,7 +278,26 @@ export function App() {
     setActiveInstanceId(nextConfig.activeInstanceId);
   };
 
-  const frontendPartition = activeInstanceId ? `persist:openfic-${activeInstanceId}` : "persist:openfic";
+  useEffect(() => {
+    if (!canCheckForUpdates) setUpdateDialogOpen(false);
+  }, [canCheckForUpdates]);
+
+  useEffect(() => {
+    if (updateState.status !== "available") {
+      automaticallyOpenedUpdate.current = null;
+      return;
+    }
+    if (compatibilityWarning) {
+      automaticallyOpenedUpdate.current = null;
+      setUpdateDialogOpen(false);
+      return;
+    }
+
+    const updateKey = updateState.version ?? "available";
+    if (automaticallyOpenedUpdate.current === updateKey) return;
+    automaticallyOpenedUpdate.current = updateKey;
+    setUpdateDialogOpen(true);
+  }, [compatibilityWarning, updateState.status, updateState.version]);
 
   useEffect(() => {
     if (shellState !== "frontend") return;
@@ -183,18 +335,54 @@ export function App() {
       <DesktopHeader
         activeInstanceId={activeInstanceId}
         config={config}
-        disabled={shellState === "setup"}
+        disabled={shellState !== "frontend"}
         onAddInstance={handleAddInstance}
         onSaveConfig={handleSaveConfig}
         onSwitchInstance={handleSwitchInstance}
+        instancePanelOpen={instancePanelOpen}
+        onInstancePanelOpenChange={(open) => {
+          setInstancePanelOpen(open);
+          if (open) setUpdateDialogOpen(false);
+        }}
+        canCheckForUpdates={canCheckForUpdates}
+        updateState={updateState}
+        onUpdateAction={() => {
+          setInstancePanelOpen(false);
+          if (!compatibilityWarning) setUpdateDialogOpen(true);
+          if (["idle", "not-available", "error"].includes(updateState.status)) {
+            void window.openficDesktop.checkForUpdate();
+          }
+        }}
       />
       <section className="desktop-content">
-        {shellState === "booting" ? <BootPage error={error} /> : null}
-        {shellState === "setup" ? <SetupPage onFinished={() => void showFrontend()} initialStep={setupInitialStep} /> : null}
+        {shellState === "booting" ? <BootPage error={error} progress={startupProgress} /> : null}
+        {shellState === "setup" ? (
+          <SetupPage
+            initialError={error}
+            initialInstallDir={setupInitialInstallDir}
+            initialStep={setupInitialStep}
+            initialRemoteUrl={setupInitialRemoteUrl}
+            onClearError={() => setError(null)}
+            onConnectRemote={(url) => void handleConnectRemote(url)}
+            onStartLocal={(installDir) => void handleStartLocal(installDir)}
+          />
+        ) : null}
         {shellState === "frontend" && frontendReadyPartition ? (
           <FrontendPage webviewKey={webviewKey} partition={frontendReadyPartition} webviewRef={frontendWebviewRef} />
         ) : null}
       </section>
+      <DesktopNotices
+        compatibilityWarning={compatibilityWarning}
+        updateDialogOpen={updateDialogOpen}
+        updateState={updateState}
+        onCheckForUpdate={() => void window.openficDesktop.checkForUpdate()}
+        onDownloadUpdate={() => void window.openficDesktop.downloadUpdate()}
+        onCancelDownload={() => void window.openficDesktop.cancelUpdateDownload()}
+        onInstallUpdate={() => void window.openficDesktop.installUpdate()}
+        onOpenRelease={() => void window.openficDesktop.openUpdateRelease()}
+        onCloseCompatibilityWarning={() => setCompatibilityWarning(null)}
+        onCloseUpdateDialog={() => setUpdateDialogOpen(false)}
+      />
     </main>
   );
 }

--- a/desktop/src/ui/components/desktop-notices.tsx
+++ b/desktop/src/ui/components/desktop-notices.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useState } from "react";
+import { AlertTriangle, ChevronRight, Download, ExternalLink, PackageSearch, RefreshCw, RotateCcw, X } from "lucide-react";
+import ReactMarkdown from "react-markdown";
+import type { UpdateState } from "../../shared/ipc";
+
+interface DesktopNoticesProps {
+  compatibilityWarning: string | null;
+  updateDialogOpen: boolean;
+  updateState: UpdateState;
+  onCheckForUpdate: () => void;
+  onDownloadUpdate: () => void;
+  onCancelDownload: () => void;
+  onInstallUpdate: () => void;
+  onOpenRelease: () => void;
+  onCloseCompatibilityWarning: () => void;
+  onCloseUpdateDialog: () => void;
+}
+
+function formatBytes(bytes: number | undefined): string {
+  if (!bytes) return "0 B";
+  const units = ["B", "KB", "MB", "GB"];
+  const unitIndex = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / 1024 ** unitIndex;
+  return `${value.toFixed(value >= 100 ? 0 : 1)} ${units[unitIndex]}`;
+}
+
+function getReleaseNotesText(releaseNotes: string | undefined, fallback: string): string {
+  return releaseNotes || fallback;
+}
+
+function ReleaseNotes({ releaseNotes }: { releaseNotes: string }) {
+  return (
+    <div className="desktop-release-notes-content">
+      <ReactMarkdown
+        components={{
+          a: ({ href, children }) => <a href={href} target="_blank" rel="noreferrer">{children}</a>,
+        }}
+      >
+        {releaseNotes}
+      </ReactMarkdown>
+    </div>
+  );
+}
+
+export function DesktopNotices({
+  compatibilityWarning,
+  updateDialogOpen,
+  updateState,
+  onCheckForUpdate,
+  onDownloadUpdate,
+  onCancelDownload,
+  onInstallUpdate,
+  onOpenRelease,
+  onCloseCompatibilityWarning,
+  onCloseUpdateDialog,
+}: DesktopNoticesProps) {
+  const [updatePanelVisible, setUpdatePanelVisible] = useState(false);
+  const [releaseNotesOpen, setReleaseNotesOpen] = useState(true);
+  const releaseNotes = getReleaseNotesText(updateState.releaseNotes, "本次更新包含稳定性改进与体验优化。");
+  const hasVersionDetails = ["available", "downloading", "downloaded"].includes(updateState.status);
+
+  useEffect(() => {
+    if (updateDialogOpen) {
+      setUpdatePanelVisible(true);
+      return;
+    }
+
+    const timeout = window.setTimeout(() => setUpdatePanelVisible(false), 160);
+    return () => window.clearTimeout(timeout);
+  }, [updateDialogOpen]);
+
+  const showUpdatePanel = !compatibilityWarning && updatePanelVisible;
+  if (!compatibilityWarning && !showUpdatePanel) return null;
+
+  return (
+    <>
+      {compatibilityWarning ? (
+        <aside className="desktop-notices" aria-live="polite">
+          <section className="desktop-notice desktop-notice-warning" role="status">
+            <AlertTriangle size={17} strokeWidth={2} aria-hidden="true" />
+            <p>{compatibilityWarning}</p>
+            <button
+              className="desktop-notice-warning-dismiss"
+              type="button"
+              aria-label="关闭兼容性提示"
+              onClick={onCloseCompatibilityWarning}
+            >
+              <X size={16} strokeWidth={2} />
+            </button>
+          </section>
+        </aside>
+      ) : null}
+      {showUpdatePanel ? (
+        <>
+          <button
+            className="desktop-update-panel-scrim"
+            data-state={updateDialogOpen ? "open" : "closed"}
+            type="button"
+            aria-label="关闭更新面板"
+            onClick={onCloseUpdateDialog}
+          />
+          <aside className="desktop-notice desktop-notice-update desktop-update-panel" data-state={updateDialogOpen ? "open" : "closed"} role="status" aria-live="polite">
+            {!hasVersionDetails ? (
+              <button className="desktop-notice-dismiss" type="button" aria-label="关闭更新提示" onClick={onCloseUpdateDialog}>
+                <X size={16} strokeWidth={2} />
+              </button>
+            ) : null}
+            {updateState.status === "checking" || updateState.status === "idle" ? (
+              <div className="desktop-update-simple-state">
+                <p className="desktop-notice-title">正在检查更新</p>
+                <p>正在连接更新服务，请稍候。</p>
+              </div>
+            ) : null}
+            {updateState.status === "not-available" ? (
+              <div className="desktop-update-simple-state">
+                <p className="desktop-notice-title">已是最新版本</p>
+                <p>当前安装的 OpenFic 已是最新版本。</p>
+              </div>
+            ) : null}
+            {hasVersionDetails ? (
+              <>
+                <div className="desktop-update-heading">
+                  <p className="desktop-notice-title">
+                    <PackageSearch size={16} strokeWidth={2} aria-hidden="true" />
+                    发现新版本 <span>v{updateState.version}</span>
+                  </p>
+                  <button className="desktop-notice-dismiss" type="button" aria-label="关闭更新提示" onClick={onCloseUpdateDialog}>
+                    <X size={16} strokeWidth={2} />
+                  </button>
+                </div>
+                <section className="desktop-update-release-section">
+                  <div className="desktop-release-notes-header">
+                    <button
+                      className="desktop-release-notes-toggle"
+                      type="button"
+                      aria-expanded={releaseNotesOpen}
+                      onClick={() => setReleaseNotesOpen((open) => !open)}
+                    >
+                      <span>更新日志</span>
+                      <ChevronRight size={16} strokeWidth={2} />
+                    </button>
+                    <button className="desktop-release-details" type="button" onClick={onOpenRelease}>
+                      查看详情
+                      <ExternalLink size={12} strokeWidth={2} aria-hidden="true" />
+                    </button>
+                  </div>
+                  {releaseNotesOpen ? <ReleaseNotes releaseNotes={releaseNotes} /> : null}
+                </section>
+              </>
+            ) : null}
+            {updateState.status === "available" ? (
+              <>
+                <footer className="desktop-update-footer">
+                  <button className="desktop-notice-primary" type="button" onClick={onDownloadUpdate}>
+                    <Download size={15} strokeWidth={2} />
+                    开始下载
+                  </button>
+                </footer>
+              </>
+            ) : null}
+            {updateState.status === "downloading" ? (
+              <section className="desktop-download-state">
+                <div className="desktop-download-heading">
+                  <span>下载中</span>
+                  <button type="button" onClick={onCancelDownload}>取消</button>
+                  <strong>{Math.round((updateState.progress ?? 0) * 100)}%</strong>
+                </div>
+                <div className="desktop-update-progress" aria-label={`下载进度 ${Math.round((updateState.progress ?? 0) * 100)}%`}>
+                  <span style={{ width: `${Math.min(Math.max(updateState.progress ?? 0, 0), 1) * 100}%` }} />
+                </div>
+                <div className="desktop-download-metrics">
+                  <span>{formatBytes(updateState.transferred)}</span>
+                  <span>{formatBytes(updateState.bytesPerSecond)}/s</span>
+                </div>
+              </section>
+            ) : null}
+            {updateState.status === "downloaded" ? (
+              <footer className="desktop-update-footer">
+                <button className="desktop-notice-primary" type="button" onClick={onInstallUpdate}>
+                  <RotateCcw size={15} strokeWidth={2} />
+                  重启并安装
+                </button>
+              </footer>
+            ) : null}
+            {updateState.status === "error" ? (
+              <div className="desktop-update-simple-state">
+                <p className="desktop-notice-title">检查更新失败</p>
+                <p>{updateState.message ?? "更新服务暂时不可用。"}</p>
+                <button className="desktop-notice-secondary" type="button" onClick={onCheckForUpdate}>
+                  <RefreshCw size={15} strokeWidth={2} />
+                  重试
+                </button>
+              </div>
+            ) : null}
+          </aside>
+        </>
+      ) : null}
+    </>
+  );
+}

--- a/desktop/src/ui/components/header.tsx
+++ b/desktop/src/ui/components/header.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useState, type MouseEvent } from "react";
+import { useEffect, useState, type CSSProperties, type MouseEvent } from "react";
 import { Link2, Link2Off, Minus, Plus, RefreshCw, Square, Star, Trash2, X } from "lucide-react";
 import type { DesktopConfig, DesktopInstance } from "../../shared/config";
+import type { UpdateState } from "../../shared/ipc";
 
 interface DesktopHeaderProps {
   activeInstanceId: string | null;
@@ -9,6 +10,11 @@ interface DesktopHeaderProps {
   onAddInstance: () => void;
   onSaveConfig: (config: DesktopConfig) => Promise<void>;
   onSwitchInstance: (instanceId: string) => Promise<void>;
+  instancePanelOpen: boolean;
+  onInstancePanelOpenChange: (open: boolean) => void;
+  canCheckForUpdates: boolean;
+  updateState: UpdateState;
+  onUpdateAction: () => void;
 }
 
 type PingState =
@@ -33,14 +39,46 @@ function sortInstances(instances: DesktopInstance[]): DesktopInstance[] {
   return [...instances].sort((left, right) => Number(Boolean(right.favorite)) - Number(Boolean(left.favorite)));
 }
 
-export function DesktopHeader({ activeInstanceId, config, disabled, onAddInstance, onSaveConfig, onSwitchInstance }: DesktopHeaderProps) {
-  const [panelOpen, setPanelOpen] = useState(false);
+export function DesktopHeader({
+  activeInstanceId,
+  config,
+  disabled,
+  onAddInstance,
+  onSaveConfig,
+  onSwitchInstance,
+  instancePanelOpen,
+  onInstancePanelOpenChange,
+  canCheckForUpdates,
+  updateState,
+  onUpdateAction,
+}: DesktopHeaderProps) {
   const [panelVisible, setPanelVisible] = useState(false);
   const [pingStates, setPingStates] = useState<Record<string, PingState>>({});
   const [switchingId, setSwitchingId] = useState<string | null>(null);
-  const rootRef = useRef<HTMLDivElement | null>(null);
   const instances = sortInstances(config?.instances ?? []);
   const hasUsableRuntime = instances.some((instance) => pingStates[instance.id]?.status === "ok") || Boolean(activeInstanceId);
+  const updateProgress = Math.min(Math.max(updateState.progress ?? 0, 0), 1);
+  const updateProgressStyle = { "--update-progress": String(updateProgress) } as CSSProperties;
+  const isCheckingForUpdate = updateState.status === "checking";
+  const isDownloadingUpdate = updateState.status === "downloading";
+  const updateIconState = isCheckingForUpdate
+    ? "checking"
+    : isDownloadingUpdate
+      ? "downloading"
+      : updateState.status === "available" || updateState.status === "downloaded"
+        ? "available"
+        : updateState.status === "error"
+          ? "error"
+          : "idle";
+  const updateAriaLabel = isDownloadingUpdate
+    ? `正在下载更新，${Math.round(updateProgress * 100)}%`
+    : isCheckingForUpdate
+      ? "正在检查更新"
+      : updateIconState === "available"
+        ? "发现更新"
+        : updateIconState === "error"
+          ? "更新失败，点击重试"
+          : "检查更新";
 
   const refreshPings = () => {
     if (!instances.length) return;
@@ -66,40 +104,32 @@ export function DesktopHeader({ activeInstanceId, config, disabled, onAddInstanc
   };
 
   useEffect(() => {
-    if (panelOpen) refreshPings();
-  }, [panelOpen, config?.activeInstanceId, instances.length]);
+    if (instancePanelOpen) refreshPings();
+  }, [instancePanelOpen, config?.activeInstanceId, instances.length]);
 
   useEffect(() => {
-    if (panelOpen) {
+    if (instancePanelOpen) {
       setPanelVisible(true);
       return;
     }
 
     const timeout = window.setTimeout(() => setPanelVisible(false), 160);
     return () => window.clearTimeout(timeout);
-  }, [panelOpen]);
-
-  useEffect(() => {
-    const handlePointerDown = (event: PointerEvent) => {
-      if (!rootRef.current?.contains(event.target as Node)) setPanelOpen(false);
-    };
-    document.addEventListener("pointerdown", handlePointerDown);
-    return () => document.removeEventListener("pointerdown", handlePointerDown);
-  }, []);
+  }, [instancePanelOpen]);
 
   const handleSwitch = async (instanceId: string) => {
     if (instanceId === activeInstanceId || switchingId) return;
     setSwitchingId(instanceId);
     try {
       await onSwitchInstance(instanceId);
-      setPanelOpen(false);
+      onInstancePanelOpenChange(false);
     } finally {
       setSwitchingId(null);
     }
   };
 
   const handleAddInstance = () => {
-    setPanelOpen(false);
+    onInstancePanelOpenChange(false);
     onAddInstance();
   };
 
@@ -131,7 +161,7 @@ export function DesktopHeader({ activeInstanceId, config, disabled, onAddInstanc
     await onSaveConfig(nextConfig);
     if (config.activeInstanceId === instance.id && nextActiveInstanceId) {
       await onSwitchInstance(nextActiveInstanceId);
-      setPanelOpen(false);
+      onInstancePanelOpenChange(false);
     }
   };
 
@@ -139,14 +169,32 @@ export function DesktopHeader({ activeInstanceId, config, disabled, onAddInstanc
     <header className="desktop-header">
       <div className="desktop-titlebar-brand">OpenFic</div>
       <div className="desktop-titlebar-actions">
-        <div className="instance-switcher" ref={rootRef}>
+        <button
+          className="titlebar-button titlebar-update-button"
+          data-update-state={updateIconState}
+          aria-label={updateAriaLabel}
+          aria-busy={isCheckingForUpdate || isDownloadingUpdate}
+          type="button"
+          disabled={!canCheckForUpdates}
+          onClick={onUpdateAction}
+        >
+          {isCheckingForUpdate ? <RefreshCw className="titlebar-update-checking" size={15} strokeWidth={2} /> : null}
+          {isDownloadingUpdate ? (
+            <svg className="titlebar-update-progress" style={updateProgressStyle} viewBox="0 0 20 20" aria-hidden="true">
+              <circle className="titlebar-update-progress-track" cx="10" cy="10" r="7" />
+              <circle className="titlebar-update-progress-value" cx="10" cy="10" r="7" />
+            </svg>
+          ) : null}
+          {!isCheckingForUpdate && !isDownloadingUpdate ? <RefreshCw size={15} strokeWidth={2} /> : null}
+        </button>
+        <div className="instance-switcher">
           <button
             className="titlebar-button titlebar-link-button"
             data-connected={hasUsableRuntime}
             aria-label="实例"
             type="button"
             disabled={disabled}
-            onClick={() => setPanelOpen((open) => !open)}
+            onClick={() => onInstancePanelOpenChange(!instancePanelOpen)}
           >
             {hasUsableRuntime ? <Link2 size={15} strokeWidth={2} /> : <Link2Off size={15} strokeWidth={2} />}
           </button>
@@ -154,12 +202,12 @@ export function DesktopHeader({ activeInstanceId, config, disabled, onAddInstanc
             <>
               <button
                 className="instance-panel-scrim"
-                data-state={panelOpen ? "open" : "closed"}
+                data-state={instancePanelOpen ? "open" : "closed"}
                 type="button"
                 aria-label="关闭实例面板"
-                onClick={() => setPanelOpen(false)}
+                onClick={() => onInstancePanelOpenChange(false)}
               />
-              <div className="instance-panel" data-state={panelOpen ? "open" : "closed"} role="dialog" aria-label="实例">
+              <div className="instance-panel" data-state={instancePanelOpen ? "open" : "closed"} role="dialog" aria-label="实例">
                 <div className="instance-panel-head">
                   <div>
                     <p className="instance-panel-title">切换实例</p>

--- a/desktop/src/ui/components/startup-progress.tsx
+++ b/desktop/src/ui/components/startup-progress.tsx
@@ -1,0 +1,37 @@
+import type { StartupProgressEvent } from "../../shared/ipc";
+
+interface StartupProgressProps {
+  progress: StartupProgressEvent | null;
+  bare?: boolean;
+}
+
+export function StartupProgress({ progress, bare = false }: StartupProgressProps) {
+  const value = Math.round((progress?.progress ?? 0) * 100);
+  const title = progress?.title ?? "正在准备 OpenFic";
+  const message = progress?.message ?? "正在初始化启动服务";
+
+  return (
+    <section
+      className="startup-progress"
+      data-bare={bare}
+      data-status={progress?.status ?? "running"}
+      aria-live="polite"
+    >
+      <div className="startup-progress-heading">
+        <strong>{title}</strong>
+        <span>{value}%</span>
+      </div>
+      <div
+        className="startup-progress-track"
+        role="progressbar"
+        aria-label={title}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={value}
+      >
+        <span style={{ width: `${value}%` }} />
+      </div>
+      <p>{message}</p>
+    </section>
+  );
+}

--- a/desktop/src/ui/global.d.ts
+++ b/desktop/src/ui/global.d.ts
@@ -1,9 +1,11 @@
 import type { DesktopConfig } from "../shared/config";
 import type {
-  CheckDirectoryEmptyResult,
+  InspectLocalRuntimeResult,
   InitializeAppResult,
   PingInstanceResult,
   SetupProgressEvent,
+  StartupProgressEvent,
+  UpdateState,
 } from "../shared/ipc";
 import type { DesktopInstance } from "../shared/config";
 
@@ -21,14 +23,23 @@ declare global {
       switchInstance: (instanceId: string) => Promise<InitializeAppResult>;
       pingInstance: (instance: DesktopInstance) => Promise<PingInstanceResult>;
       selectDirectory: () => Promise<string | null>;
-      checkDirectoryEmpty: (dirPath: string) => Promise<CheckDirectoryEmptyResult>;
+      inspectLocalRuntime: (installDir: string) => Promise<InspectLocalRuntimeResult>;
       closeSetup: () => Promise<void>;
       showSetup: () => Promise<void>;
       frontendHostPreloadPath: string;
       minimizeWindow: () => Promise<void>;
       toggleMaximizeWindow: () => Promise<void>;
       closeWindow: () => Promise<void>;
+      getUpdateState: () => Promise<UpdateState>;
+      getStartupProgress: () => Promise<StartupProgressEvent | null>;
+      checkForUpdate: () => Promise<void>;
+      downloadUpdate: () => Promise<void>;
+      cancelUpdateDownload: () => Promise<void>;
+      installUpdate: () => Promise<void>;
+      openUpdateRelease: () => Promise<void>;
       onSetupProgress: (handler: (event: SetupProgressEvent) => void) => () => void;
+      onStartupProgress: (handler: (event: StartupProgressEvent) => void) => () => void;
+      onUpdateState: (handler: (state: UpdateState) => void) => () => void;
     };
   }
 }

--- a/desktop/src/ui/pages/boot/page.tsx
+++ b/desktop/src/ui/pages/boot/page.tsx
@@ -1,19 +1,18 @@
+import { StartupProgress } from "../../components/startup-progress";
+import type { StartupProgressEvent } from "../../../shared/ipc";
+
 interface BootPageProps {
   error: string | null;
+  progress: StartupProgressEvent | null;
 }
 
-export function BootPage({ error }: BootPageProps) {
+export function BootPage({ error, progress }: BootPageProps) {
   return (
-    <section className="content-page content-page-centered">
-      <section className="setup-card">
-        <p className="eyebrow">OpenFic Desktop</p>
-        <h1>正在准备 OpenFic</h1>
-        <p className="description">正在检查现有配置与后端状态。</p>
-        <div className="boot-state">
-          <div className="boot-spinner" aria-hidden="true" />
-          {error ? <p className="error">{error}</p> : null}
-        </div>
-      </section>
+    <section className="content-page content-page-centered startup-page">
+      <div className="boot-state">
+        <StartupProgress bare progress={progress} />
+        {error ? <p className="error">{error}</p> : null}
+      </div>
     </section>
   );
 }

--- a/desktop/src/ui/pages/setup/page.tsx
+++ b/desktop/src/ui/pages/setup/page.tsx
@@ -11,8 +11,7 @@ import {
   Server,
   X,
 } from "lucide-react";
-import type { DesktopConfig } from "../../../shared/config";
-import type { SetupProgressEvent, SetupStep } from "../../../shared/ipc";
+import type { InspectLocalRuntimeResult, SetupProgressEvent, SetupStep } from "../../../shared/ipc";
 import "./setup.css";
 
 type WizardStep = "mode" | "remote" | "local-directory" | "local-installing" | "local-success";
@@ -51,34 +50,20 @@ const INITIAL_STEPS: StepState = {
   "install-openfic": { status: "pending", message: "" },
 };
 
+function getRuntimeDisplayPath(installDir: string): string {
+  if (!installDir) return "";
+  const separator = installDir.includes("\\") ? "\\" : "/";
+  return `${installDir.replace(/[\\/]+$/, "")}${separator}runtime`;
+}
+
 interface SetupPageProps {
-  initialStep?: "mode" | "remote";
-  onFinished: () => void;
-}
-
-function createInstanceId(): string {
-  return `instance-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
-}
-
-function getRemoteInstanceName(url: string): string {
-  try {
-    return new URL(url).host || "Remote";
-  } catch {
-    return url || "Remote";
-  }
-}
-
-function normalizeRemoteUrl(url: string): string {
-  const trimmed = url.trim().replace(/\/+$/, "");
-  try {
-    const parsed = new URL(trimmed);
-    parsed.protocol = parsed.protocol.toLowerCase();
-    parsed.hostname = parsed.hostname.toLowerCase();
-    parsed.pathname = parsed.pathname.replace(/\/+$/, "");
-    return parsed.toString().replace(/\/+$/, "");
-  } catch {
-    return trimmed;
-  }
+  initialStep?: "mode" | "remote" | "local-directory" | "local-success";
+  initialError?: string | null;
+  initialInstallDir?: string | null;
+  initialRemoteUrl?: string | null;
+  onClearError: () => void;
+  onConnectRemote: (url: string) => void;
+  onStartLocal: (installDir: string) => void;
 }
 
 function applyProgress(prev: StepState, event: SetupProgressEvent): StepState {
@@ -100,18 +85,22 @@ function applyProgress(prev: StepState, event: SetupProgressEvent): StepState {
   return next;
 }
 
-export function SetupPage({ initialStep = "mode", onFinished }: SetupPageProps) {
+export function SetupPage({
+  initialStep = "mode",
+  initialError,
+  initialInstallDir,
+  initialRemoteUrl,
+  onClearError,
+  onConnectRemote,
+  onStartLocal,
+}: SetupPageProps) {
   const [step, setStep] = useState<WizardStep>(initialStep);
-  const [remoteUrl, setRemoteUrl] = useState("http://127.0.0.1:8000");
+  const [remoteUrl, setRemoteUrl] = useState(initialRemoteUrl ?? "http://127.0.0.1:8000");
   const [installDir, setInstallDir] = useState("");
-  const [dirCheck, setDirCheck] = useState<{ exists: boolean; empty: boolean } | null>(null);
-  const [dirChecking, setDirChecking] = useState(false);
-  const [connecting, setConnecting] = useState(false);
-  const [remoteError, setRemoteError] = useState<string | null>(null);
+  const [runtimeInspection, setRuntimeInspection] = useState<InspectLocalRuntimeResult | null>(null);
+  const [runtimeChecking, setRuntimeChecking] = useState(false);
   const [steps, setSteps] = useState<StepState>(INITIAL_STEPS);
   const [installError, setInstallError] = useState<string | null>(null);
-  const [startingBackend, setStartingBackend] = useState(false);
-  const [startError, setStartError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
@@ -121,33 +110,32 @@ export function SetupPage({ initialStep = "mode", onFinished }: SetupPageProps) 
     ]).then(([defaultDir, config]) => {
       if (cancelled) return;
       const localInstance = config?.instances.find((instance) => instance.mode === "local");
-      setInstallDir(localInstance?.installDir ?? defaultDir);
+      setInstallDir(initialInstallDir ?? localInstance?.installDir ?? defaultDir);
       const activeInstance = config?.instances.find((instance) => instance.id === config.activeInstanceId);
-      if (activeInstance?.mode === "remote" && activeInstance.remoteUrl) setRemoteUrl(activeInstance.remoteUrl);
+      if (!initialRemoteUrl && activeInstance?.mode === "remote" && activeInstance.remoteUrl) {
+        setRemoteUrl(activeInstance.remoteUrl);
+      }
     });
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [initialInstallDir, initialRemoteUrl]);
 
   useEffect(() => {
     if (!installDir || step !== "local-directory") return;
     let cancelled = false;
-    setDirChecking(true);
-    setDirCheck(null);
+    setRuntimeChecking(true);
+    setRuntimeInspection(null);
     void window.openficDesktop
-      .checkDirectoryEmpty(installDir)
+      .inspectLocalRuntime(installDir)
       .then((result) => {
         if (!cancelled) {
-          setDirCheck(result);
-          setDirChecking(false);
+          setRuntimeInspection(result);
+          setRuntimeChecking(false);
         }
       })
       .catch(() => {
-        if (!cancelled) {
-          setDirCheck(null);
-          setDirChecking(false);
-        }
+        if (!cancelled) setRuntimeChecking(false);
       });
     return () => {
       cancelled = true;
@@ -162,11 +150,13 @@ export function SetupPage({ initialStep = "mode", onFinished }: SetupPageProps) 
   }, []);
 
   const pickDirectory = async () => {
+    onClearError();
     const picked = await window.openficDesktop.selectDirectory();
     if (picked) setInstallDir(picked);
   };
 
   const beginInstall = async () => {
+    onClearError();
     setStep("local-installing");
     setSteps(INITIAL_STEPS);
     setInstallError(null);
@@ -178,87 +168,30 @@ export function SetupPage({ initialStep = "mode", onFinished }: SetupPageProps) 
     }
   };
 
-  const connectRemote = async () => {
-    setConnecting(true);
-    setRemoteError(null);
-    try {
-      const normalizedRemoteUrl = normalizeRemoteUrl(remoteUrl);
-      await window.openficDesktop.checkRemote(normalizedRemoteUrl);
-      const previousConfig = await window.openficDesktop.getConfig();
-      const existingInstance = previousConfig?.instances.find(
-        (item) => item.mode === "remote" && item.remoteUrl && normalizeRemoteUrl(item.remoteUrl) === normalizedRemoteUrl,
-      );
-
-      if (existingInstance) {
-        const config: DesktopConfig = {
-          activeInstanceId: existingInstance.id,
-          instances: previousConfig?.instances ?? [existingInstance],
-        };
-        await window.openficDesktop.saveConfig(config);
-        await window.openficDesktop.switchInstance(existingInstance.id);
-        onFinished();
-        return;
-      }
-
-      const instance = {
-        id: createInstanceId(),
-        name: getRemoteInstanceName(normalizedRemoteUrl),
-        mode: "remote" as const,
-        remoteUrl: normalizedRemoteUrl,
-        autoStartLocal: false,
-        installDir: null,
-      };
-      const config: DesktopConfig = {
-        activeInstanceId: instance.id,
-        instances: [...(previousConfig?.instances ?? []), instance],
-      };
-      await window.openficDesktop.saveConfig(config);
-      await window.openficDesktop.switchInstance(instance.id);
-      onFinished();
-    } catch (err) {
-      setRemoteError(err instanceof Error ? err.message : "无法连接到该地址");
-    } finally {
-      setConnecting(false);
-    }
-  };
-
-  const startUsing = async () => {
-    setStartingBackend(true);
-    setStartError(null);
-    try {
-      await window.openficDesktop.startLocalBackend(installDir);
-      const previousConfig = await window.openficDesktop.getConfig();
-      const instance = {
-        id: createInstanceId(),
-        name: "Local",
-        mode: "local" as const,
-        remoteUrl: null,
-        autoStartLocal: true,
-        installDir,
-      };
-      const config: DesktopConfig = {
-        activeInstanceId: instance.id,
-        instances: [...(previousConfig?.instances ?? []), instance],
-      };
-      await window.openficDesktop.saveConfig(config);
-      await window.openficDesktop.switchInstance(instance.id);
-      onFinished();
-    } catch (err) {
-      setStartError(err instanceof Error ? err.message : "启动后端失败");
-    } finally {
-      setStartingBackend(false);
-    }
-  };
-
   const goBack = () => {
-    if (step === "remote" || step === "local-directory") setStep("mode");
+    if (step === "remote" || step === "local-directory") {
+      onClearError();
+      setStep("mode");
+    }
+  };
+
+  const selectMode = (nextStep: "remote" | "local-directory") => {
+    onClearError();
+    setStep(nextStep);
   };
 
   const canGoBack = step === "remote" || step === "local-directory";
 
-  const dirIsClean = dirCheck?.exists === true && dirCheck.empty;
-  const dirNeedsCreate = dirCheck?.exists === false;
-  const dirIsOccupied = dirCheck?.exists === true && !dirCheck.empty;
+  const runtimeIsReady = runtimeInspection?.status === "ready";
+  const runtimeNeedsRepair = runtimeInspection?.status === "incomplete";
+  const configuredInstance = runtimeInspection?.configuredInstance ?? null;
+  const primaryActionLabel = runtimeIsReady
+    ? configuredInstance
+      ? "使用已有实例"
+      : "使用已有运行环境"
+    : runtimeNeedsRepair
+      ? "修复运行环境"
+      : "开始安装";
 
   return (
     <section className="content-page content-page-centered">
@@ -272,7 +205,7 @@ export function SetupPage({ initialStep = "mode", onFinished }: SetupPageProps) 
               </button>
             ) : null}
             <div className="setup-heading">
-              <p className="eyebrow">{EYEBROW[step]}</p>
+              {EYEBROW[step] ? <p className="eyebrow">{EYEBROW[step]}</p> : null}
               <h1>{TITLE[step]}</h1>
               {DESCRIPTION[step] ? <p className="description">{DESCRIPTION[step]}</p> : null}
             </div>
@@ -280,9 +213,17 @@ export function SetupPage({ initialStep = "mode", onFinished }: SetupPageProps) 
         ) : null}
 
         <div className="setup-step-enter" key={step}>
+          {initialError ? (
+            <div className="setup-startup-error">
+              <div className="setup-alert setup-alert-error">
+                <AlertTriangle size={16} strokeWidth={2} className="setup-alert-icon" />
+                <span>{initialError}</span>
+              </div>
+            </div>
+          ) : null}
           {step === "mode" ? (
             <div className="setup-choices">
-              <button className="setup-choice" type="button" onClick={() => setStep("remote")}>
+              <button className="setup-choice" type="button" onClick={() => selectMode("remote")}>
                 <span className="setup-choice-icon">
                   <Server size={20} strokeWidth={2} />
                 </span>
@@ -295,7 +236,7 @@ export function SetupPage({ initialStep = "mode", onFinished }: SetupPageProps) 
                   <ArrowRight size={15} strokeWidth={2} />
                 </span>
               </button>
-              <button className="setup-choice" type="button" onClick={() => setStep("local-directory")}>
+              <button className="setup-choice" type="button" onClick={() => selectMode("local-directory")}>
                 <span className="setup-choice-icon">
                   <HardDriveDownload size={20} strokeWidth={2} />
                 </span>
@@ -317,38 +258,25 @@ export function SetupPage({ initialStep = "mode", onFinished }: SetupPageProps) 
                 <span className="setup-field-label">后端服务地址</span>
                 <input
                   value={remoteUrl}
-                  onChange={(event) => setRemoteUrl(event.target.value)}
+                  onChange={(event) => {
+                    onClearError();
+                    setRemoteUrl(event.target.value);
+                  }}
                   placeholder="http://127.0.0.1:8000"
-                  disabled={connecting}
                   onKeyDown={(event) => {
-                    if (event.key === "Enter") void connectRemote();
+                    if (event.key === "Enter" && remoteUrl.trim()) onConnectRemote(remoteUrl);
                   }}
                 />
-                <span className="setup-field-hint">我们将通过健康检查接口确认服务可用。</span>
               </label>
-
-              {connecting ? (
-                <div className="setup-status">
-                  <div className="setup-step-spinner" style={{ width: 20, height: 20, borderWidth: 3 }} />
-                  <span className="setup-status-text">正在连接 {remoteUrl} …</span>
-                </div>
-              ) : null}
-
-              {remoteError ? (
-                <div className="setup-alert setup-alert-error">
-                  <AlertTriangle size={16} strokeWidth={2} className="setup-alert-icon" />
-                  <span>{remoteError}</span>
-                </div>
-              ) : null}
 
               <div className="setup-actions">
                 <button
                   className="primary-button"
                   type="button"
-                  disabled={connecting || !remoteUrl.trim()}
-                  onClick={() => void connectRemote()}
+                  disabled={!remoteUrl.trim()}
+                  onClick={() => onConnectRemote(remoteUrl)}
                 >
-                  {connecting ? "连接中…" : "连接"}
+                  连接
                 </button>
               </div>
             </div>
@@ -357,46 +285,43 @@ export function SetupPage({ initialStep = "mode", onFinished }: SetupPageProps) 
           {step === "local-directory" ? (
             <div className="setup-form">
               <div className="setup-field">
-                <span className="setup-field-label">安装目录</span>
+                <span className="setup-field-label">运行环境目录</span>
                 <div className="setup-dir-row">
-                  <span className="setup-dir-value" data-empty={!installDir} title={installDir}>
-                    {installDir || "正在读取默认目录…"}
+                  <span className="setup-dir-value" data-empty={!installDir} title={getRuntimeDisplayPath(installDir)}>
+                    {getRuntimeDisplayPath(installDir) || "正在读取默认目录…"}
                   </span>
                   <button className="setup-secondary-button" type="button" onClick={() => void pickDirectory()}>
                     <FolderOpen size={15} strokeWidth={2} style={{ verticalAlign: "-2px", marginRight: 6 }} />
                     选择目录
                   </button>
                 </div>
-                <span className="setup-field-hint">运行环境将安装到该目录下的 runtime 子目录，不会删除已有文件。</span>
               </div>
 
-              {dirChecking ? (
+              {runtimeChecking ? (
                 <div className="setup-status">
                   <div className="setup-step-spinner" style={{ width: 18, height: 18, borderWidth: 2 }} />
-                  <span className="setup-status-text">正在检查目录…</span>
+                  <span className="setup-status-text">正在检查已有运行环境…</span>
                 </div>
               ) : null}
 
-              {dirIsOccupied ? (
+              {runtimeIsReady && configuredInstance ? (
+                <div className="setup-alert setup-alert-success">
+                  <Check size={16} strokeWidth={2.5} className="setup-alert-icon" />
+                  <span>此目录已有已配置且完整的本地实例“{configuredInstance.name}”，将直接启动该实例。</span>
+                </div>
+              ) : null}
+
+              {runtimeIsReady && !configuredInstance ? (
+                <div className="setup-alert setup-alert-success">
+                  <Check size={16} strokeWidth={2.5} className="setup-alert-icon" />
+                  <span>检测到完整的本地运行环境，启动后将添加为本地实例。</span>
+                </div>
+              ) : null}
+
+              {runtimeNeedsRepair ? (
                 <div className="setup-alert setup-alert-warning">
                   <AlertTriangle size={16} strokeWidth={2} className="setup-alert-icon" />
-                  <span>
-                    该目录非空。继续安装将在其中创建 runtime 子目录，不会影响已有文件；如需使用空目录，请选择其他目录。
-                  </span>
-                </div>
-              ) : null}
-
-              {dirNeedsCreate ? (
-                <div className="setup-alert setup-alert-success">
-                  <Check size={16} strokeWidth={2.5} className="setup-alert-icon" />
-                  <span>该目录不存在，安装时将自动创建。</span>
-                </div>
-              ) : null}
-
-              {dirIsClean ? (
-                <div className="setup-alert setup-alert-success">
-                  <Check size={16} strokeWidth={2.5} className="setup-alert-icon" />
-                  <span>目录为空，可以开始安装。</span>
+                  <span>检测到不完整的本地运行环境：{runtimeInspection.message}。继续将修复缺失或损坏的组件。</span>
                 </div>
               ) : null}
 
@@ -404,10 +329,16 @@ export function SetupPage({ initialStep = "mode", onFinished }: SetupPageProps) 
                 <button
                   className="primary-button"
                   type="button"
-                  disabled={!installDir || dirChecking || !dirCheck}
-                  onClick={() => void beginInstall()}
+                  disabled={!installDir || runtimeChecking || !runtimeInspection}
+                  onClick={() => {
+                    if (runtimeIsReady) {
+                      onStartLocal(installDir);
+                      return;
+                    }
+                    void beginInstall();
+                  }}
                 >
-                  {dirIsOccupied ? "仍然安装" : "开始安装"}
+                  {primaryActionLabel}
                 </button>
               </div>
             </div>
@@ -489,29 +420,16 @@ export function SetupPage({ initialStep = "mode", onFinished }: SetupPageProps) 
               <div>
                 <p className="setup-success-title">安装完成</p>
                 <p className="setup-success-desc">
-                  OpenFic 运行环境已就绪。点击下方按钮启动后端服务并进入 OpenFic。
+                  OpenFic 运行环境已就绪，开始体验吧
                 </p>
               </div>
-              {startError ? (
-                <div className="setup-alert setup-alert-error" style={{ textAlign: "left" }}>
-                  <AlertTriangle size={16} strokeWidth={2} className="setup-alert-icon" />
-                  <span>{startError}</span>
-                </div>
-              ) : null}
-              {startingBackend ? (
-                <div className="setup-status">
-                  <div className="setup-step-spinner" style={{ width: 20, height: 20, borderWidth: 3 }} />
-                  <span className="setup-status-text">正在启动后端服务…</span>
-                </div>
-              ) : null}
               <div className="setup-actions" style={{ width: "100%", justifyContent: "center" }}>
                 <button
                   className="primary-button"
                   type="button"
-                  disabled={startingBackend}
-                  onClick={() => void startUsing()}
+                  onClick={() => onStartLocal(installDir)}
                 >
-                  {startingBackend ? "启动中…" : "开始使用"}
+                  开始使用
                 </button>
               </div>
             </div>
@@ -523,11 +441,11 @@ export function SetupPage({ initialStep = "mode", onFinished }: SetupPageProps) 
 }
 
 const EYEBROW: Record<WizardStep, string> = {
-  mode: "OpenFic Desktop",
-  remote: "连接到已有服务",
-  "local-directory": "设置本地运行环境",
-  "local-installing": "设置本地运行环境",
-  "local-success": "设置本地运行环境",
+  mode: "",
+  remote: "",
+  "local-directory": "",
+  "local-installing": "",
+  "local-success": "",
 };
 
 const TITLE: Record<WizardStep, string> = {
@@ -539,9 +457,9 @@ const TITLE: Record<WizardStep, string> = {
 };
 
 const DESCRIPTION: Record<WizardStep, string> = {
-  mode: "连接到 OpenFic 服务以继续",
-  remote: "输入远程 OpenFic 后端的服务地址，我们将检查服务是否可用。",
-  "local-directory": "运行环境将安装到所选目录的 runtime 子目录中。",
+  mode: "",
+  remote: "",
+  "local-directory": "",
   "local-installing": "请保持窗口开启，安装完成后将自动进入下一步。",
   "local-success": "",
 };

--- a/desktop/src/ui/pages/setup/setup.css
+++ b/desktop/src/ui/pages/setup/setup.css
@@ -139,6 +139,12 @@
   gap: 18px;
 }
 
+.setup-startup-error {
+  display: grid;
+  gap: 14px;
+  margin-bottom: 18px;
+}
+
 .setup-field {
   display: flex;
   flex-direction: column;
@@ -269,9 +275,9 @@
 /* busy / status states */
 .setup-status {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 16px;
+  justify-content: center;
+  gap: 8px;
   padding: 8px 0 4px;
 }
 

--- a/desktop/src/ui/styles.css
+++ b/desktop/src/ui/styles.css
@@ -33,6 +33,450 @@ body {
   min-height: 0;
 }
 
+.desktop-notices {
+  position: fixed;
+  top: 60px;
+  right: 18px;
+  z-index: 30;
+  display: grid;
+  width: min(370px, calc(100vw - 36px));
+  gap: 10px;
+  -webkit-app-region: no-drag;
+}
+
+.desktop-notice {
+  display: grid;
+  gap: 14px;
+  padding: 14px;
+  border: 1px solid var(--gray-a5);
+  border-radius: 12px;
+  background: var(--color-panel-solid);
+  box-shadow: 0 14px 34px var(--gray-a6);
+}
+
+.desktop-notice-update,
+.desktop-notice-error {
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+}
+
+.desktop-notice-update {
+  position: relative;
+}
+
+.desktop-notice-warning {
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: start;
+  border-color: var(--amber-a6, rgba(217, 119, 6, 0.35));
+  color: var(--amber-11, #a16207);
+}
+
+.desktop-notice-error {
+  border-color: var(--red-a6, rgba(220, 38, 38, 0.35));
+}
+
+.desktop-notice-copy {
+  min-width: 0;
+}
+
+.desktop-notice p {
+  margin: 0;
+  font-size: 12px;
+  line-height: 1.55;
+}
+
+.desktop-notice-title {
+  margin-bottom: 3px !important;
+  color: var(--gray-12);
+  font-size: 13px !important;
+  font-weight: 650;
+}
+
+.desktop-release-notes {
+  max-height: 9.3em;
+  overflow-y: auto;
+  white-space: pre-wrap;
+}
+
+.desktop-update-simple-state {
+  display: grid;
+  gap: 4px;
+  padding: 4px 0;
+}
+
+.desktop-update-simple-state .desktop-notice-secondary {
+  justify-self: end;
+  margin-top: 8px;
+}
+
+.desktop-update-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 0;
+  padding: 1px 0 2px;
+}
+
+.desktop-update-heading .desktop-notice-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+  margin-bottom: 0 !important;
+}
+
+.desktop-update-heading .desktop-notice-dismiss {
+  position: static;
+  flex: 0 0 auto;
+  margin: -6px -6px -6px 0;
+}
+
+.desktop-update-heading .desktop-notice-title span {
+  color: var(--accent-11);
+  font-size: 12px;
+  font-weight: inherit;
+}
+
+.desktop-update-release-section {
+  min-width: 0;
+  border-top: 1px solid var(--gray-a4);
+  border-bottom: 1px solid var(--gray-a4);
+}
+
+.desktop-release-notes-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 34px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--gray-12);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 650;
+  cursor: pointer;
+}
+
+.desktop-release-notes-toggle svg {
+  color: var(--gray-9);
+  transition: transform 150ms ease;
+}
+
+.desktop-release-notes-toggle[aria-expanded="true"] svg {
+  transform: rotate(90deg);
+}
+
+.desktop-release-notes-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 34px;
+}
+
+.desktop-release-details {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--accent-11);
+  font: inherit;
+  font-size: 11px;
+  font-weight: 600;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  cursor: pointer;
+}
+
+.desktop-release-details:hover {
+  color: var(--accent-12);
+}
+
+.desktop-release-notes-content {
+  max-height: 158px;
+  margin: 0 0 10px;
+  padding: 10px 11px;
+  overflow-y: auto;
+  border: 1px solid var(--gray-a4);
+  border-radius: 8px;
+  background: var(--gray-a2);
+}
+
+.desktop-release-notes-content p {
+  margin: 0 0 6px;
+  color: var(--gray-11);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.desktop-release-notes-content h2 {
+  margin: 0 0 8px;
+  color: var(--gray-12);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.desktop-release-notes-content h3 {
+  margin: 10px 0 6px;
+  color: var(--gray-12);
+  font-size: 11px;
+  font-weight: 650;
+}
+
+.desktop-release-notes-content ul,
+.desktop-release-notes-content ol {
+  display: grid;
+  gap: 5px;
+  margin: 0;
+  padding-left: 17px;
+}
+
+.desktop-release-notes-content li {
+  color: var(--gray-11);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.desktop-release-notes-content strong {
+  color: var(--gray-12);
+  font-weight: 650;
+}
+
+.desktop-release-notes-content code {
+  padding: 1px 3px;
+  border-radius: 3px;
+  background: var(--gray-a3);
+  color: var(--gray-12);
+  font-family: var(--code-font-family, monospace);
+  font-size: 0.95em;
+}
+
+.desktop-release-notes-content a {
+  color: var(--accent-11);
+  text-decoration: none;
+}
+
+.desktop-release-notes-content a:hover {
+  text-decoration: underline;
+}
+
+.desktop-notice-warning p {
+  color: inherit;
+}
+
+.desktop-notice-warning-dismiss {
+  display: grid;
+  width: 26px;
+  height: 26px;
+  margin: -5px -5px -5px 0;
+  place-items: center;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+}
+
+.desktop-notice-warning-dismiss:hover {
+  background: color-mix(in srgb, currentColor 10%, transparent);
+}
+
+.desktop-notice-warning-dismiss:focus-visible {
+  outline: 2px solid currentColor;
+  outline-offset: 2px;
+}
+
+.desktop-notice-primary,
+.desktop-notice-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  min-height: 30px;
+  padding: 0 10px;
+  border-radius: 7px;
+  font: inherit;
+  font-size: 12px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.desktop-notice-primary {
+  border: 0;
+  background: var(--accent-9);
+  color: var(--accent-contrast);
+}
+
+.desktop-notice-secondary {
+  border: 1px solid var(--gray-a5);
+  background: transparent;
+  color: var(--gray-12);
+}
+
+.desktop-notice-primary:hover,
+.desktop-notice-secondary:hover {
+  filter: brightness(0.97);
+}
+
+.desktop-update-footer {
+  display: flex;
+  justify-content: flex-end;
+  min-height: 30px;
+}
+
+.desktop-download-state {
+  display: grid;
+  gap: 9px;
+  padding-top: 2px;
+}
+
+.desktop-download-heading {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 8px;
+  color: var(--gray-10);
+  font-size: 12px;
+}
+
+.desktop-download-heading > span {
+  color: var(--gray-11);
+  font-weight: 650;
+}
+
+.desktop-download-heading button {
+  justify-self: start;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--gray-10);
+  font: inherit;
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.desktop-download-heading button:hover {
+  color: var(--gray-12);
+}
+
+.desktop-download-heading strong {
+  color: var(--accent-11);
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+}
+
+.desktop-notice-dismiss {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  display: grid;
+  width: 28px;
+  height: 28px;
+  place-items: center;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--gray-10);
+  cursor: pointer;
+}
+
+.desktop-notice-dismiss:hover {
+  background: var(--gray-a3);
+  color: var(--gray-12);
+}
+
+.desktop-notice-dismiss:focus-visible,
+.desktop-notice-primary:focus-visible,
+.desktop-notice-secondary:focus-visible,
+.titlebar-button:focus-visible {
+  outline: 2px solid var(--accent-8);
+  outline-offset: 2px;
+}
+
+.desktop-update-progress {
+  grid-column: 1 / -1;
+  height: 4px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--gray-a4);
+}
+
+.desktop-update-progress span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--accent-9);
+  transition: width 160ms ease;
+}
+
+.desktop-download-state .desktop-update-progress {
+  height: 6px;
+  background: var(--gray-a3);
+}
+
+.desktop-download-metrics {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: var(--gray-10);
+  font-family: var(--code-font-family, monospace);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+
+.desktop-update-panel-scrim {
+  position: fixed;
+  top: 44px;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 19;
+  border: 0;
+  background: transparent;
+  cursor: default;
+  -webkit-app-region: no-drag;
+}
+
+.desktop-update-panel-scrim[data-state="closed"] {
+  pointer-events: none;
+}
+
+.desktop-update-panel {
+  position: fixed;
+  top: 52px;
+  right: 18px;
+  z-index: 20;
+  width: min(370px, calc(100vw - 36px));
+  box-sizing: border-box;
+  opacity: 0;
+  transform: translateY(-6px) scale(0.98);
+  transform-origin: top right;
+  transition:
+    opacity 150ms ease,
+    transform 150ms cubic-bezier(0.16, 1, 0.3, 1);
+  -webkit-app-region: no-drag;
+}
+
+.desktop-update-panel.desktop-notice-update {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 12px;
+}
+
+.desktop-update-panel[data-state="open"] {
+  opacity: 1;
+  transform: translateY(0) scale(1);
+  animation: desktop-panel-enter 150ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.desktop-update-panel[data-state="closed"] {
+  pointer-events: none;
+}
+
 .content-page {
   height: 100%;
 }
@@ -89,6 +533,62 @@ body {
   background: transparent;
 }
 
+.titlebar-update-checking {
+  animation: titlebar-update-spin 820ms linear infinite;
+}
+
+.titlebar-update-progress {
+  width: 17px;
+  height: 17px;
+  overflow: visible;
+  transform: rotate(-90deg);
+}
+
+.titlebar-update-progress-track,
+.titlebar-update-progress-value {
+  fill: none;
+  stroke-width: 2.2;
+}
+
+.titlebar-update-progress-track {
+  stroke: var(--gray-a5);
+}
+
+.titlebar-update-progress-value {
+  stroke: currentColor;
+  stroke-dasharray: 43.982;
+  stroke-dashoffset: calc(43.982 * (1 - var(--update-progress)));
+  stroke-linecap: round;
+  transition: stroke-dashoffset 160ms ease;
+}
+
+.titlebar-update-button[data-update-state="available"],
+.titlebar-update-button[data-update-state="downloading"] {
+  color: var(--green-11, #15803d);
+}
+
+.titlebar-update-button[data-update-state="error"] {
+  color: var(--red-11, #b91c1c);
+}
+
+@keyframes titlebar-update-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes desktop-panel-enter {
+  from {
+    opacity: 0;
+    transform: translateY(-6px) scale(0.98);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
 .titlebar-link-button[data-connected="true"] {
   color: var(--green-11, #15803d);
 }
@@ -108,7 +608,10 @@ body {
 
 .instance-panel-scrim {
   position: fixed;
-  inset: 0;
+  top: 44px;
+  right: 0;
+  bottom: 0;
+  left: 0;
   z-index: 19;
   border: 0;
   background: transparent;
@@ -145,6 +648,7 @@ body {
 .instance-panel[data-state="open"] {
   opacity: 1;
   transform: translateY(0) scale(1);
+  animation: desktop-panel-enter 150ms cubic-bezier(0.16, 1, 0.3, 1);
 }
 
 .instance-panel[data-state="closed"] {
@@ -245,6 +749,7 @@ body {
   border: 0;
   background: transparent;
   color: inherit;
+  font: inherit;
   text-align: left;
   cursor: pointer;
   width: 100%;
@@ -348,11 +853,7 @@ body {
 
 .setup-card {
   width: min(640px, 100%);
-  background: var(--color-panel-solid);
-  border: 1px solid var(--gray-a5);
-  border-radius: 18px;
   padding: 36px;
-  box-shadow: 0 20px 60px var(--gray-a4);
 }
 
 .eyebrow {
@@ -379,18 +880,76 @@ h1 {
 
 .boot-state {
   display: grid;
-  gap: 18px;
-  justify-items: center;
-  padding-top: 12px;
+  width: min(520px, 100%);
+  gap: 14px;
 }
 
-.boot-spinner {
-  width: 28px;
-  height: 28px;
+.startup-page {
+  padding: 32px;
+}
+
+.startup-progress {
+  display: grid;
+  width: 100%;
+  gap: 8px;
+  padding: 14px;
+  box-sizing: border-box;
+  border: 1px solid var(--gray-a5);
+  border-radius: 12px;
+  background: var(--gray-a2);
+}
+
+.startup-progress-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--gray-12);
+  font-size: 14px;
+}
+
+.startup-progress-heading strong {
+  font-weight: 650;
+}
+
+.startup-progress-heading span {
+  color: var(--accent-11);
+  font-family: var(--code-font-family, monospace);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.startup-progress-track {
+  height: 7px;
+  overflow: hidden;
   border-radius: 999px;
-  border: 3px solid var(--gray-a5);
-  border-top-color: var(--gray-12);
-  animation: setup-spin 0.8s linear infinite;
+  background: var(--gray-a4);
+}
+
+.startup-progress-track > span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--accent-9);
+  transition: width 220ms ease;
+}
+
+.startup-progress[data-status="failed"] .startup-progress-track > span {
+  background: var(--red-9, #dc2626);
+}
+
+.startup-progress > p {
+  margin: 0;
+  color: var(--gray-11);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.startup-progress[data-bare="true"] {
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
 }
 
 .primary-button {
@@ -440,12 +999,18 @@ h1 {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .instance-panel {
+  .instance-panel,
+  .desktop-update-panel {
     transition: none;
     transform: none;
+    animation: none;
   }
 
   .instance-dot[data-status="checking"] {
+    animation: none;
+  }
+
+  .titlebar-update-checking {
     animation: none;
   }
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -39,6 +39,8 @@ const queryClient = new QueryClient({
   },
 });
 
+const FRONTEND_VERSION = __OPENFIC_FRONTEND_VERSION__;
+
 const DashboardPage = lazy(() =>
   import("./features/dashboard/pages/dashboard-page").then((module) => ({
     default: module.DashboardPage,
@@ -106,7 +108,6 @@ function AppContent({
 function Root() {
   const [appearance, setAppearance] = useState<"light" | "dark">("light");
   const [settings, setSettings] = useState<Settings | null>(null);
-  const [version, setVersion] = useState("");
   const [isReady, setIsReady] = useState(false);
   const [error, setError] = useState(false);
 
@@ -123,7 +124,7 @@ function Root() {
       try {
         await loadRuntimeConfig();
 
-        const [health, settings] = await Promise.all([
+        const [, settings] = await Promise.all([
           checkHealth(),
           queryClient.fetchQuery({
             queryKey: ["settings"],
@@ -139,7 +140,6 @@ function Root() {
 
         if (mounted) {
           setSettings(settings);
-          setVersion(health.version);
           setAppearance(settings.theme);
           setIsReady(true);
         }
@@ -191,7 +191,7 @@ function Root() {
             ) : (
               <AppContent
                 appearance={appearance}
-                version={version}
+                version={FRONTEND_VERSION}
                 setAppearance={setAppearance}
                 toggleTheme={toggleTheme}
               />

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+declare const __OPENFIC_FRONTEND_VERSION__: string;

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,9 +1,11 @@
+import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
 import react from "@vitejs/plugin-react";
 import { defineConfig, type Plugin } from "vite-plus";
 
 const srcPath = fileURLToPath(new URL("./src", import.meta.url));
+const frontendVersion = (JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8")) as { version: string }).version;
 
 function cacheFontResponseHeaders(): Plugin {
   return {
@@ -20,6 +22,9 @@ function cacheFontResponseHeaders(): Plugin {
 }
 
 export default defineConfig({
+  define: {
+    __OPENFIC_FRONTEND_VERSION__: JSON.stringify(frontendVersion),
+  },
   plugins: [react(), cacheFontResponseHeaders()],
   resolve: {
     alias: {


### PR DESCRIPTION
## PR 标题

feat(desktop): 支持应用内自动更新

## 变更说明

- 问题: 桌面端缺少应用内检查、下载和安装新版本的能力，Windows 用户需要手动下载并安装 Release 资产。
- 重要性: 版本更新无法自动完成会增加升级成本，也可能导致桌面端与后端运行时版本不一致。
- 变化: 集成 `electron-updater`，新增更新状态 IPC、下载进度、取消下载、重启安装和 Release 更新日志展示。
- 变化: 支持 Windows x64、ARM64 的架构专属更新包；发布工作流生成并上传合并后的 `latest.yml`、安装器、blockmap 和 ZIP 资产。
- 变化: 增加本地更新包构建及静态更新服务脚本，并补全系统代理、运行时版本检测和启动进度相关支持。

## 关联 Issue / PR (如有)

无

## 变更类型

- [x] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

不适用。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 已执行 `pnpm build`（frontend）、`pnpm lint` 与 `pnpm type-check`（desktop）。
- 已解析 GitHub Actions 与 Electron Builder YAML，并在本地构建 Windows x64/ARM64 安装包、验证 `latest.yml` 包含两种架构的安装器。
- 新增依赖：`electron-updater` 用于桌面端更新，`react-markdown` 用于渲染 Release 更新日志。