### PR TITLE
fix(release): 统一跨平台产物命名

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -164,10 +164,10 @@ jobs:
         include:
           - runner: ubuntu-latest
             platform: linux/amd64
-            suffix: amd64
+            suffix: linux-x86_64
           - runner: ubuntu-24.04-arm
             platform: linux/arm64
-            suffix: arm64
+            suffix: linux-aarch64
     runs-on: ${{ matrix.runner }}
     env:
       BUILDX_NO_DEFAULT_ATTESTATIONS: true
@@ -215,16 +215,16 @@ jobs:
 
           docker buildx imagetools create \
             -t "${IMAGE}:latest" \
-            "${IMAGE}:latest-amd64" \
-            "${IMAGE}:latest-arm64"
+            "${IMAGE}:latest-linux-x86_64" \
+            "${IMAGE}:latest-linux-aarch64"
           docker buildx imagetools create \
             -t "${IMAGE}:${VERSION}" \
-            "${IMAGE}:${VERSION}-amd64" \
-            "${IMAGE}:${VERSION}-arm64"
+            "${IMAGE}:${VERSION}-linux-x86_64" \
+            "${IMAGE}:${VERSION}-linux-aarch64"
           docker buildx imagetools create \
             -t "${IMAGE}:${MAJOR_MINOR}" \
-            "${IMAGE}:${MAJOR_MINOR}-amd64" \
-            "${IMAGE}:${MAJOR_MINOR}-arm64"
+            "${IMAGE}:${MAJOR_MINOR}-linux-x86_64" \
+            "${IMAGE}:${MAJOR_MINOR}-linux-aarch64"
 
   # ---------------------------------------------------------------- desktop
   desktop:
@@ -235,25 +235,26 @@ jobs:
         include:
           - os: windows-latest
             electron_args: '--win --x64'
-            publish_update: true
-            artifact_name: desktop-win-x64
-          - os: ubuntu-latest
+            artifact_name: windows-update-x86_64
+          - os: windows-11-arm
+            electron_args: '--win --arm64'
+            artifact_name: windows-update-aarch64
+          - os: ubuntu-24.04
             electron_args: '--linux --x64'
-            publish_update: false
-            artifact_name: desktop-linux-x64
+            artifact_name: desktop-linux-x86_64
           - os: ubuntu-24.04-arm
             electron_args: '--linux --arm64'
-            publish_update: false
-            artifact_name: desktop-linux-arm64
-          - os: macos-14
+            artifact_name: desktop-linux-aarch64
+          - os: macos-15-intel
+            electron_args: '--mac --x64'
+            artifact_name: desktop-mac-x86_64
+          - os: macos-15
             electron_args: '--mac --arm64'
-            publish_update: false
-            artifact_name: desktop-mac-arm64
+            artifact_name: desktop-mac-aarch64
     runs-on: ${{ matrix.os }}
     env:
       ELECTRON_CACHE: ${{ github.workspace }}/.electron-cache
       ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.electron-builder-cache
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8
@@ -298,31 +299,16 @@ jobs:
       - name: 构建 Electron 安装包
         working-directory: desktop
         run: pnpm exec electron-builder --config electron-builder.yml ${{ matrix.electron_args }} --publish never
-      - name: 构建 Windows ARM64 安装包
-        if: ${{ matrix.publish_update }}
+      - name: 统一安装包架构命名
         working-directory: desktop
-        run: pnpm exec electron-builder --config electron-builder.yml --win --arm64 --publish never
-      - name: 整理 Windows 自动更新产物
-        if: ${{ matrix.publish_update }}
-        working-directory: desktop
-        run: node scripts/prepare-windows-update.mjs
-      - name: 发布 Windows 自动更新产物
-        if: ${{ matrix.publish_update }}
-        shell: bash
-        run: |
-          gh release upload "${{ needs.context.outputs.release_tag }}" \
-            desktop/dist-electron/OpenFic-*-win-setup.exe \
-            desktop/dist-electron/OpenFic-*-win-setup.exe.blockmap \
-            desktop/dist-electron/OpenFic-*-win.zip \
-            desktop/dist-electron/latest.yml \
-            --clobber
+        run: node scripts/normalize-artifact-names.mjs
 
       - uses: actions/upload-artifact@v7
