### PR TITLE
fix(frontend): 修复已删除项目仍可打开的问题

### DIFF
--- a/frontend/src/features/app-shell/components/app-sidebar.tsx
+++ b/frontend/src/features/app-shell/components/app-sidebar.tsx
@@ -1,14 +1,21 @@
 import { Box, Flex } from "@radix-ui/themes";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
 import { ChartNoAxesCombined, Globe, LibraryBig, UserRound, Workflow } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState, type PointerEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate, useParams } from "react-router";
 
+import { toast } from "@/components";
 import { saveLanguagePreference, supportedLanguages, type LanguageCode } from "@/i18n";
 import { apiClient, fetchProject } from "@/lib/api-client";
-import { getRecentProjects, openRecentProject, removeRecentProject } from "@/lib/local-db";
+import {
+  getRecentProjects,
+  openRecentProject,
+  removeRecentProject,
+  removeRecentProjectByProjectId,
+} from "@/lib/local-db";
 import type { RecentProject } from "@/lib/recent-projects";
 
 import { useAppShell } from "./app-shell-context";
@@ -77,7 +84,7 @@ export function AppSidebar({ appearance, onToggleTheme }: AppSidebarProps) {
     prevAppearanceRef.current = appearance;
   }, [appearance, shouldAnimateTheme]);
 
-  const { data: currentProject } = useQuery({
+  const { data: currentProject, error: currentProjectError } = useQuery({
     queryKey: ["project", projectId],
     queryFn: () => fetchProject(projectId!),
     enabled: !!projectId,
@@ -92,6 +99,21 @@ export function AppSidebar({ appearance, onToggleTheme }: AppSidebarProps) {
   useEffect(() => {
     if (!projectId) lastOpenedProjectIdRef.current = null;
   }, [projectId]);
+
+  useEffect(() => {
+    if (!projectId || !axios.isAxiosError(currentProjectError)) return;
+    if (currentProjectError.response?.status !== 404) return;
+
+    void (async () => {
+      await queryClient.cancelQueries({ queryKey: ["recent-projects"] });
+      queryClient.setQueryData<RecentProject[]>(["recent-projects"], (projects) =>
+        projects?.filter((project) => project.projectId !== projectId),
+      );
+      await removeRecentProjectByProjectId(projectId);
+      toast.error(t("projects.projectUnavailable"));
+      navigate("/", { replace: true });
+    })();
+  }, [currentProjectError, navigate, projectId, queryClient, t]);
 
   useEffect(() => {
     if (!currentProject || lastOpenedProjectIdRef.current === currentProject.id) return;

--- a/frontend/src/features/projects/hooks/use-projects.ts
+++ b/frontend/src/features/projects/hooks/use-projects.ts
@@ -7,7 +7,9 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { fetchProjects, createProject, updateProject, deleteProject } from "@/lib/api-client";
+import { removeRecentProjectByProjectId } from "@/lib/local-db";
 import type { ProjectCreate, ProjectUpdate, ProjectListParams } from "@/lib/project.types";
+import type { RecentProject } from "@/lib/recent-projects";
 
 /** 项目列表查询 key */
 export const projectsQueryKey = ["projects"] as const;
@@ -59,7 +61,13 @@ export function useDeleteProject() {
 
   return useMutation({
     mutationFn: (projectId: string) => deleteProject(projectId),
-    onSuccess: async () => {
+    onSuccess: async (_data, projectId) => {
+      await queryClient.cancelQueries({ queryKey: ["recent-projects"] });
+      await removeRecentProjectByProjectId(projectId);
+      queryClient.setQueryData<RecentProject[]>(["recent-projects"], (recentProjects) =>
+        recentProjects?.filter((project) => project.projectId !== projectId),
+      );
+      queryClient.removeQueries({ queryKey: ["project", projectId] });
       await queryClient.refetchQueries({ queryKey: projectsQueryKey });
     },
   });

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -76,6 +76,7 @@
     "updateFailed": "Update failed. Please try again.",
     "createFailed": "Creation failed. Please try again.",
     "projectDeleted": "Project deleted",
+    "projectUnavailable": "This project has been deleted and cannot be opened.",
     "deleteFailed": "Delete failed. Please try again."
   },
   "characters": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -76,6 +76,7 @@
     "updateFailed": "更新失败，请重试",
     "createFailed": "创建失败，请重试",
     "projectDeleted": "项目已删除",
+    "projectUnavailable": "该项目已被删除，无法打开",
     "deleteFailed": "删除失败，请重试"
   },
   "characters": {

--- a/frontend/src/lib/local-db.ts
+++ b/frontend/src/lib/local-db.ts
@@ -360,6 +360,18 @@ export async function removeRecentProject(slot: number): Promise<boolean> {
   }
 }
 
+/**
+ * 移除指定项目的最近打开记录。
+ */
+export async function removeRecentProjectByProjectId(projectId: string): Promise<boolean> {
+  try {
+    return (await db.recentProjects.where("projectId").equals(projectId).delete()) > 0;
+  } catch {
+    console.error("移除项目的最近打开记录失败");
+    return false;
+  }
+}
+
 // ==================== 提示词链Working Copy ====================
 
 /**


### PR DESCRIPTION
## PR 标题

fix(frontend): 修复已删除项目仍可打开的问题

## 变更说明

- 问题: 删除项目后，最近打开项目记录和项目详情缓存仍可能保留，旧链接会进入不可用的写作页。
- 重要性: 避免用户通过侧边栏或直达 URL 进入已删除项目的僵尸页面。
- 变化: 删除项目时同步清理本地最近记录、查询缓存和项目详情缓存；检测到项目 404 时清理遗留记录、提示用户并回退首页。
- 变化: 取消进行中的最近项目查询，避免旧查询结果覆盖清理后的缓存。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

项目删除 mutation 仅刷新项目列表，未清理 IndexedDB、最近项目缓存和项目详情缓存；侧边栏也未在项目请求返回 404 时处理失效记录。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 按要求未保留本轮新增的前端测试文件。
- 已执行 `pnpm format:check`、`pnpm type-check`、`pnpm lint` 和 `pnpm build`。
