### PR TITLE
chore(desktop): 添加窗口状态记忆能力

### DIFF
--- a/desktop/src/main/window-state.ts
+++ b/desktop/src/main/window-state.ts
@@ -1,0 +1,53 @@
+import { app } from "electron";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+export interface WindowState {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  isMaximized: boolean;
+}
+
+function getWindowStatePath(): string {
+  return path.join(app.getPath("userData"), "window-state.json");
+}
+
+function isWindowState(value: unknown): value is WindowState {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Partial<WindowState>;
+  return (
+    typeof candidate.x === "number" &&
+    Number.isFinite(candidate.x) &&
+    typeof candidate.y === "number" &&
+    Number.isFinite(candidate.y) &&
+    typeof candidate.width === "number" &&
+    Number.isFinite(candidate.width) &&
+    candidate.width > 0 &&
+    typeof candidate.height === "number" &&
+    Number.isFinite(candidate.height) &&
+    candidate.height > 0 &&
+    typeof candidate.isMaximized === "boolean"
+  );
+}
+
+export function readWindowState(): WindowState | null {
+  try {
+    const raw = readFileSync(getWindowStatePath(), "utf-8");
+    const parsed = JSON.parse(raw) as unknown;
+    return isWindowState(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveWindowStateSync(state: WindowState): void {
+  try {
+    const filePath = getWindowStatePath();
+    mkdirSync(path.dirname(filePath), { recursive: true });
+    writeFileSync(filePath, JSON.stringify(state, null, 2), "utf-8");
+  } catch {
+    // Window state persistence must never block app shutdown.
+  }
+}

--- a/desktop/src/main/windows.ts
+++ b/desktop/src/main/windows.ts
@@ -1,9 +1,16 @@
-import { app, BrowserWindow, shell } from "electron";
+import { app, BrowserWindow, screen, shell } from "electron";
 import { appendFileSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { readWindowState, saveWindowStateSync, type WindowState } from "./window-state.js";
 
 const preloadPath = fileURLToPath(new URL("../preload/preload.mjs", import.meta.url));
+
+const DEFAULT_WIDTH = 1280;
+const DEFAULT_HEIGHT = 800;
+const MIN_WIDTH = 960;
+const MIN_HEIGHT = 640;
+const SAVE_DEBOUNCE_MS = 500;
 
 function writeWindowLog(message: string): void {
   try {
@@ -33,22 +40,112 @@ function attachWindowDiagnostics(window: BrowserWindow, name: string): void {
   });
 }
 
-function applyShellWindowPresentation(window: BrowserWindow): void {
-  window.setResizable(true);
-  window.setMinimumSize(960, 640);
-  window.setSize(1280, 800);
-  window.center();
+interface Rect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+interface WindowLayout {
+  width: number;
+  height: number;
+  x?: number;
+  y?: number;
+  isMaximized: boolean;
+  needsCenter: boolean;
+}
+
+function isBoundsVisible(bounds: Rect): boolean {
+  return screen.getAllDisplays().some((display) => {
+    const displayBounds = display.bounds;
+    return (
+      bounds.x < displayBounds.x + displayBounds.width &&
+      bounds.x + bounds.width > displayBounds.x &&
+      bounds.y < displayBounds.y + displayBounds.height &&
+      bounds.y + bounds.height > displayBounds.y
+    );
+  });
+}
+
+function resolveWindowLayout(state: WindowState | null): WindowLayout {
+  if (
+    state &&
+    state.width >= MIN_WIDTH &&
+    state.height >= MIN_HEIGHT &&
+    isBoundsVisible(state)
+  ) {
+    return {
+      width: state.width,
+      height: state.height,
+      x: state.x,
+      y: state.y,
+      isMaximized: state.isMaximized,
+      needsCenter: false,
+    };
+  }
+  return {
+    width: DEFAULT_WIDTH,
+    height: DEFAULT_HEIGHT,
+    isMaximized: false,
+    needsCenter: true,
+  };
+}
+
+function readNormalBounds(window: BrowserWindow): Rect {
+  const [x, y] = window.getPosition();
+  const [width, height] = window.getSize();
+  return { x, y, width, height };
+}
+
+function attachWindowStateTracking(window: BrowserWindow): void {
+  let normalBounds = readNormalBounds(window);
+  let saveTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const captureNormalBounds = (): void => {
+    if (window.isMaximized()) return;
+    normalBounds = readNormalBounds(window);
+  };
+
+  const scheduleSave = (): void => {
+    if (saveTimer) clearTimeout(saveTimer);
+    saveTimer = setTimeout(() => {
+      saveTimer = null;
+      saveWindowStateSync({ ...normalBounds, isMaximized: window.isMaximized() });
+    }, SAVE_DEBOUNCE_MS);
+  };
+
+  window.on("resize", () => {
+    captureNormalBounds();
+    scheduleSave();
+  });
+  window.on("move", () => {
+    captureNormalBounds();
+    scheduleSave();
+  });
+  window.on("maximize", () => scheduleSave());
+  window.on("unmaximize", () => {
+    captureNormalBounds();
+    scheduleSave();
+  });
+  window.on("close", () => {
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+      saveTimer = null;
+    }
+    saveWindowStateSync({ ...normalBounds, isMaximized: window.isMaximized() });
+  });
 }
 
 export function loadMainApp(window: BrowserWindow): void {
-  applyShellWindowPresentation(window);
   void window.loadURL("app://setup/ui.html");
 }
 
 export function createMainWindow(): BrowserWindow {
-  const window = new BrowserWindow({
-    width: 1280,
-    height: 800,
+  const layout = resolveWindowLayout(readWindowState());
+  const options: Electron.BrowserWindowConstructorOptions = {
+    width: layout.width,
+    height: layout.height,
     frame: false,
     show: false,
     titleBarStyle: "hidden",
@@ -58,7 +155,17 @@ export function createMainWindow(): BrowserWindow {
       webviewTag: true,
       preload: preloadPath,
     },
-  });
+  };
+  if (layout.x !== undefined && layout.y !== undefined) {
+    options.x = layout.x;
+    options.y = layout.y;
+  }
+
+  const window = new BrowserWindow(options);
+
+  window.setResizable(true);
+  window.setMinimumSize(MIN_WIDTH, MIN_HEIGHT);
+  if (layout.needsCenter) window.center();
 
   window.webContents.setWindowOpenHandler(({ url }) => {
     shell.openExternal(url);
@@ -66,7 +173,13 @@ export function createMainWindow(): BrowserWindow {
   });
   attachWindowDiagnostics(window, "main");
 
-  window.once("ready-to-show", () => window.show());
+  window.once("ready-to-show", () => {
+    if (layout.isMaximized) window.maximize();
+    window.show();
+  });
+
+  attachWindowStateTracking(window);
+
   loadMainApp(window);
   return window;
 }


### PR DESCRIPTION
## PR 标题

chore(desktop): 添加窗口状态记忆能力

## 变更说明

- 问题: 桌面端每次启动都使用硬编码的 1280×800 并居中，无法记住用户上次的窗口大小、位置与最大化状态。
- 重要性: 多显示器/多工作区场景下用户体验差，外接显示器拔除后窗口可能消失到屏幕外。
- 变化:
  - 新增 `window-state` 模块，将窗口状态持久化到 `userData/window-state.json`
  - 创建窗口时应用记忆的尺寸与坐标，最大化状态在 `ready-to-show` 后还原
  - 监听 `resize/move/maximize/unmaximize` 事件，500ms 防抖写盘，关闭时同步落盘
  - 仅在非最大化时记录还原尺寸，避免将全屏尺寸误存为还原尺寸
  - 启动时校验窗口矩形是否仍在可见显示器范围内，无效则回退默认尺寸并居中
  - 移除 `applyShellWindowPresentation` 中硬编码的默认尺寸与居中逻辑

## 关联 Issue / PR (如有)

无

## 变更类型

- [x] 杂项 (chore)

## 问题原因(如有)

不适用

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

桌面端目前未配置测试框架（package.json 无 test 脚本），故未新增测试。窗口状态与实例配置（config.json）分离存储，职责独立；读写均采用同步方式，确保窗口关闭时状态可靠落盘。