-        if: ${{ !matrix.publish_update }}
         with:
           name: ${{ matrix.artifact_name }}
           path: |
             desktop/dist-electron/*.exe
+            desktop/dist-electron/*.blockmap
             desktop/dist-electron/*.AppImage
             desktop/dist-electron/*.tar.gz
             desktop/dist-electron/*.zip
@@ -340,10 +326,38 @@ jobs:
             .electron-builder-cache
           key: ${{ steps.electron-cache.outputs.cache-primary-key }}
 
-  # ---------------------------------------------------------------- release
-  publish-release:
+  desktop-windows-update:
     needs: [context, desktop]
     if: ${{ always() && needs.desktop.result == 'success' }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: windows-update-*
+          merge-multiple: true
+          path: desktop/dist-electron
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: 整理 Windows 自动更新产物
+        working-directory: desktop
+        run: node scripts/prepare-windows-update.mjs
+      - name: 发布 Windows 自动更新产物
+        run: |
+          gh release upload "${{ needs.context.outputs.release_tag }}" \
+            desktop/dist-electron/OpenFic-*-win-*-setup.exe \
+            desktop/dist-electron/OpenFic-*-win-*-setup.exe.blockmap \
+            desktop/dist-electron/OpenFic-*-win-*.zip \
+            desktop/dist-electron/latest*.yml \
+            --clobber
+
+  # ---------------------------------------------------------------- release
+  publish-release:
+    needs: [context, desktop, desktop-windows-update]
+    if: ${{ always() && needs.desktop.result == 'success' && needs.desktop-windows-update.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v8

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,10 @@
 # ---- 前端构建：固定到构建平台（amd64）一次构建，产物与架构无关 ----
 FROM --platform=$BUILDPLATFORM node:22-slim AS frontend
 WORKDIR /build
-RUN corepack enable
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && corepack enable
 COPY frontend/package.json frontend/pnpm-lock.yaml frontend/pnpm-workspace.yaml ./
 RUN --mount=type=cache,id=pnpm-store,target=/pnpm/store \
     pnpm install --frozen-lockfile --store-dir /pnpm/store

--- a/desktop/electron-builder.local-update.yml
+++ b/desktop/electron-builder.local-update.yml
@@ -15,7 +15,7 @@ extraResources:
       - "**/*"
 
 win:
-  artifactName: OpenFic-${version}-${arch}-win.${ext}
+  artifactName: OpenFic-${version}-win-${arch}.${ext}
   target:
     - target: nsis
       arch:
@@ -25,7 +25,7 @@ win:
 nsis:
   oneClick: false
   allowToChangeInstallationDirectory: true
-  artifactName: OpenFic-${version}-${arch}-win-setup.${ext}
+  artifactName: OpenFic-${version}-win-${arch}-setup.${ext}
 
 publish:
   provider: generic

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -21,7 +21,7 @@ extraResources:
       - "**/*"
 
 win:
-  artifactName: OpenFic-${version}-${arch}-win.${ext}
+  artifactName: OpenFic-${version}-win-${arch}.${ext}
   target:
     - target: nsis
       arch:
@@ -35,22 +35,24 @@ win:
 nsis:
   oneClick: false
   allowToChangeInstallationDirectory: true
-  artifactName: OpenFic-${version}-${arch}-win-setup.${ext}
+  artifactName: OpenFic-${version}-win-${arch}-setup.${ext}
 
 mac:
-  artifactName: OpenFic-${version}-${arch}-mac.${ext}
+  artifactName: OpenFic-${version}-mac-${arch}.${ext}
   target:
     - target: dmg
       arch:
+        - x64
         - arm64
     - target: zip
       arch:
+        - x64
         - arm64
   category: public.app-category.productivity
   identity: null
 
 linux:
-  artifactName: OpenFic-${version}-${arch}-linux.${ext}
+  artifactName: OpenFic-${version}-linux-${arch}.${ext}
   target:
     - target: AppImage
       arch:

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -12,7 +12,7 @@
     "build:setup": "vp build",
     "type-check": "tsc -p tsconfig.main.json --noEmit && tsc -p tsconfig.renderer.json --noEmit",
     "lint": "eslint . --ext .js,.jsx,.mjs,.ts,.tsx,.mts",
-    "package": "electron-builder --config electron-builder.yml",
+    "package": "electron-builder --config electron-builder.yml && node scripts/normalize-artifact-names.mjs",
     "package:local-update": "node scripts/package-local-update.mjs",
     "serve:local-update": "node scripts/serve-local-update.mjs"
   },

