### PR TITLE
fix(frontend): 取消提供商任务类型筛选

### DIFF
--- a/frontend/src/features/settings/components/model-form-dialog.tsx
+++ b/frontend/src/features/settings/components/model-form-dialog.tsx
@@ -24,7 +24,7 @@ import {
   fetchProviderModels,
 } from "../lib/model-api";
 import {
-  isSelectableModelProviderForTask,
+  isSelectableModelProvider,
   resolveProviderCatalogType,
   resolveProviderDisplayName,
   supportsEmbeddingDimensions,
@@ -175,13 +175,11 @@ export function ModelFormDialog({
     staleTime: 5 * 60 * 1000,
   });
 
-  // 根据任务类型过滤提供商（openai-compatible始终显示）
+  // 模型目录可能缺少实际支持的任务类型，因此只排除内置提供商。
   const filteredProviders = useMemo(() => {
     if (!providers) return [];
-    return providers.filter((provider) =>
-      isSelectableModelProviderForTask(provider, taskType as TaskType),
-    );
-  }, [providers, taskType]);
+    return providers.filter(isSelectableModelProvider);
+  }, [providers]);
 
   const selectedProvider = useMemo(
     () => providers?.find((p) => p.id === providerId),

--- a/frontend/src/features/settings/lib/provider-utils.ts
+++ b/frontend/src/features/settings/lib/provider-utils.ts
@@ -4,14 +4,7 @@
  * 提供商相关的工具函数。
  */
 
-import type {
-  ModelProvider,
-  ModelProviderCatalogProvider,
-  ProviderType,
-  TaskType,
-} from "@/lib/model.types";
-
-const ALL_TASK_TYPES: TaskType[] = ["llm", "embedding", "rerank"];
+import type { ModelProvider, ModelProviderCatalogProvider, ProviderType } from "@/lib/model.types";
 
 const EMBEDDING_DIMENSIONS_SUPPORTED_PROVIDER_TYPES = new Set<ProviderType>([
   "openai",
@@ -25,25 +18,14 @@ export function supportsEmbeddingDimensions(providerType: string): boolean {
   return EMBEDDING_DIMENSIONS_SUPPORTED_PROVIDER_TYPES.has(providerType);
 }
 
-export function isSelectableModelProviderForTask(
-  provider: Pick<ModelProvider, "providerType" | "supportedTaskTypes" | "isBuiltin">,
-  taskType: TaskType,
-): boolean {
-  if (provider.isBuiltin) {
-    return false;
-  }
-
-  return (
-    provider.providerType === "openai-compatible" || provider.supportedTaskTypes.includes(taskType)
-  );
+export function isSelectableModelProvider(provider: Pick<ModelProvider, "isBuiltin">): boolean {
+  return !provider.isBuiltin;
 }
 
 export function hasSelectableModelProvider(
-  providers: Array<Pick<ModelProvider, "providerType" | "supportedTaskTypes" | "isBuiltin">>,
+  providers: Array<Pick<ModelProvider, "isBuiltin">>,
 ): boolean {
-  return providers.some((provider) =>
-    ALL_TASK_TYPES.some((taskType) => isSelectableModelProviderForTask(provider, taskType)),
-  );
+  return providers.some(isSelectableModelProvider);
 }
 
 /**


### PR DESCRIPTION
## PR 标题

fix(frontend): 取消提供商任务类型筛选

## 变更说明

- 问题: models.dev 目录未收录部分实际支持嵌入或重排模型的提供商，导致模型新建和编辑表单将这些提供商隐藏。
- 重要性: 用户无法为对应提供商配置实际可用的嵌入或重排模型。
- 变化: 提供商选择仅排除内置提供商，不再依据目录返回的任务类型筛选；新建模型按钮同步采用相同规则。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

前端直接使用 models.dev 目录的 `supportedTaskTypes` 过滤提供商。该目录不是提供商能力的完整来源，缺项会错误限制表单可选项。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 已执行 `pnpm format:check`、`pnpm type-check`、`pnpm lint` 与 `pnpm build`。
- 前端仓库规范要求提交前清理 `*.test.ts`，因此未保留临时回归测试文件。
