### PR TITLE
fix(backend): 修复聊天界面 token 用量始终为 0 的问题

### DIFF
--- a/backend/app/models/clients/model_factory.py
+++ b/backend/app/models/clients/model_factory.py
@@ -76,6 +76,8 @@ def _openai_compatible_kwargs(config: ModelConfig) -> dict[str, Any]:
         presence_penalty=_non_default(config.presence_penalty, DEFAULT_PRESENCE_PENALTY),
         reasoning_effort=config.reasoning_effort,
         max_retries=0,
+        # 流式响应默认不携带 usage，需显式开启才能统计 token 消耗
+        stream_usage=True,
     )
     extra_body = {
         name: value
@@ -148,6 +150,7 @@ def create_chat_model(config: ModelConfig) -> BaseChatModel:
             max_tokens=config.max_tokens,
             reasoning_effort=config.reasoning_effort,
             max_retries=0,
+            stream_usage=True,
         ))
 
     if provider == "mistral":
@@ -179,6 +182,7 @@ def create_chat_model(config: ModelConfig) -> BaseChatModel:
                 config.presence_penalty, DEFAULT_PRESENCE_PENALTY
             ),
             max_retries=0,
+            stream_usage=True,
         ))
 
     if provider == "groq":

--- a/backend/tests/agent_runtime/test_model_factory.py
+++ b/backend/tests/agent_runtime/test_model_factory.py
@@ -118,6 +118,39 @@ def test_create_chat_model_sends_non_default_advanced_params():
     }
 
 
+def test_create_chat_model_enables_stream_usage_for_openai_like_models():
+    config = ModelConfig(
+        provider_type="openai",
+        base_url="https://api.openai.com/v1",
+        api_key="sk-test",
+        model_id="gpt-4o",
+    )
+    model = create_chat_model(config)
+    assert model.stream_usage is True
+
+
+def test_create_chat_model_enables_stream_usage_for_deepseek():
+    config = ModelConfig(
+        provider_type="deepseek",
+        base_url="https://api.deepseek.com",
+        api_key="sk-test",
+        model_id="deepseek-v4-flash",
+    )
+    model = create_chat_model(config)
+    assert model.stream_usage is True
+
+
+def test_create_chat_model_enables_stream_usage_for_openrouter():
+    config = ModelConfig(
+        provider_type="openrouter",
+        base_url="https://openrouter.ai/api/v1",
+        api_key="sk-or-test",
+        model_id="openai/gpt-4o-mini",
+    )
+    model = create_chat_model(config)
+    assert model.stream_usage is True
+
+
 def test_create_chat_model_disables_provider_internal_retries_for_openai_like_models():
     config = ModelConfig(
         provider_type="openai",


### PR DESCRIPTION
## PR 标题

fix(backend): 修复聊天界面 token 用量始终为 0 的问题

## 变更说明

- 问题: 聊天界面的 Tokens 指示器（上行/下行/缓存）始终显示 0，无法用于判断何时该做上下文总结。
- 重要性: token 计数是用户判断会话消耗与总结时机的关键信息，影响所有使用 OpenAI 兼容渠道（含 DeepSeek、OpenRouter）的用户。
- 变化: 为 `ChatOpenAI`（openai / openai-compatible / ollama 等回退路径）、`ChatDeepSeek`、`ChatOpenRouter` 显式传入 `stream_usage=True`，流式响应末尾会携带 usage 统计（对 OpenAI 兼容 API 即 `stream_options: {"include_usage": true}`）。
- 测试: 新增三个工厂测试断言上述客户端 `stream_usage` 已开启；既有 `_default_params` 精确断言测试不受影响（22 passed）。

## 关联 Issue / PR (如有)

Closes #153

## 变更类型

- [x] 错误修复 (fix)

## 问题原因(如有)

Agent 运行时通过 `astream_events` 消费 LLM 流式输出，在 `on_chat_model_end` 时从聚合输出的 `usage_metadata` 提取 token 用量（`event_translator._extract_usage`）。但 LangChain 的 OpenAI 系客户端默认 `stream_usage=False`，流式请求不带 `stream_options.include_usage`，服务端不回传 usage，`usage_metadata` 为空 → `agent:usage` 事件从未发出 → 任务 token 累计（`task_usage_delta`）与加入会话时的快照（`task_usage_snapshot`）全为 0，前端指示器因此恒为 0。Anthropic 客户端默认开启（`stream_usage=True`），故仅 OpenAI 兼容路径受影响。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- `stream_options.include_usage` 为 OpenAI 2024 年起的标准参数，vLLM、llama.cpp、one-api/new-api、SiliconFlow、DashScope 等主流兼容实现均已支持；若个别陈旧代理不支持该参数，可能需要在其侧升级（这是极少数情况，且是获取流式 usage 的唯一标准途径）。
- Groq 客户端无 `stream_usage` 参数，保持原样；Anthropic 默认已开启，无需改动。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