--- a/desktop/scripts/normalize-artifact-names.mjs
+++ b/desktop/scripts/normalize-artifact-names.mjs
@@ -1,0 +1,32 @@
+import { readdir, rename, rm } from "node:fs/promises";
+import path from "node:path";
+
+const outputDirectory = path.resolve(process.argv[2] ?? "dist-electron");
+const architectureNames = new Map([
+  ["arm_aarch64", "aarch64"],
+  ["x64", "x86_64"],
+  ["arm64", "aarch64"],
+]);
+
+function normalizeArtifactName(fileName) {
+  let normalized = fileName;
+  for (const [electronArch, artifactArch] of architectureNames) {
+    normalized = normalized.replaceAll(`-${electronArch}-`, `-${artifactArch}-`);
+    normalized = normalized.replaceAll(`-${electronArch}.`, `-${artifactArch}.`);
+  }
+  return normalized;
+}
+
+for (const entry of await readdir(outputDirectory, { withFileTypes: true })) {
+  if (!entry.isFile()) continue;
+  const normalizedName = normalizeArtifactName(entry.name);
+  if (normalizedName === entry.name) continue;
+  await rename(path.join(outputDirectory, entry.name), path.join(outputDirectory, normalizedName));
+}
+
+for (const entry of await readdir(outputDirectory, { withFileTypes: true })) {
+  if (!entry.isFile()) continue;
+  if (!/^OpenFic-.+-win-setup\.exe(?:\.blockmap)?$/.test(entry.name)) continue;
+  if (entry.name.includes("-win-x86_64-setup") || entry.name.includes("-win-aarch64-setup")) continue;
+  await rm(path.join(outputDirectory, entry.name));
+}

--- a/desktop/scripts/package-local-update.mjs
+++ b/desktop/scripts/package-local-update.mjs
@@ -56,4 +56,5 @@ await run([
   "never",
   ...versionConfig,
 ]);
+await runNode(["scripts/normalize-artifact-names.mjs"]);
 await runNode(["scripts/prepare-windows-update.mjs"]);

--- a/desktop/scripts/prepare-windows-update.mjs
+++ b/desktop/scripts/prepare-windows-update.mjs
@@ -4,8 +4,8 @@ import path from "node:path";
 
 const outputDirectory = path.resolve(process.argv[2] ?? "dist-electron");
 const packageJson = JSON.parse(await readFile(path.resolve("package.json"), "utf8"));
