### PR TITLE
fix(agent): 修复流式消息底部跟随

### DIFF
--- a/frontend/src/features/assistant/components/agent/agent-messages-scroll.test.ts
+++ b/frontend/src/features/assistant/components/agent/agent-messages-scroll.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  getStreamingFollowSignal,
+  resolveFollowBottomStateOnScroll,
+} from "./agent-messages-scroll";
+
+describe("getStreamingFollowSignal", () => {
+  it("changes when an earlier streaming message receives content", () => {
+    const initialMessages = [
+      {
+        id: "streaming-output",
+        type: "agent_output",
+        status: "running",
+        content: "draft",
+        isStreaming: true,
+      },
+      {
+        id: "latest-tool",
+        type: "tool",
+        status: "running",
+        content: "",
+        isStreaming: true,
+      },
+    ];
+    const updatedMessages = [
+      { ...initialMessages[0], content: "draft content" },
+      initialMessages[1],
+    ];
+
+    expect(getStreamingFollowSignal(initialMessages)).toBeTypeOf("string");
+    expect(getStreamingFollowSignal(updatedMessages)).not.toBe(
+      getStreamingFollowSignal(initialMessages),
+    );
+  });
+
+  it("ignores completed messages", () => {
+    const initialMessages = [
+      {
+        id: "completed-output",
+        type: "agent_output",
+        status: "completed",
+        content: "before",
+      },
+      {
+        id: "streaming-tool",
+        type: "tool",
+        status: "running",
+        content: "",
+        isStreaming: true,
+      },
+    ];
+    const updatedMessages = [{ ...initialMessages[0], content: "after" }, initialMessages[1]];
+
+    expect(getStreamingFollowSignal(updatedMessages)).toBe(
+      getStreamingFollowSignal(initialMessages),
+    );
+  });
+
+  it("changes when a streaming tool receives partial arguments", () => {
+    const initialMessages = [
+      {
+        id: "streaming-tool",
+        type: "tool",
+        status: "running",
+        isStreaming: true,
+        partialToolArgs: { title: "Draft" },
+      },
+    ];
+    const updatedMessages = [
+      { ...initialMessages[0], partialToolArgs: { title: "Draft", content: "Text" } },
+    ];
+
+    expect(getStreamingFollowSignal(updatedMessages)).not.toBe(
+      getStreamingFollowSignal(initialMessages),
+    );
+  });
+
+  it("keeps following during a thinking block height animation", () => {
+    expect(
+      resolveFollowBottomStateOnScroll({
+        previous: { scrollHeight: 1_000, scrollTop: 800, clientHeight: 200 },
+        next: { scrollHeight: 1_100, scrollTop: 700, clientHeight: 200 },
+        wasFollowingBottom: true,
+        isAutoScrollPending: true,
+      }),
+    ).toBe(true);
+  });
+
+  it("stops following when the user scrolls upward without a pending automatic scroll", () => {
+    expect(
+      resolveFollowBottomStateOnScroll({
+        previous: { scrollHeight: 1_000, scrollTop: 800, clientHeight: 200 },
+        next: { scrollHeight: 1_100, scrollTop: 700, clientHeight: 200 },
+        wasFollowingBottom: true,
+      }),
+    ).toBe(false);
+  });
+});

--- a/frontend/src/features/assistant/components/agent/agent-messages-scroll.ts
+++ b/frontend/src/features/assistant/components/agent/agent-messages-scroll.ts
@@ -7,6 +7,23 @@ export interface ScrollViewportMetrics extends ScrollFrameMetrics {
   scrollTop: number;
 }
 
