### PR TITLE
chore(frontend): 添加最近打开项目入口

### DIFF
--- a/frontend/src/features/app-shell/components/app-sidebar.tsx
+++ b/frontend/src/features/app-shell/components/app-sidebar.tsx
@@ -1,13 +1,6 @@
 import { Box, Flex } from "@radix-ui/themes";
-import { useQuery } from "@tanstack/react-query";
-import {
-  BookOpenText,
-  ChartNoAxesCombined,
-  Globe,
-  LibraryBig,
-  UserRound,
-  Workflow,
-} from "lucide-react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { ChartNoAxesCombined, Globe, LibraryBig, UserRound, Workflow } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState, type PointerEvent } from "react";
 import { useTranslation } from "react-i18next";
@@ -15,6 +8,8 @@ import { useLocation, useNavigate, useParams } from "react-router";
 
 import { saveLanguagePreference, supportedLanguages, type LanguageCode } from "@/i18n";
 import { apiClient, fetchProject } from "@/lib/api-client";
+import { getRecentProjects, openRecentProject, removeRecentProject } from "@/lib/local-db";
+import type { RecentProject } from "@/lib/recent-projects";
 
 import { useAppShell } from "./app-shell-context";
 import {
@@ -22,6 +17,7 @@ import {
   SIDEBAR_EXPANDED_WIDTH,
   type AppSidebarNavItem,
 } from "./app-sidebar.constants";
+import { RecentProjectsNav } from "./recent-projects-nav";
 import { SidebarActions } from "./sidebar-actions";
 import { SidebarBrand } from "./sidebar-brand";
 import { SidebarNav } from "./sidebar-nav";
@@ -40,6 +36,7 @@ export function AppSidebar({ appearance, onToggleTheme }: AppSidebarProps) {
   const navigate = useNavigate();
   const { projectId } = useParams<{ projectId: string }>();
   const { isMobile, isSidebarOpen, closeSidebar, openSettings } = useAppShell();
+  const queryClient = useQueryClient();
 
   const [isExpanded, setIsExpanded] = useState(false);
   const [isLogoHovered, setIsLogoHovered] = useState(false);
@@ -47,6 +44,7 @@ export function AppSidebar({ appearance, onToggleTheme }: AppSidebarProps) {
   const logoPointerInsideRef = useRef(false);
   const prevAppearanceRef = useRef(appearance);
   const prevPathnameRef = useRef(location.pathname);
+  const lastOpenedProjectIdRef = useRef<string | null>(null);
 
   const sidebarWidth = isMobile
     ? SIDEBAR_EXPANDED_WIDTH
@@ -85,6 +83,34 @@ export function AppSidebar({ appearance, onToggleTheme }: AppSidebarProps) {
     enabled: !!projectId,
   });
 
+  const { data: recentProjects = [] } = useQuery({
+    queryKey: ["recent-projects"],
+    queryFn: getRecentProjects,
+    staleTime: Infinity,
+  });
+
+  useEffect(() => {
+    if (!projectId) lastOpenedProjectIdRef.current = null;
+  }, [projectId]);
+
+  useEffect(() => {
+    if (!currentProject || lastOpenedProjectIdRef.current === currentProject.id) return;
+
+    lastOpenedProjectIdRef.current = currentProject.id;
+    let isDiscarded = false;
+
+    void openRecentProject(currentProject.id, currentProject.title).then((nextProjects) => {
+      if (!nextProjects || isDiscarded || lastOpenedProjectIdRef.current !== currentProject.id)
+        return;
+
+      queryClient.setQueryData<RecentProject[]>(["recent-projects"], nextProjects);
+    });
+
+    return () => {
+      isDiscarded = true;
+    };
+  }, [currentProject, queryClient]);
+
   const navItems = useMemo<AppSidebarNavItem[]>(() => {
     const pathname = location.pathname;
     const items: AppSidebarNavItem[] = [
@@ -120,17 +146,8 @@ export function AppSidebar({ appearance, onToggleTheme }: AppSidebarProps) {
       },
     ];
 
-    if (projectId) {
-      items.push({
-        label: t("topbar.editor"),
-        href: `/projects/${projectId}`,
-        icon: BookOpenText,
-        active: pathname.startsWith(`/projects/${projectId}`),
-      });
-    }
-
     return items;
-  }, [location.pathname, projectId, t]);
+  }, [location.pathname, t]);
 
   const handleLanguageChange = async (language: string) => {
     const nextLanguage = language as LanguageCode;
@@ -200,6 +217,18 @@ export function AppSidebar({ appearance, onToggleTheme }: AppSidebarProps) {
     }
     openSettings();
   }, [closeSidebar, isMobile, openSettings]);
