### PR TITLE
fix(agent): 回滚时同步卷章节数

### DIFF
--- a/backend/app/agent_runtime/revisions.py
+++ b/backend/app/agent_runtime/revisions.py
@@ -44,6 +44,7 @@ from app.storage.repos import (
     world_info_entry_repo,
 )
 from app.storage.services import writing_activity_service
+from app.storage.services.volume_service import refresh_volume_chapter_count
 from app.storage.services.version_control_service import refresh_project_stats
 
 
@@ -896,6 +897,7 @@ async def rollback_revision_for_session(
     rollback_revision = await revision_repo.create(session, rollback_revision)
 
     affected: list[str] = []
+    affected_volume_ids: set[str] = set()
     deletes = [item for item in restore_by_chapter.values() if not item.exists]
     upserts = [item for item in restore_by_chapter.values() if item.exists]
     for snapshot in [*deletes, *upserts]:
@@ -903,6 +905,10 @@ async def rollback_revision_for_session(
         current = await chapter_repo.get_by_id(session, snapshot.chapter_id)
         before_image = _image_from_chapter(current) if current is not None else None
         after_image = _image_from_snapshot(snapshot)
+        if before_image is not None:
+            affected_volume_ids.add(before_image.volume_id)
+        if after_image is not None:
+            affected_volume_ids.add(after_image.volume_id)
         if after_image is None:
             if current is not None:
                 await chapter_repo.delete(session, current)
@@ -949,6 +955,9 @@ async def rollback_revision_for_session(
                 before=before_image,
                 after=after_image,
             )
+
+    for volume_id in affected_volume_ids:
+        await refresh_volume_chapter_count(session, volume_id)
 
     affected_note_categories: list[str] = []
     cat_deletes = [item for item in restore_by_category.values() if not item.exists]

--- a/backend/tests/api/test_agent.py
+++ b/backend/tests/api/test_agent.py
@@ -2374,7 +2374,18 @@ class TestAgentAPI:
                 project_id="proj-rollback-created",
                 title="第一卷",
                 order=1,
-                chapter_count=1,
+                chapter_count=2,
+            )
+        )
+        session.add(
+            Chapter(
+                id="chap-existing-rollback",
+                project_id="proj-rollback-created",
+                volume_id="vol-rollback-created",
+                title="已有章节",
+                content="已有内容",
+                word_count=4,
+                order=1,
             )
         )
         session.add(
@@ -2416,7 +2427,7 @@ class TestAgentAPI:
                 title="新章节",
                 content="新内容",
                 word_count=3,
-                order=1,
+                order=2,
             )
         )
         session.add(
@@ -2472,6 +2483,10 @@ class TestAgentAPI:
             and call.args[1].get("chapter_id") == "chap-created-rollback"
             for call in emit_mock.await_args_list
         )
+        volume = await session.get(Volume, "vol-rollback-created")
+        assert volume is not None
+        await session.refresh(volume)
+        assert volume.chapter_count == 1
 
     async def test_rollback_rejects_checkpoint_id_request_body(
         self,


### PR DESCRIPTION
## PR 标题

fix(agent): 回滚时同步卷章节数

## 变更说明

- 问题: Agent 新建章节后回滚到对应用户消息前，章节已删除但所属卷的章节数缓存仍保留新增后的值。
- 重要性: `list_volumes` 会向 Agent 返回过期章节数，导致后续写作判断与实际章节状态不一致。
- 变化: 回滚章节时收集变更前后的卷，并重新计算受影响卷的 `chapter_count`。
- 变化: 增加回归测试，覆盖卷内原有 1 章、Agent 新建后回滚的场景。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

回滚链路仅刷新了项目维度的章节与字数统计，未同步刷新章节变更涉及卷的 `chapter_count` 缓存。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令：

```text
uv run pytest tests/api/test_agent.py -q
42 passed in 58.42s

uv run ruff check app/agent_runtime/revisions.py tests/api/test_agent.py
All checks passed!
```