+interface StreamingFollowMessage {
+  id: string;
+  status?: string;
+  content?: string;
+  toolArgsText?: string;
+  partialToolArgs?: Record<string, unknown>;
+  toolResult?: Record<string, unknown>;
+  isStreaming?: boolean;
+}
+
+export function getStreamingFollowSignal(messages: readonly StreamingFollowMessage[]): string {
+  return messages.reduce((signal, message) => {
+    if (!message.isStreaming && message.status !== "running") return signal;
+    return `${signal}${message.id}\u0000${message.status ?? ""}\u0000${message.content?.length ?? 0}\u0000${message.toolArgsText?.length ?? 0}\u0000${JSON.stringify(message.partialToolArgs ?? null)}\u0000${JSON.stringify(message.toolResult ?? null)}\u0000${message.isStreaming ? 1 : 0}\u0001`;
+  }, "");
+}
+
 const FOLLOW_BOTTOM_THRESHOLD_PX = 80;
 const PROGRAMMATIC_SCROLL_EPSILON_PX = 1;
 
@@ -37,14 +54,17 @@ export function resolveFollowBottomStateOnScroll({
   previous,
   next,
   wasFollowingBottom,
+  isAutoScrollPending = false,
 }: {
   previous: ScrollViewportMetrics | null;
   next: ScrollViewportMetrics;
   wasFollowingBottom: boolean;
+  isAutoScrollPending?: boolean;
 }): boolean {
   const isAtBottomNow = shouldFollowBottom(next);
   if (!previous) return isAtBottomNow;
   if (!wasFollowingBottom) return isAtBottomNow;
+  if (isAutoScrollPending) return true;
 
   const frameChanged =
     previous.scrollHeight !== next.scrollHeight || previous.clientHeight !== next.clientHeight;

--- a/frontend/src/features/assistant/components/agent/agent-messages.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-messages.tsx
@@ -14,6 +14,7 @@ import type { AgentMessage as AgentMessageType } from "@/lib/agent.types";
 
 import { AgentMessageRenderer } from "./agent-message-renderer";
 import {
+  getStreamingFollowSignal,
   hasPendingLoadedSessionBottomRestore,
   resolveFollowBottomStateOnScroll,
   shouldAutoScrollOnFrameChange,
@@ -190,16 +191,7 @@ export function AgentMessages({
   );
   const [pendingForkTarget, setPendingForkTarget] = useState<AgentRoundToolbarTarget | null>(null);
   const [collapsedNodeIds, setCollapsedNodeIds] = useState<Set<string>>(() => new Set());
-  const latestMessage = messages.at(-1);
-  const streamFollowSignal = [
-    messages.length,
-    latestMessage?.id ?? "",
-    latestMessage?.type ?? "",
-    latestMessage?.status ?? "",
-    latestMessage?.content?.length ?? 0,
-    latestMessage?.toolArgsText?.length ?? 0,
-    latestMessage?.isStreaming ? 1 : 0,
-  ].join(":");
+  const streamFollowSignal = getStreamingFollowSignal(messages);
 
   const getScrollContainer = useCallback(
     () => scrollContainerRef.current ?? bottomRef.current?.closest(".ai-sidebar-messages"),
@@ -278,6 +270,7 @@ export function AgentMessages({
         previous: viewportMetricsRef.current,
         next: nextViewport,
         wasFollowingBottom: shouldFollowBottomRef.current,
+        isAutoScrollPending: streamingScrollRafRef.current !== null,
       });
       viewportMetricsRef.current = nextViewport;
     };


### PR DESCRIPTION
## PR 标题

fix(agent): 修复流式消息底部跟随

## 变更说明

- 问题: Agent 侧边栏在思考块高度动画或前序流式消息更新后，可能将自动滚动误判为用户上滚，导致后续消息不再跟随到底部。
- 重要性: 流式执行过程中，最新状态可能离开可视区域，影响任务进度阅读。
- 变化: 跟踪所有运行中消息的内容与工具状态变化；自动滚动已排队时保留跟随意图；补充相关回归测试。

## 关联 Issue / PR (如有)

#XXXX

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [x] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

思考块的高度动画会触发滚动事件。自动滚动尚未执行时，旧逻辑将该事件视作用户上滚并关闭跟随状态；同时，触发信号此前只关注最后一条消息，遗漏前序运行中消息的更新。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 已执行 `pnpm exec vp test run --environment node`，5 项测试通过。
- 已执行 `pnpm type-check`、`pnpm lint` 和 `pnpm format:check`。
