### PR TITLE
fix(backend): 修复 Windows 后台任务队列阻塞的问题

### DIFF
--- a/backend/app/background/runtime/worker.py
+++ b/backend/app/background/runtime/worker.py
@@ -62,11 +62,18 @@ class BackgroundWorker:
     async def run(self) -> None:
         logger.bind(worker_id=self.worker_id).info("Background worker started")
         while not self._stop_event.is_set():
-            notification = await self.transport.receive_job(timeout_ms=500)
-            if notification and notification.job_id:
-                await self._run_job(notification.job_id)
-                continue
-            await self._run_pending_once()
+            try:
+                notification = await self.transport.receive_job(timeout_ms=500)
+                if notification and notification.job_id:
+                    await self._run_job(notification.job_id)
+                else:
+                    await self._run_pending_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.bind(worker_id=self.worker_id).opt(exception=True).error(
+                    f"background worker iteration failed: {exc}"
+                )
             with suppress(asyncio.TimeoutError):
                 await asyncio.wait_for(
                     self._stop_event.wait(), timeout=self.scan_interval_seconds

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -7,13 +7,24 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import os
 from pathlib import Path
+import sys
 
 from app.logging import configure_standard_logging
 
 _DEFAULT_HOST = "127.0.0.1"
 _DEFAULT_PORT = 8000
+
+
+def _configure_asyncio_event_loop_policy() -> None:
+    """Use a selector loop because pyzmq requires add_reader on Windows."""
+    if sys.platform != "win32":
+        return
+    policy_class = getattr(asyncio, "WindowsSelectorEventLoopPolicy", None)
+    if policy_class is not None:
+        asyncio.set_event_loop_policy(policy_class())
 
 
 def _ensure_data_dir() -> None:
@@ -40,6 +51,7 @@ def handle_version(_args: argparse.Namespace) -> None:
 
 def handle_serve(args: argparse.Namespace) -> None:
     _ensure_data_dir()
+    _configure_asyncio_event_loop_policy()
     configure_standard_logging()
     os.environ["OPENFIC_SERVER_HOST"] = args.host
     os.environ["OPENFIC_SERVER_PORT"] = str(args.port)

--- a/backend/tests/background/test_background_jobs.py
+++ b/backend/tests/background/test_background_jobs.py
@@ -180,6 +180,24 @@ class FailingEventTransport(RecordingTransport):
         raise RuntimeError("event transport unavailable")
 
 
+@pytest.mark.asyncio
+async def test_worker_continues_after_transport_error():
+    worker = BackgroundWorker(
+        worker_id="worker-1",
+        transport=RecordingTransport(),
+        scan_interval_seconds=0,
+    )
+    worker.transport.receive_job = AsyncMock(
+        side_effect=[RuntimeError("transport unavailable"), None]
+    )
+    worker._run_pending_once = AsyncMock(side_effect=worker.stop)
+
+    await worker.run()
+
+    assert worker.transport.receive_job.await_count == 2
+    worker._run_pending_once.assert_awaited_once()
+
+
 class _FakeBackgroundSupervisor:
     def __init__(self, transport: RecordingTransport) -> None:
         self._publisher = BackgroundEventPublisher(transport)

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1,0 +1,23 @@
+from unittest.mock import Mock
+
+import app.cli as cli
+
+
+def test_configure_asyncio_event_loop_policy_uses_selector_on_windows(monkeypatch) -> None:
+    class FakeSelectorPolicy:
+        pass
+
+    set_event_loop_policy = Mock()
+    monkeypatch.setattr(cli.sys, "platform", "win32")
+    monkeypatch.setattr(
+        cli.asyncio,
+        "WindowsSelectorEventLoopPolicy",
+        FakeSelectorPolicy,
+        raising=False,
+    )
+    monkeypatch.setattr(cli.asyncio, "set_event_loop_policy", set_event_loop_policy)
+
+    cli._configure_asyncio_event_loop_policy()
+
+    set_event_loop_policy.assert_called_once()
+    assert isinstance(set_event_loop_policy.call_args.args[0], FakeSelectorPolicy)


### PR DESCRIPTION
## PR 标题

fix(backend): 修复 Windows 后台任务队列阻塞

## 变更说明

- 问题: Windows 桌面端使用默认 Proactor 事件循环时，`pyzmq` 无法执行后台 Worker 的 ZMQ 轮询，导致 Worker 在首次空队列轮询后退出，索引、摘要和标题任务持续处于排队中。
- 重要性: 后台任务无法被抢占执行，影响桌面端所有依赖后台队列的功能。
- 变化: Windows 的 `openfic serve` 启动前改用 Selector 事件循环策略；Worker 单轮异常记录后继续运行，避免再次静默退出。
- 测试: 新增 Windows 事件循环策略与 Worker 异常恢复回归测试。

## 关联 Issue / PR (如有)

无

## 变更类型

- [x] 错误修复 (fix)

## 问题原因(如有)

Windows 默认 ProactorEventLoop 未实现 `pyzmq.asyncio` 所需的 `add_reader` 接口，且项目未安装 `tornado` 提供兼容层。Worker 未隔离接收循环异常，异常退出后没有重启或错误日志。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令：`uv run pytest tests/test_cli.py tests/background/test_background_jobs.py -q`，结果为 `46 passed`。`uv run ruff check` 通过；`ty` 仅报告 Python 3.14 对 `set_event_loop_policy` 的弃用提示，桌面运行时当前使用 Python 3.12。
