### PR TITLE
fix(backend): 修复Windows上后台任务事件无法实时同步的问题

### DIFF
--- a/backend/app/background/runtime/supervisor.py
+++ b/backend/app/background/runtime/supervisor.py
@@ -106,10 +106,16 @@ class BackgroundSupervisor:
     async def _run_event_bridge(self) -> None:
         assert self._transport is not None
         while not self._stop_event.is_set():
-            message = await self._transport.receive_event(timeout_ms=500)
-            if message is None:
-                continue
-            await self._emit_socket_background_event(message)
+            try:
+                message = await self._transport.receive_event(timeout_ms=500)
+                if message is not None:
+                    await self._emit_socket_background_event(message)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.opt(exception=True).error(
+                    f"background event bridge iteration failed: {exc}"
+                )
 
     async def _recover_stale_jobs(self) -> None:
         assert self._transport is not None

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -18,13 +18,15 @@ _DEFAULT_HOST = "127.0.0.1"
 _DEFAULT_PORT = 8000
 
 
-def _configure_asyncio_event_loop_policy() -> None:
-    """Use a selector loop because pyzmq requires add_reader on Windows."""
-    if sys.platform != "win32":
-        return
-    policy_class = getattr(asyncio, "WindowsSelectorEventLoopPolicy", None)
-    if policy_class is not None:
-        asyncio.set_event_loop_policy(policy_class())
+def _windows_selector_loop_factory() -> asyncio.AbstractEventLoop:
+    return asyncio.SelectorEventLoop()
+
+
+def _get_uvicorn_loop_factory() -> str:
+    """Use a selector loop on Windows because pyzmq requires add_reader."""
+    if sys.platform == "win32":
+        return "app.cli:_windows_selector_loop_factory"
+    return "auto"
 
 
 def _ensure_data_dir() -> None:
@@ -51,7 +53,6 @@ def handle_version(_args: argparse.Namespace) -> None:
 
 def handle_serve(args: argparse.Namespace) -> None:
     _ensure_data_dir()
-    _configure_asyncio_event_loop_policy()
     configure_standard_logging()
     os.environ["OPENFIC_SERVER_HOST"] = args.host
     os.environ["OPENFIC_SERVER_PORT"] = str(args.port)
@@ -62,6 +63,7 @@ def handle_serve(args: argparse.Namespace) -> None:
         "app.main:app",
         host=args.host,
         port=args.port,
+        loop=_get_uvicorn_loop_factory(),
         log_level="info",
         log_config=None,
         access_log=False,

--- a/backend/tests/background/test_supervisor_socket_bridge.py
+++ b/backend/tests/background/test_supervisor_socket_bridge.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock, call, patch
 
 import pytest
@@ -5,6 +6,19 @@ import pytest
 from app.background.runtime.supervisor import BackgroundSupervisor
 from app.background.transport.messages import BackgroundEventMessage
 from app.socket.handlers import agent_session_room, background_project_room
+
+
+class FailingThenEventTransport:
+    def __init__(self, message: BackgroundEventMessage) -> None:
+        self._message = message
+        self._receive_count = 0
+
+    async def receive_event(self, timeout_ms: int) -> BackgroundEventMessage:
+        _ = timeout_ms
+        self._receive_count += 1
+        if self._receive_count == 1:
+            raise RuntimeError("event transport unavailable")
+        return self._message
 
 
 @pytest.mark.asyncio
@@ -114,3 +128,30 @@ async def test_emit_task_title_updated_to_background_and_agent_rooms():
             room=agent_session_room("sess-1"),
         ),
     ]
+
+
+@pytest.mark.asyncio
+async def test_event_bridge_continues_after_transport_error():
+    supervisor = BackgroundSupervisor()
+    message = BackgroundEventMessage(
+        type="background_job_progress",
+        job_type="summary_batch",
+        job_id="job-1",
+        item_id=None,
+        item_type=None,
+        subject_type="project",
+        subject_id="proj-1",
+        payload={},
+        created_at="2026-05-23T00:00:00Z",
+        project_revision=None,
+    )
+    supervisor._transport = FailingThenEventTransport(message)  # type: ignore[assignment]
+
+    async def emit_and_stop(_message: BackgroundEventMessage) -> None:
+        supervisor._stop_event.set()
+
+    supervisor._emit_socket_background_event = AsyncMock(side_effect=emit_and_stop)
+
+    await asyncio.wait_for(supervisor._run_event_bridge(), timeout=1)
+
+    supervisor._emit_socket_background_event.assert_awaited_once_with(message)

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1,23 +1,53 @@
+import sys
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import app.cli as cli
+from uvicorn.config import Config
 
 
-def test_configure_asyncio_event_loop_policy_uses_selector_on_windows(monkeypatch) -> None:
-    class FakeSelectorPolicy:
-        pass
-
-    set_event_loop_policy = Mock()
+def test_get_uvicorn_loop_factory_uses_selector_on_windows(monkeypatch) -> None:
     monkeypatch.setattr(cli.sys, "platform", "win32")