+
+  const handleRemoveRecentProject = useCallback(
+    async (slot: number) => {
+      const isRemoved = await removeRecentProject(slot);
+      if (!isRemoved) return;
+
+      queryClient.setQueryData<RecentProject[]>(["recent-projects"], (projects = []) =>
+        projects.filter((project) => project.slot !== slot),
+      );
+    },
+    [queryClient],
+  );
 
   return (
     <>
@@ -296,6 +325,15 @@ export function AppSidebar({ appearance, onToggleTheme }: AppSidebarProps) {
               <SidebarNav
                 items={navItems}
                 isExpanded={isMobile || isExpanded}
+              />
+
+              <RecentProjectsNav
+                projects={recentProjects}
+                currentProjectId={projectId}
+                isExpanded={isMobile || isExpanded}
+                ariaLabel={t("topbar.recentProjects")}
+                closeLabel={t("common.close")}
+                onRemove={handleRemoveRecentProject}
               />
 
               <MotionFlex

--- a/frontend/src/features/app-shell/components/recent-projects-nav.css
+++ b/frontend/src/features/app-shell/components/recent-projects-nav.css
@@ -1,0 +1,148 @@
+.app-sidebar-recent-projects {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-1);
+  margin-top: var(--space-2);
+}
+
+.app-sidebar-recent-project {
+  position: relative;
+  width: 40px;
+  height: 40px;
+}
+
+.app-sidebar-recent-project__link {
+  display: flex;
+  width: 40px;
+  height: 40px;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-3);
+  overflow: hidden;
+  text-decoration: none;
+}
+
+.app-sidebar-recent-project[data-expanded="true"] .app-sidebar-recent-project__link {
+  width: 100%;
+  gap: var(--space-2);
+  justify-content: flex-start;
+}
+
+.app-sidebar-recent-project[data-expanded="false"] .app-sidebar-recent-project__link {
+  justify-content: center;
+}
+
+.app-sidebar-recent-project[data-expanded="false"] .app-sidebar-recent-project__title {
+  display: none;
+}
+
+.app-sidebar-recent-project__icon {
+  display: flex;
+  width: 40px;
+  height: 40px;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-3);
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.app-sidebar-recent-project[data-active="true"] .app-sidebar-recent-project__icon {
+  box-shadow: inset 0 0 0 2px var(--accent-5);
+}
+
+.app-sidebar-recent-project__icon--blue {
+  color: var(--blue-11);
+  background: var(--blue-a3);
+}
+
+.app-sidebar-recent-project__icon--green {
+  color: var(--green-11);
+  background: var(--green-a3);
+}
+
+.app-sidebar-recent-project__icon--orange {
+  color: var(--orange-11);
+  background: var(--orange-a3);
+}
+
+.app-sidebar-recent-project__icon--purple {
+  color: var(--purple-11);
+  background: var(--purple-a3);
+}
+
+.app-sidebar-recent-project__icon--teal {
+  color: var(--teal-11);
+  background: var(--teal-a3);
+}
+
+.app-sidebar-recent-project__icon--pink {
+  color: var(--pink-11);
+  background: var(--pink-a3);
+}
+
+.app-sidebar-recent-project__title {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--gray-11);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-sidebar-recent-project[data-expanded="true"] {
+  width: 100%;
+}
+
+.app-sidebar-recent-project[data-expanded="false"] .app-sidebar-recent-project__title {
+  display: none;
+}
+
+.app-sidebar-recent-project__close {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  display: flex;
+  width: 14px;
+  height: 14px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid var(--gray-8);
+  border-radius: 50%;
+  color: var(--gray-9);
+  background: var(--gray-1);
+  cursor: pointer;
+  z-index: 1;
+  visibility: hidden;
+  pointer-events: none;
+  transition:
+    color 0.15s ease,
+    background-color 0.15s ease;
+}
+
+.app-sidebar-recent-project:hover .app-sidebar-recent-project__close,
+.app-sidebar-recent-project:focus-within .app-sidebar-recent-project__close {
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.app-sidebar-recent-project__close:hover {
+  border-color: var(--gray-12);
+  color: var(--gray-12);
+}
+
+.app-sidebar-recent-project__close:focus-visible {
+  outline: 2px solid var(--accent-8);
+  outline-offset: 1px;
+}
+
+@media (hover: none) {
+  .app-sidebar-recent-project__close {
+    visibility: visible;
+    pointer-events: auto;
+  }
+}

--- a/frontend/src/features/app-shell/components/recent-projects-nav.tsx
+++ b/frontend/src/features/app-shell/components/recent-projects-nav.tsx
@@ -1,0 +1,114 @@
+import { Text, Tooltip } from "@radix-ui/themes";
+import { X } from "lucide-react";
+import { Link } from "react-router";
+
+import { getProjectInitial, type RecentProject } from "@/lib/recent-projects";
+
+import "./recent-projects-nav.css";
+
+interface RecentProjectsNavProps {
+  projects: RecentProject[];
+  currentProjectId: string | undefined;
+  isExpanded: boolean;
+  ariaLabel: string;
+  closeLabel: string;
+  onRemove: (slot: number) => void;
+}
+
+interface RecentProjectNavItemProps {
+  project: RecentProject;
+  isActive: boolean;
+  isExpanded: boolean;
+  closeLabel: string;
+  onRemove: (slot: number) => void;
+}
+
+function RecentProjectNavItem({
+  project,
+  isActive,
+  isExpanded,
+  closeLabel,
+  onRemove,
+}: RecentProjectNavItemProps) {
+  const link = (
+    <Link
+      to={`/projects/${project.projectId}`}
+      aria-label={project.title}
+      aria-current={isActive ? "page" : undefined}
+      className="app-sidebar-recent-project__link"
+    >
+      <span
+        aria-hidden="true"
+        className={`app-sidebar-recent-project__icon app-sidebar-recent-project__icon--${project.color}`}
+      >
+        {getProjectInitial(project.title)}
+      </span>
+      <Text
+        size="2"
+        weight={isActive ? "bold" : "medium"}
+        className="app-sidebar-recent-project__title"
+      >
+        {project.title}
+      </Text>
+    </Link>
+  );
+
+  return (
+    <div
+      className="app-sidebar-recent-project"
+      data-active={isActive ? "true" : "false"}
+      data-expanded={isExpanded ? "true" : "false"}
+    >
+      {isExpanded ? (
+        link
+      ) : (
+        <Tooltip
+          content={project.title}
+          side="right"
+        >
+          {link}
+        </Tooltip>
+      )}
+      <button
+        type="button"
+        className="app-sidebar-recent-project__close"
+        aria-label={`${closeLabel} ${project.title}`}
+        onClick={(event) => {
+          event.stopPropagation();
+          onRemove(project.slot);
+        }}
+      >
+        <X size={10} />
+      </button>
+    </div>
+  );
+}
+
+export function RecentProjectsNav({
+  projects,
+  currentProjectId,
+  isExpanded,
+  ariaLabel,
+  closeLabel,
+  onRemove,
+}: RecentProjectsNavProps) {
+  if (projects.length === 0) return null;
+
+  return (
+    <nav
+      aria-label={ariaLabel}
+      className="app-sidebar-recent-projects"
+    >
+      {projects.map((project) => (
+        <RecentProjectNavItem
+          key={project.slot}
+          project={project}
+          isActive={project.projectId === currentProjectId}
+          isExpanded={isExpanded}
+          closeLabel={closeLabel}
+          onRemove={onRemove}
+        />
+      ))}
+    </nav>
+  );
+}

--- a/frontend/src/features/projects/components/project-card.tsx
+++ b/frontend/src/features/projects/components/project-card.tsx
@@ -83,18 +83,49 @@ export function ProjectCard({ project, onEdit, onDelete }: ProjectCardProps) {
 
       {/* 项目信息 */}
       <Box>
+        <Text
+          size="3"
+          weight="bold"
+          style={{ display: "block" }}
+          truncate
+        >
+          {project.title}
+        </Text>
+
         <Flex
-          justify="between"
-          align="start"
-          mb="1"
+          gap="2"
+          align="center"
         >
           <Text
-            size="3"
-            weight="bold"
-            style={{ flex: 1 }}
-            truncate
+            size="1"
+            color="gray"
           >
-            {project.title}
+            {project.wordCount.toLocaleString()} {t("projects.words")}
+          </Text>
+          <Text
+            size="1"
+            color="gray"
+          >
+            ·
+          </Text>
+          <Text
+            size="1"
+            color="gray"
+          >
+            {project.chapterCount} {t("projects.chapters")}
+          </Text>
+        </Flex>
+
+        <Flex
+          justify="between"
+          align="center"
+          mt="1"
+        >
+          <Text
+            size="1"
+            color="gray"
+          >
+            {formatRelativeTime(project.updatedAt)}
           </Text>
           <Flex
             gap="3"
@@ -127,38 +158,6 @@ export function ProjectCard({ project, onEdit, onDelete }: ProjectCardProps) {
             </Tooltip>
           </Flex>
         </Flex>
-
-        <Flex
-          gap="2"
-          align="center"
-        >
-          <Text
-            size="1"
-            color="gray"
-          >
-            {project.wordCount.toLocaleString()} {t("projects.words")}
-          </Text>
-          <Text
-            size="1"
-            color="gray"
-          >
-            ·
-          </Text>
-          <Text
-            size="1"
-            color="gray"
-          >
-            {project.chapterCount} {t("projects.chapters")}
-          </Text>
-        </Flex>
-
-        <Text
-          size="1"
-          color="gray"
-          mt="1"
-        >
-          {formatRelativeTime(project.updatedAt)}
-        </Text>
       </Box>
     </MotionCard>
   );

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -32,6 +32,7 @@
   },
   "topbar": {
     "projects": "Projects",
+    "recentProjects": "Recently opened projects",
     "workspace": "World Book",
     "characters": "Characters",
     "promptChains": "Prompt",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -32,6 +32,7 @@
   },
   "topbar": {
     "projects": "项目",
+    "recentProjects": "最近打开的项目",
     "workspace": "世界书",
     "characters": "角色",
     "promptChains": "提示词",

--- a/frontend/src/lib/local-db.ts
+++ b/frontend/src/lib/local-db.ts
@@ -7,6 +7,12 @@
 
 import Dexie, { type EntityTable } from "dexie";
 
+import {
+  getRandomRecentProjectColor,
+  insertRecentProject,
+  type RecentProject,
+} from "./recent-projects";
+
 /**
  * 项目最后访问的章节记录
  */
@@ -76,6 +82,7 @@ class OpenFicDB extends Dexie {
   projectTabs!: EntityTable<ProjectTabs, "projectId">;
   userPreferences!: EntityTable<UserPreference, "key">;
   promptChainWorkingCopies!: EntityTable<PromptChainWorkingCopy, "chainId">;
+  recentProjects!: EntityTable<RecentProject, "slot">;
 
   constructor() {
     super("OpenFicDB");
@@ -109,6 +116,14 @@ class OpenFicDB extends Dexie {
       projectTabs: "projectId, updatedAt",
       userPreferences: "key, updatedAt",
       promptChainWorkingCopies: "chainId, updatedAt",
+    });
+
+    this.version(6).stores({
+      projectLastChapters: "projectId, updatedAt",
+      projectTabs: "projectId, updatedAt",
+      userPreferences: "key, updatedAt",
+      promptChainWorkingCopies: "chainId, updatedAt",
+      recentProjects: "slot, projectId, openedAt",
     });
   }
 }
@@ -244,6 +259,61 @@ export async function deletePreference(key: string): Promise<void> {
     await db.userPreferences.delete(key);
   } catch {
     console.error("删除用户偏好失败");
+  }
+}
+
+// ==================== 最近项目 ====================
+
+/**
+ * 获取三个固定槽位中的最近项目记录。
+ */
+export async function getRecentProjects(): Promise<RecentProject[]> {
+  try {
+    return await db.recentProjects.orderBy("slot").toArray();
+  } catch {
+    console.error("获取最近项目失败");
+    return [];
+  }
+}
+
+/**
+ * 将项目置于首槽位，并将原有记录依次后移。
+ */
+export async function openRecentProject(
+  projectId: string,
+  title: string,
+): Promise<RecentProject[] | null> {
+  try {
+    return await db.transaction("rw", db.recentProjects, async () => {
+      const recentProjects = await db.recentProjects.orderBy("slot").toArray();
+      const recentProject = recentProjects.find((project) => project.projectId === projectId);
+      const nextProjects = insertRecentProject(recentProjects, {
+        projectId,
+        title,
+        color: recentProject?.color ?? getRandomRecentProjectColor(recentProjects),
+      });
+
+      await db.recentProjects.clear();
+      await db.recentProjects.bulkPut(nextProjects);
+
+      return nextProjects;
+    });
+  } catch {
+    console.error("保存最近项目失败");
+    return null;
+  }
+}
+
+/**
+ * 移除指定槽位的最近项目，不移动其他槽位。
+ */
+export async function removeRecentProject(slot: number): Promise<boolean> {
+  try {
+    await db.recentProjects.delete(slot);
+    return true;
+  } catch {
+    console.error("移除最近项目失败");
+    return false;
   }
 }
 

