### PR TITLE
fix(agent): 完善子智能体工具状态展示

### DIFF
--- a/backend/app/agent_runtime/persistence/child_runs.py
+++ b/backend/app/agent_runtime/persistence/child_runs.py
@@ -35,9 +35,7 @@ TERMINAL_CHILD_RUN_STATUSES = {"completed", "error", "cancelled"}
 TERMINAL_CHILD_RUN_REQUEST_STATUSES = {"completed", "error", "cancelled"}
 SUBAGENT_AGENT_NUMBER_MIN = 1000
 SUBAGENT_AGENT_NUMBER_MAX = 9999
-SUBAGENT_AGENT_NUMBER_SPACE = (
-    SUBAGENT_AGENT_NUMBER_MAX - SUBAGENT_AGENT_NUMBER_MIN + 1
-)
+SUBAGENT_AGENT_NUMBER_SPACE = SUBAGENT_AGENT_NUMBER_MAX - SUBAGENT_AGENT_NUMBER_MIN + 1
 _PARENT_SUBAGENT_NUMBER_LOCKS: dict[str, asyncio.Lock] = {}
 _PARENT_SUBAGENT_NUMBER_LOCKS_GUARD = asyncio.Lock()
 
@@ -227,6 +225,42 @@ async def get_waiting_child_run_for_tool_call(
     return result.scalar_one_or_none()
 
 
+async def get_child_run_for_parent_tool_call(
+    session: AsyncSession,
+    *,
+    parent_session_id: str,
+    tool_call_id: str,
+) -> AgentChildRun | None:
+    result = await session.execute(
+        select(AgentChildRun)
+        .where(
+            col(AgentChildRun.parent_session_id) == parent_session_id,
+            col(AgentChildRun.tool_call_id) == tool_call_id,
+        )
+        .order_by(col(AgentChildRun.created_at).desc())
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def get_child_run_for_parent_dispatch_id(
+    session: AsyncSession,
+    *,
+    parent_session_id: str,
+    dispatch_id: str,
+) -> AgentChildRun | None:
+    result = await session.execute(
+        select(AgentChildRun)
+        .where(
+            col(AgentChildRun.parent_session_id) == parent_session_id,
+            col(AgentChildRun.dispatch_id) == dispatch_id,
+        )
+        .order_by(col(AgentChildRun.created_at).desc())
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
 async def get_child_run_for_parent(
     session: AsyncSession,
     *,
@@ -377,7 +411,9 @@ def _initial_request_status(child_run_status: str) -> str:
         return "error"
     if child_run_status == "cancelled":
         return "cancelled"
-    raise ValueError(f"unsupported child run status for request initialization: {child_run_status}")
+    raise ValueError(
+        f"unsupported child run status for request initialization: {child_run_status}"
+    )
 
 
 async def _next_child_request_seq(session: AsyncSession, child_run_id: str) -> int:
@@ -533,7 +569,9 @@ async def rollback_child_runs_for_parent_revisions(
         else:
             row.is_active = True
             row.status = "completed" if previous is not None else "queued"
-            row.last_assistant_content = previous.assistant_content if previous else None
+            row.last_assistant_content = (
+                previous.assistant_content if previous else None
+            )
             row.last_completed_at = previous.completed_at if previous else None
             row.error = None
 
@@ -592,7 +630,9 @@ async def complete_child_run_request(
 ) -> AgentChildRunRequest:
     _ensure_status(status, CHILD_RUN_REQUEST_STATUSES, "child run request status")
     if status not in TERMINAL_CHILD_RUN_REQUEST_STATUSES:
-        raise ValueError(f"child run request must complete with terminal status: {status}")
+        raise ValueError(
+            f"child run request must complete with terminal status: {status}"
+        )
 
     request_row = await session.get(AgentChildRunRequest, request_id)
     if request_row is None:
@@ -617,7 +657,9 @@ async def complete_child_run_request(
     row.last_completed_at = now
     row.updated_at = now
 
-    pending_exists = await _child_has_pending_requests(session, row.id, exclude_request_id=request_id)
+    pending_exists = await _child_has_pending_requests(
+        session, row.id, exclude_request_id=request_id
+    )
     if status == "completed" and pending_exists and row.is_active:
         row.status = "queued"
     else:

--- a/backend/app/agent_runtime/persistence/persister.py
+++ b/backend/app/agent_runtime/persistence/persister.py
@@ -10,6 +10,11 @@ from typing import Literal
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.persistence import repo
+from app.agent_runtime.persistence.child_runs import (
+    get_child_run_agent_number,
+    get_child_run_for_parent_dispatch_id,
+    get_child_run_for_parent_tool_call,
+)
 from app.agent_runtime.persistence.errors import PersistenceWriteError
 from app.agent_runtime.runner.event_scope import is_subagent_child_event
 from app.agent_runtime.tool_call_recovery import (
@@ -39,6 +44,7 @@ class _PendingTool:
     run_id: str
     tool_call_id: str
     tool_name: str
+    args: dict[str, object]
 
 
 class MessagePersister:
@@ -66,10 +72,7 @@ class MessagePersister:
         self._previewed_tool_runs: set[str] = set()
 
     async def handle(self, event: dict) -> None:
-        if (
-            is_subagent_child_event(event)
-            and not self._allow_subagent_child_events
-        ):
+        if is_subagent_child_event(event) and not self._allow_subagent_child_events:
             return
 
         kind = event.get("event")
@@ -121,9 +124,9 @@ class MessagePersister:
         if isinstance(content, str) and content:
             buf.content_parts.append(content)
 
-        reasoning = (
-            getattr(chunk, "additional_kwargs", {}) or {}
-        ).get("reasoning_content")
+        reasoning = (getattr(chunk, "additional_kwargs", {}) or {}).get(
+            "reasoning_content"
+        )
         if reasoning:
             chunk_received_at = datetime.now(UTC)
             if buf.reasoning_started_at is None:
@@ -155,7 +158,9 @@ class MessagePersister:
 
         output = event.get("data", {}).get("output")
         content = "".join(buf.content_parts) or self._extract_output_content(output)
-        reasoning = "".join(buf.reasoning_parts) or self._extract_output_reasoning(output)
+        reasoning = "".join(buf.reasoning_parts) or self._extract_output_reasoning(
+            output
+        )
         reasoning_duration_ms = self._get_reasoning_duration_ms(buf)
         tool_calls = self._reconcile_tool_calls(buf.tool_call_chunks, run_id=run_id)
         if not tool_calls:
@@ -193,12 +198,14 @@ class MessagePersister:
         tool_name = event.get("name") or ""
         meta = event.get("metadata") or {}
         tool_call_id = (
-            meta.get("tool_call_id")
-            or meta.get("tool_call", {}).get("id")
-            or run_id
+            meta.get("tool_call_id") or meta.get("tool_call", {}).get("id") or run_id
         )
+        input_data = event.get("data", {}).get("input")
         self._pending_tools[run_id] = _PendingTool(
-            run_id=run_id, tool_call_id=tool_call_id, tool_name=tool_name
+            run_id=run_id,
+            tool_call_id=tool_call_id,
+            tool_name=tool_name,
+            args=input_data if isinstance(input_data, dict) else {},
         )
 
     async def _on_tool_end(self, event: dict) -> None:
@@ -397,9 +404,7 @@ class MessagePersister:
         finally:
             await session.close()
 
-    async def finalize(
-        self, reason: Literal["done", "cancelled", "error"]
-    ) -> None:
+    async def finalize(self, reason: Literal["done", "cancelled", "error"]) -> None:
         """run/resume 结束时把 buffer 里未提交的 partial / aborted 写库。"""
         try:
             for run_id, buf in list(self._assistant_buffers.items()):
@@ -437,10 +442,14 @@ class MessagePersister:
             for pending in list(self._pending_tools.values()):
                 if pending.run_id in self._previewed_tool_runs:
                     continue
+                content = await self._cancelled_subagent_tool_result(
+                    pending,
+                    reason=reason,
+                )
                 await self._write(
                     role="tool",
                     status="aborted",
-                    content="[中断] 工具执行未完成",
+                    content=content or "[中断] 工具执行未完成",
                     tool_call_id=pending.tool_call_id,
                     tool_name=pending.tool_name,
                 )
@@ -453,6 +462,48 @@ class MessagePersister:
             raise PersistenceWriteError(
                 f"persister finalize failed reason={reason}"
             ) from e
+
+    async def _cancelled_subagent_tool_result(
+        self,
+        pending: _PendingTool,
+        *,
+        reason: Literal["done", "cancelled", "error"],
+    ) -> str | None:
+        if reason != "cancelled" or pending.tool_name not in {
+            "dispatch_subagent",
+            "notify_subagent",
+        }:
+            return None
+
+        session = self._make_session()
+        try:
+            child_run = await get_child_run_for_parent_tool_call(
+                session,
+                parent_session_id=self.session_id,
+                tool_call_id=pending.tool_call_id,
+            )
+            if child_run is None and pending.tool_name == "notify_subagent":
+                dispatch_id = pending.args.get("dispatch_id")
+                if isinstance(dispatch_id, str) and dispatch_id:
+                    child_run = await get_child_run_for_parent_dispatch_id(
+                        session,
+                        parent_session_id=self.session_id,
+                        dispatch_id=dispatch_id,
+                    )
+        finally:
+            await session.close()
+        if child_run is None or not child_run.is_active:
+            return None
+
+        return json.dumps(
+            {
+                "dispatch_id": child_run.dispatch_id,
+                "agent_key": child_run.agent_key,
+                "agent_number": get_child_run_agent_number(child_run.metadata_json),
+                "error": "subagent 会话已被用户中断，要通知其继续工作请使用 notify_subagent",
+            },
+            ensure_ascii=False,
+        )
 
     @staticmethod
     def _get_reasoning_duration_ms(buf: _AssistantBuffer) -> int | None:

--- a/backend/app/agent_runtime/persistence/task_projection.py
+++ b/backend/app/agent_runtime/persistence/task_projection.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, Protocol
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.persistence import repo
+from app.agent_runtime.persistence.child_runs import (
+    get_child_run_agent_number,
+    list_child_runs_for_parent,
+)
 from app.agent_runtime.persistence.types import PersistedMessage
 from app.api.schemas.task import TaskMessage
 
@@ -18,6 +22,12 @@ SUBAGENT_ORCHESTRATION_TOOL_NAMES = {
     "notify_subagent",
     "recycle_subagent",
 }
+
+
+class SubagentIdentitySource(Protocol):
+    dispatch_id: str
+    agent_key: str
+    metadata_json: dict[str, Any]
 
 
 def _message_status(status: str) -> str:
@@ -201,7 +211,43 @@ def _append_projected_tool_message(
     )
 
 
-def _project_rows(rows: list[PersistedMessage]) -> list[TaskMessage]:
+def _subagent_identity_by_dispatch_id(
+    child_runs: list[SubagentIdentitySource],
+) -> dict[str, dict[str, str]]:
+    identities: dict[str, dict[str, str]] = {}
+    for child_run in child_runs:
+        identity = {"agent_key": child_run.agent_key}
+        agent_number = get_child_run_agent_number(child_run.metadata_json)
+        if agent_number:
+            identity["agent_number"] = agent_number
+        identities[child_run.dispatch_id] = identity
+    return identities
+
+
+def _with_subagent_identity(
+    tool_result: dict[str, Any],
+    tool_args: dict[str, Any],
+    *,
+    tool_name: str | None,
+    identities_by_dispatch_id: dict[str, dict[str, str]],
+) -> dict[str, Any]:
+    if tool_name not in SUBAGENT_ORCHESTRATION_TOOL_NAMES:
+        return tool_result
+
+    dispatch_id = tool_result.get("dispatch_id") or tool_args.get("dispatch_id")
+    if not isinstance(dispatch_id, str) or not dispatch_id:
+        return tool_result
+    identity = identities_by_dispatch_id.get(dispatch_id)
+    if identity is None:
+        return tool_result
+    return {**tool_result, **identity}
+
+
+def _project_rows(
+    rows: list[PersistedMessage],
+    *,
+    identities_by_dispatch_id: dict[str, dict[str, str]] | None = None,
+) -> list[TaskMessage]:
     if _has_dispatch_subagent(rows):
         subagent_tool_call_ids = _subagent_tool_call_ids(rows)
         rows = [
@@ -307,6 +353,12 @@ def _project_rows(rows: list[PersistedMessage]) -> list[TaskMessage]:
         if row.role == "tool":
             tool_args = tool_args_by_id.get(row.tool_call_id or "", {})
             tool_result = _tool_result(row)
+            tool_result = _with_subagent_identity(
+                tool_result,
+                tool_args,
+                tool_name=row.tool_name,
+                identities_by_dispatch_id=identities_by_dispatch_id or {},
+            )
             _append_projected_tool_message(
                 projected,
                 projected_tool_index_by_id,
@@ -339,4 +391,12 @@ async def load_task_messages_for_agent_session(
     session_id: str,
 ) -> list[TaskMessage]:
     rows = await repo.list_by_session(session, session_id)
-    return _project_rows(rows)
+    child_runs = (
+        await list_child_runs_for_parent(session, session_id)
+        if _has_dispatch_subagent(rows)
+        else []
+    )
+    return _project_rows(
+        rows,
+        identities_by_dispatch_id=_subagent_identity_by_dispatch_id(child_runs),
+    )

--- a/backend/app/agent_runtime/tools/impls/orchestration/common.py
+++ b/backend/app/agent_runtime/tools/impls/orchestration/common.py
@@ -97,16 +97,22 @@ async def ensure_primary(
 ) -> None:
     active_agent = state.get("active_agent")
     if not isinstance(active_agent, str) or not active_agent:
-        raise ToolExecutionError("this orchestration tool may only be called by a primary agent")
+        raise ToolExecutionError(
+            "this orchestration tool may only be called by a primary agent"
+        )
     session = await open_session(session_factory)
     try:
         definition = await load_agent_definition(session, active_agent)
     except KeyError as exc:
-        raise ToolExecutionError("this orchestration tool may only be called by a primary agent") from exc
+        raise ToolExecutionError(
+            "this orchestration tool may only be called by a primary agent"
+        ) from exc
     finally:
         await close_session(session)
     if not definition.enabled or definition.kind != "primary":
-        raise ToolExecutionError("this orchestration tool may only be called by a primary agent")
+        raise ToolExecutionError(
+            "this orchestration tool may only be called by a primary agent"
+        )
 
 
 def build_subagent_identity_payload(row: AgentChildRun) -> dict[str, Any]:
@@ -119,6 +125,42 @@ def build_subagent_identity_payload(row: AgentChildRun) -> dict[str, Any]:
     if metadata:
         payload["metadata"] = metadata
     return payload
+
+
+async def emit_subagent_tool_preview(
+    *,
+    configurable: dict[str, Any],
+    parent_session_id: str,
+    tool_call_id: str | None,
+    tool_name: str,
+    tool_args: dict[str, Any],
+    row: AgentChildRun,
+) -> None:
+    if not tool_call_id:
+        return
+    event_sink = configurable.get("agent_event_sink")
+    if not callable(event_sink):
+        return
+
+    preview = {
+        "type": "preview",
+        "success": True,
+        "dispatch_id": row.dispatch_id,
+        **build_subagent_identity_payload(row),
+    }
+    await maybe_await(
+        event_sink(
+            "agent:tool_result",
+            {
+                "session_id": parent_session_id,
+                "tool_call_id": tool_call_id,
+                "tool": tool_name,
+                "input": tool_args,
+                "output": preview,
+                "is_preview": True,
+            },
+        )
+    )
 
 
 def make_subagent_runner(
@@ -259,7 +301,9 @@ async def ensure_child_processing(
                 )
 
     task = asyncio.create_task(_run())
-    registered = await registry.try_register_child(parent_session_id, child_run_id, task)
+    registered = await registry.try_register_child(
+        parent_session_id, child_run_id, task
+    )
     if registered:
         return True
     task.cancel()
@@ -286,7 +330,9 @@ async def wait_for_request_resolution(
             if request.status == "completed":
                 return ChildRequestResolution(child_run=child_run, request=request)
             if request.status == "cancelled":
-                raise ToolExecutionError(request.error or "subagent request was cancelled")
+                raise ToolExecutionError(
+                    request.error or "subagent request was cancelled"
+                )
             if request.status == "error":
                 raise ToolExecutionError(request.error or "subagent request failed")
             if not child_run.is_active:

--- a/backend/app/agent_runtime/tools/impls/orchestration/dispatch_subagent.py
+++ b/backend/app/agent_runtime/tools/impls/orchestration/dispatch_subagent.py
@@ -22,6 +22,7 @@ from app.agent_runtime.tools.errors import ToolExecutionError
 from app.agent_runtime.tools.impls.orchestration.common import (
     close_session,
     ensure_child_processing,
+    emit_subagent_tool_preview,
     get_configurable,
     make_subagent_runner,
     open_session,
@@ -121,7 +122,9 @@ class DispatchSubagentTool(AgentTool):
 
         count = int(self._state.get("_dispatch_subagent_count") or 0)
         if count >= MAX_DISPATCHES_PER_TURN:
-            raise ToolExecutionError("dispatch_subagent allows at most 10 dispatches per PA turn")
+            raise ToolExecutionError(
+                "dispatch_subagent allows at most 10 dispatches per PA turn"
+            )
         self._state["_dispatch_subagent_count"] = count + 1
 
         try:
@@ -246,7 +249,9 @@ class DispatchSubagentTool(AgentTool):
                 or resolution.child_run.last_assistant_content
             )
             if not assistant_content:
-                raise ToolExecutionError("subagent turn completed without assistant content")
+                raise ToolExecutionError(
+                    "subagent turn completed without assistant content"
+                )
             return assistant_content
 
     async def _execute(
@@ -310,15 +315,36 @@ class DispatchSubagentTool(AgentTool):
         }
 
         pending_approval = getattr(row, "pending_approval_json", None)
-        assistant_content = await self._wait_for_assistant_content(
+        await emit_subagent_tool_preview(
             configurable=configurable,
-            child_run_id=row.id,
-            request_id=request_id or "",
-            runner=runner,
-            start_processing=not (
-                isinstance(pending_approval, dict) and pending_approval
-            ),
+            parent_session_id=self.session_id,
+            tool_call_id=self.tool_call_id,
+            tool_name=self.name,
+            tool_args={
+                "agent_type": agent_type,
+                "description": description,
+                "prompt": prompt,
+            },
+            row=row,
         )
+        try:
+            assistant_content = await self._wait_for_assistant_content(
+                configurable=configurable,
+                child_run_id=row.id,
+                request_id=request_id or "",
+                runner=runner,
+                start_processing=not (
+                    isinstance(pending_approval, dict) and pending_approval
+                ),
+            )
+        except ToolExecutionError as exc:
+            return json.dumps(
+                {
+                    **base_payload,
+                    "error": str(exc),
+                },
+                ensure_ascii=False,
+            )
         payload = {
             **base_payload,
             "result": assistant_content,

--- a/backend/app/agent_runtime/tools/impls/orchestration/notify_subagent.py
+++ b/backend/app/agent_runtime/tools/impls/orchestration/notify_subagent.py
@@ -16,6 +16,7 @@ from app.agent_runtime.tools.impls.orchestration.common import (
     close_session,
     ensure_child_processing,
     ensure_primary,
+    emit_subagent_tool_preview,
     get_configurable,
     make_subagent_runner,
     open_session,
@@ -80,7 +81,9 @@ class NotifySubagentTool(AgentTool):
                 or resolution.child_run.last_assistant_content
             )
             if not assistant_content:
-                raise ToolExecutionError("subagent turn completed without assistant content")
+                raise ToolExecutionError(
+                    "subagent turn completed without assistant content"
+                )
             return assistant_content
 
     async def _execute(
@@ -98,8 +101,12 @@ class NotifySubagentTool(AgentTool):
         if not row.is_active:
             raise ToolExecutionError("subagent thread is inactive")
         current_revision_id = self._state.get("current_revision_id")
-        parent_revision_id = current_revision_id if isinstance(current_revision_id, str) else None
-        pre_request_checkpoint_id = await latest_checkpoint_id_for_thread(row.child_thread_id)
+        parent_revision_id = (
+            current_revision_id if isinstance(current_revision_id, str) else None
+        )
+        pre_request_checkpoint_id = await latest_checkpoint_id_for_thread(
+            row.child_thread_id
+        )
 
         session = await open_session(configurable.get("session_factory"))
         try:
@@ -135,6 +142,14 @@ class NotifySubagentTool(AgentTool):
         runner = make_subagent_runner(state=self._state, configurable=configurable)
         await runner.publish_parent_subagent_status(row.id)
         pending_approval = getattr(row, "pending_approval_json", None)
+        await emit_subagent_tool_preview(
+            configurable=configurable,
+            parent_session_id=self.session_id,
+            tool_call_id=self.tool_call_id,
+            tool_name=self.name,
+            tool_args={"dispatch_id": dispatch_id, "prompt": prompt},
+            row=row,
+        )
         assistant_content = await self._wait_for_assistant_content(
             configurable=configurable,
             child_run_id=row.id,

--- a/backend/app/agent_runtime/tools/impls/orchestration/recycle_subagent.py
+++ b/backend/app/agent_runtime/tools/impls/orchestration/recycle_subagent.py
@@ -8,6 +8,7 @@ from app.agent_runtime.persistence.child_runs import recycle_child_run
 from app.agent_runtime.runner.run_registry import get_agent_run_registry
 from app.agent_runtime.tools.base import AgentTool
 from app.agent_runtime.tools.impls.orchestration.common import (
+    build_subagent_identity_payload,
     close_session,
     ensure_primary,
     get_configurable,
@@ -27,6 +28,7 @@ class RecycleSubagentInput(BaseModel):
         default="",
         description="可选，关闭原因；会作为子代理回收时的错误/结束信息，对用户可见，应尽可能简要",
     )
+
 
 @ToolRegistry.register
 class RecycleSubagentTool(AgentTool):
@@ -60,6 +62,7 @@ class RecycleSubagentTool(AgentTool):
             return json.dumps(
                 {
                     "dispatch_id": row.dispatch_id,
+                    **build_subagent_identity_payload(row),
                     "recycled": True,
                 },
                 ensure_ascii=False,
@@ -82,6 +85,7 @@ class RecycleSubagentTool(AgentTool):
         return json.dumps(
             {
                 "dispatch_id": recycled.dispatch_id,
+                **build_subagent_identity_payload(recycled),
                 "recycled": True,
             },
             ensure_ascii=False,

--- a/backend/tests/agent_runtime/persistence/test_persister_finalize.py
+++ b/backend/tests/agent_runtime/persistence/test_persister_finalize.py
@@ -1,12 +1,15 @@
 """MessagePersister.finalize 测试 — 中断场景。"""
 
+import json
 from datetime import UTC, datetime
 
 import pytest
-from langchain_core.messages import AIMessageChunk
+from langchain_core.messages import AIMessage, AIMessageChunk, ToolMessage
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.persistence import repo
+from app.agent_runtime.persistence.child_runs import create_child_run
+from app.agent_runtime.persistence.loader import load_history
 from app.agent_runtime.persistence import persister as persister_module
 from app.agent_runtime.persistence.persister import MessagePersister
 
@@ -23,10 +26,12 @@ async def test_finalize_writes_partial_assistant_with_resolvable_tool_call(
         db_session_factory=db_session_factory,
     )
     await p.handle({"event": "on_chat_model_start", "data": {}})
-    await p.handle({
-        "event": "on_chat_model_stream",
-        "data": {"chunk": AIMessageChunk(content="half-")},
-    })
+    await p.handle(
+        {
+            "event": "on_chat_model_stream",
+            "data": {"chunk": AIMessageChunk(content="half-")},
+        }
+    )
     chunk = AIMessageChunk(
         content="",
         tool_call_chunks=[
@@ -64,10 +69,12 @@ async def test_finalize_drops_unresolvable_tool_calls(
         db_session_factory=db_session_factory,
     )
     await p.handle({"event": "on_chat_model_start", "data": {}})
-    await p.handle({
-        "event": "on_chat_model_stream",
-        "data": {"chunk": AIMessageChunk(content="thinking ")},
-    })
+    await p.handle(
+        {
+            "event": "on_chat_model_stream",
+            "data": {"chunk": AIMessageChunk(content="thinking ")},
+        }
+    )
     chunk = AIMessageChunk(
         content="",
         tool_call_chunks=[{"index": 0, "id": "c1", "name": None, "args": ""}],
@@ -96,15 +103,17 @@ async def test_finalize_persists_reasoning_duration_for_cancelled_partial_messag
         db_session_factory=db_session_factory,
     )
     await p.handle({"event": "on_chat_model_start", "data": {}})
-    await p.handle({
-        "event": "on_chat_model_stream",
-        "data": {
-            "chunk": AIMessageChunk(
-                content="",
-                additional_kwargs={"reasoning_content": "先分析到一半"},
-            ),
-        },
-    })
+    await p.handle(
+        {
+            "event": "on_chat_model_stream",
+            "data": {
+                "chunk": AIMessageChunk(
+                    content="",
+                    additional_kwargs={"reasoning_content": "先分析到一半"},
+                ),
+            },
+        }
+    )
 
     await p.finalize(reason="cancelled")
 
@@ -142,35 +151,41 @@ async def test_finalize_stops_reasoning_duration_at_last_reasoning_chunk(
     await p.handle({"event": "on_chat_model_start", "run_id": "run-1", "data": {}})
 
     FrozenDateTime.current = datetime(2026, 1, 1, 0, 0, 1, tzinfo=UTC)
-    await p.handle({
-        "event": "on_chat_model_stream",
-        "run_id": "run-1",
-        "data": {
-            "chunk": AIMessageChunk(
-                content="",
-                additional_kwargs={"reasoning_content": "先分析"},
-            ),
-        },
-    })
+    await p.handle(
+        {
+            "event": "on_chat_model_stream",
+            "run_id": "run-1",
+            "data": {
+                "chunk": AIMessageChunk(
+                    content="",
+                    additional_kwargs={"reasoning_content": "先分析"},
+                ),
+            },
+        }
+    )
 
     FrozenDateTime.current = datetime(2026, 1, 1, 0, 0, 3, tzinfo=UTC)
-    await p.handle({
-        "event": "on_chat_model_stream",
-        "run_id": "run-1",
-        "data": {
-            "chunk": AIMessageChunk(
-                content="",
-                additional_kwargs={"reasoning_content": "再推演"},
-            ),
-        },
-    })
+    await p.handle(
+        {
+            "event": "on_chat_model_stream",
+            "run_id": "run-1",
+            "data": {
+                "chunk": AIMessageChunk(
+                    content="",
+                    additional_kwargs={"reasoning_content": "再推演"},
+                ),
+            },
+        }
+    )
 
     FrozenDateTime.current = datetime(2026, 1, 1, 0, 0, 5, tzinfo=UTC)
-    await p.handle({
-        "event": "on_chat_model_stream",
-        "run_id": "run-1",
-        "data": {"chunk": AIMessageChunk(content="尾声")},
-    })
+    await p.handle(
+        {
+            "event": "on_chat_model_stream",
+            "run_id": "run-1",
+            "data": {"chunk": AIMessageChunk(content="尾声")},
+        }
+    )
 
     FrozenDateTime.current = datetime(2026, 1, 1, 0, 0, 7, tzinfo=UTC)
     await p.finalize(reason="cancelled")
@@ -193,13 +208,15 @@ async def test_finalize_writes_aborted_for_tool_started_not_ended(
         project_id=sample_task.project_id,
         db_session_factory=db_session_factory,
     )
-    await p.handle({
-        "event": "on_tool_start",
-        "name": "write_chapter",
-        "run_id": "tool-1",
-        "data": {"input": {}},
-        "metadata": {"tool_call_id": "tc1"},
-    })
+    await p.handle(
+        {
+            "event": "on_tool_start",
+            "name": "write_chapter",
+            "run_id": "tool-1",
+            "data": {"input": {}},
+            "metadata": {"tool_call_id": "tc1"},
+        }
+    )
     await p.finalize(reason="cancelled")
     items = await repo.list_by_session(db_session, sid)
     assert len(items) == 1
@@ -207,6 +224,97 @@ async def test_finalize_writes_aborted_for_tool_started_not_ended(
     assert items[0].status == "aborted"
     assert items[0].tool_call_id == "tc1"
     assert items[0].tool_name == "write_chapter"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("tool_name", "tool_call_id", "tool_args"),
+    [
+        (
+            "dispatch_subagent",
+            "call-dispatch",
+            {"agent_type": "writer", "prompt": "write scene"},
+        ),
+        (
+            "notify_subagent",
+            "call-notify",
+            {"dispatch_id": "dispatch-cancelled", "prompt": "continue scene"},
+        ),
+    ],
+)
+async def test_finalize_preserves_cancelled_subagent_tool_identity_in_history(
+    db_session: AsyncSession,
+    db_session_factory,
+    sample_task,
+    tool_name: str,
+    tool_call_id: str,
+    tool_args: dict[str, str],
+):
+    session_id = "parent-session"
+    await repo.insert_message(
+        db_session,
+        session_id=session_id,
+        task_id=sample_task.id,
+        project_id=sample_task.project_id,
+        role="assistant",
+        status="complete",
+        content="",
+        tool_calls=[
+            {
+                "id": "call-dispatch",
+                "name": "dispatch_subagent",
+                "args": {"agent_type": "writer", "prompt": "write scene"},
+            },
+            {
+                "id": "call-notify",
+                "name": "notify_subagent",
+                "args": {
+                    "dispatch_id": "dispatch-cancelled",
+                    "prompt": "continue scene",
+                },
+            },
+        ],
+    )
+    await create_child_run(
+        db_session,
+        parent_session_id=session_id,
+        parent_task_id=sample_task.id,
+        parent_thread_id=session_id,
+        child_thread_id="parent-session:child:dispatch-cancelled",
+        agent_key="writer",
+        dispatch_id="dispatch-cancelled",
+        tool_call_id="call-dispatch",
+        request={"task": "write scene"},
+        metadata={"agent_number": "#1001"},
+    )
+    persister = MessagePersister(
+        session_id=session_id,
+        task_id=sample_task.id,
+        project_id=sample_task.project_id,
+        db_session_factory=db_session_factory,
+    )
+    await persister.handle(
+        {
+            "event": "on_tool_start",
+            "name": tool_name,
+            "run_id": f"tool-{tool_name}",
+            "data": {"input": tool_args},
+            "metadata": {"tool_call_id": tool_call_id},
+        }
+    )
+
+    await persister.finalize(reason="cancelled")
+
+    messages = await load_history(db_session, session_id)
+
+    assert isinstance(messages[0], AIMessage)
+    assert isinstance(messages[1], ToolMessage)
+    assert json.loads(messages[1].content) == {
+        "dispatch_id": "dispatch-cancelled",
+        "agent_key": "writer",
+        "agent_number": "#1001",
+        "error": "subagent 会话已被用户中断，要通知其继续工作请使用 notify_subagent",
+    }
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/persistence/test_task_projection.py
+++ b/backend/tests/agent_runtime/persistence/test_task_projection.py
@@ -1,9 +1,12 @@
 """Task API projection for agent runtime messages."""
 
+import json
+
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.persistence import repo
+from app.agent_runtime.persistence.child_runs import create_child_run
 from app.agent_runtime.persistence.task_projection import (
     load_task_messages_for_agent_session,
 )
@@ -80,9 +83,7 @@ async def test_projects_runtime_messages_to_task_messages(
     ]
     assert messages[4].payload["tool_call_id"] == "call_ask"
     assert messages[4].payload["tool_name"] == "ask_user"
-    assert messages[4].payload["tool_args"] == {
-        "questions": [{"title": "剧情走向？"}]
-    }
+    assert messages[4].payload["tool_args"] == {"questions": [{"title": "剧情走向？"}]}
     assert messages[4].payload["tool_result"]["data"] == {"answer": "按原著"}
 
 
@@ -308,6 +309,120 @@ async def test_projection_filters_subagent_internal_rows_from_parent_session(
     ]
     assert messages[1].message_type == "tool"
     assert messages[1].payload["tool_name"] == "dispatch_subagent"
+
+
+@pytest.mark.asyncio
+async def test_projects_subagent_identity_for_orchestration_tool_results(
+    db_session: AsyncSession,
+    sample_task,
+) -> None:
+    session_id = "session_projection_subagent_identity"
+    dispatch_id = "dispatch-writer"
+    await repo.insert_message(
+        db_session,
+        session_id=session_id,
+        task_id=sample_task.id,
+        project_id=sample_task.project_id,
+        role="assistant",
+        agent_id="primary",
+        content="",
+        status="complete",
+        tool_calls=[
+            {
+                "id": "call-dispatch",
+                "name": "dispatch_subagent",
+                "args": {
+                    "agent_type": "writer",
+                    "description": "续写场景",
+                    "prompt": "请续写这一场景。",
+                },
+            },
+            {
+                "id": "call-notify",
+                "name": "notify_subagent",
+                "args": {
+                    "dispatch_id": dispatch_id,
+                    "prompt": "继续完善冲突。",
+                },
+            },
+            {
+                "id": "call-recycle",
+                "name": "recycle_subagent",
+                "args": {
+                    "dispatch_id": dispatch_id,
+                    "reason": "任务完成",
+                },
+            },
+        ],
+    )
+    await create_child_run(
+        db_session,
+        parent_session_id=session_id,
+        parent_task_id=sample_task.id,
+        parent_thread_id=session_id,
+        child_thread_id=f"{session_id}:child:{dispatch_id}",
+        agent_key="writer",
+        dispatch_id=dispatch_id,
+        tool_call_id="call-dispatch",
+        request={"task": "请续写这一场景。"},
+        metadata={"agent_number": "#1001"},
+    )
+    for tool_call_id, tool_name, result in [
+        (
+            "call-dispatch",
+            "dispatch_subagent",
+            {"dispatch_id": dispatch_id, "agent_number": "#1001", "result": "完成"},
+        ),
+        (
+            "call-notify",
+            "notify_subagent",
+            {"dispatch_id": dispatch_id, "agent_number": "#1001", "result": "已继续"},
+        ),
+        (
+            "call-recycle",
+            "recycle_subagent",
+            {"dispatch_id": dispatch_id, "recycled": True},
+        ),
+    ]:
+        await repo.insert_message(
+            db_session,
+            session_id=session_id,
+            task_id=sample_task.id,
+            project_id=sample_task.project_id,
+            role="tool",
+            content=json.dumps(result, ensure_ascii=False),
+            status="complete",
+            tool_call_id=tool_call_id,
+            tool_name=tool_name,
+        )
+
+    messages = await load_task_messages_for_agent_session(db_session, session_id)
+
+    tool_messages = [message for message in messages if message.message_type == "tool"]
+    assert len(tool_messages) == 3
+    assert [message.payload["tool_args"] for message in tool_messages] == [
+        {
+            "agent_type": "writer",
+            "description": "续写场景",
+            "prompt": "请续写这一场景。",
+        },
+        {"dispatch_id": dispatch_id, "prompt": "继续完善冲突。"},
+        {"dispatch_id": dispatch_id, "reason": "任务完成"},
+    ]
+    assert [
+        message.payload["tool_result"]["agent_key"] for message in tool_messages
+    ] == [
+        "writer",
+        "writer",
+        "writer",
+    ]
+    assert [
+        message.payload["tool_result"]["agent_number"] for message in tool_messages
+    ] == [
+        "#1001",
+        "#1001",
+        "#1001",
+    ]
 
 
 @pytest.mark.asyncio
@@ -543,7 +658,9 @@ async def test_projects_resumed_tool_call_as_single_tool_message(
     assert tool_messages[0].payload["tool_name"] == "write_chapter"
     assert tool_messages[0].payload["tool_args"] == {"title": "第一章"}
     assert tool_messages[0].payload["tool_result"]["success"] is True
-    assert tool_messages[0].payload["tool_result"]["data"] == {"chapter_id": "chapter_1"}
+    assert tool_messages[0].payload["tool_result"]["data"] == {
+        "chapter_id": "chapter_1"
+    }
 
 
 @pytest.mark.asyncio
@@ -588,7 +705,12 @@ async def test_projects_interrupted_tool_preview_as_completed_tool_message(
     assert len(tool_messages) == 1
     assert tool_messages[0].message_status == "completed"
     assert tool_messages[0].payload["tool_result"]["reason"] == "approval_preview"
-    assert tool_messages[0].payload["tool_result"]["data"]["metadata"]["chapter_diff"]["operation"] == "create"
+    assert (
+        tool_messages[0].payload["tool_result"]["data"]["metadata"]["chapter_diff"][
+            "operation"
+        ]
+        == "create"
+    )
 
 
 @pytest.mark.asyncio
@@ -632,7 +754,24 @@ async def test_projects_completed_write_tool_result_keeps_chapter_diff_for_reloa
     tool_messages = [message for message in messages if message.message_type == "tool"]
     assert len(tool_messages) == 1
     assert tool_messages[0].payload["tool_result"]["data"]["word_count"] == 2
-    assert tool_messages[0].payload["tool_result"]["data"]["chapter"]["id"] == "chapter_1"
-    assert tool_messages[0].payload["tool_result"]["data"]["metadata"]["chapter_diff"]["operation"] == "create"
-    assert tool_messages[0].payload["tool_result"]["data"]["metadata"]["chapter_diff"]["chapter_id"] == "chapter_1"
-    assert tool_messages[0].payload["tool_result"]["data"]["metadata"]["chapter_diff"]["sections"][0]["type"] == "content"
+    assert (
+        tool_messages[0].payload["tool_result"]["data"]["chapter"]["id"] == "chapter_1"
+    )
+    assert (
+        tool_messages[0].payload["tool_result"]["data"]["metadata"]["chapter_diff"][
+            "operation"
+        ]
+        == "create"
+    )
+    assert (
+        tool_messages[0].payload["tool_result"]["data"]["metadata"]["chapter_diff"][
+            "chapter_id"
+        ]
+        == "chapter_1"
+    )
+    assert (
+        tool_messages[0].payload["tool_result"]["data"]["metadata"]["chapter_diff"][
+            "sections"
+        ][0]["type"]
+        == "content"
+    )

--- a/backend/tests/agent_runtime/runner/test_session_runner_persistence.py
+++ b/backend/tests/agent_runtime/runner/test_session_runner_persistence.py
@@ -136,10 +136,15 @@ async def isolated_db(monkeypatch):
                 order=1,
             )
         )
-        session.add(Task(
-            id="task_x", project_id="proj_x",
-            title="t", mode="agent", agent_session_id="session_x",
-        ))
+        session.add(
+            Task(
+                id="task_x",
+                project_id="proj_x",
+                title="t",
+                mode="agent",
+                agent_session_id="session_x",
+            )
+        )
         await session.commit()
     yield factory
     await engine.dispose()
@@ -151,8 +156,13 @@ async def test_session_runner_clears_pending_on_run_start(isolated_db):
     factory = isolated_db
     async with factory() as s:
         await repo.insert_message(
-            s, session_id="s_x", task_id="task_x", project_id="proj_x",
-            role="user", content="orphan-pending", status="pending",
+            s,
+            session_id="s_x",
+            task_id="task_x",
+            project_id="proj_x",
+            role="user",
+            content="orphan-pending",
+            status="pending",
         )
 
     runner = SessionRunner(
@@ -174,13 +184,20 @@ async def test_drain_inject_queue_marks_user_sent(isolated_db):
     sid = "s_x"
     async with factory() as s:
         m = await repo.insert_message(
-            s, session_id=sid, task_id="task_x", project_id="proj_x",
-            role="user", content="hi", status="pending",
+            s,
+            session_id=sid,
+            task_id="task_x",
+            project_id="proj_x",
+            role="user",
+            content="hi",
+            status="pending",
         )
 
     runner = SessionRunner(
-        session_id=sid, task_id="task_x",
-        model_config={"max_context_tokens": 8000}, project_id="proj_x",
+        session_id=sid,
+        task_id="task_x",
+        model_config={"max_context_tokens": 8000},
+        project_id="proj_x",
     )
     runner._persister = runner._make_persister()
     await runner._inject_queue.put((m.id, "user", "hi"))
@@ -343,8 +360,7 @@ async def test_drain_inject_queue_emits_consumed_and_user_text_for_pending_messa
     text_index = next(
         index
         for index, (name, payload) in enumerate(emitted)
-        if name == "agent:text"
-        and payload.get("message_id") == pending["message_id"]
+        if name == "agent:text" and payload.get("message_id") == pending["message_id"]
     )
     assert queued_index < consumed_index < text_index
 
@@ -446,15 +462,15 @@ async def test_run_consumes_queued_follow_up_before_turn_finishes(
         items = await repo.list_by_session(session, "session_x")
 
     user_messages = [
-        (item.role, item.content, item.status)
-        for item in items
-        if item.role == "user"
+        (item.role, item.content, item.status) for item in items if item.role == "user"
     ]
     assert user_messages == [
         ("user", "help", "sent"),
         ("user", persisted_follow_up, "sent"),
     ]
-    assert not [item for item in items if item.role == "user" and item.status == "pending"]
+    assert not [
+        item for item in items if item.role == "user" and item.status == "pending"
+    ]
     assert runner._queued_user_messages == {}
 
 
@@ -483,22 +499,28 @@ async def test_injected_follow_up_persists_after_assistant_reply(
     await runner._persist_user_message("help")
     await runner.queue_pending_user_message(raw_follow_up)
     queued_message_id = next(iter(runner._queued_user_messages))
-    await persister.handle({
-        "event": "on_chain_start",
-        "name": "writer",
-        "tags": ["agent_node"],
-        "data": {},
-    })
-    await persister.handle({
-        "event": "on_chat_model_start",
-        "run_id": "run-1",
-        "data": {},
-    })
-    await persister.handle({
-        "event": "on_chat_model_end",
-        "run_id": "run-1",
-        "data": {"output": AIMessage(content="reply1")},
-    })
+    await persister.handle(
+        {
+            "event": "on_chain_start",
+            "name": "writer",
+            "tags": ["agent_node"],
+            "data": {},
+        }
+    )
+    await persister.handle(
+        {
+            "event": "on_chat_model_start",
+            "run_id": "run-1",
+            "data": {},
+        }
+    )
+    await persister.handle(
+        {
+            "event": "on_chat_model_end",
+            "run_id": "run-1",
+            "data": {"output": AIMessage(content="reply1")},
+        }
+    )
     drained = await runner._drain_inject_queue()
     assert drained == [("user", persisted_follow_up, queued_message_id)]
 
@@ -547,11 +569,14 @@ async def test_run_persists_messages_end_to_end(isolated_db, monkeypatch):
                 tasks: list = []
                 values: dict = {}
                 config = {"configurable": {}}
+
             return _S()
 
     runner = SessionRunner(
-        session_id="s_x", task_id="task_x",
-        model_config={"max_context_tokens": 8000}, project_id="proj_x",
+        session_id="s_x",
+        task_id="task_x",
+        model_config={"max_context_tokens": 8000},
+        project_id="proj_x",
     )
 
     async def fake_get_graph():
@@ -562,12 +587,16 @@ async def test_run_persists_messages_end_to_end(isolated_db, monkeypatch):
 
     async with factory() as s:
         items = await repo.list_by_session(s, "s_x")
-    assert any(m.role == "assistant" and m.status == "complete" and m.content == "hello"
-               for m in items)
+    assert any(
+        m.role == "assistant" and m.status == "complete" and m.content == "hello"
+        for m in items
+    )
 
 
 @pytest.mark.asyncio
-async def test_run_emits_and_persists_cumulative_task_token_usage(isolated_db, monkeypatch):
+async def test_run_emits_and_persists_cumulative_task_token_usage(
+    isolated_db, monkeypatch
+):
     from langchain_core.messages import AIMessage
 
     from app.storage.models.task import Task
@@ -682,7 +711,9 @@ async def test_run_emits_and_persists_cumulative_task_token_usage(isolated_db, m
             "context_length": 8000,
         },
     ]
-    assert [payload for name, payload in captured_events if name == "agent:task_usage_delta"] == [
+    assert [
+        payload for name, payload in captured_events if name == "agent:task_usage_delta"
+    ] == [
         {
             "session_id": "s_usage",
             "task_id": "task_x",
@@ -750,7 +781,9 @@ async def test_emit_persisted_task_usage_events_preserves_compaction_usage_kind(
             "usage_kind": "compaction",
         }
     ]
-    assert [payload for name, payload in captured_events if name == "agent:task_usage_delta"] == [
+    assert [
+        payload for name, payload in captured_events if name == "agent:task_usage_delta"
+    ] == [
         {
             "session_id": "s_compaction_usage",
             "task_id": "task_x",
@@ -921,13 +954,20 @@ async def test_sync_dispatch_subagent_continues_primary_run_until_done(
         and isinstance(payload, dict)
         and payload.get("tool_call_id") == "dispatch-1"
     ]
-    assert len(dispatch_results) == 1
+    assert len(dispatch_results) == 2
+    preview_result, final_result = dispatch_results
 
     async with factory() as session:
         items = await repo.list_by_session(session, "session_x")
         child_runs = (
-            await session.execute(select(AgentChildRun).order_by(AgentChildRun.created_at.asc()))
-        ).scalars().all()
+            (
+                await session.execute(
+                    select(AgentChildRun).order_by(AgentChildRun.created_at.asc())
+                )
+            )
+            .scalars()
+            .all()
+        )
 
     assert any(
         item.role == "tool"
@@ -938,6 +978,15 @@ async def test_sync_dispatch_subagent_continues_primary_run_until_done(
     assert len(child_runs) == 1
     assert child_runs[0].status == "completed"
     assert child_runs[0].request_json["description"] == "Write a scene"
+    assert preview_result["output"] == {
+        "type": "preview",
+        "success": True,
+        "dispatch_id": child_runs[0].dispatch_id,
+        "agent_key": "writer",
+        "agent_number": child_runs[0].metadata_json["agent_number"],
+        "metadata": {"agent_number": child_runs[0].metadata_json["agent_number"]},
+    }
+    assert json.loads(final_result["output"])["result"] == "writer completed"
     dispatch_item = next(
         item
         for item in items
@@ -945,5 +994,7 @@ async def test_sync_dispatch_subagent_continues_primary_run_until_done(
     )
     dispatch_result = json.loads(dispatch_item.content)
     assert dispatch_result["dispatch_id"] == child_runs[0].dispatch_id
-    assert dispatch_result["agent_number"] == child_runs[0].metadata_json["agent_number"]
+    assert (
+        dispatch_result["agent_number"] == child_runs[0].metadata_json["agent_number"]
+    )
     assert dispatch_result["result"] == "writer completed"

--- a/backend/tests/agent_runtime/tools/test_dispatch_subagent.py
+++ b/backend/tests/agent_runtime/tools/test_dispatch_subagent.py
@@ -1,5 +1,6 @@
+import json
 from dataclasses import replace
-from types import MappingProxyType
+from types import MappingProxyType, SimpleNamespace
 
 import pytest
 
@@ -49,7 +50,9 @@ async def test_dispatch_subagent_rejects_empty_primary_delegatable_agents(
     monkeypatch.setattr(DispatchSubagentTool, "_load_definition", load_definition)
     tool = DispatchSubagentTool(_state={"active_agent": "build"})
 
-    with pytest.raises(ToolExecutionError, match="not in the delegatable agents whitelist"):
+    with pytest.raises(
+        ToolExecutionError, match="not in the delegatable agents whitelist"
+    ):
         await tool._validate_dispatch("explore", {})
 
 
@@ -111,4 +114,96 @@ async def test_ensure_primary_rejects_disabled_primary_agent(
     monkeypatch.setattr(common, "load_agent_definition", load_definition)
 
     with pytest.raises(ToolExecutionError, match="primary agent"):
-        await common.ensure_primary({"active_agent": "disabled-primary"}, lambda: Session())
+        await common.ensure_primary(
+            {"active_agent": "disabled-primary"}, lambda: Session()
+        )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_subagent_returns_dispatch_id_when_child_request_is_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    import app.agent_runtime.tools.impls.orchestration.dispatch_subagent as dispatch_module
+
+    row = SimpleNamespace(
+        id="child-run-1",
+        child_thread_id="parent:child:dispatch-cancelled",
+        dispatch_id="dispatch-cancelled",
+        metadata_json={"agent_number": 3},
+        pending_approval_json=None,
+    )
+
+    async def noop(*_args, **_kwargs) -> None:
+        return None
+
+    async def open_session(*_args, **_kwargs) -> object:
+        return object()
+
+    async def load_waiting_child_run(*_args, **_kwargs):
+        return None
+
+    async def create_child_run(*_args, **_kwargs):
+        return row
+
+    async def persist_child_user_message(*_args, **_kwargs):
+        return SimpleNamespace(id="message-1", seq=1)
+
+    async def load_initial_request_id(*_args, **_kwargs) -> str:
+        return "request-1"
+
+    async def wait_for_assistant_content(*_args, **_kwargs) -> str:
+        raise ToolExecutionError("subagent request was cancelled")
+
+    class Runner:
+        async def publish_parent_subagent_status(self, _child_run_id: str) -> None:
+            return None
+
+    monkeypatch.setattr(DispatchSubagentTool, "_validate_dispatch", noop)
+    monkeypatch.setattr(
+        DispatchSubagentTool,
+        "_load_waiting_child_run",
+        load_waiting_child_run,
+    )
+    monkeypatch.setattr(DispatchSubagentTool, "_create_child_run", create_child_run)
+    monkeypatch.setattr(
+        DispatchSubagentTool,
+        "_load_initial_request_id",
+        load_initial_request_id,
+    )
+    monkeypatch.setattr(
+        DispatchSubagentTool,
+        "_wait_for_assistant_content",
+        wait_for_assistant_content,
+    )
+    monkeypatch.setattr(dispatch_module, "latest_checkpoint_id_for_thread", noop)
+    monkeypatch.setattr(
+        dispatch_module, "persist_child_user_message", persist_child_user_message
+    )
+    monkeypatch.setattr(dispatch_module, "open_session", open_session)
+    monkeypatch.setattr(dispatch_module, "close_session", noop)
+    monkeypatch.setattr(dispatch_module, "update_child_run_request_boundaries", noop)
+    monkeypatch.setattr(
+        dispatch_module, "make_subagent_runner", lambda **_kwargs: Runner()
+    )
+
+    tool = DispatchSubagentTool(
+        _state={
+            "session_id": "parent",
+            "task_id": "task-1",
+            "project_id": "project-1",
+        }
+    )
+
+    result = json.loads(
+        await tool._arun(
+            agent_type="writer",
+            description="write scene",
+            prompt="write scene",
+        )
+    )
+
+    assert result == {
+        "dispatch_id": "dispatch-cancelled",
+        "agent_number": 3,
+        "error": "subagent request was cancelled",
+    }

--- a/backend/tests/agent_runtime/tools/test_recycle_subagent.py
+++ b/backend/tests/agent_runtime/tools/test_recycle_subagent.py
@@ -1,0 +1,74 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from app.agent_runtime.tools.impls.orchestration.recycle_subagent import (
+    RecycleSubagentTool,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("is_active", [True, False])
+async def test_recycle_subagent_returns_subagent_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    is_active: bool,
+) -> None:
+    import app.agent_runtime.tools.impls.orchestration.recycle_subagent as recycle_module
+
+    row = SimpleNamespace(
+        id="child-run-1",
+        dispatch_id="dispatch-writer",
+        agent_key="writer",
+        metadata_json={"agent_number": "#1001"},
+        is_active=is_active,
+    )
+
+    async def noop(*_args, **_kwargs) -> None:
+        return None
+
+    async def resolve_child_run(*_args, **_kwargs):
+        return row
+
+    async def open_session(*_args, **_kwargs) -> object:
+        return object()
+
+    async def recycle_child_run(*_args, **_kwargs):
+        return row
+
+    class Registry:
+        async def cancel_child(self, *_args, **_kwargs) -> None:
+            return None
+
+    class Runner:
+        async def publish_parent_subagent_status(self, *_args, **_kwargs) -> None:
+            return None
+
+    monkeypatch.setattr(recycle_module, "ensure_primary", noop)
+    monkeypatch.setattr(recycle_module, "resolve_child_run", resolve_child_run)
+    monkeypatch.setattr(recycle_module, "open_session", open_session)
+    monkeypatch.setattr(recycle_module, "close_session", noop)
+    monkeypatch.setattr(recycle_module, "recycle_child_run", recycle_child_run)
+    monkeypatch.setattr(recycle_module, "get_agent_run_registry", lambda: Registry())
+    monkeypatch.setattr(
+        recycle_module, "make_subagent_runner", lambda **_kwargs: Runner()
+    )
+    tool = RecycleSubagentTool(
+        _state={
+            "session_id": "parent",
+            "project_id": "project-1",
+            "active_agent": "primary",
+        }
+    )
+
+    result = json.loads(
+        await tool._execute(dispatch_id="dispatch-writer", reason="任务完成")
+    )
+
+    assert result == {
+        "dispatch_id": "dispatch-writer",
+        "agent_key": "writer",
+        "agent_number": "#1001",
+        "metadata": {"agent_number": "#1001"},
+        "recycled": True,
+    }

--- a/backend/tests/agent_runtime/tools/test_subagent_tool_preview.py
+++ b/backend/tests/agent_runtime/tools/test_subagent_tool_preview.py
@@ -1,0 +1,258 @@
+from types import SimpleNamespace
+
+import pytest
+
+from app.agent_runtime.tools.errors import ToolExecutionError
+from app.agent_runtime.tools.impls.orchestration import common
+from app.agent_runtime.tools.impls.orchestration.dispatch_subagent import (
+    DispatchSubagentTool,
+)
+from app.agent_runtime.tools.impls.orchestration.notify_subagent import (
+    NotifySubagentTool,
+)
+
+
+@pytest.mark.asyncio
+async def test_subagent_tool_preview_emits_identity_for_running_tool() -> None:
+    emitted: list[tuple[str, dict]] = []
+    row = SimpleNamespace(
+        dispatch_id="dispatch-writer",
+        agent_key="writer",
+        metadata_json={"agent_number": "#1001"},
+    )
+
+    async def event_sink(name: str, payload: dict) -> None:
+        emitted.append((name, payload))
+
+    emit_preview = getattr(common, "emit_subagent_tool_preview", None)
+
+    assert callable(emit_preview)
+    await emit_preview(
+        configurable={"agent_event_sink": event_sink},
+        parent_session_id="parent-session",
+        tool_call_id="call-dispatch",
+        tool_name="dispatch_subagent",
+        tool_args={"agent_type": "writer", "prompt": "写场景"},
+        row=row,
+    )
+
+    assert emitted == [
+        (
+            "agent:tool_result",
+            {
+                "session_id": "parent-session",
+                "tool_call_id": "call-dispatch",
+                "tool": "dispatch_subagent",
+                "input": {"agent_type": "writer", "prompt": "写场景"},
+                "output": {
+                    "type": "preview",
+                    "success": True,
+                    "dispatch_id": "dispatch-writer",
+                    "agent_key": "writer",
+                    "agent_number": "#1001",
+                    "metadata": {"agent_number": "#1001"},
+                },
+                "is_preview": True,
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_subagent_emits_preview_after_child_run_is_created(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app.agent_runtime.tools.impls.orchestration.dispatch_subagent as dispatch_module
+
+    row = SimpleNamespace(
+        id="child-run-1",
+        child_thread_id="parent:child:dispatch-writer",
+        dispatch_id="dispatch-writer",
+        agent_key="writer",
+        metadata_json={"agent_number": "#1001"},
+        pending_approval_json=None,
+    )
+    previews: list[dict] = []
+
+    async def noop(*_args, **_kwargs) -> None:
+        return None
+
+    async def open_session(*_args, **_kwargs) -> object:
+        return object()
+
+    async def create_child_run(*_args, **_kwargs):
+        return row
+
+    async def load_initial_request_id(*_args, **_kwargs) -> str:
+        return "request-1"
+
+    async def persist_child_user_message(*_args, **_kwargs):
+        return SimpleNamespace(id="message-1", seq=1)
+
+    async def wait_for_assistant_content(*_args, **_kwargs) -> str:
+        raise ToolExecutionError("subagent request was cancelled")
+
+    async def emit_preview(**kwargs) -> None:
+        previews.append(kwargs)
+
+    class Runner:
+        async def publish_parent_subagent_status(self, _child_run_id: str) -> None:
+            return None
+
+    monkeypatch.setattr(DispatchSubagentTool, "_validate_dispatch", noop)
+    monkeypatch.setattr(DispatchSubagentTool, "_load_waiting_child_run", noop)
+    monkeypatch.setattr(DispatchSubagentTool, "_create_child_run", create_child_run)
+    monkeypatch.setattr(
+        DispatchSubagentTool, "_load_initial_request_id", load_initial_request_id
+    )
+    monkeypatch.setattr(
+        DispatchSubagentTool,
+        "_wait_for_assistant_content",
+        wait_for_assistant_content,
+    )
+    monkeypatch.setattr(dispatch_module, "latest_checkpoint_id_for_thread", noop)
+    monkeypatch.setattr(
+        dispatch_module,
+        "persist_child_user_message",
+        persist_child_user_message,
+    )
+    monkeypatch.setattr(dispatch_module, "open_session", open_session)
+    monkeypatch.setattr(dispatch_module, "close_session", noop)
+    monkeypatch.setattr(dispatch_module, "update_child_run_request_boundaries", noop)
+    monkeypatch.setattr(
+        dispatch_module, "make_subagent_runner", lambda **_kwargs: Runner()
+    )
+    monkeypatch.setattr(
+        dispatch_module,
+        "emit_subagent_tool_preview",
+        emit_preview,
+        raising=False,
+    )
+    tool = DispatchSubagentTool(
+        _state={
+            "session_id": "parent",
+            "task_id": "task-1",
+            "project_id": "project-1",
+        }
+    )
+
+    await tool._arun(
+        agent_type="writer",
+        description="写场景",
+        prompt="请续写这一场景。",
+        config={"metadata": {"tool_call_id": "call-dispatch"}},
+    )
+
+    assert previews == [
+        {
+            "configurable": {},
+            "parent_session_id": "parent",
+            "tool_call_id": "call-dispatch",
+            "tool_name": "dispatch_subagent",
+            "tool_args": {
+                "agent_type": "writer",
+                "description": "写场景",
+                "prompt": "请续写这一场景。",
+            },
+            "row": row,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_notify_subagent_emits_preview_after_request_is_queued(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import app.agent_runtime.tools.impls.orchestration.notify_subagent as notify_module
+
+    row = SimpleNamespace(
+        id="child-run-1",
+        child_thread_id="parent:child:dispatch-writer",
+        dispatch_id="dispatch-writer",
+        agent_key="writer",
+        metadata_json={"agent_number": "#1001"},
+        pending_approval_json=None,
+        is_active=True,
+    )
+    previews: list[dict] = []
+
+    async def noop(*_args, **_kwargs) -> None:
+        return None
+
+    async def open_session(*_args, **_kwargs) -> object:
+        return object()
+
+    async def resolve_child_run(*_args, **_kwargs):
+        return row
+
+    async def enqueue_child_run_request(*_args, **_kwargs):
+        return SimpleNamespace(id="request-1")
+
+    async def persist_child_user_message(*_args, **_kwargs):
+        return SimpleNamespace(id="message-1", seq=1)
+
+    async def wait_for_assistant_content(*_args, **_kwargs) -> str:
+        raise ToolExecutionError("subagent request was cancelled")
+
+    async def emit_preview(**kwargs) -> None:
+        previews.append(kwargs)
+
+    class Runner:
+        async def publish_parent_subagent_status(self, _child_run_id: str) -> None:
+            return None
+
+    monkeypatch.setattr(notify_module, "ensure_primary", noop)
+    monkeypatch.setattr(notify_module, "resolve_child_run", resolve_child_run)
+    monkeypatch.setattr(notify_module, "latest_checkpoint_id_for_thread", noop)
+    monkeypatch.setattr(
+        notify_module, "enqueue_child_run_request", enqueue_child_run_request
+    )
+    monkeypatch.setattr(
+        notify_module,
+        "persist_child_user_message",
+        persist_child_user_message,
+    )
+    monkeypatch.setattr(notify_module, "open_session", open_session)
+    monkeypatch.setattr(notify_module, "close_session", noop)
+    monkeypatch.setattr(notify_module, "update_child_run_request_boundaries", noop)
+    monkeypatch.setattr(
+        notify_module, "make_subagent_runner", lambda **_kwargs: Runner()
+    )
+    monkeypatch.setattr(
+        notify_module,
+        "emit_subagent_tool_preview",
+        emit_preview,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        NotifySubagentTool,
+        "_wait_for_assistant_content",
+        wait_for_assistant_content,
+    )
+    tool = NotifySubagentTool(
+        _state={
+            "session_id": "parent",
+            "task_id": "task-1",
+            "project_id": "project-1",
+        }
+    )
+
+    await tool._arun(
+        dispatch_id="dispatch-writer",
+        prompt="请继续完善冲突。",
+        config={"metadata": {"tool_call_id": "call-notify"}},
+    )
+
+    assert previews == [
+        {
+            "configurable": {},
+            "parent_session_id": "parent",
+            "tool_call_id": "call-notify",
+            "tool_name": "notify_subagent",
+            "tool_args": {
+                "dispatch_id": "dispatch-writer",
+                "prompt": "请继续完善冲突。",
+            },
+            "row": row,
+        }
+    ]

--- a/frontend/src/features/assistant/components/agent/active-subagent-list.tsx
+++ b/frontend/src/features/assistant/components/agent/active-subagent-list.tsx
@@ -37,7 +37,7 @@ function getStatusLabel(
 
 export function ActiveSubagentList({ items, title, onOpen }: ActiveSubagentListProps) {
   const { t } = useTranslation();
-  const [collapsed, setCollapsed] = useState(false);
+  const [collapsed, setCollapsed] = useState(true);
 
   if (items.length === 0) return null;
 

--- a/frontend/src/features/assistant/components/agent/message-blocks/messages/tool/tool-message.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/messages/tool/tool-message.tsx
@@ -234,6 +234,7 @@ export function ToolMessage({ message }: ToolMessageProps) {
     hasContent: Boolean(content),
     hasDetail: Boolean(detail),
     errorMessage,
+    showDetailOnError: descriptor?.group === "orchestration",
   });
   const titleClassName = joinClassNames(
     "agent-tool-title",
@@ -287,11 +288,25 @@ export function ToolMessage({ message }: ToolMessageProps) {
           >
             {title}
           </Text>
+          {!usesDiffHeader && visibilityState.showDetail && detail ? (
+            <Text
+              size="1"
+              color="gray"
+              className={joinClassNames(
+                "agent-tool-detail",
+                "agent-message-shell-detail",
+                visibilityState.showErrorIndicator && "agent-message-shell-detail--error",
+              )}
+            >
+              {detail}
+            </Text>
+          ) : null}
           {showMeta ? (
             <MessageBlockMeta>
               {visibilityState.showErrorIndicator && errorMessage ? (
                 <ToolErrorIndicator errorMessage={errorMessage} />
-              ) : usesDiffHeader ? (
+              ) : null}
+              {usesDiffHeader ? (
                 <AnimatePresence initial={false}>
                   {showCollapsedDiffMeta ? (
                     <motion.div
@@ -344,14 +359,6 @@ export function ToolMessage({ message }: ToolMessageProps) {
                     </motion.div>
                   ) : null}
                 </AnimatePresence>
-              ) : visibilityState.showDetail && detail ? (
-                <Text
-                  size="1"
-                  color="gray"
-                  className="agent-tool-detail agent-message-shell-detail"
-                >
-                  {detail}
-                </Text>
               ) : null}
               {visibilityState.showExpandButton ? (
                 <MessageExpandButton

--- a/frontend/src/features/assistant/components/agent/message-blocks/shared/message-shell.css
+++ b/frontend/src/features/assistant/components/agent/message-blocks/shared/message-shell.css
@@ -86,6 +86,11 @@
   transition: color 120ms ease-out;
 }
 
+.agent-message-shell-detail--error,
+.agent-tool-card .agent-message-shell-detail--error {
+  color: var(--red-11);
+}
+
 .agent-message-shell-expand-button,
 .agent-tool-card .agent-tool-expand-button {
   margin-left: 0;

--- a/frontend/src/features/assistant/components/agent/message-blocks/tools/orchestration/dispatch-subagent-tool-message-body.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/tools/orchestration/dispatch-subagent-tool-message-body.tsx
@@ -13,7 +13,7 @@ interface DispatchSubagentToolMessageBodyProps {
 }
 
 export function DispatchSubagentToolMessageBody({ message }: DispatchSubagentToolMessageBodyProps) {
-  const task = getSubagentInstructionText(message, ["task"]);
+  const task = getSubagentInstructionText(message, ["prompt", "task"]);
   if (!task) return null;
   return (
     <ToolBody>

--- a/frontend/src/features/assistant/components/agent/message-blocks/tools/orchestration/notify-subagent-tool-message.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/tools/orchestration/notify-subagent-tool-message.tsx
@@ -13,7 +13,7 @@ interface NotifySubagentToolMessageProps {
 }
 
 export function NotifySubagentToolMessage({ message }: NotifySubagentToolMessageProps) {
-  const notifyMessage = getSubagentInstructionText(message, ["message"]);
+  const notifyMessage = getSubagentInstructionText(message, ["prompt", "message"]);
   if (!notifyMessage) return null;
   return (
     <ToolBody>

--- a/frontend/src/features/assistant/components/agent/message-blocks/tools/orchestration/subagent-tool-message-utils.ts
+++ b/frontend/src/features/assistant/components/agent/message-blocks/tools/orchestration/subagent-tool-message-utils.ts
@@ -61,6 +61,7 @@ export function getSubagentTargetLabel(message: AgentMessage): string {
     "agent",
     "agent_name",
     "target_agent",
+    "agent_type",
   ]);
   const agentNumber = pickSubagentString(records, ["agent_number"]);
   return formatSubagentDisplayLabel(agentKey, agentNumber);

--- a/frontend/src/features/assistant/components/agent/message-blocks/tools/shared/tool-message-utils.ts
+++ b/frontend/src/features/assistant/components/agent/message-blocks/tools/shared/tool-message-utils.ts
@@ -406,6 +406,7 @@ export function resolveToolMessageVisibilityState(input: {
   hasContent: boolean;
   hasDetail: boolean;
   errorMessage?: string;
+  showDetailOnError?: boolean;
 }): ToolMessageVisibilityState {
   const isRunning = Boolean(input.message.isStreaming || input.message.status === "running");
   const hasError = Boolean(input.errorMessage);
@@ -416,7 +417,7 @@ export function resolveToolMessageVisibilityState(input: {
     canExpand,
     showStaticContent: !hasError && input.hasContent && input.contentMode === "static",
     showErrorIndicator: hasError,
-    showDetail: !hasError && input.hasDetail,
+    showDetail: input.hasDetail && (!hasError || input.showDetailOnError === true),
     showExpandButton: !hasError && canExpand,
   };
 }

--- a/frontend/src/features/assistant/hooks/use-agent-session-message-state.ts
+++ b/frontend/src/features/assistant/hooks/use-agent-session-message-state.ts
@@ -46,6 +46,19 @@ const CANCELLED_TOOL_RESULT: Record<string, unknown> = {
   metadata: { interrupted: true },
 };
 
+function cancelledToolResult(message: AgentMessage): Record<string, unknown> {
+  const preview = message.toolResult;
+  if (!preview || preview.type !== "preview" || typeof preview.agent_key !== "string") {
+    return CANCELLED_TOOL_RESULT;
+  }
+  return {
+    ...CANCELLED_TOOL_RESULT,
+    dispatch_id: preview.dispatch_id,
+    agent_key: preview.agent_key,
+    ...(typeof preview.agent_number === "string" ? { agent_number: preview.agent_number } : {}),
+  };
+}
+
 function getActiveNodeStart(messages: AgentMessage[]): AgentMessage | null {
   let activeNode: AgentMessage | null = null;
   for (const message of messages) {
@@ -109,6 +122,7 @@ export function stopStreamingToolMessages(
       return message;
     hasRunningTool = true;
     const isError = status === "error";
+    const toolResult = isError ? cancelledToolResult(message) : message.toolResult;
     return {
       ...message,
       status,
@@ -118,10 +132,10 @@ export function stopStreamingToolMessages(
         ? {
             ...(message.payload ?? {}),
             success: false,
-            tool_result: CANCELLED_TOOL_RESULT,
+            tool_result: toolResult,
           }
         : message.payload,
-      toolResult: isError ? CANCELLED_TOOL_RESULT : message.toolResult,
+      toolResult,
       content: isError ? i18n.t("assistant.userAbortedToolCall") : message.content,
     };
   });
@@ -135,6 +149,7 @@ function markLastUnresolvedToolCancelled(messages: AgentMessage[]): AgentMessage
   if (lastTool.status === "error" || lastTool.toolResult) return messages;
 
   const next = [...messages];
+  const toolResult = cancelledToolResult(lastTool);
   next[lastToolIndex] = {
     ...lastTool,
     status: "error",
@@ -143,9 +158,9 @@ function markLastUnresolvedToolCancelled(messages: AgentMessage[]): AgentMessage
     payload: {
       ...(lastTool.payload ?? {}),
       success: false,
-      tool_result: CANCELLED_TOOL_RESULT,
+      tool_result: toolResult,
     },
-    toolResult: CANCELLED_TOOL_RESULT,
+    toolResult,
     content: i18n.t("assistant.userAbortedToolCall"),
   };
   return next;

--- a/frontend/src/features/assistant/lib/agent-socket-events.ts
+++ b/frontend/src/features/assistant/lib/agent-socket-events.ts
@@ -58,6 +58,7 @@ function getToolEventStatus(
   _toolName: string,
   result: Record<string, unknown>,
 ): AgentEvent["status"] {
+  if (result.type === "preview") return "running";
   return result.success === false ? "error" : "completed";
 }
 

--- a/frontend/src/features/assistant/lib/streaming-message-merge.ts
+++ b/frontend/src/features/assistant/lib/streaming-message-merge.ts
@@ -1,5 +1,37 @@
 import type { AgentMessage } from "@/lib/agent.types";
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function preserveSubagentPreviewIdentity(
+  previous: Record<string, unknown> | undefined,
+  next: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!previous || !next) return next;
+  if (previous.type !== "preview") return next;
+  if (typeof previous.agent_key !== "string" || typeof next.agent_key === "string") return next;
+
+  const previousData = isRecord(previous.data) ? previous.data : null;
+  const nextData = isRecord(next.data) ? next.data : null;
+  const identity = {
+    agent_key: previous.agent_key,
+    ...(typeof previous.agent_number === "string" ? { agent_number: previous.agent_number } : {}),
+  };
+  return {
+    ...next,
+    ...identity,
+    ...(previousData && nextData
+      ? {
+          data: {
+            ...nextData,
+            ...identity,
+          },
+        }
+      : {}),
+  };
+}
+
 function isStreamingDeltaMessage(message: AgentMessage): boolean {
   return Boolean(message.payload?.is_delta && ["text", "reasoning", "tool"].includes(message.type));
 }
@@ -56,7 +88,7 @@ export function mergeStreamingMessage(previous: AgentMessage, message: AgentMess
       message.status === "running"
         ? (message.partialToolArgs ?? previous.partialToolArgs)
         : undefined,
-    toolResult: message.toolResult ?? previous.toolResult,
+    toolResult: preserveSubagentPreviewIdentity(previous.toolResult, message.toolResult),
     toolSuccess: message.toolSuccess ?? previous.toolSuccess,
     isStreaming: message.status === "running" ? true : false,
     thinkingDurationMs: message.thinkingDurationMs ?? previous.thinkingDurationMs,


### PR DESCRIPTION
## PR 标题

fix(agent): 完善子智能体工具状态展示

## 变更说明

- 问题: 子智能体派发、通知和回收工具在流式、取消及历史加载阶段的身份信息不一致，工具卡片可能显示 Unknown 或丢失可管理的 dispatch_id。
- 重要性: 主 Agent 在取消后无法获知仍在运行的子智能体，用户也无法从工具消息确认目标子智能体。
- 变化: 为派发和通知增加实时身份预览；取消收尾保留 dispatch_id、类型和编号；回收工具直接返回身份字段；统一前端错误卡片的类型、编号、颜色和排列。
- 变化: 子智能体侧边栏面板调整为默认收起，并补充派发、通知、回收、取消持久化与任务投影的回归测试。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [x] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

实时工具结果没有统一携带子智能体身份；取消流程会以通用中断结果覆盖工具卡片；持久化投影与实时事件的数据来源不一致。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令：

- `uv run pytest tests/agent_runtime/tools/test_dispatch_subagent.py tests/agent_runtime/tools/test_recycle_subagent.py tests/agent_runtime/tools/test_subagent_tool_preview.py tests/agent_runtime/persistence/test_persister_finalize.py tests/agent_runtime/persistence/test_task_projection.py tests/agent_runtime/runner/test_session_runner_persistence.py -q`，42 passed
- `uv run ruff check ...` 与 `uv run ruff format --check ...`
- `pnpm type-check`
- `pnpm lint`
- `pnpm format:check`
