### PR TITLE
fix(build): 修复 wheel 重复收录

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -104,7 +104,6 @@ packages = ["app"]
 "alembic.ini" = "alembic.ini"
 "LICENSE" = "LICENSE"
 "frontend" = "frontend"
-"app/skills" = "app/skills"
 
 [tool.hatch.build.targets.sdist]
 force-include = { "alembic.ini" = "alembic.ini", "../LICENSE" = "LICENSE", "frontend" = "frontend", "app/skills" = "app/skills" }


### PR DESCRIPTION
## PR 标题

fix(build): 修复 wheel 重复收录

## 变更说明

- 问题: `uv build` 从源码分发包构建 wheel 时，`app/skills/__init__.py` 被重复写入归档，导致 PyPI Job 在上传前失败。
- 重要性: `v0.7.4` 标签的 Python 包无法构建和发布，后续桌面端与 Release 附件任务也被阻塞。
- 变化: 删除 wheel 目标中与 `packages = ["app"]` 重复的 `app/skills` 强制收录配置；源码分发包仍保留该目录，确保内置 Skill YAML 资源参与 wheel 构建。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

wheel 同时通过 `packages = ["app"]` 和 `force-include` 收录 `app/skills`。Hatch 构建时检测到 `app/skills/__init__.py` 的重复归档路径并中止。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 验证: `uv build` 成功生成 `openfic-0.7.4.tar.gz` 和 `openfic-0.7.4-py3-none-any.whl`。
- 验证: wheel 内 `app/skills/__init__.py` 仅存在一次，且包含内置 Skill YAML 资源。
- 合并后需将 `v0.7.4` 标签移动至该修复提交并重新触发 Package 工作流。合并提交需要带 `[skip ci]`，避免 Release Please 提前创建 `0.7.5` 发版 PR。