--- a/frontend/src/lib/recent-projects.ts
+++ b/frontend/src/lib/recent-projects.ts
@@ -1,0 +1,82 @@
+export const RECENT_PROJECT_COLORS = ["blue", "green", "orange", "purple", "teal", "pink"] as const;
+
+export type RecentProjectColor = (typeof RECENT_PROJECT_COLORS)[number];
+
+const projectInitialPattern = /[\p{L}\p{N}]/u;
+
+export interface RecentProject {
+  slot: number;
+  projectId: string;
+  title: string;
+  color: RecentProjectColor;
+  openedAt: Date;
+}
+
+interface RecentProjectInput {
+  projectId: string;
+  title: string;
+  color: RecentProjectColor;
+}
+
+export function getProjectInitial(title: string): string {
+  for (const character of title) {
+    if (projectInitialPattern.test(character)) return character;
+  }
+
+  return "?";
+}
+
+export function getAvailableRecentProjectColors(
+  recentProjects: RecentProject[],
+): RecentProjectColor[] {
+  const usedColors = new Set(recentProjects.map((project) => project.color));
+  return RECENT_PROJECT_COLORS.filter((color) => !usedColors.has(color));
+}
+
+export function getRandomRecentProjectColor(
+  recentProjects: RecentProject[] = [],
+): RecentProjectColor {
+  const availableColors = getAvailableRecentProjectColors(recentProjects);
+  const colors = availableColors.length > 0 ? availableColors : RECENT_PROJECT_COLORS;
+  const index = Math.floor(Math.random() * colors.length);
+  return colors[index];
+}
+
+export function insertRecentProject(
+  recentProjects: RecentProject[],
+  project: RecentProjectInput,
+): RecentProject[] {
+  const existingProject = recentProjects.find((item) => item.projectId === project.projectId);
+
+  if (existingProject?.slot === 0) {
+    return recentProjects.map((item) =>
+      item.slot === 0
+        ? {
+            ...item,
+            title: project.title,
+            openedAt: new Date(),
+          }
+        : item,
+    );
+  }
+
+  const nextProjects: RecentProject[] = [
+    {
+      slot: 0,
+      projectId: project.projectId,
+      title: project.title,
+      color: existingProject?.color ?? project.color,
+      openedAt: new Date(),
+    },
+  ];
+
+  for (const currentProject of recentProjects) {
+    if (currentProject.projectId === project.projectId) continue;
+
+    const shouldShift = !existingProject || currentProject.slot < existingProject.slot;
+    const nextSlot = shouldShift ? currentProject.slot + 1 : currentProject.slot;
+    if (nextSlot <= 2) nextProjects.push({ ...currentProject, slot: nextSlot });
+  }
+
+  return nextProjects.sort((projectA, projectB) => projectA.slot - projectB.slot);
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,7 +5,11 @@ import react from "@vitejs/plugin-react";
 import { defineConfig, type Plugin } from "vite-plus";
 
 const srcPath = fileURLToPath(new URL("./src", import.meta.url));
-const frontendVersion = (JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8")) as { version: string }).version;
+const frontendVersion = (
+  JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8")) as {
+    version: string;
+  }
+).version;
 
 function cacheFontResponseHeaders(): Plugin {
   return {


### PR DESCRIPTION
## PR 标题

feat(frontend): 添加最近打开项目入口

## 变更说明

- 问题: 项目编辑入口只能显示当前项目，长项目标题会挤压首页网格卡片操作区。
- 重要性: 需要提供稳定的最近项目切换入口，并避免长标题影响项目卡片操作。
- 变化: 侧栏改为展示最多三个最近打开的项目，使用 Dexie 缓存标题与配色；支持固定槽位、重新打开置顶、移除不补位、颜色去重及关闭操作。
- 变化: 调整网格项目卡片，将编辑和删除按钮移至更新时间行右侧。
- 变化: 一并格式化 Vite 配置中的版本读取表达式。

## 关联 Issue / PR (如有)

无

## 变更类型

- [x] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

不适用

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- Dexie 本地数据库升级至 v6，新增最近项目记录表，不涉及后端数据库迁移。
- 已运行 `pnpm format:check`、`pnpm lint`、`pnpm type-check` 和 `pnpm build`；构建仅保留现有的大体积 chunk 警告。