+
+    assert cli._get_uvicorn_loop_factory() == "app.cli:_windows_selector_loop_factory"
+
+
+def test_get_uvicorn_loop_factory_uses_default_on_non_windows(monkeypatch) -> None:
+    monkeypatch.setattr(cli.sys, "platform", "linux")
+
+    assert cli._get_uvicorn_loop_factory() == "auto"
+
+
+def test_windows_selector_loop_factory_creates_selector_loop() -> None:
+    loop = cli._windows_selector_loop_factory()
+    try:
+        assert isinstance(loop, cli.asyncio.SelectorEventLoop)
+    finally:
+        loop.close()
+
+
+def test_uvicorn_loads_windows_selector_loop_factory() -> None:
+    config = Config("app.main:app", loop="app.cli:_windows_selector_loop_factory")
+    factory = config.get_loop_factory()
+    assert factory is not None
+    loop = factory()
+    try:
+        assert isinstance(loop, cli.asyncio.SelectorEventLoop)
+    finally:
+        loop.close()
+
+
+def test_handle_serve_passes_loop_factory_to_uvicorn(monkeypatch) -> None:
+    uvicorn_run = Mock()
+    monkeypatch.setattr(cli, "_ensure_data_dir", Mock())
+    monkeypatch.setattr(cli, "configure_standard_logging", Mock())
     monkeypatch.setattr(
-        cli.asyncio,
-        "WindowsSelectorEventLoopPolicy",
-        FakeSelectorPolicy,
-        raising=False,
+        cli,
+        "_get_uvicorn_loop_factory",
+        Mock(return_value="app.cli:_windows_selector_loop_factory"),
     )
-    monkeypatch.setattr(cli.asyncio, "set_event_loop_policy", set_event_loop_policy)
+    monkeypatch.setitem(sys.modules, "uvicorn", SimpleNamespace(run=uvicorn_run))
 
-    cli._configure_asyncio_event_loop_policy()
+    cli.handle_serve(type("Args", (), {"host": "127.0.0.1", "port": 8000})())
 
-    set_event_loop_policy.assert_called_once()
-    assert isinstance(set_event_loop_policy.call_args.args[0], FakeSelectorPolicy)
+    assert uvicorn_run.call_args.kwargs["loop"] == "app.cli:_windows_selector_loop_factory"


### PR DESCRIPTION
## PR 标题

fix(backend): 修复Windows上后台任务事件无法实时同步的问题

## 变更说明

- 问题: Windows 上 Uvicorn 在单进程模式下自行创建 ProactorEventLoop，导致 `pyzmq.asyncio` 无法轮询后台事件通道，后台任务可执行但前端无法实时接收状态更新。
- 重要性: 索引、摘要和标题生成的状态只能在页面刷新后同步，实时进度与完成结果不可见。
- 变化: Windows 的 `openfic serve` 显式传入 Selector 事件循环工厂；后台事件桥接单轮异常后记录日志并继续运行。
- 测试: 覆盖 Uvicorn 自定义 loop factory 加载、Windows Selector 循环创建和事件桥接异常恢复。

## 关联 Issue / PR (如有)

关联 #147

## 变更类型

- [x] 错误修复 (fix)

## 问题原因(如有)

Uvicorn 0.49 的默认 asyncio loop factory 在 Windows 单进程模式下强制创建 ProactorEventLoop，覆盖了此前设置的全局事件循环策略。该循环未实现 `pyzmq.asyncio` 所需的 `add_reader`，使后台 Supervisor 无法从 ZMQ event socket 接收事件并转发至 Socket.IO。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令：`uv run pytest tests/test_cli.py tests/background/test_background_jobs.py tests/background/test_supervisor_socket_bridge.py -q`，结果为 `53 passed`。Ruff 与 ty 检查均通过；已使用 Selector 事件循环实际验证 ZMQ event socket 轮询正常返回。
