### PR TITLE
feat: 添加界面缩放设置以支持自定义字体大小

### DIFF
--- a/backend/app/api/routers/settings.py
+++ b/backend/app/api/routers/settings.py
@@ -62,6 +62,7 @@ SETTING_KEY_LANGUAGE = "language"
 SETTING_KEY_THEME = "theme"
 SETTING_KEY_FONT_FAMILY = "font_family"
 SETTING_KEY_CODE_FONT_FAMILY = "code_font_family"
+SETTING_KEY_UI_SCALE = "ui_scale"
 SETTING_KEY_DEFAULT_MODEL = "default_model"
 SETTING_KEY_LIGHT_MODEL = "light_model"
 SETTING_KEY_DEFAULT_EMBEDDING_MODEL = "default_embedding_model"
@@ -72,6 +73,7 @@ DEFAULT_SETTINGS = {
     SETTING_KEY_THEME: "light",
     SETTING_KEY_FONT_FAMILY: "SourceHanSerifCN-VF",
     SETTING_KEY_CODE_FONT_FAMILY: "JetBrainsMapleMono",
+    SETTING_KEY_UI_SCALE: "100",
     SETTING_KEY_DEFAULT_MODEL: "",
     SETTING_KEY_LIGHT_MODEL: "",
     SETTING_KEY_DEFAULT_EMBEDDING_MODEL: "",
@@ -239,6 +241,13 @@ async def get_settings(
         code_font_family=settings_dict.get(
             SETTING_KEY_CODE_FONT_FAMILY, DEFAULT_SETTINGS[SETTING_KEY_CODE_FONT_FAMILY]
         ),
+        ui_scale=_parse_int_setting(
+            settings_dict.get(
+                SETTING_KEY_UI_SCALE,
+                DEFAULT_SETTINGS[SETTING_KEY_UI_SCALE],
+            ),
+            default=100,
+        ),
         default_model=settings_dict.get(
             SETTING_KEY_DEFAULT_MODEL, DEFAULT_SETTINGS[SETTING_KEY_DEFAULT_MODEL]
         ),
@@ -370,6 +379,8 @@ async def update_settings(
         settings_to_update[SETTING_KEY_FONT_FAMILY] = request.font_family
     if request.code_font_family is not None:
         settings_to_update[SETTING_KEY_CODE_FONT_FAMILY] = request.code_font_family
+    if request.ui_scale is not None:
+        settings_to_update[SETTING_KEY_UI_SCALE] = str(min(200, max(50, request.ui_scale)))
     if request.default_model is not None:
         settings_to_update[SETTING_KEY_DEFAULT_MODEL] = request.default_model
     if request.light_model is not None:

--- a/backend/app/api/schemas/setting.py
+++ b/backend/app/api/schemas/setting.py
@@ -40,6 +40,7 @@ class SettingsResponse(BaseModel):
     theme: str = Field(default="light", description="主题")
     font_family: str = Field(default="SourceHanSerifCN-VF", description="字体")
     code_font_family: str = Field(default="JetBrainsMapleMono", description="代码字体")
+    ui_scale: int = Field(default=100, description="界面缩放百分比")
     default_model: str = Field(default="", description="默认模型 ID")
     light_model: str = Field(default="", description="轻量模型 ID")
     default_embedding_model: str = Field(default="", description="默认 Embedding 模型 ID")
@@ -74,6 +75,7 @@ class SettingsUpdateRequest(BaseModel):
     theme: str | None = Field(default=None, description="主题")
     font_family: str | None = Field(default=None, description="字体")
     code_font_family: str | None = Field(default=None, description="代码字体")
+    ui_scale: int | None = Field(default=None, ge=50, le=200, description="界面缩放百分比")
     default_model: str | None = Field(default=None, description="默认模型 ID")
     light_model: str | None = Field(default=None, description="轻量模型 ID")
     default_embedding_model: str | None = Field(

--- a/backend/tests/api/test_settings.py
+++ b/backend/tests/api/test_settings.py
@@ -82,6 +82,7 @@ async def test_get_settings_default(client: AsyncClient) -> None:
     assert data["theme"] == "light"
     assert data["font_family"] == "SourceHanSerifCN-VF"
     assert data["code_font_family"] == "JetBrainsMapleMono"
+    assert data["ui_scale"] == 100
     assert data["default_model"] == ""
     assert data["light_model"] == ""
     assert data["default_embedding_model"] == ""
@@ -134,6 +135,28 @@ async def test_update_settings_font(client: AsyncClient) -> None:
     assert response.status_code == 200
     data = response.json()
     assert data["font_family"] == "SourceHanSansCN-VF"
+
+
+@pytest.mark.asyncio
+async def test_update_settings_ui_scale(client: AsyncClient) -> None:
+    """测试更新界面缩放设置。"""
+    response = await client.put(
+        "/api/v1/settings",
+        json={"ui_scale": 125},
+    )
+    assert response.status_code == 200
+    assert response.json()["ui_scale"] == 125
+
+    # 持久化验证
+    response = await client.get("/api/v1/settings")
+    assert response.json()["ui_scale"] == 125
+
+    # 超出范围的值被 schema 拒绝
+    response = await client.put(
+        "/api/v1/settings",
+        json={"ui_scale": 300},
+    )
+    assert response.status_code == 422
 
 
 @pytest.mark.asyncio

--- a/frontend/src/features/settings/components/general-settings.tsx
+++ b/frontend/src/features/settings/components/general-settings.tsx
@@ -9,6 +9,7 @@ import { useTranslation } from "react-i18next";
 
 import { LabeledSelect } from "@/components/select";
 import { supportedLanguages, type LanguageCode } from "@/i18n";
+import { UI_SCALE_OPTIONS, normalizeUiScale } from "@/lib/ui-scale";
 
 import type { Settings, ThemeMode } from "../lib/settings.types";
 import { getCodeFontOptions, getFontOptions } from "../lib/settings.types";
@@ -46,6 +47,11 @@ export function GeneralSettings({
   /** 更新代码字体 */
   const handleCodeFontChange = (codeFontFamily: string) => {
     onSettingsChange({ ...settings, codeFontFamily });
+  };
+
+  /** 更新界面缩放 */
+  const handleUiScaleChange = (uiScale: string) => {
+    onSettingsChange({ ...settings, uiScale: normalizeUiScale(uiScale) });
   };
 
   return (
@@ -109,6 +115,30 @@ export function GeneralSettings({
           disabled={isSaving}
           triggerStyle={{ width: 200 }}
         />
+
+        {/* 界面缩放设置 */}
+        <Flex
+          direction="column"
+          gap="1"
+        >
+          <LabeledSelect
+            label={t("settings.uiScale")}
+            value={String(normalizeUiScale(settings.uiScale))}
+            options={UI_SCALE_OPTIONS.map((scale) => ({
+              value: String(scale),
+              label: `${scale}%`,
+            }))}
+            onChange={handleUiScaleChange}
+            disabled={isSaving}
+            triggerStyle={{ width: 200 }}
+          />
+          <Text
+            size="1"
+            color="gray"
+          >
+            {t("settings.uiScaleHint")}
+          </Text>
+        </Flex>
       </Flex>
     </Box>
   );

--- a/frontend/src/features/settings/components/settings-content.tsx
+++ b/frontend/src/features/settings/components/settings-content.tsx
@@ -13,6 +13,7 @@ import "./settings-dialog.css";
 
 import { applyCodeFontFamily, applyFontFamily, loadConfiguredFonts } from "@/lib/font-utils";
 import { OVERALL_INDEX_STATUS_QUERY_KEY } from "@/lib/index-status";
+import { applyUiScale } from "@/lib/ui-scale";
 
 import { AdvancedSettings } from "../components/advanced-settings";
 import { AgentDefinitionsSettings } from "../components/agent-definitions-settings";
@@ -130,7 +131,8 @@ export function SettingsContent({
   useEffect(() => {
     if (serverSettings?.fontFamily) applyFontFamily(serverSettings.fontFamily);
     if (serverSettings?.codeFontFamily) applyCodeFontFamily(serverSettings.codeFontFamily);
-  }, [serverSettings?.fontFamily, serverSettings?.codeFontFamily]);
+    if (serverSettings?.uiScale) applyUiScale(serverSettings.uiScale);
+  }, [serverSettings?.fontFamily, serverSettings?.codeFontFamily, serverSettings?.uiScale]);
 
   useEffect(() => {
     function handleResize() {
@@ -159,6 +161,7 @@ export function SettingsContent({
         theme: settings.theme,
         font_family: settings.fontFamily,
         code_font_family: settings.codeFontFamily,
+        ui_scale: settings.uiScale,
         agent_tool_permissions: settings.agentToolPermissions.map((item) => ({
           tool_name: item.toolName,
           mode: item.mode,
@@ -184,6 +187,7 @@ export function SettingsContent({
         onAppearanceChange(previousSettings.theme);
         applyFontFamily(previousSettings.fontFamily);
         applyCodeFontFamily(previousSettings.codeFontFamily);
+        applyUiScale(previousSettings.uiScale);
         void loadConfiguredFonts(previousSettings.fontFamily, previousSettings.codeFontFamily);
       }
 
@@ -203,6 +207,7 @@ export function SettingsContent({
       onAppearanceChange(newSettings.theme);
       applyFontFamily(newSettings.fontFamily);
       applyCodeFontFamily(newSettings.codeFontFamily);
+      applyUiScale(newSettings.uiScale);
       void loadConfiguredFonts(newSettings.fontFamily, newSettings.codeFontFamily);
       setEditedSettings(newSettings);
       saveMutation.mutate(newSettings);

--- a/frontend/src/features/settings/lib/settings-api.ts
+++ b/frontend/src/features/settings/lib/settings-api.ts
@@ -5,6 +5,7 @@
  */
 
 import { apiClient } from "@/lib/api-client";
+import { DEFAULT_UI_SCALE, normalizeUiScale } from "@/lib/ui-scale";
 
 import type {
   AgentToolMetadata,
@@ -28,6 +29,7 @@ export function transformSettings(raw: SettingsResponse): Settings {
     theme: raw.theme as Settings["theme"],
     fontFamily: getSupportedFontFamily(raw.font_family),
     codeFontFamily: getSupportedCodeFontFamily(raw.code_font_family || DEFAULT_CODE_FONT_FAMILY),
+    uiScale: normalizeUiScale(raw.ui_scale ?? DEFAULT_UI_SCALE),
     defaultModel: raw.default_model || "",
     lightModel: raw.light_model || "",
     defaultEmbeddingModel: raw.default_embedding_model || "",

--- a/frontend/src/features/settings/lib/settings.types.ts
+++ b/frontend/src/features/settings/lib/settings.types.ts
@@ -30,6 +30,7 @@ export interface Settings {
   theme: ThemeMode;
   fontFamily: string;
   codeFontFamily: string;
+  uiScale: number;
   defaultModel: string;
   lightModel: string;
   defaultEmbeddingModel: string;
@@ -51,6 +52,7 @@ export interface SettingsResponse {
   theme: string;
   font_family: string;
   code_font_family?: string;
+  ui_scale?: number;
   default_model: string;
   light_model: string;
   default_embedding_model: string;
@@ -75,6 +77,7 @@ export interface SettingsUpdateRequest {
   theme?: string;
   font_family?: string;
   code_font_family?: string;
+  ui_scale?: number;
   default_model?: string;
   light_model?: string;
   default_embedding_model?: string;

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -721,6 +721,8 @@
     "themeDark": "Dark",
     "fontFamily": "Font",
     "codeFontFamily": "Code Font",
+    "uiScale": "Interface zoom",
+    "uiScaleHint": "Scale up the whole interface and text, useful on high-resolution screens",
     "fontOptionSystemDefault": "System default",
     "fontOptionSourceHanSerif": "Source Han Serif",
     "fontOptionSourceHanSans": "Source Han Sans",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -721,6 +721,8 @@
     "themeDark": "深色",
     "fontFamily": "字体",
     "codeFontFamily": "代码字体",
+    "uiScale": "界面缩放",
+    "uiScaleHint": "放大整体界面与文字，适合高分辨率屏幕",
     "fontOptionSystemDefault": "系统默认",
     "fontOptionSourceHanSerif": "思源宋体",
     "fontOptionSourceHanSans": "思源黑体",

--- a/frontend/src/lib/ui-scale.ts
+++ b/frontend/src/lib/ui-scale.ts
@@ -1,0 +1,30 @@
+/**
+ * UI Scale Utils
+ *
+ * 界面缩放：以百分比缩放整个应用界面（含字体），
+ * 用于高分屏下增大文字与控件尺寸。
+ */
+
+export const UI_SCALE_OPTIONS = [75, 90, 100, 110, 125, 150] as const;
+
+export const DEFAULT_UI_SCALE = 100;
+
+export const MIN_UI_SCALE = 50;
+export const MAX_UI_SCALE = 200;
+
+export function normalizeUiScale(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed)) return DEFAULT_UI_SCALE;
+  return Math.min(MAX_UI_SCALE, Math.max(MIN_UI_SCALE, Math.round(parsed)));
+}
+
+/** 将界面缩放应用到文档根元素。 */
+export function applyUiScale(scale: number): void {
+  const normalized = normalizeUiScale(scale);
+  const root = document.documentElement;
+  if (normalized === DEFAULT_UI_SCALE) {
+    root.style.removeProperty("zoom");
+    return;
+  }
+  root.style.setProperty("zoom", `${normalized}%`);
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -20,6 +20,7 @@ import { getOrCreateRoot } from "./lib/get-or-create-root";
 import { loadRuntimeConfig } from "./lib/runtime-config";
 import { connectSocket } from "./lib/socket-client";
 import { preloadTiktokenEncoding } from "./lib/tiktoken-utils";
+import { applyUiScale } from "./lib/ui-scale";
 import { registerSW } from "./pwa/register-sw";
 
 import "streamdown/styles.css";
@@ -136,6 +137,7 @@ function Root() {
 
         applyFontFamily(settings.fontFamily);
         applyCodeFontFamily(settings.codeFontFamily);
+        applyUiScale(settings.uiScale);
         await loadConfiguredFonts(settings.fontFamily, settings.codeFontFamily);
 
         if (mounted) {


### PR DESCRIPTION
## PR 标题

feat: 添加界面缩放设置以支持自定义字体大小

## 变更说明

- 问题: 高分辨率屏幕（如 34 寸 4K 125% 缩放）下界面文字过小，且没有任何自定义字体大小/缩放的入口。
- 重要性: 影响高分屏用户的基本可读性与长时间写作的舒适度。
- 变化: 设置新增 `ui_scale`（50–200%，默认 100%）并持久化到后端设置存储；前端在应用启动与设置变更时通过根元素 `zoom` 应用缩放，统一放大控件与文字（含编辑器正文，桌面端同样生效）；通用设置页新增「界面缩放」下拉（75%/90%/100%/110%/125%/150% 预设），即时生效、保存失败自动回滚。
- 测试: 新增 settings API 的 `ui_scale` 默认值、更新、持久化与越界（422）校验测试。

## 关联 Issue / PR (如有)

Closes #133

## 变更类型

- [x] 新功能 (feat)

## 问题原因(如有)

不适用（新功能）。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 选择根元素 `zoom` 而非 Radix Themes 的 `scaling` prop：后者最高仅 110% 且不影响自定义 px 样式与编辑器正文；`zoom` 可整体等比放大，Chromium（桌面端）、Safari 及 Firefox 126+ 均支持。
- 后端 `just check`（ruff、ty）与 settings 相关 pytest（20 passed）、前端 `oxlint`/`type-check`/`build` 均通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
