### PR TITLE
fix(agent): 修复会话结束后设置仍锁定的问题

### DIFF
--- a/backend/app/agent_runtime/runner/subagent_runner.py
+++ b/backend/app/agent_runtime/runner/subagent_runner.py
@@ -754,6 +754,14 @@ class SubagentRunner:
                 room=background_project_room(self.project_id),
             )
 
+        await emit(
+            "agent:settings_lock_changed",
+            {
+                "session_id": parent_session_id,
+                "is_running": is_running,
+            },
+        )
+
     async def _mark_child_running(self, child_run_id: str) -> AgentChildRun:
         session = await _open_session(self.session_factory)
         try:

--- a/backend/app/api/routers/agent_runtime.py
+++ b/backend/app/api/routers/agent_runtime.py
@@ -411,6 +411,14 @@ async def _set_task_running_state(
             room=background_project_room(project_id),
         )
 
+    await emit(
+        "agent:settings_lock_changed",
+        {
+            "session_id": session_id,
+            "is_running": is_running,
+        },
+    )
+
 
 def _make_status_session_factory(session: AsyncSession) -> Callable[[], AsyncSession]:
     if session.bind is None:
@@ -1211,6 +1219,10 @@ async def cancel_agent_session(
         await finalize_revision_status(session, revision.id, "cancelled")
     await task_service.update_task(session, task.id, is_running=False)
     await session.commit()
+    await emit(
+        "agent:settings_lock_changed",
+        {"session_id": session_id, "is_running": False},
+    )
     return AgentCancelResponse(
         success=True,
         session_id=session_id,

--- a/backend/tests/api/test_agent.py
+++ b/backend/tests/api/test_agent.py
@@ -817,6 +817,11 @@ class TestAgentAPI:
             for call in emit_mock.await_args_list
             if call.args and call.args[0] == "background:event"
         ]
+        lock_payloads = [
+            call.args[1]
+            for call in emit_mock.await_args_list
+            if call.args and call.args[0] == "agent:settings_lock_changed"
+        ]
         assert any(
             payload.get("type") == "task_run_status_updated"
             and payload.get("task_id") == task_id
@@ -828,6 +833,14 @@ class TestAgentAPI:
             and payload.get("task_id") == task_id
             and payload.get("is_running") is False
             for payload in status_payloads
+        )
+        assert any(
+            payload.get("session_id") == session_id and payload.get("is_running") is True
+            for payload in lock_payloads
+        )
+        assert any(
+            payload.get("session_id") == session_id and payload.get("is_running") is False
+            for payload in lock_payloads
         )
 
     async def test_get_session_state_reports_active_background_run(

--- a/backend/tests/api/test_agent_settings_lock.py
+++ b/backend/tests/api/test_agent_settings_lock.py
@@ -4,7 +4,7 @@ import pytest
 from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from app.agent_runtime.persistence.child_runs import create_child_run
 from app.api.routers.agent_runtime import _SESSION_RUNNERS
@@ -213,15 +213,20 @@ async def test_cancelling_waiting_agent_session_releases_settings_lock(
     runner = MagicMock(project_id=task.project_id, model_config={})
     _SESSION_RUNNERS[task.agent_session_id or ""] = runner
     try:
-        cancel_response = await client.post(
-            f"/api/v1/agent/sessions/{task.agent_session_id}/cancel",
-        )
+        with patch("app.api.routers.agent_runtime.emit", new=AsyncMock()) as emit_mock:
+            cancel_response = await client.post(
+                f"/api/v1/agent/sessions/{task.agent_session_id}/cancel",
+            )
         lock_response = await client.get("/api/v1/settings/agent-session-lock")
     finally:
         _SESSION_RUNNERS.pop(task.agent_session_id or "", None)
 
     assert cancel_response.status_code == 200
     runner.cancel.assert_called_once_with()
+    emit_mock.assert_awaited_once_with(
+        "agent:settings_lock_changed",
+        {"session_id": task.agent_session_id, "is_running": False},
+    )
     assert lock_response.json() == {"is_locked": False}
     await session.refresh(task)
     await session.refresh(revision)

--- a/frontend/src/features/settings/lib/agent-settings-lock.ts
+++ b/frontend/src/features/settings/lib/agent-settings-lock.ts
@@ -1,7 +1,9 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
+import { useEffect } from "react";
 
 import { apiClient } from "@/lib/api-client";
+import { getSocket } from "@/lib/socket-client";
 
 export const AGENT_SETTINGS_LOCK_QUERY_KEY = ["agent-settings-lock"] as const;
 
@@ -19,10 +21,27 @@ export async function fetchAgentSettingsLock(): Promise<boolean> {
 }
 
 export function useAgentSettingsLock() {
-  return useQuery({
+  const queryClient = useQueryClient();
+  const query = useQuery({
     queryKey: AGENT_SETTINGS_LOCK_QUERY_KEY,
     queryFn: fetchAgentSettingsLock,
+    staleTime: 0,
+    refetchOnMount: "always",
   });
+
+  useEffect(() => {
+    const socket = getSocket();
+    const handleLockStateChanged = () => {
+      void queryClient.invalidateQueries({ queryKey: AGENT_SETTINGS_LOCK_QUERY_KEY });
+    };
+
+    socket.on("agent:settings_lock_changed", handleLockStateChanged);
+    return () => {
+      socket.off("agent:settings_lock_changed", handleLockStateChanged);
+    };
+  }, [queryClient]);
+
+  return query;
 }
 
 export function isAgentSettingsLockedError(error: unknown): boolean {


### PR DESCRIPTION
## PR 标题

fix(agent): 修复会话结束后设置仍锁定的问题

## 变更说明

- 问题: 设置面板首次读取的 Agent 会话锁定状态被缓存，会话状态变更后提示和操作状态不能同步更新。
- 重要性: 会话已结束或取消时，用户仍无法修改相关设置；会话开始后也可能没有及时锁定。
- 变化: 设置面板打开时强制获取锁定状态，并订阅会话运行状态事件以刷新查询。
- 变化: 主会话、取消会话和子 Agent 收尾时均推送锁定状态变更事件。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

锁定状态查询沿用全局 React Query 的缓存策略，且没有订阅 Agent 会话状态变化，因此设置面板只保留首次打开时的结果。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 前端验证: `pnpm type-check`、`pnpm lint`、`pnpm format:check`。
- 后端验证: `uv run pytest tests/api/test_agent.py tests/api/test_agent_settings_lock.py tests/agent_runtime/runner/test_subagent_runner.py -q`，结果为 `65 passed`；Ruff 检查通过。
