### PR TITLE
fix(frontend): 防止写作编辑内容丢失

### DIFF
--- a/frontend/src/components/markdown-editor.tsx
+++ b/frontend/src/components/markdown-editor.tsx
@@ -109,7 +109,7 @@ export function MarkdownEditor({
     if (content === contentSyncedRef.current) return;
 
     contentSyncedRef.current = content;
-    currentEditor.commands.setContent(content, { emitUpdate: false });
+    currentEditor.commands.setContent(content, { contentType: "markdown", emitUpdate: false });
   }, [content]);
 
   useHotkeys(

--- a/frontend/src/features/assistant/components/agent/agent-mention-suggestions.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-mention-suggestions.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, FileText, Folder, ScrollText, StickyNote, UserRound } from "lucide-react";
+import { BookOpen, FileText, Folder, ScrollText, NotebookText, UserRound } from "lucide-react";
 import { motion } from "motion/react";
 import { useEffect, useRef } from "react";
 import type { CSSProperties } from "react";
@@ -20,12 +20,12 @@ interface AgentMentionSuggestionsProps {
 }
 
 function getItemIcon(kind: AssistantMentionCandidate["kind"]) {
-  if (kind === "volume") return <BookOpen size={12} />;
-  if (kind === "note") return <StickyNote size={12} />;
-  if (kind === "note_category") return <Folder size={12} />;
-  if (kind === "world_info_entry") return <ScrollText size={12} />;
-  if (kind === "character") return <UserRound size={12} />;
-  return <FileText size={12} />;
+  if (kind === "volume") return <BookOpen size={14} />;
+  if (kind === "note") return <NotebookText size={14} />;
+  if (kind === "note_category") return <Folder size={14} />;
+  if (kind === "world_info_entry") return <ScrollText size={14} />;
+  if (kind === "character") return <UserRound size={14} />;
+  return <FileText size={14} />;
 }
 
 function getItemMeta(

--- a/frontend/src/features/assistant/components/agent/mention-chip.tsx
+++ b/frontend/src/features/assistant/components/agent/mention-chip.tsx
@@ -1,4 +1,12 @@
-import { BookOpen, FileText, Folder, Quote, ScrollText, StickyNote, UserRound } from "lucide-react";
+import {
+  BookOpen,
+  FileText,
+  Folder,
+  Quote,
+  ScrollText,
+  NotebookText,
+  UserRound,
+} from "lucide-react";
 import type { ReactNode } from "react";
 
 import type { AssistantMentionKind } from "@/features/assistant/lib/mention-text";
@@ -6,13 +14,13 @@ import type { AssistantMentionKind } from "@/features/assistant/lib/mention-text
 import "./agent-mentions.css";
 
 function getMentionIcon(kind: AssistantMentionKind): ReactNode {
-  if (kind === "volume") return <BookOpen size={12} />;
-  if (kind === "chapter") return <FileText size={12} />;
-  if (kind === "note") return <StickyNote size={12} />;
-  if (kind === "note_category") return <Folder size={12} />;
-  if (kind === "world_info_entry") return <ScrollText size={12} />;
-  if (kind === "character") return <UserRound size={12} />;
-  return <Quote size={12} />;
+  if (kind === "volume") return <BookOpen size={14} />;
+  if (kind === "chapter") return <FileText size={14} />;
+  if (kind === "note") return <NotebookText size={14} />;
+  if (kind === "note_category") return <Folder size={14} />;
+  if (kind === "world_info_entry") return <ScrollText size={14} />;
+  if (kind === "character") return <UserRound size={14} />;
+  return <Quote size={14} />;
 }
 
 export function MentionChip({

--- a/frontend/src/features/writing/components/chapter-editor.tsx
+++ b/frontend/src/features/writing/components/chapter-editor.tsx
@@ -16,14 +16,25 @@ import {
   buildLineRangeMentionTag,
 } from "@/features/assistant/lib/mention-text";
 import { useScrollbarAutoHide } from "@/hooks/use-scrollbar-auto-hide";
+import { fetchChapter } from "@/lib/api-client";
 import type { Chapter } from "@/lib/chapter.types";
 import { htmlToNewlines, newlinesToHtml } from "@/lib/html-utils";
 import { createToastThrottler } from "@/lib/ui-utils";
 
 import { useAutoSave } from "../hooks/use-auto-save";
-import { useChapter, useUpdateChapter } from "../hooks/use-chapters";
+import { useUpdateChapter } from "../hooks/use-chapters";
+import { useWritingEditorEntity } from "../hooks/use-writing-editor-entity";
+import {
+  useWritingWorkingCopy,
+  type WritingDraft,
+  type WritingWorkingCopyController,
+} from "../hooks/use-writing-working-copy";
 import { createChapterEditorDraft, isChapterEditorDraftDirty } from "../lib/chapter-editor-draft";
 import { createEditorExtensions } from "../lib/editor-config";
+import {
+  getNextWritingWorkingCopyTimestamp,
+  isRemoteWritingEntityNewer,
+} from "../lib/writing-working-copy";
 import { useTabsStore } from "../store/use-tabs-store";
 import { FindReplacePanel } from "./find-replace-panel";
 
@@ -44,41 +55,56 @@ interface ChapterEditorProps {
   onOpenSummary?: () => void;
 }
 
-function ChapterEditorInner({
-  chapter,
-  onChapterUpdate,
-  onAddToConversation,
-  projectId,
-  isAgentLocked = false,
-  onOpenSummary,
-}: {
+interface ChapterEditorContentProps {
   chapter: Chapter;
+  initialDraft: WritingDraft;
+  initialDraftUpdatedAt: Date;
+  workingCopy: WritingWorkingCopyController;
   onChapterUpdate?: (chapter: Chapter) => void;
   onAddToConversation?: (markup: string) => void;
   projectId?: string;
   isAgentLocked?: boolean;
   onOpenSummary?: () => void;
-}) {
+}
+
+function ChapterEditorContent({
+  chapter,
+  initialDraft,
+  initialDraftUpdatedAt,
+  workingCopy,
+  onChapterUpdate,
+  onAddToConversation,
+  projectId,
+  isAgentLocked = false,
+  onOpenSummary,
+}: ChapterEditorContentProps) {
   const { t } = useTranslation();
   const updateMutation = useUpdateChapter();
   const { containerRef, scrollbarProps } = useScrollbarAutoHide();
   const editorContentRef = useRef<HTMLDivElement>(null);
   const { updateTabTitle } = useTabsStore();
   const navigate = useNavigate();
+  const { clearWorkingCopy, persistWorkingCopy } = workingCopy;
 
-  const [title, setTitle] = useState(chapter.title);
-  const titleRef = useRef(chapter.title);
+  const [title, setTitle] = useState(initialDraft.title);
+  const titleRef = useRef(initialDraft.title);
   const lastSavedDraftRef = useRef(
     createChapterEditorDraft({
       title: chapter.title,
       content: chapter.content,
     }),
   );
-  const [hasChanges, setHasChanges] = useState(false);
+  const [hasChanges, setHasChanges] = useState(
+    isChapterEditorDraftDirty(lastSavedDraftRef.current, initialDraft),
+  );
   const [isSaving, setIsSaving] = useState(false);
   const [findReplaceMode, setFindReplaceMode] = useState<"closed" | "find" | "replace">("closed");
-  const [wordCount, setWordCount] = useState(() => wordsCount(chapter.content || ""));
+  const [wordCount, setWordCount] = useState(() => wordsCount(initialDraft.content));
   const saveStatus = isSaving ? "saving" : hasChanges ? "unsaved" : "saved";
+  const latestDraftRef = useRef(initialDraft);
+  const latestDraftUpdatedAtRef = useRef(initialDraftUpdatedAt);
+  const hasChangesRef = useRef(isChapterEditorDraftDirty(lastSavedDraftRef.current, initialDraft));
+  const baseUpdatedAtRef = useRef(chapter.updatedAt);
 
   const showLockedToast = useMemo(
     () => createToastThrottler(t("writing.agentLockedChapterEdit")),
@@ -139,18 +165,37 @@ function ChapterEditorInner({
     setFindReplaceMode("replace");
   }, [isAgentLocked, showLockedToast]);
 
-  const updateDirtyState = useCallback((nextTitle: string, nextHtmlContent: string) => {
-    const nextDraft = createChapterEditorDraft({
-      title: nextTitle,
-      content: htmlToNewlines(nextHtmlContent),
-    });
-    setHasChanges(isChapterEditorDraftDirty(lastSavedDraftRef.current, nextDraft));
-    return nextDraft;
-  }, []);
+  const persistDraft = useCallback(
+    (draft: WritingDraft) => {
+      latestDraftUpdatedAtRef.current = getNextWritingWorkingCopyTimestamp(
+        latestDraftUpdatedAtRef.current,
+      );
+      persistWorkingCopy(draft, baseUpdatedAtRef.current, latestDraftUpdatedAtRef.current);
+    },
+    [persistWorkingCopy],
+  );
+
+  const updateDirtyState = useCallback(
+    (nextTitle: string, nextHtmlContent: string) => {
+      const nextDraft = createChapterEditorDraft({
+        title: nextTitle,
+        content: htmlToNewlines(nextHtmlContent),
+      });
+      const isDirty = isChapterEditorDraftDirty(lastSavedDraftRef.current, nextDraft);
+      latestDraftRef.current = nextDraft;
+      hasChangesRef.current = isDirty;
+      setHasChanges(isDirty);
+      if (isDirty) {
+        persistDraft(nextDraft);
+      }
+      return { draft: nextDraft, isDirty };
+    },
+    [persistDraft],
+  );
 
   const syncDirtyStateFromEditor = useCallback(
     (editorInstance: { getHTML: () => string }) => {
-      updateDirtyState(titleRef.current, editorInstance.getHTML());
+      return updateDirtyState(titleRef.current, editorInstance.getHTML());
     },
     [updateDirtyState],
   );
@@ -171,7 +216,7 @@ function ChapterEditorInner({
       },
     }),
     editable: !isAgentLocked,
-    content: chapter.content ? newlinesToHtml(chapter.content) : "",
+    content: initialDraft.content ? newlinesToHtml(initialDraft.content) : "",
     onUpdate: ({ editor }) => {
       if (isAgentLocked) return;
       syncDirtyStateFromEditor(editor);
@@ -190,15 +235,13 @@ function ChapterEditorInner({
         return;
       }
 
-      const htmlContent = editor.getHTML();
-      const draftToSave = createChapterEditorDraft({
-        title,
-        content: htmlToNewlines(htmlContent),
-      });
-      const currentWordCount = wordsCount(editor.getText());
+      const draftToSave = latestDraftRef.current;
+      const draftUpdatedAt = latestDraftUpdatedAtRef.current;
+      const currentWordCount = wordsCount(draftToSave.content);
 
       setIsSaving(true);
       try {
+        persistWorkingCopy(draftToSave, baseUpdatedAtRef.current, draftUpdatedAt);
         const updatedChapter = await updateMutation.mutateAsync({
           chapterId: chapter.id,
           data: {
@@ -211,6 +254,8 @@ function ChapterEditorInner({
           title: updatedChapter.title,
           content: updatedChapter.content,
         });
+        baseUpdatedAtRef.current = updatedChapter.updatedAt;
+        void clearWorkingCopy(draftToSave, draftUpdatedAt);
         syncDirtyStateFromEditor(editor);
         onChapterUpdate?.(updatedChapter);
 
@@ -231,8 +276,9 @@ function ChapterEditorInner({
       showLockedToast,
       syncDirtyStateFromEditor,
       t,
-      title,
       updateMutation,
+      clearWorkingCopy,
+      persistWorkingCopy,
     ],
   );
 
@@ -255,34 +301,25 @@ function ChapterEditorInner({
   }, [editor, isAgentLocked]);
 
   useEffect(() => {
-    if (!editor || hasChanges) return;
-
-    const nextTitle = chapter.title;
-    const nextContent = chapter.content ? newlinesToHtml(chapter.content) : "";
-    const currentContent = editor.getHTML();
-    lastSavedDraftRef.current = createChapterEditorDraft({
-      title: nextTitle,
-      content: chapter.content,
-    });
-
-    if (title !== nextTitle) {
-      titleRef.current = nextTitle;
-      queueMicrotask(() => {
-        setTitle(nextTitle);
-        updateTabTitle(chapter.id, nextTitle);
-      });
-    }
-
-    if (currentContent !== nextContent) {
-      editor.commands.setContent(nextContent, { emitUpdate: false });
-      queueMicrotask(() => {
-        setWordCount(wordsCount(editor.getText()));
-      });
-    }
-  }, [editor, chapter.title, chapter.content, chapter.id, hasChanges, title, updateTabTitle]);
+    return () => {
+      if (hasChangesRef.current) {
+        persistWorkingCopy(
+          latestDraftRef.current,
+          baseUpdatedAtRef.current,
+          latestDraftUpdatedAtRef.current,
+        );
+      }
+    };
+  }, [persistWorkingCopy]);
 
   useEffect(() => {
-    if (!editor || !isAgentLocked) return;
+    if (
+      !editor ||
+      hasChanges ||
+      !isRemoteWritingEntityNewer(chapter.updatedAt, baseUpdatedAtRef.current)
+    ) {
+      return;
+    }
 
     const nextTitle = chapter.title;
     const nextContent = chapter.content ? newlinesToHtml(chapter.content) : "";
@@ -291,6 +328,9 @@ function ChapterEditorInner({
       title: nextTitle,
       content: chapter.content,
     });
+    latestDraftRef.current = lastSavedDraftRef.current;
+    latestDraftUpdatedAtRef.current = new Date(chapter.updatedAt);
+    baseUpdatedAtRef.current = chapter.updatedAt;
 
     if (title !== nextTitle) {
       titleRef.current = nextTitle;
@@ -306,16 +346,22 @@ function ChapterEditorInner({
         setWordCount(wordsCount(editor.getText()));
       });
     }
-
-    queueMicrotask(() => {
-      setHasChanges(false);
-    });
-  }, [editor, chapter.title, chapter.content, chapter.id, isAgentLocked, title, updateTabTitle]);
+  }, [
+    editor,
+    chapter.title,
+    chapter.content,
+    chapter.id,
+    chapter.updatedAt,
+    hasChanges,
+    title,
+    updateTabTitle,
+  ]);
 
   useAutoSave({
     onSave: handleSave,
     hasChanges,
     enabled: !isAgentLocked,
+    interval: 3000,
   });
 
   useHotkeys(
@@ -367,7 +413,17 @@ function ChapterEditorInner({
     if (editor) {
       updateDirtyState(newTitle, editor.getHTML());
     } else {
-      setHasChanges(newTitle !== lastSavedDraftRef.current.title);
+      const draft = createChapterEditorDraft({
+        title: newTitle,
+        content: latestDraftRef.current.content,
+      });
+      latestDraftRef.current = draft;
+      const isDirty = draft.title !== lastSavedDraftRef.current.title;
+      hasChangesRef.current = isDirty;
+      setHasChanges(isDirty);
+      if (isDirty) {
+        persistDraft(draft);
+      }
     }
     updateTabTitle(chapter.id, newTitle);
   };
@@ -535,7 +591,11 @@ export function ChapterEditor({
   onOpenSummary,
 }: ChapterEditorProps) {
   const { t } = useTranslation();
-  const { data: chapter, isLoading } = useChapter(chapterId);
+  const { data, isFetching, isLoading } = useWritingEditorEntity({
+    type: "chapter",
+    entityId: chapterId,
+    fetchEntity: fetchChapter,
+  });
 
   if (!chapterId) {
     return (
@@ -554,7 +614,7 @@ export function ChapterEditor({
     );
   }
 
-  if (isLoading || !chapter) {
+  if (isLoading || isFetching || !data) {
     return (
       <Flex
         align="center"
@@ -567,9 +627,42 @@ export function ChapterEditor({
   }
 
   return (
-    <ChapterEditorInner
-      key={chapter.id}
+    <ChapterEditorWorkingCopy
+      key={`${data.entity.id}:${data.draftUpdatedAt.getTime()}`}
+      chapter={data.entity}
+      initialDraft={data.draft}
+      initialDraftUpdatedAt={data.draftUpdatedAt}
+      onChapterUpdate={onChapterUpdate}
+      onAddToConversation={onAddToConversation}
+      projectId={projectId}
+      isAgentLocked={isAgentLocked}
+      onOpenSummary={onOpenSummary}
+    />
+  );
+}
+
+function ChapterEditorWorkingCopy({
+  chapter,
+  initialDraft,
+  initialDraftUpdatedAt,
+  onChapterUpdate,
+  onAddToConversation,
+  projectId,
+  isAgentLocked,
+  onOpenSummary,
+}: Omit<ChapterEditorContentProps, "workingCopy">) {
+  const workingCopy = useWritingWorkingCopy({
+    type: "chapter",
+    entityId: chapter.id,
+  });
+
+  return (
+    <ChapterEditorContent
+      key={`${chapter.id}:${initialDraftUpdatedAt.getTime()}`}
       chapter={chapter}
+      initialDraft={initialDraft}
+      initialDraftUpdatedAt={initialDraftUpdatedAt}
+      workingCopy={workingCopy}
       onChapterUpdate={onChapterUpdate}
       onAddToConversation={onAddToConversation}
       projectId={projectId}

--- a/frontend/src/features/writing/components/editor-tabs.tsx
+++ b/frontend/src/features/writing/components/editor-tabs.tsx
@@ -30,7 +30,7 @@ import {
   FileText,
   Lock,
   Plus,
-  StickyNote,
+  NotebookText,
   Unlock,
   X,
   XCircle,
@@ -113,12 +113,12 @@ const SortableTabItem = memo(function SortableTabItem({
         {/* 类型图标 */}
         {tab.type === "chapter" ? (
           <FileText
-            size={12}
+            size={14}
             style={{ flexShrink: 0, marginRight: 4, opacity: 0.6 }}
           />
         ) : (
-          <StickyNote
-            size={12}
+          <NotebookText
+            size={14}
             style={{ flexShrink: 0, marginRight: 4, opacity: 0.6 }}
           />
         )}

--- a/frontend/src/features/writing/components/note-editor.tsx
+++ b/frontend/src/features/writing/components/note-editor.tsx
@@ -4,10 +4,23 @@ import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import { MarkdownEditor, Spinner } from "@/components";
+import { fetchNote } from "@/lib/api-client";
+import type { Note } from "@/lib/note.types";
 import { createToastThrottler } from "@/lib/ui-utils";
 
 import { useAutoSave } from "../hooks/use-auto-save";
-import { useNote, useUpdateNote } from "../hooks/use-notes";
+import { useUpdateNote } from "../hooks/use-notes";
+import { useWritingEditorEntity } from "../hooks/use-writing-editor-entity";
+import {
+  useWritingWorkingCopy,
+  type WritingDraft,
+  type WritingWorkingCopyController,
+} from "../hooks/use-writing-working-copy";
+import {
+  areWritingWorkingCopyDraftsEqual,
+  getNextWritingWorkingCopyTimestamp,
+  isRemoteWritingEntityNewer,
+} from "../lib/writing-working-copy";
 import { useTabsStore } from "../store/use-tabs-store";
 
 interface NoteEditorProps {
@@ -17,27 +30,59 @@ interface NoteEditorProps {
   onAddToConversation?: (markup: string) => void;
 }
 
-function NoteEditorInner({
-  note,
-  isAgentLocked = false,
-}: {
-  note: NonNullable<ReturnType<typeof useNote>["data"]>;
+interface NoteEditorContentProps {
+  note: Note;
+  initialDraft: WritingDraft;
+  initialDraftUpdatedAt: Date;
+  workingCopy: WritingWorkingCopyController;
   isAgentLocked?: boolean;
-}) {
+}
+
+function NoteEditorContent({
+  note,
+  initialDraft,
+  initialDraftUpdatedAt,
+  workingCopy,
+  isAgentLocked = false,
+}: NoteEditorContentProps) {
   const { t } = useTranslation();
   const updateMutation = useUpdateNote(note.projectId);
   const { updateTabTitle } = useTabsStore();
+  const { clearWorkingCopy, persistWorkingCopy } = workingCopy;
 
   const showLockedToast = useMemo(
     () => createToastThrottler(t("writing.agentLockedNoteEdit")),
     [t],
   );
 
-  const [title, setTitle] = useState(note.title);
-  const titleRef = useRef(note.title);
-  const [hasChanges, setHasChanges] = useState(false);
+  const [title, setTitle] = useState(initialDraft.title);
+  const titleRef = useRef(initialDraft.title);
+  const [hasChanges, setHasChanges] = useState(
+    !areWritingWorkingCopyDraftsEqual(initialDraft, { title: note.title, content: note.content }),
+  );
   const [isSaving, setIsSaving] = useState(false);
-  const savedContentRef = useRef(note.content ?? "");
+  const [editorContent, setEditorContent] = useState(initialDraft.content);
+  const savedContentRef = useRef(initialDraft.content);
+  const latestDraftRef = useRef(initialDraft);
+  const latestDraftUpdatedAtRef = useRef(initialDraftUpdatedAt);
+  const hasChangesRef = useRef(
+    !areWritingWorkingCopyDraftsEqual(initialDraft, { title: note.title, content: note.content }),
+  );
+  const lastSavedDraftRef = useRef<WritingDraft>({
+    title: note.title,
+    content: note.content,
+  });
+  const baseUpdatedAtRef = useRef(note.updatedAt);
+
+  const persistDraft = useCallback(
+    (draft: WritingDraft) => {
+      latestDraftUpdatedAtRef.current = getNextWritingWorkingCopyTimestamp(
+        latestDraftUpdatedAtRef.current,
+      );
+      persistWorkingCopy(draft, baseUpdatedAtRef.current, latestDraftUpdatedAtRef.current);
+    },
+    [persistWorkingCopy],
+  );
 
   const handleSave = useCallback(async () => {
     if (isAgentLocked) {
@@ -45,61 +90,85 @@ function NoteEditorInner({
       return;
     }
 
-    const markdown = savedContentRef.current;
+    const draftToSave = latestDraftRef.current;
+    const draftUpdatedAt = latestDraftUpdatedAtRef.current;
 
     setIsSaving(true);
     try {
+      persistWorkingCopy(draftToSave, baseUpdatedAtRef.current, draftUpdatedAt);
       const updatedNote = await updateMutation.mutateAsync({
         noteId: note.id,
         data: {
-          title,
-          content: markdown,
+          title: draftToSave.title,
+          content: draftToSave.content,
         },
       });
-      updateTabTitle(`note:${updatedNote.id}`, updatedNote.title);
-      setHasChanges(false);
+      lastSavedDraftRef.current = {
+        title: updatedNote.title,
+        content: updatedNote.content,
+      };
+      baseUpdatedAtRef.current = updatedNote.updatedAt;
+      void clearWorkingCopy(draftToSave, draftUpdatedAt);
+      updateTabTitle(`note:${updatedNote.id}`, latestDraftRef.current.title);
+      const isDirty = !areWritingWorkingCopyDraftsEqual(
+        latestDraftRef.current,
+        lastSavedDraftRef.current,
+      );
+      hasChangesRef.current = isDirty;
+      setHasChanges(isDirty);
+    } catch {
+      hasChangesRef.current = true;
+      setHasChanges(true);
     } finally {
       setIsSaving(false);
     }
-  }, [note.id, title, updateMutation, updateTabTitle, isAgentLocked, showLockedToast]);
+  }, [
+    clearWorkingCopy,
+    isAgentLocked,
+    note.id,
+    persistWorkingCopy,
+    showLockedToast,
+    updateMutation,
+    updateTabTitle,
+  ]);
 
   useEffect(() => {
     titleRef.current = title;
   }, [title]);
 
   useEffect(() => {
-    if (!hasChanges) return;
+    if (hasChanges || !isRemoteWritingEntityNewer(note.updatedAt, baseUpdatedAtRef.current)) {
+      return;
+    }
 
-    if (title !== note.title) {
+    const draft = { title: note.title, content: note.content ?? "" };
+    latestDraftRef.current = draft;
+    savedContentRef.current = draft.content;
+    setEditorContent(draft.content);
+    lastSavedDraftRef.current = draft;
+    baseUpdatedAtRef.current = note.updatedAt;
+    latestDraftUpdatedAtRef.current = new Date(note.updatedAt);
+
+    if (title !== draft.title) {
       titleRef.current = note.title;
       queueMicrotask(() => {
-        setTitle(note.title);
+        setTitle(draft.title);
         updateTabTitle(`note:${note.id}`, note.title);
       });
     }
-
-    if (note.content !== savedContentRef.current) {
-      savedContentRef.current = note.content ?? "";
-    }
-  }, [note.title, note.content, note.id, hasChanges, title, updateTabTitle]);
+  }, [note.title, note.content, note.id, note.updatedAt, hasChanges, title, updateTabTitle]);
 
   useEffect(() => {
-    if (!isAgentLocked) return;
-
-    if (title !== note.title) {
-      titleRef.current = note.title;
-      queueMicrotask(() => {
-        setTitle(note.title);
-        updateTabTitle(`note:${note.id}`, note.title);
-      });
-    }
-
-    savedContentRef.current = note.content ?? "";
-
-    queueMicrotask(() => {
-      setHasChanges(false);
-    });
-  }, [note.title, note.content, note.id, isAgentLocked, title, updateTabTitle]);
+    return () => {
+      if (hasChangesRef.current) {
+        persistWorkingCopy(
+          latestDraftRef.current,
+          baseUpdatedAtRef.current,
+          latestDraftUpdatedAtRef.current,
+        );
+      }
+    };
+  }, [persistWorkingCopy]);
 
   useAutoSave({
     onSave: handleSave,
@@ -111,16 +180,31 @@ function NoteEditorInner({
   const handleTitleChange = (newTitle: string) => {
     setTitle(newTitle);
     titleRef.current = newTitle;
-    setHasChanges(newTitle !== note.title || savedContentRef.current !== note.content);
+    const draft = { title: newTitle, content: savedContentRef.current };
+    latestDraftRef.current = draft;
+    const isDirty = !areWritingWorkingCopyDraftsEqual(draft, lastSavedDraftRef.current);
+    hasChangesRef.current = isDirty;
+    setHasChanges(isDirty);
+    if (isDirty) {
+      persistDraft(draft);
+    }
     updateTabTitle(`note:${note.id}`, newTitle);
   };
 
   const handleContentChange = useCallback(
     (markdown: string) => {
       savedContentRef.current = markdown;
-      setHasChanges(markdown !== note.content || title !== note.title);
+      setEditorContent(markdown);
+      const draft = { title, content: markdown };
+      latestDraftRef.current = draft;
+      const isDirty = !areWritingWorkingCopyDraftsEqual(draft, lastSavedDraftRef.current);
+      hasChangesRef.current = isDirty;
+      setHasChanges(isDirty);
+      if (isDirty) {
+        persistDraft(draft);
+      }
     },
-    [note.content, note.title, title],
+    [persistDraft, title],
   );
 
   const lockedBanner = note.isLocked ? (
@@ -151,7 +235,7 @@ function NoteEditorInner({
     <MarkdownEditor
       title={title}
       onTitleChange={handleTitleChange}
-      content={note.content ?? ""}
+      content={editorContent}
       onContentChange={handleContentChange}
       onSave={handleSave}
       isSaving={isSaving}
@@ -166,7 +250,11 @@ function NoteEditorInner({
 
 export function NoteEditor(props: NoteEditorProps) {
   const { t } = useTranslation();
-  const { data: note, isLoading } = useNote(props.noteId);
+  const { data, isFetching, isLoading } = useWritingEditorEntity({
+    type: "note",
+    entityId: props.noteId,
+    fetchEntity: fetchNote,
+  });
 
   if (!props.noteId) {
     return (
@@ -185,7 +273,7 @@ export function NoteEditor(props: NoteEditorProps) {
     );
   }
 
-  if (isLoading || !note) {
+  if (isLoading || isFetching || !data) {
     return (
       <Flex
         align="center"
@@ -198,10 +286,35 @@ export function NoteEditor(props: NoteEditorProps) {
   }
 
   return (
-    <NoteEditorInner
-      key={note.id}
-      note={note}
+    <NoteEditorWorkingCopy
+      key={`${data.entity.id}:${data.draftUpdatedAt.getTime()}`}
+      note={data.entity}
+      initialDraft={data.draft}
+      initialDraftUpdatedAt={data.draftUpdatedAt}
       isAgentLocked={props.isAgentLocked ?? false}
+    />
+  );
+}
+
+function NoteEditorWorkingCopy({
+  note,
+  initialDraft,
+  initialDraftUpdatedAt,
+  isAgentLocked,
+}: Omit<NoteEditorContentProps, "workingCopy">) {
+  const workingCopy = useWritingWorkingCopy({
+    type: "note",
+    entityId: note.id,
+  });
+
+  return (
+    <NoteEditorContent
+      key={`${note.id}:${initialDraftUpdatedAt.getTime()}`}
+      note={note}
+      initialDraft={initialDraft}
+      initialDraftUpdatedAt={initialDraftUpdatedAt}
+      workingCopy={workingCopy}
+      isAgentLocked={isAgentLocked}
     />
   );
 }

--- a/frontend/src/features/writing/components/note-tree-item.tsx
+++ b/frontend/src/features/writing/components/note-tree-item.tsx
@@ -4,7 +4,7 @@ import { Flex, Text } from "@radix-ui/themes";
 import {
   Folder,
   FolderOpen,
-  StickyNote,
+  NotebookText,
   Lock,
   EyeOff,
   MoreHorizontal,
@@ -239,7 +239,7 @@ export const NoteTreeItem = memo(function NoteTreeItem({
   );
 
   const iconSize = 14;
-  const Icon = data.type === "category" ? (data.isExpanded ? FolderOpen : Folder) : StickyNote;
+  const Icon = data.type === "category" ? (data.isExpanded ? FolderOpen : Folder) : NotebookText;
 
   const handleRowClick = useCallback(() => {
     if (longPressTriggeredRef.current) {

--- a/frontend/src/features/writing/hooks/use-writing-editor-entity.ts
+++ b/frontend/src/features/writing/hooks/use-writing-editor-entity.ts
@@ -1,0 +1,71 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  deleteWritingWorkingCopyIfUpdatedAt,
+  getWritingWorkingCopy,
+  type WritingWorkingCopyType,
+} from "@/lib/local-db";
+
+import { resolveWritingWorkingCopy } from "../lib/writing-working-copy";
+import type { WritingDraft } from "./use-writing-working-copy";
+
+export async function loadWritingEditorEntity<TEntity extends WritingEditorEntity>(
+  type: WritingWorkingCopyType,
+  entityId: string,
+  fetchEntity: (entityId: string) => Promise<TEntity>,
+): Promise<WritingEditorEntityResult<TEntity>> {
+  const [entity, workingCopy] = await Promise.all([
+    fetchEntity(entityId),
+    getWritingWorkingCopy(type, entityId),
+  ]);
+  const resolved = resolveWritingWorkingCopy(entity, workingCopy);
+
+  if (resolved.shouldDelete) {
+    await deleteWritingWorkingCopyIfUpdatedAt(type, entity.id, workingCopy!.updatedAt);
+  }
+
+  return {
+    entity,
+    draft: resolved.draft,
+    draftUpdatedAt:
+      !resolved.shouldDelete && workingCopy !== null
+        ? workingCopy.updatedAt
+        : new Date(entity.updatedAt),
+    isWorkingCopyRecovered: !resolved.shouldDelete && workingCopy !== null,
+  };
+}
+
+interface WritingEditorEntity {
+  id: string;
+  title: string;
+  content: string;
+  updatedAt: string;
+}
+
+interface WritingEditorEntityResult<TEntity> {
+  entity: TEntity;
+  draft: WritingDraft;
+  draftUpdatedAt: Date;
+  isWorkingCopyRecovered: boolean;
+}
+
+interface UseWritingEditorEntityOptions<TEntity extends WritingEditorEntity> {
+  type: WritingWorkingCopyType;
+  entityId: string | null;
+  fetchEntity: (entityId: string) => Promise<TEntity>;
+}
+
+export function useWritingEditorEntity<TEntity extends WritingEditorEntity>({
+  type,
+  entityId,
+  fetchEntity,
+}: UseWritingEditorEntityOptions<TEntity>) {
+  return useQuery<WritingEditorEntityResult<TEntity>>({
+    queryKey: ["writing-editor", type, entityId],
+    queryFn: () => loadWritingEditorEntity(type, entityId!, fetchEntity),
+    enabled: !!entityId,
+    staleTime: 0,
+    gcTime: 0,
+    refetchOnMount: "always",
+  });
+}

--- a/frontend/src/features/writing/hooks/use-writing-working-copy.ts
+++ b/frontend/src/features/writing/hooks/use-writing-working-copy.ts
@@ -1,0 +1,56 @@
+import { useCallback } from "react";
+
+import {
+  deleteWritingWorkingCopy,
+  deleteWritingWorkingCopyIfMatches,
+  saveWritingWorkingCopy,
+  type WritingWorkingCopyType,
+} from "@/lib/local-db";
+
+export interface WritingDraft {
+  title: string;
+  content: string;
+}
+
+export interface WritingWorkingCopyController {
+  persistWorkingCopy: (draft: WritingDraft, baseUpdatedAt: string, updatedAt: Date) => void;
+  clearWorkingCopy: (draft: WritingDraft, updatedAt: Date) => Promise<void>;
+}
+
+interface UseWritingWorkingCopyOptions {
+  type: WritingWorkingCopyType;
+  entityId: string;
+}
+
+export function useWritingWorkingCopy({ type, entityId }: UseWritingWorkingCopyOptions) {
+  const persistWorkingCopy = useCallback(
+    (draft: WritingDraft, baseUpdatedAt: string, updatedAt: Date) => {
+      void saveWritingWorkingCopy({
+        entityId,
+        type,
+        title: draft.title,
+        content: draft.content,
+        baseUpdatedAt,
+        updatedAt,
+      });
+    },
+    [entityId, type],
+  );
+
+  const clearWorkingCopy = useCallback(
+    (draft: WritingDraft, updatedAt: Date) =>
+      deleteWritingWorkingCopyIfMatches(type, entityId, draft, updatedAt),
+    [entityId, type],
+  );
+
+  const discardWorkingCopy = useCallback(
+    () => deleteWritingWorkingCopy(type, entityId),
+    [entityId, type],
+  );
+
+  return {
+    persistWorkingCopy,
+    clearWorkingCopy,
+    discardWorkingCopy,
+  };
+}

--- a/frontend/src/features/writing/lib/writing-working-copy.ts
+++ b/frontend/src/features/writing/lib/writing-working-copy.ts
@@ -1,0 +1,81 @@
+export interface TimestampedWritingWorkingCopy {
+  updatedAt: Date;
+}
+
+export interface WritingWorkingCopyDraft {
+  title: string;
+  content: string;
+}
+
+export interface RemoteWritingEntity extends WritingWorkingCopyDraft {
+  updatedAt: string;
+}
+
+export interface LocalWritingWorkingCopy extends WritingWorkingCopyDraft {
+  updatedAt: Date;
+}
+
+function getTimestamp(value: string): number {
+  const timestamp = Date.parse(value);
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+export function isRemoteWritingEntityNewer(
+  remoteUpdatedAt: string,
+  currentUpdatedAt: string,
+): boolean {
+  return getTimestamp(remoteUpdatedAt) > getTimestamp(currentUpdatedAt);
+}
+
+export function getNextWritingWorkingCopyTimestamp(current: Date): Date {
+  return new Date(Math.max(Date.now(), current.getTime() + 1));
+}
+
+export function isWritingWorkingCopyNewer(
+  workingCopy: TimestampedWritingWorkingCopy,
+  remoteUpdatedAt: string,
+): boolean {
+  return workingCopy.updatedAt.getTime() > getTimestamp(remoteUpdatedAt);
+}
+
+export function shouldReplaceWritingWorkingCopy(
+  next: TimestampedWritingWorkingCopy,
+  current: TimestampedWritingWorkingCopy | undefined,
+): boolean {
+  return !current || next.updatedAt.getTime() >= current.updatedAt.getTime();
+}
+
+export function shouldDeleteWritingWorkingCopy(
+  workingCopy: TimestampedWritingWorkingCopy,
+  remoteUpdatedAt: string,
+): boolean {
+  return !isWritingWorkingCopyNewer(workingCopy, remoteUpdatedAt);
+}
+
+export function areWritingWorkingCopyDraftsEqual(
+  left: WritingWorkingCopyDraft,
+  right: WritingWorkingCopyDraft,
+): boolean {
+  return left.title === right.title && left.content === right.content;
+}
+
+export function resolveWritingWorkingCopy(
+  remote: RemoteWritingEntity,
+  workingCopy: LocalWritingWorkingCopy | null,
+): { draft: WritingWorkingCopyDraft; shouldDelete: boolean } {
+  if (
+    workingCopy &&
+    isWritingWorkingCopyNewer(workingCopy, remote.updatedAt) &&
+    !areWritingWorkingCopyDraftsEqual(workingCopy, remote)
+  ) {
+    return {
+      draft: { title: workingCopy.title, content: workingCopy.content },
+      shouldDelete: false,
+    };
+  }
+
+  return {
+    draft: { title: remote.title, content: remote.content },
+    shouldDelete: workingCopy !== null,
+  };
+}

--- a/frontend/src/lib/local-db.ts
+++ b/frontend/src/lib/local-db.ts
@@ -74,6 +74,18 @@ interface PromptChainWorkingCopy {
   updatedAt: Date;
 }
 
+export type WritingWorkingCopyType = "chapter" | "note";
+
+export interface WritingWorkingCopy {
+  id: string;
+  entityId: string;
+  type: WritingWorkingCopyType;
+  title: string;
+  content: string;
+  baseUpdatedAt: string;
+  updatedAt: Date;
+}
+
 /**
  * OpenFic 本地数据库
  */
@@ -82,6 +94,7 @@ class OpenFicDB extends Dexie {
   projectTabs!: EntityTable<ProjectTabs, "projectId">;
   userPreferences!: EntityTable<UserPreference, "key">;
   promptChainWorkingCopies!: EntityTable<PromptChainWorkingCopy, "chainId">;
+  writingWorkingCopies!: EntityTable<WritingWorkingCopy, "id">;
   recentProjects!: EntityTable<RecentProject, "slot">;
 
   constructor() {
@@ -125,11 +138,41 @@ class OpenFicDB extends Dexie {
       promptChainWorkingCopies: "chainId, updatedAt",
       recentProjects: "slot, projectId, openedAt",
     });
+
+    this.version(7).stores({
+      projectLastChapters: "projectId, updatedAt",
+      projectTabs: "projectId, updatedAt",
+      userPreferences: "key, updatedAt",
+      promptChainWorkingCopies: "chainId, updatedAt",
+      writingWorkingCopies: "id, entityId, type, updatedAt",
+      recentProjects: "slot, projectId, openedAt",
+    });
   }
 }
 
 // 单例数据库实例
 export const db = new OpenFicDB();
+
+const writingWorkingCopyOperations = new Map<string, Promise<void>>();
+
+function enqueueWritingWorkingCopyOperation<T>(
+  id: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const previous = writingWorkingCopyOperations.get(id) ?? Promise.resolve();
+  const next = previous.then(operation);
+  const settled = next.then(
+    () => undefined,
+    () => undefined,
+  );
+  writingWorkingCopyOperations.set(id, settled);
+  void settled.finally(() => {
+    if (writingWorkingCopyOperations.get(id) === settled) {
+      writingWorkingCopyOperations.delete(id);
+    }
+  });
+  return next;
+}
 
 // ==================== 项目最后访问章节 ====================
 
@@ -362,6 +405,107 @@ export async function deletePromptChainWorkingCopy(chainId: string): Promise<voi
     await db.promptChainWorkingCopies.delete(chainId);
   } catch {
     console.error("删除Working Copy失败");
+  }
+}
+
+// ==================== 写作 Working Copy ====================
+
+function getWritingWorkingCopyId(type: WritingWorkingCopyType, entityId: string): string {
+  return `${type}:${entityId}`;
+}
+
+export async function getWritingWorkingCopy(
+  type: WritingWorkingCopyType,
+  entityId: string,
+): Promise<WritingWorkingCopy | null> {
+  const id = getWritingWorkingCopyId(type, entityId);
+  try {
+    await writingWorkingCopyOperations.get(id);
+    return (await db.writingWorkingCopies.get(id)) ?? null;
+  } catch {
+    console.error("获取写作草稿失败");
+    return null;
+  }
+}
+
+export async function saveWritingWorkingCopy(
+  workingCopy: Omit<WritingWorkingCopy, "id">,
+): Promise<WritingWorkingCopy> {
+  const record: WritingWorkingCopy = {
+    ...workingCopy,
+    id: getWritingWorkingCopyId(workingCopy.type, workingCopy.entityId),
+  };
+
+  try {
+    await enqueueWritingWorkingCopyOperation(record.id, () =>
+      db.transaction("rw", db.writingWorkingCopies, async () => {
+        const current = await db.writingWorkingCopies.get(record.id);
+        if (!current || record.updatedAt.getTime() >= current.updatedAt.getTime()) {
+          await db.writingWorkingCopies.put(record);
+        }
+      }),
+    );
+  } catch {
+    console.error("保存写作草稿失败");
+  }
+
+  return record;
+}
+
+export async function deleteWritingWorkingCopy(
+  type: WritingWorkingCopyType,
+  entityId: string,
+): Promise<void> {
+  const id = getWritingWorkingCopyId(type, entityId);
+  try {
+    await enqueueWritingWorkingCopyOperation(id, () => db.writingWorkingCopies.delete(id));
+  } catch {
+    console.error("删除写作草稿失败");
+  }
+}
+
+export async function deleteWritingWorkingCopyIfUpdatedAt(
+  type: WritingWorkingCopyType,
+  entityId: string,
+  updatedAt: Date,
+): Promise<void> {
+  const id = getWritingWorkingCopyId(type, entityId);
+  try {
+    await enqueueWritingWorkingCopyOperation(id, () =>
+      db.transaction("rw", db.writingWorkingCopies, async () => {
+        const workingCopy = await db.writingWorkingCopies.get(id);
+        if (workingCopy?.updatedAt.getTime() === updatedAt.getTime()) {
+          await db.writingWorkingCopies.delete(id);
+        }
+      }),
+    );
+  } catch {
+    console.error("清理过期写作草稿失败");
+  }
+}
+
+export async function deleteWritingWorkingCopyIfMatches(
+  type: WritingWorkingCopyType,
+  entityId: string,
+  draft: Pick<WritingWorkingCopy, "title" | "content">,
+  updatedAt: Date,
+): Promise<void> {
+  const id = getWritingWorkingCopyId(type, entityId);
+  try {
+    await enqueueWritingWorkingCopyOperation(id, () =>
+      db.transaction("rw", db.writingWorkingCopies, async () => {
+        const workingCopy = await db.writingWorkingCopies.get(id);
+        if (
+          workingCopy?.title === draft.title &&
+          workingCopy.content === draft.content &&
+          workingCopy.updatedAt.getTime() === updatedAt.getTime()
+        ) {
+          await db.writingWorkingCopies.delete(id);
+        }
+      }),
+    );
+  } catch {
+    console.error("清理写作草稿失败");
   }
 }
 


### PR DESCRIPTION
## PR 标题

fix(frontend): 防止写作编辑内容丢失

## 变更说明

- 问题: 笔记和章节在标签、列表、搜索、创建或路由切换时，自动保存尚未完成会丢失编辑内容。
- 重要性: 写作内容属于核心用户数据，切换编辑对象不应造成未保存内容丢失。
- 变化: 新增 IndexedDB Working Copy，在编辑时立即异步持久化；打开实体时并行读取远端内容和本地草稿，按更新时间恢复较新版本并清理过期草稿。
- 变化: 为同一实体的草稿读写和清理建立串行队列与版本校验，处理快速切换、旧实例卸载及草稿清理的竞态；同时修复 Markdown 重新加载时未按 Markdown 解析的问题。
- 变化: 一并统一笔记相关图标和提及图标的样式。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

编辑器的未保存状态只存在组件内存中，标签和路由切换会直接卸载编辑器；原有自动保存定时器与 `beforeunload` 提示无法保证 SPA 切换时保留内容。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 未保留本次新增的前端测试文件，遵循项目的前端测试文件清理约定。
- 验证命令: `pnpm format:check`、`pnpm lint`、`pnpm type-check`、`pnpm build`。
- 生产构建通过，保留现有大体积 chunk 警告。
