### PR TITLE
fix(backend): 修复部分提供商流式 token 用量缺失的问题

### DIFF
--- a/backend/app/models/clients/model_factory.py
+++ b/backend/app/models/clients/model_factory.py
@@ -76,6 +76,7 @@ def _openai_compatible_kwargs(config: ModelConfig) -> dict[str, Any]:
         presence_penalty=_non_default(config.presence_penalty, DEFAULT_PRESENCE_PENALTY),
         reasoning_effort=config.reasoning_effort,
         max_retries=0,
+        stream_usage=True,
     )
     extra_body = {
         name: value
@@ -148,6 +149,7 @@ def create_chat_model(config: ModelConfig) -> BaseChatModel:
             max_tokens=config.max_tokens,
             reasoning_effort=config.reasoning_effort,
             max_retries=0,
+            stream_usage=True,
         ))
 
     if provider == "mistral":

--- a/backend/tests/agent_runtime/test_model_factory.py
+++ b/backend/tests/agent_runtime/test_model_factory.py
@@ -289,3 +289,31 @@ def test_create_chat_model_amazon_nova_uses_native_client():
     from langchain_amazon_nova import ChatAmazonNova
 
     assert isinstance(model, ChatAmazonNova)
+
+
+def test_create_chat_model_openai_compatible_enables_stream_usage_for_custom_base_url():
+    config = ModelConfig(
+        provider_type="openai-compatible",
+        base_url="https://custom.api/v1",
+        api_key="sk-test",
+        model_id="custom-model",
+    )
+    model = create_chat_model(config)
+
+    from langchain_openai import ChatOpenAI
+    assert isinstance(model, ChatOpenAI)
+    assert model.stream_usage is True
+
+
+def test_create_chat_model_deepseek_enables_stream_usage():
+    config = ModelConfig(
+        provider_type="deepseek",
+        base_url="https://api.deepseek.com",
+        api_key="sk-test",
+        model_id="deepseek-v4-flash",
+    )
+    model = create_chat_model(config)
+
+    from langchain_deepseek import ChatDeepSeek
+    assert isinstance(model, ChatDeepSeek)
+    assert model.stream_usage is True


### PR DESCRIPTION
## PR 标题

fix(backend): 修复部分提供商流式 token 用量缺失的问题

## 变更说明

- 问题: Agent 侧边栏的输入/输出/缓存 token 数始终为 0
- 重要性: token 用量是判断何时触发会话摘要/压缩的关键依据，缺失会直接影响上下文管理
- 变化: 在 `model_factory.py` 的 openai-compatible 与 deepseek 两个分支显式传入 `stream_usage=True`，并补充回归测试

## 关联 Issue / PR (如有)

Closes #153

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

`langchain-openai` 的 `ChatOpenAI`/`ChatDeepSeek`（均基于 `BaseChatOpenAI`）仅在「使用默认 base_url 且未传 client」时自动开启 `stream_usage`；一旦传入自定义 `base_url`（第三方中转），自动开启失效，`stream_usage` 保持 `None`，流式请求不带 `stream_options.include_usage`，导致流式响应不返回 usage，`AIMessage.usage_metadata` 为空，token 计数全为 0。

已确认其余原生 SDK（anthropic / google-genai / mistral / openrouter / groq / cohere / amazon-nova / nvidia）流式默认返回 usage，不受影响，故未改动。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

测试证据：
- `pytest tests/agent_runtime/test_model_factory.py` → 21 passed
- `ruff check .` → All checks passed
- `ty check app` → All checks passed
