### PR TITLE
fix(agent): 优化用户消息展开动画

### DIFF
--- a/frontend/src/features/assistant/components/agent/agent-message-blocks.css
+++ b/frontend/src/features/assistant/components/agent/agent-message-blocks.css
@@ -127,26 +127,13 @@
 }
 
 .agent-user-message-preview-text {
-  display: -webkit-box;
-  overflow: hidden;
-  -webkit-box-orient: vertical;
-  -webkit-line-clamp: 4;
-  line-clamp: 4;
-  max-height: calc(1.35em * 4);
+  display: block;
   font-size: inherit;
   white-space: pre-wrap;
 }
 
-.agent-user-message-preview--expanded .agent-user-message-preview-text {
-  display: block;
-  overflow: visible;
-  -webkit-line-clamp: unset;
-  line-clamp: unset;
-  max-height: none;
-}
-
-.agent-user-message-preview--expanded {
-  overflow: visible;
+.agent-user-message-content-viewport {
+  overflow: hidden;
 }
 
 .agent-user-message-expand-overlay {
@@ -173,9 +160,9 @@
 
 .agent-user-message-collapse-indicator {
   display: flex;
+  overflow: hidden;
   align-items: center;
   justify-content: center;
-  margin-top: 6px;
   color: var(--gray-11);
 }
 

--- a/frontend/src/features/assistant/components/agent/message-blocks/messages/user/user-request-message.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/messages/user/user-request-message.tsx
@@ -1,6 +1,6 @@
 import { ChevronDown } from "lucide-react";
-import { AnimatePresence, motion } from "motion/react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { motion } from "motion/react";
+import { useCallback, useLayoutEffect, useRef, useState } from "react";
 
 import type { AgentMessage } from "@/lib/agent.types";
 
@@ -23,26 +23,60 @@ const USER_MESSAGE_AFFORDANCE_TRANSITION = {
   ease: [0.22, 1, 0.36, 1] as const,
 };
 
+interface UserMessageMeasurements {
+  contentHeight: number;
+  previewHeight: number;
+}
+
 export function UserRequestMessage({ message, onOpenMentionChapter }: UserRequestMessageProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const [isClamped, setIsClamped] = useState(false);
   const [isPointerInside, setIsPointerInside] = useState(false);
   const [suppressCollapsedOverlay, setSuppressCollapsedOverlay] = useState(false);
+  const [measurements, setMeasurements] = useState<UserMessageMeasurements | null>(null);
+  const [shouldAnimateHeight, setShouldAnimateHeight] = useState(false);
   const textRef = useRef<HTMLSpanElement>(null);
 
-  useEffect(() => {
-    const el = textRef.current;
-    if (!el) return;
-    setIsClamped(el.scrollHeight > el.clientHeight);
-  }, [message.content]);
+  const updateMeasurements = useCallback(() => {
+    const text = textRef.current;
+    if (!text) return;
 
+    const lineHeight = Number.parseFloat(window.getComputedStyle(text).lineHeight);
+    const contentHeight = text.scrollHeight;
+    const previewHeight = Math.min(contentHeight, Math.ceil(lineHeight * 4));
+
+    setMeasurements((current) => {
+      if (current?.contentHeight === contentHeight && current.previewHeight === previewHeight) {
+        return current;
+      }
+      return { contentHeight, previewHeight };
+    });
+  }, []);
+
+  useLayoutEffect(() => {
+    const text = textRef.current;
+    if (!text) return;
+
+    updateMeasurements();
+    const resizeObserver = new ResizeObserver(updateMeasurements);
+    resizeObserver.observe(text);
+    return () => resizeObserver.disconnect();
+  }, [message.content, updateMeasurements]);
+
+  const isClamped =
+    measurements !== null && measurements.contentHeight > measurements.previewHeight;
   const canToggle = isClamped || isExpanded;
-  const showExpandOverlay =
-    isClamped && !isExpanded && isPointerInside && !suppressCollapsedOverlay;
+  const showCollapsedMask = isClamped && !isExpanded;
+  const showExpandArrow = showCollapsedMask && isPointerInside && !suppressCollapsedOverlay;
+  const targetHeight = measurements
+    ? isExpanded
+      ? measurements.contentHeight
+      : measurements.previewHeight
+    : "auto";
 
   const handleToggle = useCallback(() => {
     if (!canToggle) return;
 
+    setShouldAnimateHeight(true);
     if (isExpanded) {
       setIsExpanded(false);
       setSuppressCollapsedOverlay(true);
@@ -52,6 +86,10 @@ export function UserRequestMessage({ message, onOpenMentionChapter }: UserReques
     setSuppressCollapsedOverlay(false);
     setIsExpanded(true);
   }, [canToggle, isExpanded]);
+
+  const handleHeightAnimationComplete = useCallback(() => {
+    setShouldAnimateHeight(false);
+  }, []);
 
   const handlePointerEnter = useCallback(() => {
     setIsPointerInside(true);
@@ -64,24 +102,26 @@ export function UserRequestMessage({ message, onOpenMentionChapter }: UserReques
 
   return (
     <UserMessageShell>
-      <motion.div
-        layout
-        transition={USER_MESSAGE_LAYOUT_TRANSITION}
-        style={{ width: "100%" }}
+      <MessageCardShell
+        className={joinClassNames(
+          "ai-sidebar-user-message",
+          "agent-user-message-preview",
+          isExpanded && "agent-user-message-preview--expanded",
+          isClamped && "agent-user-message-preview--clamped",
+        )}
+        onClick={handleToggle}
+        onPointerEnter={handlePointerEnter}
+        onPointerLeave={handlePointerLeave}
+        role={canToggle ? "button" : undefined}
+        tabIndex={canToggle ? 0 : undefined}
+        aria-expanded={isClamped ? isExpanded : undefined}
       >
-        <MessageCardShell
-          className={joinClassNames(
-            "ai-sidebar-user-message",
-            "agent-user-message-preview",
-            isExpanded && "agent-user-message-preview--expanded",
-            isClamped && "agent-user-message-preview--clamped",
-          )}
-          onClick={handleToggle}
-          onPointerEnter={handlePointerEnter}
-          onPointerLeave={handlePointerLeave}
-          role={canToggle ? "button" : undefined}
-          tabIndex={canToggle ? 0 : undefined}
-          aria-expanded={isClamped ? isExpanded : undefined}
+        <motion.div
+          className="agent-user-message-content-viewport"
+          initial={false}
+          animate={{ height: targetHeight }}
+          transition={shouldAnimateHeight ? USER_MESSAGE_LAYOUT_TRANSITION : { duration: 0 }}
+          onAnimationComplete={handleHeightAnimationComplete}
         >
           <InlineMentionText
             ref={textRef}
@@ -89,53 +129,46 @@ export function UserRequestMessage({ message, onOpenMentionChapter }: UserReques
             className="agent-user-message-preview-text"
             onOpenMentionChapter={onOpenMentionChapter}
           />
-          <AnimatePresence initial={false}>
-            {showExpandOverlay ? (
-              <motion.div
-                key="expand-overlay"
-                className="agent-user-message-expand-overlay"
-                initial={{ opacity: 0, y: 6 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: 6 }}
-                transition={USER_MESSAGE_AFFORDANCE_TRANSITION}
-              >
-                <motion.span
-                  className="agent-user-message-chevron-motion"
-                  initial={{ rotate: 180 }}
-                  animate={{ rotate: 0 }}
-                  transition={USER_MESSAGE_LAYOUT_TRANSITION}
-                >
-                  <ChevronDown
-                    size={14}
-                    className="agent-user-message-expand-icon"
-                  />
-                </motion.span>
-              </motion.div>
-            ) : null}
-          </AnimatePresence>
-          <AnimatePresence initial={false}>
-            {isExpanded ? (
-              <motion.div
-                key="collapse-indicator"
-                className="agent-user-message-collapse-indicator"
-                initial={{ opacity: 0, y: -4 }}
-                animate={{ opacity: 1, y: 0 }}
-                exit={{ opacity: 0, y: -4 }}
-                transition={USER_MESSAGE_AFFORDANCE_TRANSITION}
-              >
-                <motion.span
-                  className="agent-user-message-chevron-motion"
-                  initial={{ rotate: 0 }}
-                  animate={{ rotate: 180 }}
-                  transition={USER_MESSAGE_LAYOUT_TRANSITION}
-                >
-                  <ChevronDown size={14} />
-                </motion.span>
-              </motion.div>
-            ) : null}
-          </AnimatePresence>
-        </MessageCardShell>
-      </motion.div>
+        </motion.div>
+        <motion.div
+          className="agent-user-message-expand-overlay"
+          initial={false}
+          animate={{ opacity: showCollapsedMask ? 1 : 0 }}
+          transition={USER_MESSAGE_AFFORDANCE_TRANSITION}
+          aria-hidden={!showCollapsedMask}
+        >
+          <motion.span
+            className="agent-user-message-chevron-motion"
+            animate={{ opacity: showExpandArrow ? 1 : 0, y: showExpandArrow ? 0 : 6 }}
+            transition={USER_MESSAGE_AFFORDANCE_TRANSITION}
+          >
+            <ChevronDown
+              size={14}
+              className="agent-user-message-expand-icon"
+            />
+          </motion.span>
+        </motion.div>
+        <motion.div
+          className="agent-user-message-collapse-indicator"
+          initial={false}
+          animate={{
+            height: isExpanded ? "auto" : 0,
+            marginTop: isExpanded ? 6 : 0,
+            opacity: isExpanded ? 1 : 0,
+            y: isExpanded ? 0 : -4,
+          }}
+          transition={USER_MESSAGE_AFFORDANCE_TRANSITION}
+          aria-hidden={!isExpanded}
+        >
+          <motion.span
+            className="agent-user-message-chevron-motion"
+            animate={{ rotate: isExpanded ? 180 : 0 }}
+            transition={USER_MESSAGE_LAYOUT_TRANSITION}
+          >
+            <ChevronDown size={14} />
+          </motion.span>
+        </motion.div>
+      </MessageCardShell>
     </UserMessageShell>
   );
 }


### PR DESCRIPTION
## PR 标题

fix(agent): 优化用户消息展开动画

## 变更说明

- 问题: 长用户消息在展开和收起时，依赖 line-clamp 切换会造成高度跳变或视觉残留。
- 重要性: 用户消息的阅读与折叠交互需要保持稳定，避免影响侧边栏消息列表观感。
- 变化: 显式测量完整内容和预览高度，以动画方式切换内容视口高度；收起态持续展示渐变遮罩，箭头仅在悬停时显示。

## 关联 Issue / PR (如有)

#XXXX

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [x] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

通过 CSS line-clamp 在预览态和展开态之间切换时，内容高度无法连续过渡，导致长消息展开或收起时出现跳变。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 已执行 `pnpm type-check`、`pnpm lint` 和 `pnpm format:check`。
- 本次变更未包含后端和内置 Agent 提示词的未提交修改。