-const version = packageJson.version;
-const architectures = ["x64", "arm64"];
+const version = process.env.OPENFIC_UPDATE_VERSION ?? packageJson.version;
+const architectures = ["x86_64", "aarch64"];
 
 async function exists(filePath) {
   try {
@@ -34,17 +34,45 @@ for (const fileName of [universalInstaller, `${universalInstaller}.blockmap`]) {
 }
 
 const files = await Promise.all(
-  architectures.map((arch) => getFileInfo(`OpenFic-${version}-${arch}-win-setup.exe`)),
+  architectures.map(async (architecture) => ({
+    architecture,
+    ...(await getFileInfo(`OpenFic-${version}-win-${architecture}-setup.exe`)),
+  })),
 );
-const primaryFile = files[0];
-const latestYml = [
+const releaseDate = new Date().toISOString();
+
+function createUpdateInfo(file, compatibilityArchitecture) {
+  const url = compatibilityArchitecture ? `${file.fileName}?arch=${compatibilityArchitecture}` : file.fileName;
+  return [
+    `version: ${version}`,
+    "files:",
+    `  - url: ${url}`,
+    `    sha512: ${file.sha512}`,
+    `    size: ${file.size}`,
+    `path: ${url}`,
+    `sha512: ${file.sha512}`,
+    `releaseDate: '${releaseDate}'`,
+    "",
+  ].join("\n");
+}
+
+const legacyArchitectures = ["x64", "arm64"];
+const legacyLatestYml = [
   `version: ${version}`,
   "files:",
-  ...files.flatMap((file) => [`  - url: ${file.fileName}`, `    sha512: ${file.sha512}`, `    size: ${file.size}`]),
-  `path: ${primaryFile.fileName}`,
-  `sha512: ${primaryFile.sha512}`,
-  `releaseDate: '${new Date().toISOString()}'`,
+  ...files.flatMap((file, index) => [
+    `  - url: ${file.fileName}?arch=${legacyArchitectures[index]}`,
+    `    sha512: ${file.sha512}`,
+    `    size: ${file.size}`,
+  ]),
+  `path: ${files[0].fileName}?arch=${legacyArchitectures[0]}`,
+  `sha512: ${files[0].sha512}`,
+  `releaseDate: '${releaseDate}'`,
   "",
 ].join("\n");
 
-await writeFile(path.join(outputDirectory, "latest.yml"), latestYml, "utf8");
+await Promise.all([
+  // Older clients select Windows assets by x64/arm64 substring; query aliases retain that compatibility.
+  writeFile(path.join(outputDirectory, "latest.yml"), legacyLatestYml, "utf8"),
+  ...files.map((file) => writeFile(path.join(outputDirectory, `latest-win-${file.architecture}.yml`), createUpdateInfo(file), "utf8")),
+]);

--- a/desktop/src/main/update-support.ts
+++ b/desktop/src/main/update-support.ts
@@ -3,6 +3,13 @@ export interface UpdateSupportEnvironment {
   arch: string;
 }
 
+export function getUpdateArchitectureName(environment: UpdateSupportEnvironment): "x86_64" | "aarch64" | null {
+  if (environment.platform !== "win32") return null;
+  if (environment.arch === "x64") return "x86_64";
+  if (environment.arch === "arm64") return "aarch64";
+  return null;
+}
+
 export function isAutoUpdateSupported(environment: UpdateSupportEnvironment): boolean {
-  return environment.platform === "win32" && (environment.arch === "x64" || environment.arch === "arm64");
+  return getUpdateArchitectureName(environment) !== null;
 }

--- a/desktop/src/main/updater.ts
+++ b/desktop/src/main/updater.ts
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs";
 import path from "node:path";
 import electronUpdater, { CancellationToken, NsisUpdater, type ProgressInfo, type UpdateInfo } from "electron-updater";
 import { IpcChannels, type UpdateState } from "../shared/ipc.js";
-import { isAutoUpdateSupported } from "./update-support.js";
+import { getUpdateArchitectureName, isAutoUpdateSupported } from "./update-support.js";
 import { configureSystemProxy } from "./proxy.js";
 
 const { autoUpdater } = electronUpdater;
@@ -80,8 +80,16 @@ export async function initializeUpdater(window: BrowserWindow): Promise<void> {
     return;
   }
 
+  const updateArchitecture = getUpdateArchitectureName({ platform: process.platform, arch: process.arch });
+  if (!updateArchitecture) {
+    publishState({ status: "unsupported" });
+    return;
+  }
+
   autoUpdater.autoDownload = false;
   autoUpdater.autoInstallOnAppQuit = false;
+  autoUpdater.channel = `latest-win-${updateArchitecture}`;
+  autoUpdater.allowDowngrade = false;
   configurePortableInstallDirectory();
   autoUpdater.on("checking-for-update", () => publishState({ status: "checking" }));
   autoUpdater.on("update-available", onUpdateAvailable);


### PR DESCRIPTION
## PR 标题

fix(release): 统一跨平台产物命名

## 变更说明

- 问题: 当前发布流程混用 `x64`、`arm64`、`x86_64` 等架构命名，Windows ARM64 由 x64 runner 交叉构建，Docker 前端构建在 slim 镜像中缺少系统 CA 证书会失败。
- 重要性: 命名不一致会降低 Release 资产可辨识性；Windows ARM64 交叉构建耗时较长；缺失 CA 会阻断 AMD64/ARM64 Docker 镜像发布。
- 变化: 统一桌面产物为 `OpenFic-版本-平台-架构[-setup].后缀`，对外使用 `x86_64`、`aarch64`；新增构建产物命名规范化脚本。
- 变化: Windows x86_64 与 ARM64 分别在 `windows-latest`、`windows-11-arm` 原生构建，汇总后发布架构专属更新清单；增加 macOS Intel 原生构建矩阵。
- 变化: 保持已发布 0.7.0 客户端的 Windows 自动更新兼容，同时新增架构专属 channel；Docker 前端阶段安装 CA 根证书。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

Electron Builder 对各 target 使用不同的默认架构别名；原发布工作流在 x64 Windows runner 中顺序构建两种 Windows 架构；`node:22-slim` 前端构建层未显式提供系统 CA 证书。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 已执行 frontend `pnpm build`、desktop `pnpm type-check` 和打包脚本 ESLint。
- 已在本地实际构建并验证 Windows x86_64、aarch64 NSIS/ZIP 产物，及 `OPENFIC_UPDATE_VERSION` 覆写下的更新清单。
- 已验证架构专属与旧客户端兼容的 Windows 更新 metadata、工作流 YAML、runner 矩阵与 Release 资产上传模式。
- 本机不是 macOS，无法本地构建 DMG/ZIP；已根据 GitHub runner 官方清单确认 `macos-15-intel` 和 `macos-15` 的原生架构标签。