### PR TITLE
fix(backend): 修复会话标题模型会话异常

### DIFF
--- a/backend/app/background/jobs/definitions/session_title.py
+++ b/backend/app/background/jobs/definitions/session_title.py
@@ -70,6 +70,9 @@ async def handle_session_title(context: JobContext) -> dict[str, str] | None:
     resolved, messages = await context.with_short_session(prepare_generation)
     if resolved is None or messages is None:
         return None
+    model_id = resolved.model.model_id
+    model_provider = resolved.provider.provider_type
+    model_name = resolved.model.name
     await context.check_cancelled()
 
     async def load_task_audit_context(session, _job):
@@ -92,9 +95,9 @@ async def handle_session_title(context: JobContext) -> dict[str, str] | None:
         return None
     async with audit_context.llm_call(
         operation="session_title",
-        model_id=resolved.model.model_id,
-        model_provider=resolved.provider.provider_type,
-        model_name=resolved.model.name,
+        model_id=model_id,
+        model_provider=model_provider,
+        model_name=model_name,
         request_messages=messages,
     ) as audit:
         response = await resolved.client.generate(messages, timeout=60)

--- a/backend/tests/background/test_background_jobs.py
+++ b/backend/tests/background/test_background_jobs.py
@@ -46,6 +46,7 @@ from app.background.transport.base import BackgroundTransport
 from app.background.transport.messages import BackgroundEventMessage, JobNotification
 from app.background.transport.zmq import ZmqBackgroundTransport
 from app.memory.chapter import summary_service
+from app.models.entities.model import Model
 from app.storage import database
 from app.storage.models.chapter import Chapter
 from app.storage.models.chapter_summary import ChapterSummary
@@ -540,6 +541,70 @@ async def test_session_title_records_audited_model_call(tmp_path, monkeypatch):
             "background_job_id": job.id,
             "seed_message": "请命名这个会话",
         }
+    finally:
+        if context is not None and context.session is not session:
+            await context.session.close()
+        await session.close()
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_session_title_keeps_audit_model_metadata_after_short_session_closes(tmp_path, monkeypatch):
+    engine, factory = await _configure_file_database(tmp_path)
+    session = factory()
+    context: JobContext | None = None
+    try:
+        project = Project(title="项目", description="")
+        task = Task(project_id=project.id, title="临时标题", mode="agent")
+        model = Model(
+            name="GPT Test",
+            provider_id="provider-test",
+            model_id="gpt-test",
+        )
+        session.add_all([project, task, model])
+        await session.commit()
+        job = await background_service.submit_job(
+            session,
+            job_type="session_title",
+            payload={"task_id": task.id, "seed_message": "请命名这个会话"},
+            context={"project_id": project.id, "model_policy": "light_model"},
+            subject_type="task",
+            subject_id=task.id,
+        )
+        await session.commit()
+        context = JobContext(
+            session=session,
+            job=job,
+            publisher=BackgroundEventPublisher(RecordingTransport()),
+        )
+
+        async def fake_resolve_background_llm(resolver_session, **_kwargs):
+            resolved_model = await resolver_session.get(Model, model.id)
+            assert resolved_model is not None
+            return SimpleNamespace(
+                client=SimpleNamespace(
+                    generate=AsyncMock(
+                        return_value=SimpleNamespace(content="标题测试", usage={})
+                    )
+                ),
+                model=resolved_model,
+                provider=SimpleNamespace(provider_type="openai-compatible"),
+            )
+
+        async def fake_enqueue(_audit_log):
+            return None
+
+        monkeypatch.setattr("app.audit.context.enqueue_audit_log", fake_enqueue)
+        with patch(
+            "app.background.jobs.definitions.session_title.resolve_background_llm",
+            AsyncMock(side_effect=fake_resolve_background_llm),
+        ), patch(
+            "app.background.jobs.definitions.session_title.build_chat_messages",
+            AsyncMock(return_value=[]),
+        ):
+            result = await handle_session_title(context)
+
+        assert result == {"title": "标题测试", "task_id": task.id}
     finally:
         if context is not None and context.session is not session:
             await context.session.close()


### PR DESCRIPTION
## PR 标题

fix(backend): 修复会话标题模型会话异常

## 变更说明

- 问题: 会话标题任务在切换短生命周期数据库会话后继续读取已脱离会话的 `Model` ORM 实例，导致标题生成失败。
- 重要性: 标题生成任务会稳定触发 `DetachedInstanceError`，无法完成标题更新。
- 变化: 在首次短会话关闭前提取审计所需的模型标识、提供商类型和名称，后续流程只使用普通值。
- 变化: 新增回归测试，覆盖真实 ORM `Model` 跨短会话切换后的标题生成路径。

## 关联 Issue / PR (如有)

关联 #107

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [x] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

`resolve_background_llm` 返回的 `Model` 与首次短会话绑定。加载审计上下文时，`with_short_session` 会关闭该会话；之后审计代码再次访问 `resolved.model` 的属性，SQLAlchemy 尝试刷新已脱离会话的实例并抛出 `DetachedInstanceError`。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令: `cd backend && just check`，结果为 Ruff 和 ty 检查通过，pytest `1072 passed, 1 warning`。警告来自既有 FastEmbed 参数转发，不由本次变更引入。
