### PR TITLE
fix(desktop): 优化运行环境下载源

### DIFF
--- a/desktop/src/main/runtime/archive.ts
+++ b/desktop/src/main/runtime/archive.ts
@@ -6,15 +6,27 @@ import { pipeline } from "node:stream/promises";
 import { spawn } from "node:child_process";
 import { Transform } from "node:stream";
 
-export async function downloadFile(
-  url: string,
+const FIRST_BYTE_TIMEOUT_MS = 8_000;
+
+type FetchResponse = Awaited<ReturnType<typeof net.fetch>>;
+
+async function fetchWithFirstByteTimeout(url: string): Promise<FetchResponse> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FIRST_BYTE_TIMEOUT_MS);
+  try {
+    return await net.fetch(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function streamResponseToPath(
+  response: FetchResponse,
   outputPath: string,
   onProgress?: (received: number, total: number) => void,
 ): Promise<void> {
-  await mkdir(path.dirname(outputPath), { recursive: true });
-  const response = await net.fetch(url);
   if (!response.ok || !response.body) {
-    throw new Error(`failed to download ${url}: ${response.status}`);
+    throw new Error(`download responded with status ${response.status}`);
   }
 
   const total = Number(response.headers.get("content-length") ?? 0);
@@ -34,6 +46,29 @@ export async function downloadFile(
   });
 
   await pipeline(response.body, counting, createWriteStream(outputPath));
+}
+
+export async function downloadFile(
+  urls: string[],
+  outputPath: string,
+  onProgress?: (received: number, total: number) => void,
+): Promise<void> {
+  if (urls.length === 0) throw new Error("no download urls provided");
+  await mkdir(path.dirname(outputPath), { recursive: true });
+
+  let lastError: unknown;
+  for (const url of urls) {
+    try {
+      const response = await fetchWithFirstByteTimeout(url);
+      await streamResponseToPath(response, outputPath, onProgress);
+      return;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      lastError = new Error(`failed to download ${url}: ${message}`);
+      await rm(outputPath, { force: true });
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
 }
 
 export async function extractTarGz(

--- a/desktop/src/main/runtime/openfic.ts
+++ b/desktop/src/main/runtime/openfic.ts
@@ -1,9 +1,10 @@
+import { net } from "electron";
 import { spawn } from "node:child_process";
 import { access, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { findFreePort } from "../ports.js";
 import { startBackendProcess, stopBackendProcess, type BackendProcessHandle } from "../process.js";
-import { getSystemProxyEnvironment } from "../proxy.js";
+import { configureDefaultSystemProxy, getSystemProxyEnvironment } from "../proxy.js";
 import { waitForBackend } from "../health.js";
 import type { PortablePython, RuntimeIntegrityCheck } from "./python.js";
 import {
@@ -17,6 +18,15 @@ import type { StartupProgressTracker } from "../startup-progress.js";
 export type OpenFicRuntimeStep = "create-venv" | "install-uv" | "install-openfic";
 
 const ANSI_ESCAPE_SEQUENCE = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-9;]*[A-Za-z]`, "g");
+const DEFAULT_PYPI_INDEX_URL = "https://pypi.org/simple/";
+const TSINGHUA_PYPI_INDEX_URL = "https://pypi.tuna.tsinghua.edu.cn/simple/";
+const PYPI_INDEX_PROBE_TIMEOUT_MS = 5_000;
+const PYPI_INDEX_PROBE_PACKAGE = "openfic";
+
+interface PypiIndexProbe {
+  indexUrl: string;
+  elapsedMs: number;
+}
 
 function getVenvDir(runtimeDir: string): string {
   return path.join(runtimeDir, "venv");
@@ -78,6 +88,48 @@ function forwardLines(
 
 function stripAnsi(value: string): string {
   return value.replace(ANSI_ESCAPE_SEQUENCE, "");
+}
+
+async function probePypiIndex(indexUrl: string, expectedVersion: string): Promise<PypiIndexProbe | null> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), PYPI_INDEX_PROBE_TIMEOUT_MS);
+  const startedAt = performance.now();
+  try {
+    const response = await net.fetch(`${indexUrl}${PYPI_INDEX_PROBE_PACKAGE}/`, {
+      cache: "no-store",
+      signal: controller.signal,
+    });
+    if (!response.ok) return null;
+    const packageIndex = await response.text();
+    const elapsedMs = performance.now() - startedAt;
+    if (!packageIndex.includes(`openfic-${expectedVersion}`)) return null;
+    return { indexUrl, elapsedMs };
+  } catch {
+    return null;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function getFastestPypiEnvironment(expectedVersion: string): Promise<NodeJS.ProcessEnv> {
+  await configureDefaultSystemProxy();
+  const probes = await Promise.all(
+    [DEFAULT_PYPI_INDEX_URL, TSINGHUA_PYPI_INDEX_URL].map((indexUrl) => probePypiIndex(indexUrl, expectedVersion)),
+  );
+  let fastestProbe: PypiIndexProbe | null = null;
+  for (const probe of probes) {
+    if (probe && (!fastestProbe || probe.elapsedMs < fastestProbe.elapsedMs)) fastestProbe = probe;
+  }
+
+  const indexUrl = fastestProbe?.indexUrl ?? DEFAULT_PYPI_INDEX_URL;
+  const proxyEnvironment = await getSystemProxyEnvironment(indexUrl);
+  return {
+    ...proxyEnvironment,
+    PIP_INDEX_URL: indexUrl,
+    UV_INDEX_URL: indexUrl,
+    pip_index_url: indexUrl,
+    uv_index_url: indexUrl,
+  };
 }
 
 function run(
@@ -177,6 +229,8 @@ export async function ensureOpenFicRuntime(
   const venvDir = getVenvDir(runtimeDir);
   const venvPythonPath = getVenvPythonPath(runtimeDir);
   const uvPath = getUvPath(runtimeDir);
+  let pypiEnvironment: Promise<NodeJS.ProcessEnv> | null = null;
+  const getPypiEnvironment = () => (pypiEnvironment ??= getFastestPypiEnvironment(expectedVersion));
 
   await mkdir(runtimeDir, { recursive: true });
 
@@ -193,13 +247,13 @@ export async function ensureOpenFicRuntime(
   const uvIsUsable = (await pathExists(uvPath)) && Boolean(await readOutput(uvPath, ["--version"], runtimeDir));
   if (!uvIsUsable) {
     onProgress("install-uv", "安装 uv");
-    const proxyEnvironment = await getSystemProxyEnvironment("https://pypi.org/");
+    const packageIndexEnvironment = await getPypiEnvironment();
     await run(
       venvPythonPath,
       ["-m", "pip", "install", "--force-reinstall", "uv"],
       runtimeDir,
       (message) => onProgress("install-uv", message),
-      proxyEnvironment,
+      packageIndexEnvironment,
     );
   }
 
@@ -210,7 +264,7 @@ export async function ensureOpenFicRuntime(
     (await pathExists(openFicCliPath)) && (await succeeds(openFicCliPath, ["--help"], runtimeDir));
   if (installedVersion !== expectedVersion || !openFicCliIsUsable) {
     onProgress("install-openfic", installedVersion ? "更新 OpenFic 后端" : "安装 OpenFic 后端");
-    const proxyEnvironment = await getSystemProxyEnvironment("https://pypi.org/");
+    const packageIndexEnvironment = await getPypiEnvironment();
     const installCommand = createOpenFicInstallCommand(
       venvPythonPath,
       expectedVersion,
@@ -221,7 +275,7 @@ export async function ensureOpenFicRuntime(
       installCommand.args,
       runtimeDir,
       (message) => onProgress("install-openfic", message),
-      proxyEnvironment,
+      packageIndexEnvironment,
     );
   }
 

--- a/desktop/src/main/runtime/python-assets.ts
+++ b/desktop/src/main/runtime/python-assets.ts
@@ -2,20 +2,26 @@ export interface PythonAsset {
   version: string;
   tag: string;
   target: string;
-  url: string;
+  urls: string[];
 }
 
 const PYTHON_VERSION = "3.13.14";
 const RELEASE_TAG = "20260623";
-const BASE_URL = `https://github.com/astral-sh/python-build-standalone/releases/download/${RELEASE_TAG}`;
+const GITHUB_BASE_URL = `https://github.com/astral-sh/python-build-standalone/releases/download/${RELEASE_TAG}`;
+const MIRROR_PREFIX = "https://gh-proxy.com/";
+
+function buildGithubUrl(target: string): string {
+  const filename = `cpython-${PYTHON_VERSION}+${RELEASE_TAG}-${target}-install_only.tar.gz`;
+  return `${GITHUB_BASE_URL}/${encodeURIComponent(filename).replace(/%2F/g, "/")}`;
+}
 
 function buildAsset(target: string): PythonAsset {
-  const filename = `cpython-${PYTHON_VERSION}+${RELEASE_TAG}-${target}-install_only.tar.gz`;
+  const githubUrl = buildGithubUrl(target);
   return {
     version: PYTHON_VERSION,
     tag: RELEASE_TAG,
     target,
-    url: `${BASE_URL}/${encodeURIComponent(filename).replace(/%2F/g, "/")}`,
+    urls: [githubUrl, `${MIRROR_PREFIX}${githubUrl}`],
   };
 }
 

--- a/desktop/src/main/runtime/python.ts
+++ b/desktop/src/main/runtime/python.ts
@@ -111,7 +111,7 @@ export async function ensurePortablePython(
   await mkdir(runtimeDir, { recursive: true });
 
   onPhase("download", `下载 Python ${asset.version}`);
-  await downloadFile(asset.url, archivePath, (received, total) => onDownload({ received, total }));
+  await downloadFile(asset.urls, archivePath, (received, total) => onDownload({ received, total }));
 
   onPhase("extract", "解压 Python");
   await extractTarGz(archivePath, rootDir);


### PR DESCRIPTION
## PR 标题

fix(desktop): 优化运行环境下载源

## 变更说明

- 问题: 国内网络环境下，GitHub Releases 与 PyPI 官方源可能连接慢或不可达。
- 重要性: 首次初始化本地运行环境时，便携 Python、uv 或 OpenFic 后端的下载可能失败。
- 变化: 便携 Python 下载增加 GitHub 主源、gh-proxy 回退源及 8 秒响应超时；失败时会清理部分文件后换源重试。
- 变化: 并行探测官方 PyPI 与清华镜像，校验目标 OpenFic 版本存在后选择更快的源，并通过 `PIP_INDEX_URL` 和 `UV_INDEX_URL` 复用于 uv 与 OpenFic 安装。

## 关联 Issue / PR (如有)

无。

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

运行环境下载依赖单一 GitHub 或 PyPI 源，未对首个响应设置超时，也没有可用源测速、版本校验与回退机制。

## 自查清单

- [ ] 已添加/更新必要的测试（desktop 未配置测试运行器）
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过（desktop 未配置测试脚本）
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理（不涉及数据库变更）
- [x] 提交信息符合规范

## 补充信息

验证命令：`pnpm type-check`、`pnpm lint`。

当前环境未执行 Windows 上的便携 Python 下载和本地后端完整安装流程，需由 CI 或 Windows 环境进一步验证。
