### PR TITLE
fix(frontend): 修复桌面端后端资源地址

### DIFF
--- a/frontend/src/features/projects/lib/import-api.ts
+++ b/frontend/src/features/projects/lib/import-api.ts
@@ -2,11 +2,8 @@
  * 导入 API - TXT 文件导入相关接口。
  */
 
-import axios from "axios";
-
 import i18n from "@/i18n";
-
-const API_BASE = "/api/v1";
+import { apiClient, getApiBaseUrl } from "@/lib/api-client";
 
 /** 预览章节信息 */
 export interface PreviewChapter {
@@ -41,7 +38,7 @@ export async function previewTxtFile(file: File): Promise<ImportPreviewResponse>
   const formData = new FormData();
   formData.append("file", file);
 
-  const response = await axios.post<ImportPreviewResponse>(`${API_BASE}/import/preview`, formData, {
+  const response = await apiClient.post<ImportPreviewResponse>("/import/preview", formData, {
     headers: {
       "Content-Type": "multipart/form-data",
     },
@@ -77,7 +74,7 @@ export async function confirmImport(
     formData.append("cover", cover);
   }
 
-  const response = await axios.post<ImportConfirmResponse>(`${API_BASE}/import/confirm`, formData, {
+  const response = await apiClient.post<ImportConfirmResponse>("/import/confirm", formData, {
     headers: {
       "Content-Type": "multipart/form-data",
     },
@@ -141,7 +138,7 @@ export async function confirmImportStream(
     formData.append("cover", cover);
   }
 
-  const response = await fetch(`${API_BASE}/import/confirm-stream`, {
+  const response = await fetch(`${getApiBaseUrl()}/import/confirm-stream`, {
     method: "POST",
     body: formData,
   });

--- a/frontend/src/features/settings/lib/provider-icon-url.ts
+++ b/frontend/src/features/settings/lib/provider-icon-url.ts
@@ -1,11 +1,13 @@
+import { getApiBaseUrl, resolveBackendUrl } from "@/lib/api-client";
+
 export function getProviderIconUrl(iconPath?: string | null): string | null {
   if (!iconPath) {
     return null;
   }
 
   if (iconPath.startsWith("/")) {
-    return iconPath;
+    return resolveBackendUrl(iconPath);
   }
 
-  return `/api/v1/${iconPath.replace(/^\/+/, "")}`;
+  return `${getApiBaseUrl()}/${iconPath.replace(/^\/+/, "")}`;
 }

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -14,6 +14,18 @@ export function getApiBaseUrl(): string {
   return "/api/v1";
 }
 
+/**
+ * Resolves a backend-provided root-relative URL for the desktop webview.
+ * Browser deployments keep root-relative URLs so the frontend origin serves them.
+ */
+export function resolveBackendUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  if (!url.startsWith("/") || url.startsWith("//")) return url;
+
+  const backendBaseUrl = getRuntimeConfig()?.backendBaseUrl;
+  return backendBaseUrl ? `${backendBaseUrl}${url}` : url;
+}
+
 function getApiUrl(path: string): string {
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
   return `${getApiBaseUrl().replace(/\/+$/, "")}${normalizedPath}`;
@@ -101,7 +113,7 @@ function transformProject(raw: Record<string, unknown>): Project {
     description: raw.description as string | null,
     wordCount: raw.word_count as number,
     chapterCount: raw.chapter_count as number,
-    coverUrl: raw.cover_url as string | null,
+    coverUrl: resolveBackendUrl(raw.cover_url as string | null | undefined),
     createdAt: raw.created_at as string,
     updatedAt: raw.updated_at as string,
   };
@@ -181,7 +193,7 @@ function transformCharacter(raw: Record<string, unknown>): Character {
     projectId: raw.project_id as string,
     name: raw.name as string,
     description: (raw.description as string) || "",
-    imageUrl: raw.image_url as string | null,
+    imageUrl: resolveBackendUrl(raw.image_url as string | null | undefined),
     isFavorited: raw.is_favorited as boolean,
     createdAt: raw.created_at as string,
     updatedAt: raw.updated_at as string,
@@ -193,7 +205,7 @@ function transformCharacterListItem(raw: Record<string, unknown>): CharacterList
     id: raw.id as string,
     projectId: raw.project_id as string,
     name: raw.name as string,
-    imageUrl: raw.image_url as string | null,
+    imageUrl: resolveBackendUrl(raw.image_url as string | null | undefined),
     tokenCount: raw.token_count as number,
     isFavorited: raw.is_favorited as boolean,
     createdAt: raw.created_at as string,


### PR DESCRIPTION
## PR 标题

fix(frontend): 修复桌面端后端资源地址

## 变更说明

- 问题: 桌面端 WebView 会将绕过运行时 API 地址的相对请求解析为 `app://`，导致 TXT 导入以及封面、头像和模型图标无法访问后端资源。
- 重要性: 导入 TXT 后预览请求未到达后端，可能触发前端异常并导致白屏；其他后端静态资源也无法在桌面端加载。
- 变化: TXT 导入请求统一通过 `apiClient` 或 `getApiBaseUrl()` 发往运行时后端地址。
- 变化: 增加后端资源 URL 解析，桌面端为封面、角色头像和提供商图标补全后端源站；Web 端继续保留相对路径。

## 关联 Issue / PR (如有)

无

## 变更类型

- [x] 错误修复 (fix)
- [ ] 新功能 (feat)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

导入模块硬编码 `/api/v1`，而后端返回的资源地址也是根路径。在桌面端自定义 `app://` 协议中，这些 URL 未经过运行时后端地址解析，因而被发送到前端静态资源协议而不是后端服务。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 验证命令：`pnpm lint`、`pnpm type-check`、`pnpm exec oxfmt --check src/features/projects/lib/import-api.ts src/features/settings/lib/provider-icon-url.ts src/lib/api-client.ts`、`pnpm build`。
- 全量 `pnpm format:check` 因仓库既有的 385 个文件格式差异失败，本次修改的 3 个文件已单独通过格式检查。
