### PR TITLE
fix(desktop): 修复更新日志渲染

### DIFF
--- a/desktop/electron-builder.local-update.yml
+++ b/desktop/electron-builder.local-update.yml
@@ -13,6 +13,8 @@ extraResources:
     to: frontend-dist
     filter:
       - "**/*"
+  - from: resources/app-update.local.yml
+    to: app-update.yml
 
 win:
   artifactName: OpenFic-${version}-win-${arch}.${ext}

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -19,6 +19,8 @@ extraResources:
     to: frontend-dist
     filter:
       - "**/*"
+  - from: resources/app-update.yml
+    to: app-update.yml
 
 win:
   artifactName: OpenFic-${version}-win-${arch}.${ext}

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -23,6 +23,8 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-markdown": "^10.1.0",
+    "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "scheduler": "^0.27.0"
   },
   "devDependencies": {

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -26,6 +26,12 @@ importers:
       react-markdown:
         specifier: ^10.1.0
         version: 10.1.0(@types/react@19.2.17)(react@19.2.7)
+      rehype-raw:
+        specifier: ^7.0.0
+        version: 7.0.0
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
       scheduler:
         specifier: ^0.27.0
         version: 0.27.0
@@ -2157,6 +2163,10 @@ packages:
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
+  entities@4.3.0:
+    resolution: {integrity: sha512-/iP1rZrSEJ0DTlPiX+jbzlA3eVkY/e8L8SozroF395fIqE3TYF/Nz7YOMAawta+vLmyJ/hkGNNPcSbMADCCXbg==}
+    engines: {node: '>=0.12'}
+
   env-paths@2.2.0:
     resolution: {integrity: sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==}
     engines: {node: '>=6'}
@@ -2439,11 +2449,29 @@ packages:
     resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
+  hast-util-from-parse5@8.0.3:
+    resolution: {integrity: sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==}
+
+  hast-util-parse-selector@4.0.0:
+    resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
+
+  hast-util-raw@9.1.0:
+    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
+
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
+  hast-util-to-parse5@8.0.1:
+    resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
+
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
+  hastscript@9.0.1:
+    resolution: {integrity: sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==}
 
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
@@ -2451,6 +2479,9 @@ packages:
 
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  html-void-elements@3.0.0:
+    resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
@@ -3119,6 +3150,9 @@ packages:
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
 
+  parse5@7.0.0:
+    resolution: {integrity: sha512-y/t8IXSPWTuRZqXc0ajH/UwDj4mnqLEbSttNbThcFhGrZuOyoyvNBO85PBp2jQa55wY9d07PBNjsK8ZP3K5U6g==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -3290,6 +3324,12 @@ packages:
 
   readdir-glob@1.0.0:
     resolution: {integrity: sha512-km0DIcwQVZ1ZUhXhMWpF74/Wm5aFEd5/jDiVWF1Hkw2myPQovG8vCQ8+FQO2KXE9npQQvCnAMZhhWuUee4WcCQ==}
+
+  rehype-raw@7.0.0:
+    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
 
   remark-parse@11.0.0:
     resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
@@ -3670,6 +3710,9 @@ packages:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
     engines: {node: '>=0.6.0'}
 
+  vfile-location@5.0.3:
+    resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
+
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
 
@@ -3775,6 +3818,9 @@ packages:
 
   wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
+  web-namespaces@2.0.1:
+    resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
   which@2.0.1:
     resolution: {integrity: sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==}
@@ -5978,6 +6024,8 @@ snapshots:
     dependencies:
       once: 1.4.0
 
+  entities@4.3.0: {}
+
   env-paths@2.2.0: {}
 
   err-code@2.0.3: {}
@@ -6326,6 +6374,43 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  hast-util-from-parse5@8.0.3:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      devlop: 1.1.0
+      hastscript: 9.0.1
+      property-information: 7.2.0
+      vfile: 6.0.3
+      vfile-location: 5.0.3
+      web-namespaces: 2.0.1
+
+  hast-util-parse-selector@4.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+
+  hast-util-raw@9.1.0:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.3.3
+      hast-util-from-parse5: 8.0.3
+      hast-util-to-parse5: 8.0.1
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      parse5: 7.0.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@ungap/structured-clone': 1.3.3
+      unist-util-position: 5.0.0
+
   hast-util-to-jsx-runtime@2.3.6:
     dependencies:
       '@types/estree': 1.0.9
@@ -6346,15 +6431,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  hast-util-to-parse5@8.0.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.5
+
+  hastscript@9.0.1:
+    dependencies:
+      '@types/hast': 3.0.5
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 4.0.0
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
 
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
 
   html-url-attributes@3.0.1: {}
+
+  html-void-elements@3.0.0: {}
 
   http-cache-semantics@4.2.0: {}
 
@@ -7145,6 +7250,10 @@ snapshots:
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
 
+  parse5@7.0.0:
+    dependencies:
+      entities: 4.3.0
+
   path-exists@4.0.0: {}
 
   path-is-absolute@1.0.1: {}
@@ -7361,6 +7470,17 @@ snapshots:
   readdir-glob@1.0.0:
     dependencies:
       minimatch: 3.1.5
+
+  rehype-raw@7.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+      hast-util-raw: 9.1.0
+      vfile: 6.0.3
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.5
+      hast-util-sanitize: 5.0.2
 
   remark-parse@11.0.0:
     dependencies:
@@ -7763,6 +7883,11 @@ snapshots:
       extsprintf: 1.4.1
     optional: true
 
+  vfile-location@5.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile: 6.0.3
+
   vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
@@ -7873,6 +7998,8 @@ snapshots:
   wcwidth@1.0.1:
     dependencies:
       defaults: 1.0.4
+
+  web-namespaces@2.0.1: {}
 
   which@2.0.1:
     dependencies:

--- a/desktop/resources/app-update.local.yml
+++ b/desktop/resources/app-update.local.yml
@@ -1,0 +1,4 @@
+provider: generic
+url: http://127.0.0.1:4567
+updaterCacheDirName: openfic-desktop-updater
+useMultipleRangeRequest: false

--- a/desktop/resources/app-update.yml
+++ b/desktop/resources/app-update.yml
@@ -1,0 +1,4 @@
+provider: github
+owner: syrizelink
+repo: OpenFic
+releaseType: release

--- a/desktop/src/main/updater.ts
+++ b/desktop/src/main/updater.ts
@@ -12,6 +12,7 @@ let shellWindow: BrowserWindow | null = null;
 let updateState: UpdateState = { status: "idle" };
 let initialized = false;
 let downloadCancellationToken: CancellationToken | null = null;
+const releaseNotesByVersion = new Map<string, string>();
 
 function publishState(nextState: UpdateState): void {
   updateState = nextState;
@@ -22,7 +23,7 @@ function describeError(error: Error): string {
   return error.message || "更新服务暂时不可用";
 }
 
-function getReleaseNotes(info: UpdateInfo): string | undefined {
+function getUpdaterReleaseNotes(info: UpdateInfo): string | undefined {
   if (typeof info.releaseNotes === "string") return info.releaseNotes.trim() || undefined;
   if (!Array.isArray(info.releaseNotes)) return undefined;
   const notes = info.releaseNotes
@@ -31,8 +32,36 @@ function getReleaseNotes(info: UpdateInfo): string | undefined {
   return notes.length ? notes.join("\n\n") : undefined;
 }
 
-function onUpdateAvailable(info: UpdateInfo): void {
-  publishState({ status: "available", version: info.version, releaseNotes: getReleaseNotes(info) });
+async function getReleaseNotes(info: UpdateInfo): Promise<string | undefined> {
+  const cachedReleaseNotes = releaseNotesByVersion.get(info.version);
+  if (cachedReleaseNotes) return cachedReleaseNotes;
+
+  try {
+    const response = await autoUpdater.netSession.fetch(
+      `https://api.github.com/repos/syrizelink/OpenFic/releases/tags/v${encodeURIComponent(info.version)}`,
+      { headers: { Accept: "application/vnd.github+json" } },
+    );
+    if (!response.ok) return getUpdaterReleaseNotes(info);
+
+    const release = (await response.json()) as { body?: unknown };
+    const releaseNotes = typeof release.body === "string" && release.body.trim() ? release.body.trim() : getUpdaterReleaseNotes(info);
+    if (releaseNotes) releaseNotesByVersion.set(info.version, releaseNotes);
+    return releaseNotes;
+  } catch {
+    const releaseNotes = getUpdaterReleaseNotes(info);
+    if (releaseNotes) releaseNotesByVersion.set(info.version, releaseNotes);
+    return releaseNotes;
+  }
+}
+
+async function enrichReleaseNotes(info: UpdateInfo): Promise<void> {
+  const releaseNotes = await getReleaseNotes(info);
+  if (
+    updateState.version === info.version
+    && ["available", "downloading", "downloaded"].includes(updateState.status)
+  ) {
+    publishState({ ...updateState, releaseNotes });
+  }
 }
 
 function onDownloadProgress(progress: ProgressInfo): void {
@@ -44,10 +73,6 @@ function onDownloadProgress(progress: ProgressInfo): void {
     total: progress.total,
     bytesPerSecond: progress.bytesPerSecond,
   });
-}
-
-function onUpdateCancelled(info: UpdateInfo): void {
-  publishState({ status: "available", version: info.version, releaseNotes: getReleaseNotes(info) });
 }
 
 function canUseAutoUpdater(): boolean {
@@ -92,11 +117,17 @@ export async function initializeUpdater(window: BrowserWindow): Promise<void> {
   autoUpdater.allowDowngrade = false;
   configurePortableInstallDirectory();
   autoUpdater.on("checking-for-update", () => publishState({ status: "checking" }));
-  autoUpdater.on("update-available", onUpdateAvailable);
+  autoUpdater.on("update-available", (info) => {
+    publishState({ status: "available", version: info.version, releaseNotes: getUpdaterReleaseNotes(info) });
+    void enrichReleaseNotes(info);
+  });
   autoUpdater.on("update-not-available", () => publishState({ status: "not-available" }));
   autoUpdater.on("download-progress", onDownloadProgress);
-  autoUpdater.on("update-cancelled", onUpdateCancelled);
-  autoUpdater.on("update-downloaded", (info) => publishState({ status: "downloaded", version: info.version, releaseNotes: getReleaseNotes(info) }));
+  autoUpdater.on("update-cancelled", (info) => {
+    publishState({ status: "available", version: info.version, releaseNotes: releaseNotesByVersion.get(info.version) ?? getUpdaterReleaseNotes(info) });
+    void enrichReleaseNotes(info);
+  });
+  autoUpdater.on("update-downloaded", (info) => publishState({ status: "downloaded", version: info.version, releaseNotes: releaseNotesByVersion.get(info.version) ?? getUpdaterReleaseNotes(info) }));
   autoUpdater.on("error", (error) => publishState({ status: "error", message: describeError(error) }));
   publishState({ status: "idle" });
 }

--- a/desktop/src/ui/components/desktop-notices.tsx
+++ b/desktop/src/ui/components/desktop-notices.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { AlertTriangle, ChevronRight, Download, ExternalLink, PackageSearch, RefreshCw, RotateCcw, X } from "lucide-react";
 import ReactMarkdown from "react-markdown";
+import rehypeRaw from "rehype-raw";
+import rehypeSanitize from "rehype-sanitize";
 import type { UpdateState } from "../../shared/ipc";
 
 interface DesktopNoticesProps {
@@ -32,6 +34,7 @@ function ReleaseNotes({ releaseNotes }: { releaseNotes: string }) {
   return (
     <div className="desktop-release-notes-content">
       <ReactMarkdown
+        rehypePlugins={[rehypeRaw, rehypeSanitize]}
         components={{
           a: ({ href, children }) => <a href={href} target="_blank" rel="noreferrer">{children}</a>,
         }}


### PR DESCRIPTION
## PR 标题

fix(desktop): 修复更新日志渲染

## 变更说明

- 问题: `electron-updater` 从 GitHub Atom feed 获取的更新日志是 HTML，桌面端按 Markdown 文本直接显示，导致 `<h2>`、`<ul>` 等标签外露；`--publish never` 构建的安装包缺少 `app-update.yml`，更新器无法初始化。
- 重要性: 用户无法正常阅读更新日志，且正式与本地更新包可能在启动时因缺失更新配置报错。
- 变化: 优先从 GitHub Releases REST API 获取原始 Markdown `body`，并在 API 不可用时安全解析 Atom feed 的 HTML 回退内容。
- 变化: 显式将 GitHub 与本地更新配置作为资源打入安装包，确保分架构发布工作流的 `--publish never` 构建仍可初始化自动更新。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

GitHub Atom feed 的 `content` 是渲染后的 HTML，而 `react-markdown` 默认将 HTML 视为普通文本。发布流程改用 `--publish never` 后，Electron Builder 不再自动生成 `resources/app-update.yml`。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 已执行 desktop `pnpm type-check`、`pnpm lint`、`pnpm build` 及 diff 空白检查。
- 已验证 GitHub Releases API 的 `body` 返回原始 Markdown。
- 已分别实际构建生产与本地 Windows 解包目录，确认资源目录包含正确的 GitHub / generic `app-update.yml`。
- HTML 回退使用 `rehype-raw` 与 `rehype-sanitize`，仅在无法获取原始 Markdown 时生效。