### PR TITLE
feat: 添加项目级规则支持

### DIFF
--- a/backend/app/agent_runtime/context/build_context.py
+++ b/backend/app/agent_runtime/context/build_context.py
@@ -42,7 +42,7 @@ async def build_context_parts(
     parts: list[ContextMessage] = []
     if prompt_messages := await build_system_prompt(state, agent_name, db_session):
         parts.extend(prompt_messages)
-    if (m := await build_rules(db_session)) is not None:
+    if (m := await build_rules(db_session, state.get("project_id"))) is not None:
         parts.append(m)
     if (m := await build_skills(state, agent_name, db_session)) is not None:
         parts.append(m)

--- a/backend/app/agent_runtime/context/parts/rules.py
+++ b/backend/app/agent_runtime/context/parts/rules.py
@@ -2,21 +2,30 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.context.errors import ContextBuildError
 from app.agent_runtime.context.types import ContextMessage
-from app.storage.services import agent_rule_service
+from app.storage.services import agent_rule_service, project_rule_service
 
 
-async def build_rules(db_session: AsyncSession) -> ContextMessage | None:
-    """构建 p3 Rules 上下文片段：列出所有用户规则；空列表返回 None；DB 失败抛 ContextBuildError。"""
+async def build_rules(
+    db_session: AsyncSession, project_id: str | None = None
+) -> ContextMessage | None:
+    """构建 p3 Rules 上下文片段：列出全局规则与项目规则；均为空返回 None；DB 失败抛 ContextBuildError。"""
     try:
         rules = await agent_rule_service.list_all_rules(db_session)
+        project_rules = (
+            await project_rule_service.list_all_rules(db_session, project_id)
+            if project_id
+            else []
+        )
     except Exception as e:
         raise ContextBuildError("rules", "failed to load rules", cause=e) from e
 
-    if not rules:
+    if not rules and not project_rules:
         return None
 
     lines = ["<rules>"]
     for rule in rules:
+        lines.append(f"- {rule.content}")
+    for rule in project_rules:
         lines.append(f"- {rule.content}")
     lines.append("</rules>")
 

--- a/backend/app/api/routers/project_rules.py
+++ b/backend/app/api/routers/project_rules.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+"""ProjectRule Router - 项目规则 CRUD API。"""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from loguru import logger
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.agent_settings_lock import require_agent_settings_unlocked
+from app.api.schemas.project_rule import (
+    ProjectRuleCreate,
+    ProjectRuleListResponse,
+    ProjectRuleReorder,
+    ProjectRuleResponse,
+    ProjectRuleUpdate,
+)
+from app.core.errors import NotFoundError
+from app.storage.database import get_session
+from app.storage.services import project_rule_service
+
+router = APIRouter(tags=["project-rules"])
+
+
+def _to_response(rule) -> ProjectRuleResponse:
+    return ProjectRuleResponse(
+        id=rule.id,
+        project_id=rule.project_id,
+        title=rule.title,
+        content=rule.content,
+        order_index=rule.order_index,
+        created_at=rule.created_at,
+        updated_at=rule.updated_at,
+    )
+
+
+@router.post(
+    "/projects/{project_id}/rules",
+    response_model=ProjectRuleResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_rule(
+    project_id: str,
+    data: ProjectRuleCreate,
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> ProjectRuleResponse:
+    await require_agent_settings_unlocked(session)
+    logger.info(f"创建 ProjectRule: project_id={project_id}")
+    try:
+        rule = await project_rule_service.create_rule(
+            session,
+            project_id,
+            title=data.title,
+            content=data.content,
+        )
+        return _to_response(rule)
+    except NotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+
+
+@router.get("/projects/{project_id}/rules", response_model=ProjectRuleListResponse)
+async def list_rules(
+    project_id: str,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    page: Annotated[int, Query(ge=1)] = 1,
+    page_size: Annotated[int, Query(ge=1, le=100)] = 50,
+) -> ProjectRuleListResponse:
+    try:
+        result = await project_rule_service.list_rules(
+            session, project_id, page=page, page_size=page_size
+        )
+        return ProjectRuleListResponse(
+            items=[_to_response(rule) for rule in result.items],
+            total=result.total,
+            page=result.page,
+            page_size=result.page_size,
+        )
+    except NotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+
+
+@router.get("/projects/{project_id}/rules/{rule_id}", response_model=ProjectRuleResponse)
+async def get_rule(
+    project_id: str,
+    rule_id: str,
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> ProjectRuleResponse:
+    try:
+        rule = await project_rule_service.get_rule(session, project_id, rule_id)
+        return _to_response(rule)
+    except NotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+
+
+@router.patch("/projects/{project_id}/rules/{rule_id}", response_model=ProjectRuleResponse)
+async def update_rule(
+    project_id: str,
+    rule_id: str,
+    data: ProjectRuleUpdate,
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> ProjectRuleResponse:
+    await require_agent_settings_unlocked(session)
+    try:
+        rule = await project_rule_service.update_rule(
+            session,
+            project_id,
+            rule_id,
+            title=data.title,
+            content=data.content,
+        )
+        return _to_response(rule)
+    except NotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+
+
+@router.post("/projects/{project_id}/rules/reorder", response_model=list[ProjectRuleResponse])
+async def reorder_rules(
+    project_id: str,
+    data: ProjectRuleReorder,
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> list[ProjectRuleResponse]:
+    await require_agent_settings_unlocked(session)
+    try:
+        rules = await project_rule_service.reorder_rules(session, project_id, data.rule_ids)
+        return [_to_response(rule) for rule in rules]
+    except NotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+
+
+@router.delete(
+    "/projects/{project_id}/rules/{rule_id}", status_code=status.HTTP_204_NO_CONTENT
+)
+async def delete_rule(
+    project_id: str,
+    rule_id: str,
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> None:
+    await require_agent_settings_unlocked(session)
+    try:
+        await project_rule_service.delete_rule(session, project_id, rule_id)
+    except NotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))

--- a/backend/app/api/schemas/project_rule.py
+++ b/backend/app/api/schemas/project_rule.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+"""ProjectRule API Schemas。"""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class ProjectRuleCreate(BaseModel):
+    title: str = Field(default="", description="规则标题")
+    content: str = Field(default="", description="规则内容")
+
+
+class ProjectRuleUpdate(BaseModel):
+    title: str | None = Field(default=None, description="规则标题")
+    content: str | None = Field(default=None, description="规则内容")
+
+
+class ProjectRuleReorder(BaseModel):
+    rule_ids: list[str] = Field(description="按新顺序排列的规则 ID 列表")
+
+
+class ProjectRuleResponse(BaseModel):
+    id: str
+    project_id: str
+    title: str
+    content: str
+    order_index: int
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class ProjectRuleListResponse(BaseModel):
+    items: list[ProjectRuleResponse]
+    total: int
+    page: int
+    page_size: int

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -40,6 +40,7 @@ from app.api.routers import (
     models,
     notes,
     projects,
+    project_rules,
     prompt_chains,
     retrieval_index,
     settings,
@@ -344,6 +345,7 @@ def create_app() -> FastAPI:
     app.include_router(skills.router, prefix=app_settings.api_v1_prefix)
     app.include_router(skill_reference_docs.router, prefix=app_settings.api_v1_prefix)
     app.include_router(agent_rules.router, prefix=app_settings.api_v1_prefix)
+    app.include_router(project_rules.router, prefix=app_settings.api_v1_prefix)
     app.include_router(agent_memories.router, prefix=app_settings.api_v1_prefix)
     app.include_router(chapter_context.router, prefix=app_settings.api_v1_prefix)
     app.include_router(tasks.router, prefix=app_settings.api_v1_prefix)

--- a/backend/app/storage/migrations/versions/1015_add_project_rules.py
+++ b/backend/app/storage/migrations/versions/1015_add_project_rules.py
@@ -1,0 +1,46 @@
+"""add project rules
+
+Revision ID: 1015
+Revises: 1014
+Create Date: 2026-07-26 00:00:00.000000
+
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "1015"
+down_revision: Union[str, Sequence[str], None] = "1014"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "project_rules",
+        sa.Column("id", sa.String(), nullable=False),
+        sa.Column("project_id", sa.String(), nullable=False),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("content", sa.String(), nullable=False),
+        sa.Column("order_index", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_project_rules_project_id"), "project_rules", ["project_id"], unique=False
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_project_rules_project_id"), table_name="project_rules")
+    op.drop_table("project_rules")

--- a/backend/app/storage/models/__init__.py
+++ b/backend/app/storage/models/__init__.py
@@ -19,6 +19,7 @@ from app.storage.models.chapter import Chapter
 from app.storage.models.chapter_summary import ChapterSummary
 from app.storage.models.commit import Commit
 from app.storage.models.project import Project
+from app.storage.models.project_rule import ProjectRule
 from app.storage.models.prompt_chain_version import PromptChainVersion
 from app.storage.models.prompt_entry import PromptEntry
 from app.storage.models.revision import Revision
@@ -60,6 +61,7 @@ __all__ = [
     "Note",
     "NoteCategory",
     "Project",
+    "ProjectRule",
     "PromptChainVersion",
     "PromptEntry",
     "Revision",

--- a/backend/app/storage/models/project_rule.py
+++ b/backend/app/storage/models/project_rule.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""ProjectRule 数据模型 - 项目级智能体行为规则。"""
+
+from datetime import UTC, datetime
+
+from sqlmodel import Field, SQLModel
+
+from app.core.ids import generate_id
+
+
+class ProjectRule(SQLModel, table=True):
+    """项目级智能体行为规则。"""
+
+    __tablename__ = "project_rules"
+
+    id: str = Field(default_factory=generate_id, primary_key=True)
+    project_id: str = Field(index=True, foreign_key="projects.id")
+    title: str = Field(default="")
+    content: str = Field(default="")
+    order_index: int = Field(default=0)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/backend/app/storage/repos/project_rule_repo.py
+++ b/backend/app/storage/repos/project_rule_repo.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+"""ProjectRule Repository - 项目规则数据访问层。"""
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
+
+from app.storage.models.project_rule import ProjectRule
+
+
+async def create(session: AsyncSession, rule: ProjectRule) -> ProjectRule:
+    session.add(rule)
+    await session.flush()
+    await session.refresh(rule)
+    return rule
+
+
+async def get_by_id(session: AsyncSession, rule_id: str) -> ProjectRule | None:
+    result = await session.execute(select(ProjectRule).where(col(ProjectRule.id) == rule_id))
+    return result.scalar_one_or_none()
+
+
+async def get_all_by_project(
+    session: AsyncSession,
+    project_id: str,
+    page: int = 1,
+    page_size: int = 100,
+) -> tuple[list[ProjectRule], int]:
+    count_result = await session.execute(
+        select(func.count(col(ProjectRule.id))).where(col(ProjectRule.project_id) == project_id)
+    )
+    total = count_result.scalar_one()
+
+    offset = (page - 1) * page_size
+    result = await session.execute(
+        select(ProjectRule)
+        .where(col(ProjectRule.project_id) == project_id)
+        .order_by(col(ProjectRule.order_index).asc(), col(ProjectRule.created_at).asc())
+        .offset(offset)
+        .limit(page_size)
+    )
+    return list(result.scalars().all()), total
+
+
+async def get_all_ordered(session: AsyncSession, project_id: str) -> list[ProjectRule]:
+    result = await session.execute(
+        select(ProjectRule)
+        .where(col(ProjectRule.project_id) == project_id)
+        .where(col(ProjectRule.content) != "")
+        .order_by(col(ProjectRule.order_index).asc(), col(ProjectRule.created_at).asc())
+    )
+    return list(result.scalars().all())
+
+
+async def get_max_order_index(session: AsyncSession, project_id: str) -> int:
+    result = await session.execute(
+        select(func.max(col(ProjectRule.order_index))).where(
+            col(ProjectRule.project_id) == project_id
+        )
+    )
+    return result.scalar_one() or 0
+
+
+async def get_by_ids(session: AsyncSession, rule_ids: list[str]) -> list[ProjectRule]:
+    if not rule_ids:
+        return []
+    result = await session.execute(
+        select(ProjectRule).where(col(ProjectRule.id).in_(rule_ids))
+    )
+    return list(result.scalars().all())
+
+
+async def update(session: AsyncSession, rule: ProjectRule) -> ProjectRule:
+    session.add(rule)
+    await session.flush()
+    await session.refresh(rule)
+    return rule
+
+
+async def delete(session: AsyncSession, rule: ProjectRule) -> None:
+    await session.delete(rule)
+    await session.flush()

--- a/backend/app/storage/services/project_rule_service.py
+++ b/backend/app/storage/services/project_rule_service.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""ProjectRule Service - 项目规则业务逻辑层。"""
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.errors import NotFoundError
+from app.storage.models.project_rule import ProjectRule
+from app.storage.repos import project_repo, project_rule_repo
+
+
+@dataclass
+class ProjectRuleListResult:
+    items: list[ProjectRule]
+    total: int
+    page: int
+    page_size: int
+
+
+async def _require_project(session: AsyncSession, project_id: str) -> None:
+    project = await project_repo.get_by_id(session, project_id)
+    if project is None:
+        raise NotFoundError(f"项目不存在: {project_id}")
+
+
+async def create_rule(
+    session: AsyncSession,
+    project_id: str,
+    *,
+    title: str = "",
+    content: str = "",
+) -> ProjectRule:
+    await _require_project(session, project_id)
+    max_order = await project_rule_repo.get_max_order_index(session, project_id)
+    rule = ProjectRule(
+        project_id=project_id,
+        title=title,
+        content=content,
+        order_index=max_order + 1,
+    )
+    return await project_rule_repo.create(session, rule)
+
+
+async def get_rule(session: AsyncSession, project_id: str, rule_id: str) -> ProjectRule:
+    rule = await project_rule_repo.get_by_id(session, rule_id)
+    if rule is None or rule.project_id != project_id:
+        raise NotFoundError(f"规则不存在: {rule_id}")
+    return rule
+
+
+async def list_rules(
+    session: AsyncSession,
+    project_id: str,
+    page: int = 1,
+    page_size: int = 100,
+) -> ProjectRuleListResult:
+    await _require_project(session, project_id)
+    items, total = await project_rule_repo.get_all_by_project(session, project_id, page, page_size)
+    return ProjectRuleListResult(items=items, total=total, page=page, page_size=page_size)
+
+
+async def list_all_rules(session: AsyncSession, project_id: str) -> list[ProjectRule]:
+    return await project_rule_repo.get_all_ordered(session, project_id)
+
+
+async def update_rule(
+    session: AsyncSession,
+    project_id: str,
+    rule_id: str,
+    *,
+    title: str | None = None,
+    content: str | None = None,
+) -> ProjectRule:
+    rule = await get_rule(session, project_id, rule_id)
+    if title is not None:
+        rule.title = title
+    if content is not None:
+        rule.content = content
+    rule.updated_at = datetime.now(UTC)
+    return await project_rule_repo.update(session, rule)
+
+
+async def reorder_rules(
+    session: AsyncSession, project_id: str, rule_ids: list[str]
+) -> list[ProjectRule]:
+    await _require_project(session, project_id)
+    rules = await project_rule_repo.get_by_ids(session, rule_ids)
+    rule_map = {r.id: r for r in rules if r.project_id == project_id}
+
+    now = datetime.now(UTC)
+    updated: list[ProjectRule] = []
+    for idx, rule_id in enumerate(rule_ids):
+        rule = rule_map.get(rule_id)
+        if rule is None:
+            continue
+        rule.order_index = idx
+        rule.updated_at = now
+        await project_rule_repo.update(session, rule)
+        updated.append(rule)
+    return updated
+
+
+async def delete_rule(session: AsyncSession, project_id: str, rule_id: str) -> None:
+    rule = await get_rule(session, project_id, rule_id)
+    await project_rule_repo.delete(session, rule)

--- a/backend/tests/agent_runtime/context/parts/test_rules.py
+++ b/backend/tests/agent_runtime/context/parts/test_rules.py
@@ -35,6 +35,60 @@ async def test_rules_renders_pseudo_xml(mock_session):
 
 
 @pytest.mark.asyncio
+async def test_rules_includes_project_rules_after_global(mock_session):
+    global_rules = [SimpleNamespace(content="全局规则")]
+    project_rules = [SimpleNamespace(content="项目规则")]
+    with (
+        patch(
+            "app.agent_runtime.context.parts.rules.agent_rule_service.list_all_rules",
+            AsyncMock(return_value=global_rules),
+        ),
+        patch(
+            "app.agent_runtime.context.parts.rules.project_rule_service.list_all_rules",
+            AsyncMock(return_value=project_rules),
+        ),
+    ):
+        msg = await build_rules(mock_session, "p1")
+    assert msg is not None
+    assert msg.content.index("- 全局规则") < msg.content.index("- 项目规则")
+
+
+@pytest.mark.asyncio
+async def test_rules_project_rules_only(mock_session):
+    project_rules = [SimpleNamespace(content="项目规则")]
+    with (
+        patch(
+            "app.agent_runtime.context.parts.rules.agent_rule_service.list_all_rules",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "app.agent_runtime.context.parts.rules.project_rule_service.list_all_rules",
+            AsyncMock(return_value=project_rules),
+        ),
+    ):
+        msg = await build_rules(mock_session, "p1")
+    assert msg is not None
+    assert "- 项目规则" in msg.content
+
+
+@pytest.mark.asyncio
+async def test_rules_without_project_id_skips_project_rules(mock_session):
+    project_rules_mock = AsyncMock(return_value=[SimpleNamespace(content="项目规则")])
+    with (
+        patch(
+            "app.agent_runtime.context.parts.rules.agent_rule_service.list_all_rules",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "app.agent_runtime.context.parts.rules.project_rule_service.list_all_rules",
+            project_rules_mock,
+        ),
+    ):
+        assert await build_rules(mock_session) is None
+    project_rules_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_rules_db_error_raises_context_build_error(mock_session):
     from app.agent_runtime.context.errors import ContextBuildError
     with patch(

--- a/backend/tests/api/test_project_rules.py
+++ b/backend/tests/api/test_project_rules.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+
+import pytest
+from httpx import AsyncClient
+
+
+async def _create_project(client: AsyncClient) -> str:
+    response = await client.post("/api/v1/projects", data={"title": "项目规则测试"})
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_create_update_and_list_project_rules(client: AsyncClient) -> None:
+    project_id = await _create_project(client)
+
+    create_response = await client.post(
+        f"/api/v1/projects/{project_id}/rules",
+        json={
+            "title": "文风",
+            "content": "本项目使用古风文体",
+        },
+    )
+
+    assert create_response.status_code == 201
+    created = create_response.json()
+    assert created["project_id"] == project_id
+    assert created["title"] == "文风"
+    assert created["content"] == "本项目使用古风文体"
+
+    rule_id = created["id"]
+    update_response = await client.patch(
+        f"/api/v1/projects/{project_id}/rules/{rule_id}",
+        json={
+            "title": "叙事文风",
+            "content": "本项目使用第一人称古风文体",
+        },
+    )
+
+    assert update_response.status_code == 200
+    updated = update_response.json()
+    assert updated["title"] == "叙事文风"
+    assert updated["content"] == "本项目使用第一人称古风文体"
+
+    list_response = await client.get(f"/api/v1/projects/{project_id}/rules")
+    assert list_response.status_code == 200
+    payload = list_response.json()
+    assert payload["total"] == 1
+    assert payload["items"][0]["title"] == "叙事文风"
+
+
+@pytest.mark.asyncio
+async def test_project_rules_isolated_by_project(client: AsyncClient) -> None:
+    project_a = await _create_project(client)
+    project_b = await _create_project(client)
+
+    create_response = await client.post(
+        f"/api/v1/projects/{project_a}/rules",
+        json={"title": "规则A", "content": "只属于项目A"},
+    )
+    assert create_response.status_code == 201
+    rule_id = create_response.json()["id"]
+
+    list_b = await client.get(f"/api/v1/projects/{project_b}/rules")
+    assert list_b.status_code == 200
+    assert list_b.json()["total"] == 0
+
+    get_via_b = await client.get(f"/api/v1/projects/{project_b}/rules/{rule_id}")
+    assert get_via_b.status_code == 404
+
+    delete_via_b = await client.delete(f"/api/v1/projects/{project_b}/rules/{rule_id}")
+    assert delete_via_b.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_project_rules_reorder_and_delete(client: AsyncClient) -> None:
+    project_id = await _create_project(client)
+
+    first = await client.post(
+        f"/api/v1/projects/{project_id}/rules",
+        json={"title": "规则1", "content": "内容1"},
+    )
+    second = await client.post(
+        f"/api/v1/projects/{project_id}/rules",
+        json={"title": "规则2", "content": "内容2"},
+    )
+    first_id = first.json()["id"]
+    second_id = second.json()["id"]
+
+    reorder_response = await client.post(
+        f"/api/v1/projects/{project_id}/rules/reorder",
+        json={"rule_ids": [second_id, first_id]},
+    )
+    assert reorder_response.status_code == 200
+
+    list_response = await client.get(f"/api/v1/projects/{project_id}/rules")
+    items = list_response.json()["items"]
+    assert [item["id"] for item in items] == [second_id, first_id]
+
+    delete_response = await client.delete(f"/api/v1/projects/{project_id}/rules/{first_id}")
+    assert delete_response.status_code == 204
+
+    list_response = await client.get(f"/api/v1/projects/{project_id}/rules")
+    assert list_response.json()["total"] == 1
+
+
+@pytest.mark.asyncio
+async def test_project_rules_requires_existing_project(client: AsyncClient) -> None:
+    response = await client.post(
+        "/api/v1/projects/nonexistent/rules",
+        json={"title": "规则", "content": "内容"},
+    )
+    assert response.status_code == 404
+
+    list_response = await client.get("/api/v1/projects/nonexistent/rules")
+    assert list_response.status_code == 404

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -35,6 +35,7 @@ from app.api.routers import (
     models,
     notes,
     projects,
+    project_rules,
     prompt_chains,
     retrieval_index,
     skills,
@@ -75,6 +76,7 @@ def _create_test_app() -> FastAPI:
     test_app.include_router(prompt_chains.router, prefix="/api/v1")
     test_app.include_router(agent_definitions.router, prefix="/api/v1")
     test_app.include_router(agent_rules.router, prefix="/api/v1")
+    test_app.include_router(project_rules.router, prefix="/api/v1")
     test_app.include_router(retrieval_index.router, prefix="/api/v1")
     test_app.include_router(retrieval_index.global_router, prefix="/api/v1")
     test_app.include_router(skills.router, prefix="/api/v1")

--- a/backend/tests/model_registry.py
+++ b/backend/tests/model_registry.py
@@ -27,6 +27,7 @@ def register_sqlmodel_models() -> None:
     from app.storage.models.chapter_summary import ChapterSummary
     from app.storage.models.commit import Commit
     from app.storage.models.project import Project
+    from app.storage.models.project_rule import ProjectRule
     from app.storage.models.prompt_chain_version import PromptChainVersion
     from app.storage.models.prompt_entry import PromptEntry
     from app.storage.models.retrieval_index import RetrievalIndex
@@ -65,6 +66,7 @@ def register_sqlmodel_models() -> None:
         Note,
         NoteCategory,
         Project,
+        ProjectRule,
         PromptChainVersion,
         PromptEntry,
         RetrievalIndex,

--- a/frontend/src/features/writing/components/project-rules-sidebar.css
+++ b/frontend/src/features/writing/components/project-rules-sidebar.css
@@ -1,0 +1,8 @@
+.project-rules-sidebar-item:hover {
+  background: var(--gray-a3);
+}
+
+.project-rules-sidebar-item:focus-visible {
+  outline: 2px solid var(--focus-8);
+  outline-offset: -2px;
+}

--- a/frontend/src/features/writing/components/project-rules-sidebar.tsx
+++ b/frontend/src/features/writing/components/project-rules-sidebar.tsx
@@ -1,0 +1,388 @@
+import {
+  Box,
+  Button,
+  Dialog,
+  Flex,
+  IconButton,
+  Text,
+  TextArea,
+  TextField,
+  Tooltip,
+} from "@radix-ui/themes";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Plus, ScrollText, Trash2 } from "lucide-react";
+import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { ConfirmDialog, ContextMenu, Spinner, toast } from "@/components";
+import type { ContextMenuItem, ContextMenuPosition } from "@/components";
+import {
+  createProjectRule,
+  deleteProjectRule,
+  fetchProjectRules,
+  updateProjectRule,
+} from "@/lib/api-client";
+import type { ProjectRule } from "@/lib/project-rule.types";
+import { createToastThrottler } from "@/lib/ui-utils";
+
+import "./project-rules-sidebar.css";
+
+interface ProjectRulesSidebarProps {
+  projectId: string;
+  isAgentLocked?: boolean;
+  compact?: boolean;
+}
+
+interface RuleFormState {
+  title: string;
+  content: string;
+}
+
+export function ProjectRulesSidebar({
+  projectId,
+  isAgentLocked = false,
+  compact = false,
+}: ProjectRulesSidebarProps) {
+  const { t } = useTranslation();
+  const queryClient = useQueryClient();
+
+  const [editingRule, setEditingRule] = useState<ProjectRule | null>(null);
+  const [form, setForm] = useState<RuleFormState>({ title: "", content: "" });
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<ProjectRule | null>(null);
+  const [contextMenuPos, setContextMenuPos] = useState<ContextMenuPosition | null>(null);
+  const [contextMenuRule, setContextMenuRule] = useState<ProjectRule | null>(null);
+
+  const showLockedToast = useMemo(
+    () => createToastThrottler(t("writing.projectRules.agentLocked")),
+    [t],
+  );
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["project-rules", projectId],
+    queryFn: () => fetchProjectRules(projectId, { page: 1, pageSize: 100 }),
+  });
+
+  const rules = data?.items ?? [];
+
+  const invalidate = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: ["project-rules", projectId] });
+  }, [queryClient, projectId]);
+
+  const createMutation = useMutation({
+    mutationFn: () =>
+      createProjectRule(projectId, {
+        title: t("writing.projectRules.newRule"),
+        content: "",
+      }),
+    onSuccess: (createdRule) => {
+      invalidate();
+      setEditingRule(createdRule);
+      setForm({ title: createdRule.title, content: createdRule.content });
+    },
+    onError: () => toast.error(t("common.error")),
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ ruleId, payload }: { ruleId: string; payload: RuleFormState }) =>
+      updateProjectRule(projectId, ruleId, payload),
+    onSuccess: () => {
+      invalidate();
+      setEditingRule(null);
+    },
+    onError: () => toast.error(t("settings.saveFailed")),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (ruleId: string) => deleteProjectRule(projectId, ruleId),
+    onSuccess: () => {
+      invalidate();
+      setDeleteDialogOpen(false);
+      setDeleteTarget(null);
+      toast.success(t("common.delete"));
+    },
+    onError: () => toast.error(t("common.error")),
+  });
+
+  const handleCreate = useCallback(() => {
+    if (isAgentLocked) {
+      showLockedToast();
+      return;
+    }
+    createMutation.mutate();
+  }, [createMutation, isAgentLocked, showLockedToast]);
+
+  const handleOpenRule = useCallback((rule: ProjectRule) => {
+    setEditingRule(rule);
+    setForm({ title: rule.title, content: rule.content });
+  }, []);
+
+  const handleSave = useCallback(() => {
+    if (!editingRule) return;
+    if (isAgentLocked) {
+      showLockedToast();
+      return;
+    }
+    updateMutation.mutate({ ruleId: editingRule.id, payload: form });
+  }, [editingRule, form, isAgentLocked, showLockedToast, updateMutation]);
+
+  const handleContextMenu = useCallback(
+    (rule: ProjectRule, position: ContextMenuPosition) => {
+      if (isAgentLocked) return;
+      setContextMenuPos(position);
+      setContextMenuRule(rule);
+    },
+    [isAgentLocked],
+  );
+
+  const handleCloseContextMenu = useCallback(() => {
+    setContextMenuPos(null);
+    setContextMenuRule(null);
+  }, []);
+
+  const contextMenuItems = useMemo<ContextMenuItem[]>(() => {
+    if (!contextMenuRule) return [];
+    return [
+      {
+        id: "delete",
+        label: t("common.delete"),
+        icon: Trash2,
+        danger: true,
+        onClick: () => {
+          setDeleteTarget(contextMenuRule);
+          setDeleteDialogOpen(true);
+          handleCloseContextMenu();
+        },
+      },
+    ];
+  }, [contextMenuRule, handleCloseContextMenu, t]);
+
+  if (isLoading) {
+    return (
+      <Flex
+        align="center"
+        justify="center"
+        style={{ flex: 1 }}
+      >
+        <Spinner size={18} />
+      </Flex>
+    );
+  }
+
+  if (error) {
+    return (
+      <Flex
+        align="center"
+        justify="center"
+        p="4"
+        style={{ flex: 1 }}
+      >
+        <Text
+          size="2"
+          color="red"
+        >
+          {t("writing.projectRules.loadFailed")}
+        </Text>
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex
+      direction="column"
+      style={{ flex: 1, minHeight: 0 }}
+    >
+      <Box
+        px="3"
+        py="2"
+        style={{ borderBottom: "1px solid var(--gray-a4)" }}
+      >
+        <Flex
+          align="center"
+          justify="between"
+        >
+          <Text
+            size="1"
+            color="gray"
+          >
+            {t("writing.projectRules.hint")}
+          </Text>
+          <Tooltip content={t("writing.projectRules.newRule")}>
+            <IconButton
+              variant="ghost"
+              size="2"
+              aria-label={t("writing.projectRules.newRule")}
+              onClick={handleCreate}
+              disabled={createMutation.isPending}
+            >
+              <Plus size={16} />
+            </IconButton>
+          </Tooltip>
+        </Flex>
+      </Box>
+
+      <Box
+        style={{ flex: 1, minHeight: 0, overflowY: "auto" }}
+        p={compact ? "1" : "2"}
+      >
+        {rules.length === 0 ? (
+          <Flex
+            direction="column"
+            align="center"
+            justify="center"
+            gap="2"
+            py="6"
+          >
+            <ScrollText
+              size={20}
+              color="var(--gray-8)"
+            />
+            <Text
+              size="1"
+              color="gray"
+              align="center"
+            >
+              {t("writing.projectRules.empty")}
+            </Text>
+          </Flex>
+        ) : (
+          <Flex
+            direction="column"
+            gap="1"
+          >
+            {rules.map((rule) => (
+              <button
+                key={rule.id}
+                type="button"
+                onClick={() => handleOpenRule(rule)}
+                onContextMenu={(event) => {
+                  event.preventDefault();
+                  handleContextMenu(rule, { x: event.clientX, y: event.clientY });
+                }}
+                style={{
+                  all: "unset",
+                  cursor: "pointer",
+                  padding: "6px 8px",
+                  borderRadius: "var(--radius-2)",
+                  width: "100%",
+                  boxSizing: "border-box",
+                }}
+                className="project-rules-sidebar-item"
+              >
+                <Flex
+                  direction="column"
+                  gap="1"
+                  style={{ minWidth: 0 }}
+                >
+                  <Text
+                    size="2"
+                    truncate
+                  >
+                    {rule.title || t("writing.projectRules.untitled")}
+                  </Text>
+                  {rule.content ? (
+                    <Text
+                      size="1"
+                      color="gray"
+                      truncate
+                    >
+                      {rule.content}
+                    </Text>
+                  ) : null}
+                </Flex>
+              </button>
+            ))}
+          </Flex>
+        )}
+      </Box>
+
+      <ContextMenu
+        position={contextMenuPos}
+        items={contextMenuItems}
+        onClose={handleCloseContextMenu}
+      />
+
+      <Dialog.Root
+        open={editingRule !== null}
+        onOpenChange={(open) => {
+          if (!open) setEditingRule(null);
+        }}
+      >
+        <Dialog.Content style={{ maxWidth: 480 }}>
+          <Dialog.Title>{t("writing.projectRules.editTitle")}</Dialog.Title>
+          <Flex
+            direction="column"
+            gap="3"
+            mt="3"
+          >
+            <Box>
+              <Text
+                size="2"
+                weight="medium"
+                as="label"
+              >
+                {t("writing.projectRules.title")}
+              </Text>
+              <TextField.Root
+                mt="1"
+                value={form.title}
+                onChange={(event) => setForm((prev) => ({ ...prev, title: event.target.value }))}
+                placeholder={t("writing.projectRules.titlePlaceholder")}
+              />
+            </Box>
+            <Box>
+              <Text
+                size="2"
+                weight="medium"
+                as="label"
+              >
+                {t("writing.projectRules.content")}
+              </Text>
+              <TextArea
+                mt="1"
+                value={form.content}
+                onChange={(event) => setForm((prev) => ({ ...prev, content: event.target.value }))}
+                placeholder={t("writing.projectRules.contentPlaceholder")}
+                rows={8}
+              />
+            </Box>
+          </Flex>
+          <Flex
+            justify="end"
+            gap="2"
+            mt="4"
+          >
+            <Button
+              variant="soft"
+              color="gray"
+              onClick={() => setEditingRule(null)}
+            >
+              {t("common.cancel")}
+            </Button>
+            <Button
+              onClick={handleSave}
+              disabled={updateMutation.isPending || !form.title.trim()}
+            >
+              {updateMutation.isPending ? t("writing.projectRules.saving") : t("common.save")}
+            </Button>
+          </Flex>
+        </Dialog.Content>
+      </Dialog.Root>
+
+      <ConfirmDialog
+        open={deleteDialogOpen}
+        onOpenChange={(open) => {
+          setDeleteDialogOpen(open);
+          if (!open) setDeleteTarget(null);
+        }}
+        onConfirm={() => {
+          if (deleteTarget) deleteMutation.mutate(deleteTarget.id);
+        }}
+        title={t("writing.projectRules.deleteTitle")}
+        description={t("writing.projectRules.deleteDescription")}
+        confirmText={t("common.delete")}
+        cancelText={t("common.cancel")}
+      />
+    </Flex>
+  );
+}

--- a/frontend/src/features/writing/components/writing-sidebar.tsx
+++ b/frontend/src/features/writing/components/writing-sidebar.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useWritingStore } from "../store/use-writing-store";
 import { ChapterSidebar } from "./chapter-sidebar";
 import { NoteSidebar } from "./note-sidebar";
+import { ProjectRulesSidebar } from "./project-rules-sidebar";
 
 interface WritingSidebarProps {
   projectId: string;
@@ -47,12 +48,13 @@ export function WritingSidebar({
       >
         <SegmentedControl.Root
           value={sidebarView}
-          onValueChange={(value) => setSidebarView(value as "chapters" | "notes")}
+          onValueChange={(value) => setSidebarView(value as "chapters" | "notes" | "rules")}
           size="2"
           style={{ width: "100%" }}
         >
           <SegmentedControl.Item value="chapters">{t("writing.chapters")}</SegmentedControl.Item>
           <SegmentedControl.Item value="notes">{t("writing.notes")}</SegmentedControl.Item>
+          <SegmentedControl.Item value="rules">{t("writing.rules")}</SegmentedControl.Item>
         </SegmentedControl.Root>
       </div>
 
@@ -66,11 +68,17 @@ export function WritingSidebar({
           initialCurrentChapterNavigationKey={initialCurrentChapterNavigationKey}
           onOpenSummary={onOpenSummary}
         />
-      ) : (
+      ) : sidebarView === "notes" ? (
         <NoteSidebar
           projectId={projectId}
           onNoteSelect={onNoteSelect}
           onAddToConversation={onAddToConversation}
+          isAgentLocked={isAgentLocked}
+          compact={compact}
+        />
+      ) : (
+        <ProjectRulesSidebar
+          projectId={projectId}
           isAgentLocked={isAgentLocked}
           compact={compact}
         />

--- a/frontend/src/features/writing/store/use-writing-store.ts
+++ b/frontend/src/features/writing/store/use-writing-store.ts
@@ -20,7 +20,7 @@ interface WritingStore {
   expandedVolumeIds: Set<string>;
   hasHydratedExpandedVolumeIds: boolean;
   hasStoredExpandedVolumeIdsPreference: boolean;
-  sidebarView: "chapters" | "notes";
+  sidebarView: "chapters" | "notes" | "rules";
 
   // 拖拽排序临时数据：章节ID -> 新排序
   dragOrderMap: Record<string, number>;
@@ -38,7 +38,7 @@ interface WritingStore {
   hydrateExpandedVolumeIds: () => Promise<void>;
   setVolumeExpanded: (volumeId: string, expanded: boolean) => void;
   toggleVolumeExpanded: (volumeId: string) => void;
-  setSidebarView: (view: "chapters" | "notes") => void;
+  setSidebarView: (view: "chapters" | "notes" | "rules") => void;
   hydrateSidebarView: () => Promise<void>;
 }
 
@@ -172,8 +172,8 @@ export const useWritingStore = create<WritingStore>((set, get) => ({
 
   hydrateSidebarView: async () => {
     const rawValue = await getPreference(SIDEBAR_VIEW_KEY);
-    if (rawValue === "notes") {
-      set({ sidebarView: "notes" });
+    if (rawValue === "notes" || rawValue === "rules") {
+      set({ sidebarView: rawValue });
     }
   },
 }));

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -231,6 +231,7 @@
     },
     "words": "words",
     "notes": "Notes",
+    "rules": "Rules",
     "newNote": "New Note",
     "untitledNote": "Untitled Note",
     "deleteNoteConfirm": "Are you sure you want to delete \"{{title}}\"? This action cannot be undone.",
@@ -413,6 +414,22 @@
         "rebuildSuccess": "Index rebuild job submitted",
         "rebuildFailed": "Failed to rebuild index"
       }
+    },
+    "projectRules": {
+      "hint": "Applies to this project only",
+      "newRule": "New rule",
+      "empty": "No project rules yet. Click the button above to create one.",
+      "loadFailed": "Failed to load project rules",
+      "untitled": "Untitled rule",
+      "editTitle": "Edit project rule",
+      "title": "Title",
+      "titlePlaceholder": "Enter rule title",
+      "content": "Content",
+      "contentPlaceholder": "Enter rule content. It will be injected into AI conversations for this project.",
+      "saving": "Saving…",
+      "deleteTitle": "Delete rule",
+      "deleteDescription": "This cannot be undone. Delete this project rule?",
+      "agentLocked": "Agent session is running; project rules cannot be modified"
     }
   },
   "editor": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -231,6 +231,7 @@
     },
     "words": "字",
     "notes": "笔记",
+    "rules": "规则",
     "newNote": "新建笔记",
     "untitledNote": "未命名笔记",
     "deleteNoteConfirm": "确定要删除「{{title}}」吗？此操作不可撤销。",
@@ -413,6 +414,22 @@
         "rebuildSuccess": "索引重建任务已提交",
         "rebuildFailed": "索引重建失败"
       }
+    },
+    "projectRules": {
+      "hint": "仅对当前项目生效",
+      "newRule": "新建规则",
+      "empty": "暂无项目规则，点击右上角新建",
+      "loadFailed": "加载项目规则失败",
+      "untitled": "未命名规则",
+      "editTitle": "编辑项目规则",
+      "title": "标题",
+      "titlePlaceholder": "输入规则标题",
+      "content": "内容",
+      "contentPlaceholder": "输入规则内容，将注入当前项目的 AI 对话上下文",
+      "saving": "保存中…",
+      "deleteTitle": "删除规则",
+      "deleteDescription": "删除后无法恢复，确定要删除这条项目规则吗？",
+      "agentLocked": "Agent 会话运行中，无法修改项目规则"
     }
   },
   "editor": {

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -515,6 +515,86 @@ export async function reorderAgentRules(ruleIds: string[]): Promise<AgentRule[]>
 }
 
 // ============================================
+// Project Rules API
+// ============================================
+
+import type {
+  ProjectRule,
+  ProjectRuleCreate,
+  ProjectRuleUpdate,
+  ProjectRuleListResponse,
+  ProjectRuleListParams,
+} from "./project-rule.types";
+
+function transformProjectRule(raw: Record<string, unknown>): ProjectRule {
+  return {
+    id: raw.id as string,
+    projectId: raw.project_id as string,
+    title: raw.title as string,
+    content: raw.content as string,
+    orderIndex: (raw.order_index as number) ?? 0,
+    createdAt: raw.created_at as string,
+    updatedAt: raw.updated_at as string,
+  };
+}
+
+export async function fetchProjectRules(
+  projectId: string,
+  params?: ProjectRuleListParams,
+): Promise<ProjectRuleListResponse> {
+  const response = await apiClient.get(`/projects/${projectId}/rules`, {
+    params: {
+      page: params?.page ?? 1,
+      page_size: params?.pageSize ?? 100,
+    },
+  });
+  const data = response.data;
+  return {
+    items: (data.items as Record<string, unknown>[]).map(transformProjectRule),
+    total: data.total,
+    page: data.page,
+    pageSize: data.page_size,
+  };
+}
+
+export async function createProjectRule(
+  projectId: string,
+  data: ProjectRuleCreate,
+): Promise<ProjectRule> {
+  const response = await apiClient.post(`/projects/${projectId}/rules`, {
+    title: data.title,
+    content: data.content,
+  });
+  return transformProjectRule(response.data);
+}
+
+export async function updateProjectRule(
+  projectId: string,
+  ruleId: string,
+  data: ProjectRuleUpdate,
+): Promise<ProjectRule> {
+  const response = await apiClient.patch(`/projects/${projectId}/rules/${ruleId}`, {
+    title: data.title,
+    content: data.content,
+  });
+  return transformProjectRule(response.data);
+}
+
+export async function deleteProjectRule(projectId: string, ruleId: string): Promise<void> {
+  await apiClient.delete(`/projects/${projectId}/rules/${ruleId}`);
+}
+
+export async function reorderProjectRules(
+  projectId: string,
+  ruleIds: string[],
+): Promise<ProjectRule[]> {
+  const response = await apiClient.post(`/projects/${projectId}/rules/reorder`, {
+    rule_ids: ruleIds,
+  });
+  return (response.data as Record<string, unknown>[]).map(transformProjectRule);
+}
+
+// ============================================
 // Agent Memories API
 // ============================================
 

--- a/frontend/src/lib/project-rule.types.ts
+++ b/frontend/src/lib/project-rule.types.ts
@@ -1,0 +1,31 @@
+export interface ProjectRule {
+  id: string;
+  projectId: string;
+  title: string;
+  content: string;
+  orderIndex: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface ProjectRuleCreate {
+  title: string;
+  content: string;
+}
+
+export interface ProjectRuleUpdate {
+  title?: string;
+  content?: string;
+}
+
+export interface ProjectRuleListResponse {
+  items: ProjectRule[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+export interface ProjectRuleListParams {
+  page?: number;
+  pageSize?: number;
+}


### PR DESCRIPTION
## PR 标题

feat: 添加项目级规则支持

## 变更说明

- 问题: 目前仅支持全局规则，所有项目共享同一套 AI 行为规则，无法为单个作品设置独立的文风、设定等约束。
- 重要性: 不同作品往往需要不同的写作规范（文体、人称、禁忌等），全局规则无法满足多项目并行创作场景。
- 变化: 新增 `project_rules` 表（Alembic 迁移 1015）与 `/projects/{project_id}/rules` CRUD API（含 reorder）；Agent 上下文组装时在全局规则之后注入当前项目的项目级规则；写作页左侧栏新增「规则」视图，支持项目规则的新建、编辑、删除（中英文案均已补充）。
- 测试: 新增项目规则 API 测试（CRUD、跨项目隔离、项目不存在校验）与规则注入单元测试（全局+项目合并顺序、仅项目规则、无 project_id 时跳过）。

## 关联 Issue / PR (如有)

Closes #150

## 变更类型

- [x] 新功能 (feat)

## 问题原因(如有)

不适用（新功能）。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 设计决策: 采用独立 `project_rules` 表而非在 `agent_rules` 上加可空 `project_id`，全局规则的查询、UI 与锁逻辑完全不受影响；注入时按「全局规则 → 项目规则」顺序合并到同一 `<rules>` 片段。
- 项目规则的写操作与全局规则一致，受 Agent 设置锁（会话运行中禁止修改）保护。
- 迁移已在本地空库验证 `alembic upgrade head` 通过（1001→1015），`ruff check`、`ty check`、相关 pytest（17 passed）、前端 `oxlint`/`type-check`/`build` 均通过。
- 项目规则编辑入口放在写作页左侧栏（章节/笔记/规则第三个分段），如维护者希望改放全局设置弹窗或其他位置，乐意调整。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
