### PR TITLE
chore(backend): 调整摘要上下文结构

### DIFF
--- a/backend/app/memory/chapter/__init__.py
+++ b/backend/app/memory/chapter/__init__.py
@@ -8,10 +8,6 @@ from app.memory.chapter.context_builder import (
     BuiltContext,
     ContextPart,
 )
-from app.memory.chapter.summary_generator import (
-    generate_chapter_summary,
-    generate_long_term_summary,
-)
 from app.memory.chapter.summary_service import (
     get_chapter_summary,
     list_chapter_summaries,
@@ -24,9 +20,6 @@ __all__ = [
     "build_context",
     "BuiltContext",
     "ContextPart",
-    # Summary Generator
-    "generate_chapter_summary",
-    "generate_long_term_summary",
     # Summary Service
     "get_chapter_summary",
     "list_chapter_summaries",

--- a/backend/app/memory/chapter/summary_generator.py
+++ b/backend/app/memory/chapter/summary_generator.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Structured summary generation using tool calls."""
 
+import json
 from dataclasses import dataclass
 from typing import Any
 from xml.sax.saxutils import escape
@@ -18,7 +19,7 @@ from app.memory.chapter.summary_tools import (
 from app.models.clients import LLMClient
 from app.storage.models.chapter import Chapter
 from app.storage.models.chapter_summary import ChapterSummary
-from app.storage.repos import chapter_repo
+from app.storage.repos import chapter_repo, chapter_summary_repo
 from app.storage.services import prompt_chain_service
 
 
@@ -72,11 +73,10 @@ async def _get_prompt_entries(
     ]
 
 
-async def _build_prompt_messages(
+async def _build_system_messages(
     session: AsyncSession,
     *,
     prompt_id: str,
-    target_xml: str,
 ) -> list[SystemMessage]:
     compiler = PromptChainCompiler()
     compile_result = await compiler.compile(entries=await _get_prompt_entries(session, prompt_id))
@@ -86,25 +86,51 @@ async def _build_prompt_messages(
         for entry in compile_result.entries
         if entry.role == "system" and entry.content
     ]
-    messages.append(SystemMessage(content=target_xml))
     return messages
 
 
-def _chapter_target_message(chapter: Chapter) -> str:
+def _xml_tag(name: str, value: str) -> str:
+    return f"<{name}>{escape(value)}</{name}>"
+
+
+def _summary_list_value(value: str) -> str:
+    try:
+        items = json.loads(value)
+    except json.JSONDecodeError:
+        return ""
+    return value if isinstance(items, list) and items else ""
+
+
+def _previous_chapter_message(chapter: Chapter, summary: ChapterSummary | None) -> str:
+    parts = [
+        _xml_tag("title", chapter.title) if chapter.title else "",
+        _xml_tag("start_time", summary.start_time) if summary and summary.start_time else "",
+        _xml_tag("end_time", summary.end_time) if summary and summary.end_time else "",
+        _xml_tag("characters", _summary_list_value(summary.characters_json)) if summary else "",
+        _xml_tag("locations", _summary_list_value(summary.locations_json)) if summary else "",
+        _xml_tag("content", chapter.content) if chapter.content else "",
+    ]
+    content = "\n  ".join(part for part in parts if part)
     return (
-        "<target>\n"
-        f"  <chapter_title>{escape(chapter.title)}</chapter_title>\n"
-        f"  <chapter_content>{escape(chapter.content)}</chapter_content>\n"
-        "</target>"
+        "以下部分是上一个章节的有关内容，用以帮助你连贯的理解剧情信息，该部分与你要总结的内容**无关**。\n"
+        "<previous_chapter>\n"
+        f"  {content}\n"
+        "</previous_chapter>"
+    )
+
+
+def _target_chapter_message(chapter: Chapter) -> str:
+    return (
+        "以下部分是你需要总结的章节内容。\n"
+        "<target_chapter>\n"
+        f"  {_xml_tag('title', chapter.title)}\n"
+        f"  {_xml_tag('content', chapter.content)}\n"
+        "</target_chapter>"
     )
 
 
 def _summaries_target_message(chapter_summaries: str) -> str:
-    return (
-        "<target>\n"
-        f"  <summaries>{escape(chapter_summaries)}</summaries>\n"
-        "</target>"
-    )
+    return "以下部分是你需要总结的摘要内容\n" f"{chapter_summaries}"
 
 
 def _usage_token_count(usage: dict[str, Any] | None, fallback_text: str) -> int:
@@ -133,15 +159,6 @@ def _clean_text(value: Any) -> str:
     return str(value or "").strip()
 
 
-async def generate_chapter_summary(
-    session: AsyncSession,
-    llm_client: LLMClient,
-    chapter_id: str,
-) -> GeneratedChapterSummary:
-    prompt = await build_chapter_summary_prompt(session, chapter_id)
-    return await generate_chapter_summary_from_prompt(llm_client, prompt)
-
-
 async def build_chapter_summary_prompt(
     session: AsyncSession,
     chapter_id: str,
@@ -150,11 +167,16 @@ async def build_chapter_summary_prompt(
     if not chapter:
         raise NotFoundError(f"章节不存在: {chapter_id}")
 
-    messages = await _build_prompt_messages(
+    messages = await _build_system_messages(
         session,
         prompt_id="memory-chapter-summary",
-        target_xml=_chapter_target_message(chapter),
     )
+    chapters = await chapter_repo.list_by_volume(session, chapter.volume_id)
+    previous_chapter = next((item for item in reversed(chapters) if item.order < chapter.order), None)
+    if previous_chapter:
+        previous_summary = await chapter_summary_repo.get_by_chapter_id(session, previous_chapter.id)
+        messages.append(SystemMessage(content=_previous_chapter_message(previous_chapter, previous_summary)))
+    messages.append(SystemMessage(content=_target_chapter_message(chapter)))
     return ChapterSummaryPrompt(messages=messages)
 
 
@@ -182,16 +204,6 @@ async def generate_chapter_summary_from_prompt(
     )
 
 
-async def generate_long_term_summary(
-    session: AsyncSession,
-    llm_client: LLMClient,
-    chapter_summaries: list[ChapterSummary],
-    chapters: list[Chapter],
-) -> GeneratedLongTermSummary:
-    prompt = await build_long_term_summary_prompt(session, chapter_summaries, chapters)
-    return await generate_long_term_summary_from_prompt(llm_client, prompt)
-
-
 async def build_long_term_summary_prompt(
     session: AsyncSession,
     chapter_summaries: list[ChapterSummary],
@@ -199,21 +211,37 @@ async def build_long_term_summary_prompt(
 ) -> LongTermSummaryPrompt:
     chapter_by_id = {chapter.id: chapter for chapter in chapters}
     parts: list[str] = []
-    for item in sorted(chapter_summaries, key=lambda summary: summary.chapter_order or 0):
+    for index, item in enumerate(
+        sorted(chapter_summaries, key=lambda summary: summary.chapter_order or 0),
+        start=1,
+    ):
         chapter = chapter_by_id.get(item.chapter_id or "")
         title = chapter.title if chapter else f"第{item.chapter_order}章"
+        characters = _summary_list_value(item.characters_json)
+        locations = _summary_list_value(item.locations_json)
+        summary_parts = [
+            _xml_tag("title", title),
+            _xml_tag("start_time", item.start_time) if item.start_time else "",
+            _xml_tag("end_time", item.end_time) if item.end_time else "",
+            _xml_tag("characters", characters) if characters else "",
+            _xml_tag("locations", locations) if locations else "",
+            _xml_tag("content", item.summary),
+        ]
+        content = "\n    ".join(part for part in summary_parts if part)
         parts.append(
-            f"<chapter{item.chapter_order}>\n{title}\n时间：{item.start_time} - {item.end_time}\n人物：{item.characters_json}\n地点：{item.locations_json}\n摘要：{item.summary}\n</chapter{item.chapter_order}>"
+            f"  <sum{index}>\n"
+            f"    {content}\n"
+            f"  </sum{index}>"
         )
-    summaries_text = "\n\n".join(parts)
-    if not summaries_text:
+    if not parts:
         raise NotFoundError("没有可聚合的章节摘要")
+    summaries_text = "<target_summaries>\n" + "\n".join(parts) + "\n</target_summaries>"
 
-    messages = await _build_prompt_messages(
+    messages = await _build_system_messages(
         session,
         prompt_id="memory-range-summary",
-        target_xml=_summaries_target_message(summaries_text),
     )
+    messages.append(SystemMessage(content=_summaries_target_message(summaries_text)))
     return LongTermSummaryPrompt(messages=messages, summaries_text=summaries_text)
 
 

--- a/backend/app/prompts/memory/chapter-summary.yaml
+++ b/backend/app/prompts/memory/chapter-summary.yaml
@@ -57,35 +57,3 @@ entries:
       </extra_requirements>
     order_index: 2
     is_enabled: true
-
-  - name: 上下文
-    role: system
-    content: |
-      <context>
-      下面为你提供了一些上下文信息，这些信息可能对你总结内容有所帮助，请仔细阅读并合理利用这些信息。
-      这些信息仅用于帮助你更好地理解章节内容和背景，你的总结仍应该聚焦于target中的内容。
-      下述的“第x个”的描述指的是相对于最新章节的逆序，如最新的章节是《第三十章 XXX》，那么“第1个”就是指《第三十章 XXX》，“第2个”就是指《第二十九章 XXX》，以此类推。
-      在当前章节数较小的情况下，可能存在某些级别的内容为空的情况，此时应以摘要实际内容为准，不要过度关注是否存在某个级别的内容。
-        <far_summary>
-        这一级的内容是对于每10个章节的总结，每十个章节一个部分，由于范围较广，因此可能只会包含必要的剧情发展信息，仅提供对于前文大致走向的把握。
-        第20个章节以后的总结：
-        {{getmem::chapter::far}}
-        </far_summary>
-        <middle_summary>
-        这一级的内容是对每个章节原文的总结，但可能会遗漏某些细节，每个章节一个部分。
-        第11-20个章节的总结：
-        {{getmem::chapter::middle}}
-        </middle_summary>
-        <near_chapter>
-        这一级的内容是实时提供的章节原文内容，每个章节一个部分。
-        第1-10个章节的内容：
-        {{getmem::chapter::near}}
-        {{getmem::chapter::latest}}
-        </near_chapter>
-        <world_info>
-        这一级的内容是用户录入的设定信息，可能包含人物设定、世界观设定等：
-        {{getworld}}
-        </world_info>
-      </context>
-    order_index: 3
-    is_enabled: true

--- a/backend/app/prompts/memory/range-summary.yaml
+++ b/backend/app/prompts/memory/range-summary.yaml
@@ -48,35 +48,3 @@ entries:
       </extra_requirements>
     order_index: 2
     is_enabled: true
-
-  - name: 上下文
-    role: system
-    content: |
-      <context>
-      下面为你提供了一些上下文信息，这些信息可能对你总结内容有所帮助，请仔细阅读并合理利用这些信息。
-      这些信息仅用于帮助你更好地理解章节内容和背景，你的总结仍应该聚焦于target中的内容。
-      下述的“第x个”的描述指的是相对于最新章节的逆序，如最新的章节是《第三十章 XXX》，那么“第1个”就是指《第三十章 XXX》，“第2个”就是指《第二十九章 XXX》，以此类推。
-      在当前章节数较小的情况下，可能存在某些级别的内容为空的情况，此时应以摘要实际内容为准，不要过度关注是否存在某个级别的内容。
-        <far_summary>
-        这一级的内容是对于每10个章节的总结，每十个章节一个部分，由于范围较广，因此可能只会包含必要的剧情发展信息，仅提供对于前文大致走向的把握。
-        第20个章节以后的总结：
-        {{getmem::chapter::far}}
-        </far_summary>
-        <middle_summary>
-        这一级的内容是对每个章节原文的总结，但可能会遗漏某些细节，每个章节一个部分。
-        第11-20个章节的总结：
-        {{getmem::chapter::middle}}
-        </middle_summary>
-        <near_chapter>
-        这一级的内容是实时提供的章节原文内容，每个章节一个部分。
-        第1-10个章节的内容：
-        {{getmem::chapter::near}}
-        {{getmem::chapter::latest}}
-        </near_chapter>
-        <world_info>
-        这一级的内容是用户录入的设定信息，可能包含人物设定、世界观设定等：
-        {{getworld}}
-        </world_info>
-      </context>
-    order_index: 3
-    is_enabled: true

--- a/backend/tests/memory/test_chapter_summary_generator.py
+++ b/backend/tests/memory/test_chapter_summary_generator.py
@@ -3,21 +3,160 @@
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.memory.chapter.summary_generator import _build_prompt_messages
+from app.memory.chapter.summary_generator import (
+    build_chapter_summary_prompt,
+    build_long_term_summary_prompt,
+)
+from app.storage.models.chapter import Chapter
+from app.storage.models.chapter_summary import ChapterSummary
+from app.storage.models.project import Project
+from app.storage.models.volume import Volume
+@pytest.mark.asyncio
+async def test_build_chapter_summary_prompt_includes_previous_chapter_and_target(
+    session: AsyncSession,
+) -> None:
+    project = Project(title="项目", description="")
+    session.add(project)
+    await session.flush()
+    volume = Volume(project_id=project.id, title="第一卷", order=1, chapter_count=2)
+    session.add(volume)
+    await session.flush()
+    previous_chapter = Chapter(
+        project_id=project.id,
+        volume_id=volume.id,
+        title="第一章",
+        content="上一章原文",
+        order=1,
+    )
+    target_chapter = Chapter(
+        project_id=project.id,
+        volume_id=volume.id,
+        title="第二章",
+        content="本章原文",
+        order=2,
+    )
+    session.add_all([previous_chapter, target_chapter])
+    await session.flush()
+    session.add(
+        ChapterSummary(
+            project_id=project.id,
+            summary_type="chapter",
+            status="ready",
+            chapter_id=previous_chapter.id,
+            volume_id=volume.id,
+            chapter_order=1,
+            start_time="地球历 2026-01-01 00:00",
+            characters_json='["张三"]',
+            locations_json='["京城"]',
+        )
+    )
+    await session.flush()
+
+    prompt = await build_chapter_summary_prompt(session, target_chapter.id)
+
+    assert len(prompt.messages) >= 3
+    assert any("emit_chapter_summary" in message.content for message in prompt.messages)
+    assert prompt.messages[-2].content == (
+        "以下部分是上一个章节的有关内容，用以帮助你连贯的理解剧情信息，该部分与你要总结的内容**无关**。\n"
+        "<previous_chapter>\n"
+        "  <title>第一章</title>\n"
+        "  <start_time>地球历 2026-01-01 00:00</start_time>\n"
+        "  <characters>[\"张三\"]</characters>\n"
+        "  <locations>[\"京城\"]</locations>\n"
+        "  <content>上一章原文</content>\n"
+        "</previous_chapter>"
+    )
+    assert prompt.messages[-1].content == (
+        "以下部分是你需要总结的章节内容。\n"
+        "<target_chapter>\n"
+        "  <title>第二章</title>\n"
+        "  <content>本章原文</content>\n"
+        "</target_chapter>"
+    )
+    assert all("{{getmem" not in message.content for message in prompt.messages)
+    assert all("{{getworld}}" not in message.content for message in prompt.messages)
 
 
 @pytest.mark.asyncio
-async def test_build_prompt_messages_appends_target_xml(
+async def test_build_chapter_summary_prompt_omits_previous_chapter_part_for_first_volume_chapter(
     session: AsyncSession,
 ) -> None:
-    messages = await _build_prompt_messages(
-        session,
-        prompt_id="memory-chapter-summary",
-        target_xml="<target><chapter_title>第一章</chapter_title></target>",
+    project = Project(title="项目", description="")
+    session.add(project)
+    await session.flush()
+    previous_volume = Volume(project_id=project.id, title="第一卷", order=1, chapter_count=1)
+    target_volume = Volume(project_id=project.id, title="第二卷", order=2, chapter_count=1)
+    session.add_all([previous_volume, target_volume])
+    await session.flush()
+    session.add(
+        Chapter(
+            project_id=project.id,
+            volume_id=previous_volume.id,
+            title="上一卷第一章",
+            content="不应注入的原文",
+            order=1,
+        )
+    )
+    chapter = Chapter(
+        project_id=project.id,
+        volume_id=target_volume.id,
+        title="第一章",
+        content="本章原文",
+        order=1,
+    )
+    session.add(chapter)
+    await session.flush()
+
+    prompt = await build_chapter_summary_prompt(session, chapter.id)
+
+    assert all("<previous_chapter>" not in message.content for message in prompt.messages)
+    assert prompt.messages[-1].content == (
+        "以下部分是你需要总结的章节内容。\n"
+        "<target_chapter>\n"
+        "  <title>第一章</title>\n"
+        "  <content>本章原文</content>\n"
+        "</target_chapter>"
     )
 
-    assert messages[0].content
-    assert any("emit_chapter_summary" in message.content for message in messages)
-    assert "<target><chapter_title>第一章</chapter_title></target>" == messages[-1].content
-    assert all("{{chapter_title}}" not in message.content for message in messages)
-    assert all("{{chapter_content}}" not in message.content for message in messages)
+
+@pytest.mark.asyncio
+async def test_build_long_term_summary_prompt_omits_default_context(session: AsyncSession) -> None:
+    project = Project(title="项目", description="")
+    session.add(project)
+    await session.flush()
+    volume = Volume(project_id=project.id, title="第一卷", order=1, chapter_count=1)
+    session.add(volume)
+    await session.flush()
+    chapter = Chapter(
+        project_id=project.id,
+        volume_id=volume.id,
+        title="第一章",
+        content="章节原文",
+        order=1,
+    )
+    session.add(chapter)
+    await session.flush()
+    summary = ChapterSummary(
+        project_id=project.id,
+        summary_type="chapter",
+        status="ready",
+        chapter_id=chapter.id,
+        volume_id=volume.id,
+        chapter_order=1,
+        summary="章节摘要",
+    )
+
+    prompt = await build_long_term_summary_prompt(session, [summary], [chapter])
+
+    assert any("emit_long_term_summary" in message.content for message in prompt.messages)
+    assert prompt.messages[-1].content == (
+        "以下部分是你需要总结的摘要内容\n"
+        "<target_summaries>\n"
+        "  <sum1>\n"
+        "    <title>第一章</title>\n"
+        "    <content>章节摘要</content>\n"
+        "  </sum1>\n"
+        "</target_summaries>"
+    )
+    assert all("{{getmem" not in message.content for message in prompt.messages)
+    assert all("{{getworld}}" not in message.content for message in prompt.messages)


### PR DESCRIPTION
## PR 标题

chore(backend): 调整摘要上下文结构

## 变更说明

- 问题: 摘要提示词中的宏上下文不会在当前提示词编译链路中展开，模型会接收到无效占位文本。
- 重要性: 无效上下文会干扰章节摘要与长期摘要对输入内容的理解。
- 变化: 移除默认提示词中的宏上下文，章节摘要改为显式注入同卷上一章信息和目标章节原文。
- 变化: 长期摘要改为以 XML 结构传入待聚合摘要，并移除未使用的摘要生成包装函数。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因(如有)

默认提示词引用的 `getmem` 和 `getworld` 宏未在摘要提示词编译链路中执行，导致模型收到原始宏文本而不是有效上下文。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令：

- `uv run pytest tests/memory/test_chapter_summary_generator.py`
- `uv run ruff check app/memory/chapter tests/memory/test_chapter_summary_generator.py`
- `uv run ty check app`（在本次提交的隔离快照中通过；当前工作区另有未提交的统一审计改动）
