### PR TITLE
fix(storage): 修复章节排序更新冲突

### DIFF
--- a/backend/app/storage/repos/chapter_repo.py
+++ b/backend/app/storage/repos/chapter_repo.py
@@ -330,7 +330,7 @@ async def shift_orders(
     """
     批量调整排序序号。
 
-    用于章节移动时调整其他章节的顺序。
+    用于章节移动时调整其他章节的顺序。通过两阶段更新避免唯一索引冲突。
 
     Args:
         session: 数据库 session。
@@ -339,16 +339,15 @@ async def shift_orders(
         end_order: 结束序号（包含）。
         delta: 调整量（+1 或 -1）。
     """
-    await session.execute(
-        update(Chapter)
-        .where(
+    result = await session.execute(
+        select(Chapter).where(
             col(Chapter.volume_id) == volume_id,
             col(Chapter.order) >= start_order,
             col(Chapter.order) <= end_order,
         )
-        .values(order=col(Chapter.order) + delta)
     )
-    await session.flush()
+    orders = {chapter.id: chapter.order + delta for chapter in result.scalars().all()}
+    await update_orders(session, orders)
 
 
 async def delete_by_project(session: AsyncSession, project_id: str) -> None:

--- a/backend/tests/api/test_chapters.py
+++ b/backend/tests/api/test_chapters.py
@@ -294,6 +294,35 @@ async def test_delete_chapter_updates_orders_and_stats(client: AsyncClient) -> N
 
 
 @pytest.mark.asyncio
+async def test_delete_reordered_chapter_updates_orders(client: AsyncClient) -> None:
+    """测试删除章节时能安全收紧已重排章节的顺序。"""
+    project_id, volume_id = await _create_project(client)
+    chapters = [
+        await _create_chapter(client, project_id, volume_id, title=f"第{i + 1}章")
+        for i in range(4)
+    ]
+    reordered_ids = [
+        chapters[0]["id"],
+        chapters[2]["id"],
+        chapters[1]["id"],
+        chapters[3]["id"],
+    ]
+    reorder_response = await client.post(
+        "/api/v1/chapters/reorder",
+        json={"volume_id": volume_id, "chapter_ids": reordered_ids},
+    )
+    assert reorder_response.status_code == 200
+
+    response = await client.delete(f"/api/v1/chapters/{chapters[0]['id']}")
+
+    assert response.status_code == 204
+    tree = (await client.get(f"/api/v1/projects/{project_id}/chapters")).json()
+    items = tree["volumes"][0]["chapters"]
+    assert [item["id"] for item in items] == reordered_ids[1:]
+    assert [item["order"] for item in items] == [1, 2, 3]
+
+
+@pytest.mark.asyncio
 async def test_delete_chapter_removes_summary_and_affected_long_term_summaries(
     client: AsyncClient, session
 ) -> None:

--- a/backend/tests/api/test_volumes.py
+++ b/backend/tests/api/test_volumes.py
@@ -196,16 +196,66 @@ async def test_move_chapter_to_volume_appends_to_target(
     assert [chapter["order"] for chapter in target_chapters] == [1, 2]
 
     events = (
-        await session.execute(
-            select(WritingActivityEvent).where(
-                col(WritingActivityEvent.chapter_id) == source_chapter_ids[0],
-                col(WritingActivityEvent.operation) == "move_to_volume",
+        (
+            await session.execute(
+                select(WritingActivityEvent).where(
+                    col(WritingActivityEvent.chapter_id) == source_chapter_ids[0],
+                    col(WritingActivityEvent.operation) == "move_to_volume",
+                )
             )
         )
-    ).scalars().all()
+        .scalars()
+        .all()
+    )
     assert len(events) == 1
     assert events[0].source == "user"
     assert events[0].word_delta == 0
+
+
+@pytest.mark.asyncio
+async def test_move_reordered_chapter_to_volume_updates_source_orders(
+    client: AsyncClient,
+) -> None:
+    project_id = await _create_project(client)
+    source_volume = await _default_volume(client, project_id)
+    target_response = await client.post(
+        f"/api/v1/projects/{project_id}/volumes",
+        json={"title": "第二卷"},
+    )
+    target_volume = target_response.json()
+    chapters = []
+    for title in ["第一章", "第二章", "第三章", "第四章"]:
+        response = await client.post(
+            f"/api/v1/projects/{project_id}/chapters",
+            json={"volume_id": source_volume["id"], "title": title},
+        )
+        assert response.status_code == 201
+        chapters.append(response.json())
+    reordered_ids = [
+        chapters[0]["id"],
+        chapters[2]["id"],
+        chapters[1]["id"],
+        chapters[3]["id"],
+    ]
+    reorder_response = await client.post(
+        "/api/v1/chapters/reorder",
+        json={"volume_id": source_volume["id"], "chapter_ids": reordered_ids},
+    )
+    assert reorder_response.status_code == 200
+
+    response = await client.post(
+        f"/api/v1/chapters/{chapters[0]['id']}/move-to-volume",
+        json={"volume_id": target_volume["id"]},
+    )
+
+    assert response.status_code == 200
+    tree = (await client.get(f"/api/v1/projects/{project_id}/chapters")).json()
+    source_chapters = tree["volumes"][0]["chapters"]
+    target_chapters = tree["volumes"][1]["chapters"]
+    assert [chapter["id"] for chapter in source_chapters] == reordered_ids[1:]
+    assert [chapter["order"] for chapter in source_chapters] == [1, 2, 3]
+    assert [chapter["id"] for chapter in target_chapters] == [chapters[0]["id"]]
+    assert [chapter["order"] for chapter in target_chapters] == [1]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## PR 标题

fix(storage): 修复章节排序更新冲突

## 变更说明

- 问题: 重排后的章节在删除或跨卷移动时，批量收紧序号可能触发 SQLite 的 `(volume_id, order)` 唯一约束冲突。
- 重要性: 该异常会回滚删除和跨卷移动操作，导致用户及 Agent 均无法完成章节管理操作。
- 变化: `shift_orders()` 改为复用两阶段排序更新，先写入临时负序号再写入目标序号。
- 测试: 新增重排后删除章节、跨卷移动章节的 API 回归测试。

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [x] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

SQLite 对单条批量 `UPDATE` 的每行更新期间即时校验唯一约束。当重排后的章节需要统一调整序号时，物理更新顺序可能使某一行先占用尚未释放的目标序号，从而触发 `(volume_id, order)` 唯一约束冲突。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证记录：

- `uv run pytest`：1139 passed
- `uv run ruff check .`：通过
- `uv run ty check app`：通过
