### PR TITLE
feat(backend): 为 edit_chapter 和 edit_note 引入模糊匹配与归一化机制

### DIFF
--- a/backend/app/agent_runtime/tools/impls/chapter/diff_preview.py
+++ b/backend/app/agent_runtime/tools/impls/chapter/diff_preview.py
@@ -12,6 +12,7 @@ from app.agent_runtime.tools.impls.chapter.refs import (
     resolve_chapter_from_list,
     resolve_volume_from_list,
 )
+from app.agent_runtime.tools.text_match import fuzzy_replace
 from app.storage.models.chapter import Chapter
 from app.storage.models.volume import Volume
 from app.storage.repos import chapter_repo, volume_repo
@@ -165,12 +166,12 @@ async def build_edit_chapter_tool_result_preview(
     updated_title = new_title if new_title is not None else before.title
     updated_content = before.content
     if old_content is not None and new_content is not None:
-        if old_content not in updated_content:
+        replace_result = fuzzy_replace(
+            updated_content, old_content, new_content, replace_all=replace_all
+        )
+        if replace_result is None:
             return None
-        if replace_all:
-            updated_content = updated_content.replace(old_content, new_content)
-        else:
-            updated_content = updated_content.replace(old_content, new_content, 1)
+        updated_content = replace_result.new_content
 
     after = ChapterPreviewData(
         id=before.id,

--- a/backend/app/agent_runtime/tools/impls/chapter/edit_chapter.py
+++ b/backend/app/agent_runtime/tools/impls/chapter/edit_chapter.py
@@ -24,6 +24,7 @@ from app.agent_runtime.tools.impls.chapter.refs import (
     resolve_volume_from_list,
 )
 from app.agent_runtime.tools.registry import ToolRegistry
+from app.agent_runtime.tools.text_match import fuzzy_replace
 from app.storage.database import create_session
 from app.storage.repos import chapter_repo, volume_repo
 from app.storage.services.version_control_service import refresh_project_stats
@@ -57,6 +58,13 @@ class EditChapterInput(BaseModel):
         default=False,
         description="是否替换命中的全部 old_content，false 时只替换首个匹配项",
     )
+
+    @field_validator("old_content", mode="after")
+    @classmethod
+    def reject_empty_old_content(cls, v):
+        if v is not None and v == "":
+            raise ValueError("old_content 不能为空字符串")
+        return v
 
     @field_validator("new_content", mode="after")
     @classmethod
@@ -132,12 +140,12 @@ class EditChapterTool(AgentTool):
             if new_title is not None:
                 match.title = new_title
             if old_content is not None and new_content is not None:
-                if old_content not in match.content:
+                replace_result = fuzzy_replace(
+                    match.content, old_content, new_content, replace_all=replace_all
+                )
+                if replace_result is None:
                     raise ToolExecutionError("未在章节内容中找到要替换的文本")
-                if replace_all:
-                    match.content = match.content.replace(old_content, new_content)
-                else:
-                    match.content = match.content.replace(old_content, new_content, 1)
+                match.content = replace_result.new_content
                 match.word_count = count_words(match.content)
             await chapter_repo.update_chapter(session, match)
             chapter_diff = build_chapter_diff_preview(

--- a/backend/app/agent_runtime/tools/impls/context/character.py
+++ b/backend/app/agent_runtime/tools/impls/context/character.py
@@ -12,6 +12,7 @@ from app.agent_runtime.revisions import (
 from app.agent_runtime.tools.base import AgentTool
 from app.agent_runtime.tools.errors import ToolExecutionError
 from app.agent_runtime.tools.registry import ToolRegistry
+from app.agent_runtime.tools.text_match import fuzzy_replace
 from app.storage.database import create_session
 from app.storage.models.character import Character
 from app.storage.repos import character_repo
@@ -37,6 +38,13 @@ class EditCharacterInput(BaseModel):
     old_description: str | None = Field(default=None, description="要查找并替换的原始描述文本")
     new_description: str | None = Field(default=None, description="用于替换 old_description 的新描述文本")
     replace_all: bool = Field(default=False, description="是否替换命中的全部 old_description")
+
+    @field_validator("old_description", mode="after")
+    @classmethod
+    def reject_empty_old_description(cls, v):
+        if v is not None and v == "":
+            raise ValueError("old_description 不能为空字符串")
+        return v
 
     @field_validator("new_description", mode="after")
     @classmethod
@@ -304,13 +312,13 @@ class EditCharacterTool(AgentTool):
             before = _preview_from_character(character)
             description = before.description
             if old_description is not None and new_description is not None:
-                if old_description not in description:
-                    return None
-                description = (
-                    description.replace(old_description, new_description)
-                    if bool(args.get("replace_all"))
-                    else description.replace(old_description, new_description, 1)
+                replace_result = fuzzy_replace(
+                    description, old_description, new_description,
+                    replace_all=bool(args.get("replace_all")),
                 )
+                if replace_result is None:
+                    return None
+                description = replace_result.new_content
             updated_name = (
                 await _ensure_name_available(
                     session,
@@ -351,13 +359,13 @@ class EditCharacterTool(AgentTool):
             before = _preview_from_character(character)
             description = character.description
             if old_description is not None and new_description is not None:
-                if old_description not in description:
-                    raise ToolExecutionError("未在角色描述中找到要替换的文本")
-                description = (
-                    description.replace(old_description, new_description)
-                    if replace_all
-                    else description.replace(old_description, new_description, 1)
+                replace_result = fuzzy_replace(
+                    description, old_description, new_description,
+                    replace_all=replace_all,
                 )
+                if replace_result is None:
+                    raise ToolExecutionError("未在角色描述中找到要替换的文本")
+                description = replace_result.new_content
             normalized_new_name = None
             if new_name is not None:
                 normalized_new_name = await _ensure_name_available(

--- a/backend/app/agent_runtime/tools/impls/context/world_entry.py
+++ b/backend/app/agent_runtime/tools/impls/context/world_entry.py
@@ -12,6 +12,7 @@ from app.agent_runtime.revisions import (
 from app.agent_runtime.tools.base import AgentTool
 from app.agent_runtime.tools.errors import ToolExecutionError
 from app.agent_runtime.tools.registry import ToolRegistry
+from app.agent_runtime.tools.text_match import fuzzy_replace
 from app.storage.database import create_session
 from app.storage.models.world_info_entry import WorldInfoEntry
 from app.storage.repos import world_info_entry_repo, world_info_repo
@@ -37,6 +38,13 @@ class EditWorldEntryInput(BaseModel):
     old_content: str | None = Field(default=None, description="要查找并替换的原始文本")
     new_content: str | None = Field(default=None, description="用于替换 old_content 的新文本")
     replace_all: bool = Field(default=False, description="是否替换命中的全部 old_content，false 时只替换首个匹配项")
+
+    @field_validator("old_content", mode="after")
+    @classmethod
+    def reject_empty_old_content(cls, v):
+        if v is not None and v == "":
+            raise ValueError("old_content 不能为空字符串")
+        return v
 
     @field_validator("new_content", mode="after")
     @classmethod
@@ -334,13 +342,13 @@ class EditWorldEntryTool(AgentTool):
             before = _preview_from_entry(entry)
             content = before.content
             if old_content is not None and new_content is not None:
-                if old_content not in content:
-                    return None
-                content = (
-                    content.replace(old_content, new_content)
-                    if bool(args.get("replace_all"))
-                    else content.replace(old_content, new_content, 1)
+                replace_result = fuzzy_replace(
+                    content, old_content, new_content,
+                    replace_all=bool(args.get("replace_all")),
                 )
+                if replace_result is None:
+                    return None
+                content = replace_result.new_content
             updated_title = (
                 await _ensure_title_available(
                     session,
@@ -386,13 +394,12 @@ class EditWorldEntryTool(AgentTool):
             before = _preview_from_entry(entry)
             content = entry.content
             if old_content is not None and new_content is not None:
-                if old_content not in content:
-                    raise ToolExecutionError("未在世界书条目内容中找到要替换的文本")
-                content = (
-                    content.replace(old_content, new_content)
-                    if replace_all
-                    else content.replace(old_content, new_content, 1)
+                replace_result = fuzzy_replace(
+                    content, old_content, new_content, replace_all=replace_all
                 )
+                if replace_result is None:
+                    raise ToolExecutionError("未在世界书条目内容中找到要替换的文本")
+                content = replace_result.new_content
             normalized_new_title = None
             if new_title is not None:
                 normalized_new_title = await _ensure_title_available(

--- a/backend/app/agent_runtime/tools/impls/note/edit_note.py
+++ b/backend/app/agent_runtime/tools/impls/note/edit_note.py
@@ -7,7 +7,7 @@ import json
 from difflib import SequenceMatcher
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from app.agent_runtime.tools.base import AgentTool
 from app.agent_runtime.revisions import (
@@ -21,6 +21,7 @@ from app.agent_runtime.tools.impls.note.refs import (
     resolve_note_from_list,
 )
 from app.agent_runtime.tools.registry import ToolRegistry
+from app.agent_runtime.tools.text_match import fuzzy_replace
 from app.storage.database import create_session
 from app.storage.repos import note_category_repo, note_repo
 
@@ -67,6 +68,13 @@ class EditNoteInput(BaseModel):
     old_content: str = Field(description="要查找并替换的原始文本")
     new_content: str = Field(description="用于替换 old_content 的新文本")
 
+    @field_validator("old_content", mode="after")
+    @classmethod
+    def reject_empty_old_content(cls, v: str) -> str:
+        if v == "":
+            raise ValueError("old_content 不能为空字符串")
+        return v
+
 
 @ToolRegistry.register
 class EditNoteTool(AgentTool):
@@ -105,11 +113,15 @@ class EditNoteTool(AgentTool):
             note.project_id != self.project_id
             or note.is_locked
             or note.is_hidden
-            or old_content not in note.content
         ):
             return None
 
-        preview_content = note.content.replace(old_content, new_content)
+        preview_result = fuzzy_replace(
+            note.content, old_content, new_content, replace_all=True
+        )
+        if preview_result is None:
+            return None
+        preview_content = preview_result.new_content
         return {
             "type": "preview",
             "success": True,
@@ -162,16 +174,18 @@ class EditNoteTool(AgentTool):
             if note.is_hidden:
                 raise ToolExecutionError("该笔记已隐藏")
 
-            if old_content not in note.content:
-                raise ToolExecutionError("未在笔记内容中找到要替换的文本")
-
             before = note_images_by_id(
                 await note_repo.list_by_project(
                     session, self.project_id, include_hidden=True
                 )
             )
             before_content = note.content
-            note.content = note.content.replace(old_content, new_content)
+            replace_result = fuzzy_replace(
+                note.content, old_content, new_content, replace_all=True
+            )
+            if replace_result is None:
+                raise ToolExecutionError("未在笔记内容中找到要替换的文本")
+            note.content = replace_result.new_content
             await note_repo.update_note(session, note)
             after = note_images_by_id(
                 await note_repo.list_by_project(

--- a/backend/app/agent_runtime/tools/text_match.py
+++ b/backend/app/agent_runtime/tools/text_match.py
@@ -141,6 +141,28 @@ class FuzzyReplaceResult:
     used_fuzzy_match: bool
 
 
+def _query_had_stripped_trailing_whitespace(text: str) -> bool:
+    """Return whether normalization stripped trailing whitespace from the
+    last line of ``text`` (already LF-normalized).
+
+    Stripping the query's last line can turn it into a *prefix* of a longer
+    run in the content -- e.g. query ``"foo "`` matching the ``"foo"`` head
+    of ``"foobar"`` -- which would let a sloppy query silently rewrite text
+    the agent never quoted, so such matches must be boundary-checked. Only the
+    final line's trailing whitespace matters: a query ending in a newline
+    keeps that newline verbatim in normalized form, so it cannot create a
+    prefix.
+    """
+    last_line = text.rsplit("\n", 1)[-1]
+    return bool(last_line) and last_line != last_line.rstrip()
+
+
+def _match_end_is_whitespace_or_end(content: str, pos: int, length: int) -> bool:
+    """Return whether ``pos`` is at or past the end of ``content`` or points at
+    a whitespace character."""
+    return pos >= length or content[pos].isspace()
+
+
 def fuzzy_replace(
     content: str,
     old_text: str,
@@ -187,16 +209,35 @@ def fuzzy_replace(
     if not fuzzy_old_text:
         return None
 
+    # When the query's trailing whitespace was stripped by normalization,
+    # ``fuzzy_old_text`` may be a *prefix* of a longer run in the content --
+    # e.g. query ``"foo "`` matches the ``"foo"`` head of ``"foobar"`` --
+    # which would let a sloppy query silently rewrite text the agent never
+    # quoted. Guard such matches: the content must continue with whitespace
+    # (or end) right after the match, so the stripped trailing whitespace still
+    # aligns with real whitespace in the original. Otherwise the match is a
+    # prefix artifact and is skipped; if none survive, the call is "not found".
+    boundary_check = _query_had_stripped_trailing_whitespace(old_text)
+    fuzzy_len = len(fuzzy_old_text)
+    content_len = len(fuzzy_content)
+
     replacements: list[tuple[int, int, str]] = []
     start = 0
     while True:
         idx = fuzzy_content.find(fuzzy_old_text, start)
         if idx == -1:
             break
-        replacements.append((idx, len(fuzzy_old_text), new_text))
+        match_end = idx + fuzzy_len
+        if boundary_check and not _match_end_is_whitespace_or_end(
+            fuzzy_content, match_end, content_len
+        ):
+            # Prefix artifact: keep scanning for a genuine occurrence.
+            start = idx + 1
+            continue
+        replacements.append((idx, fuzzy_len, new_text))
         if not replace_all:
             break
-        start = idx + len(fuzzy_old_text)
+        start = match_end
 
     if not replacements:
         return None

--- a/backend/app/agent_runtime/tools/text_match.py
+++ b/backend/app/agent_runtime/tools/text_match.py
@@ -1,0 +1,207 @@
+"""Fuzzy text matching for edit tools."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+_LINE_SPLIT_RE = re.compile(r"[^\n]*\n|[^\n]+")
+
+
+def normalize_for_fuzzy_match(text: str) -> str:
+    """Normalize text for fuzzy matching.
+
+    Strips trailing whitespace per line, and converts smart quotes, Unicode
+    dashes and special spaces to ASCII. NFKC normalization is intentionally
+    NOT applied: it would convert fullwidth CJK punctuation (，！？：； …) to
+    halfwidth, corrupting Chinese prose style on the rewritten lines.
+    """
+    text = "\n".join(line.rstrip() for line in text.split("\n"))
+    # Smart single quotes -> '
+    text = re.sub(r"[\u2018\u2019\u201A\u201B]", "'", text)
+    # Smart double quotes -> "
+    text = re.sub(r"[\u201C\u201D\u201E\u201F]", '"', text)
+    # Various dashes/hyphens -> -
+    # U+2010 hyphen, U+2011 non-breaking hyphen, U+2012 figure dash,
+    # U+2013 en-dash, U+2014 em-dash, U+2015 horizontal bar, U+2212 minus
+    text = re.sub(r"[\u2010\u2011\u2012\u2013\u2014\u2015\u2212]", "-", text)
+    # Special spaces -> regular space
+    # U+00A0 NBSP, U+2002-U+200A various spaces, U+202F narrow NBSP,
+    # U+205F medium math space, U+3000 ideographic space
+    text = re.sub(r"[\u00A0\u2002-\u200A\u202F\u205F\u3000]", " ", text)
+    return text
+
+
+def _split_lines_with_endings(content: str) -> list[str]:
+    return _LINE_SPLIT_RE.findall(content)
+
+
+def _get_line_spans(content: str) -> list[tuple[int, int]]:
+    spans: list[tuple[int, int]] = []
+    offset = 0
+    for line in _split_lines_with_endings(content):
+        spans.append((offset, offset + len(line)))
+        offset = spans[-1][1]
+    return spans
+
+
+def _apply_replacements(
+    content: str,
+    replacements: list[tuple[int, int, str]],
+    offset: int = 0,
+) -> str:
+    """Apply replacements (match_index, match_length, new_text) in reverse order."""
+    result = content
+    for match_index, match_length, new_text in reversed(replacements):
+        idx = match_index - offset
+        result = result[:idx] + new_text + result[idx + match_length:]
+    return result
+
+
+def _apply_replacements_preserving_unchanged(
+    original_content: str,
+    base_content: str,
+    replacements: list[tuple[int, int, str]],
+) -> str:
+    """Apply replacements matched against ``base_content`` to ``original_content``.
+
+    Each replacement is widened to the lines it touches, those touched lines
+    are rewritten from the normalized base, and all other lines are copied back
+    from ``original_content``. The actual replacement ranges drive preservation
+    so duplicate normalized lines cannot be aligned to the wrong occurrence.
+
+    Replacements must be processed in source order. A single monotonic line
+    cursor advances across the sorted matches, so the whole pass is O(n) in the
+    number of lines/matches instead of O(n^2).
+    """
+    original_lines = _split_lines_with_endings(original_content)
+    base_spans = _get_line_spans(base_content)
+    if len(original_lines) != len(base_spans):
+        raise ValueError(
+            "Cannot preserve unchanged lines: base content has a different line count."
+        )
+    line_ends = [e for _, e in base_spans]
+    n_lines = len(base_spans)
+
+    sorted_reps = sorted(replacements, key=lambda r: r[0])
+    groups: list[dict] = []
+    # Monotonic cursor: because replacements are sorted by match_index, the
+    # containing line index never decreases across iterations.
+    cursor = 0
+    for rep in sorted_reps:
+        match_index, match_length, _ = rep
+        match_end = match_index + match_length
+        # Advance the cursor to the line containing match_index.
+        while cursor < n_lines and line_ends[cursor] <= match_index:
+            cursor += 1
+        if cursor >= n_lines:
+            raise ValueError("Replacement range is outside the base content.")
+        start_line = cursor
+        # The end line is >= start_line; advance a separate cursor so the outer
+        # cursor stays valid for subsequent (later) replacements.
+        end_cursor = cursor
+        while end_cursor < n_lines and line_ends[end_cursor] < match_end:
+            end_cursor += 1
+        if end_cursor >= n_lines:
+            raise ValueError("Replacement range is outside the base content.")
+        end_line = end_cursor + 1
+        if groups and start_line < groups[-1]["end_line"]:
+            groups[-1]["end_line"] = max(groups[-1]["end_line"], end_line)
+            groups[-1]["replacements"].append(rep)
+            continue
+        groups.append(
+            {"start_line": start_line, "end_line": end_line, "replacements": [rep]}
+        )
+    # Collect fragments into a list and join once at the end. Repeated
+    # ``result += ...`` would copy the growing accumulator on every group,
+    # degrading to O(n^2) when ``replace_all`` produces many groups.
+    fragments: list[str] = []
+    original_line_index = 0
+    for group in groups:
+        fragments.append(
+            "".join(original_lines[original_line_index:group["start_line"]])
+        )
+        group_start_offset = base_spans[group["start_line"]][0]
+        group_end_offset = base_spans[group["end_line"] - 1][1]
+        fragments.append(
+            _apply_replacements(
+                base_content[group_start_offset:group_end_offset],
+                group["replacements"],
+                group_start_offset,
+            )
+        )
+        original_line_index = group["end_line"]
+    fragments.append("".join(original_lines[original_line_index:]))
+    return "".join(fragments)
+
+
+@dataclass(frozen=True)
+class FuzzyReplaceResult:
+    new_content: str
+    used_fuzzy_match: bool
+
+
+def fuzzy_replace(
+    content: str,
+    old_text: str,
+    new_text: str,
+    *,
+    replace_all: bool = False,
+) -> FuzzyReplaceResult | None:
+    """Find ``old_text`` in ``content`` and replace it with ``new_text``.
+
+    Exact match is attempted first. If that fails, a fuzzy match is attempted
+    by normalizing both texts (see :func:`normalize_for_fuzzy_match`). When
+    fuzzy matching is used, unchanged line blocks are preserved from the
+    original content so only the touched lines are rewritten from the
+    normalized space.
+
+    Returns ``None`` if ``old_text`` cannot be found (even after fuzzy
+    normalization). Raises ``ValueError`` if ``old_text`` is empty.
+    """
+    if not old_text:
+        raise ValueError("old_text must not be empty")
+
+    # Normalize line endings to LF first (mirrors Pi's normalizeToLF).
+    content = content.replace("\r\n", "\n").replace("\r", "\n")
+    old_text = old_text.replace("\r\n", "\n").replace("\r", "\n")
+    new_text = new_text.replace("\r\n", "\n").replace("\r", "\n")
+
+    # 1. Exact match
+    exact_index = content.find(old_text)
+    if exact_index != -1:
+        if replace_all:
+            new_content = content.replace(old_text, new_text)
+        else:
+            new_content = content.replace(old_text, new_text, 1)
+        return FuzzyReplaceResult(new_content, used_fuzzy_match=False)
+
+    # 2. Fuzzy match - work in normalized space
+    fuzzy_content = normalize_for_fuzzy_match(content)
+    fuzzy_old_text = normalize_for_fuzzy_match(old_text)
+
+    # A whitespace-only query (spaces, tabs, line-trailing whitespace) collapses
+    # to an empty string after normalization. ``find("")`` would match at every
+    # position -- corrupting content with ``replace_all=False`` and looping
+    # forever with ``replace_all=True``. Treat it as "not found".
+    if not fuzzy_old_text:
+        return None
+
+    replacements: list[tuple[int, int, str]] = []
+    start = 0
+    while True:
+        idx = fuzzy_content.find(fuzzy_old_text, start)
+        if idx == -1:
+            break
+        replacements.append((idx, len(fuzzy_old_text), new_text))
+        if not replace_all:
+            break
+        start = idx + len(fuzzy_old_text)
+
+    if not replacements:
+        return None
+
+    new_content = _apply_replacements_preserving_unchanged(
+        content, fuzzy_content, replacements
+    )
+    return FuzzyReplaceResult(new_content, used_fuzzy_match=True)

--- a/backend/tests/agent_runtime/tools/test_chapter_tools.py
+++ b/backend/tests/agent_runtime/tools/test_chapter_tools.py
@@ -684,3 +684,20 @@ async def test_move_chapter_to_volume_appends_to_target_volume() -> None:
         "vol-2",
         record_activity=False,
     )
+
+
+def test_edit_chapter_input_rejects_empty_old_content() -> None:
+    # Regression: an empty old_content previously passed model validation but
+    # made fuzzy_replace raise / corrupt content. It must be rejected early.
+    import pytest
+    from pydantic import ValidationError
+
+    from app.agent_runtime.tools.impls.chapter.edit_chapter import EditChapterInput
+
+    with pytest.raises(ValidationError):
+        EditChapterInput.model_validate({
+            "volume_ref": {"type": "order", "value": 1},
+            "chapter_ref": {"type": "order", "value": 1},
+            "old_content": "",
+            "new_content": "x",
+        })

--- a/backend/tests/agent_runtime/tools/test_context_tools.py
+++ b/backend/tests/agent_runtime/tools/test_context_tools.py
@@ -282,6 +282,19 @@ async def test_create_character_returns_diff() -> None:
     }
 
 
+def test_edit_character_input_rejects_empty_old_description() -> None:
+    from pydantic import ValidationError
+
+    from app.agent_runtime.tools.impls.context.character import EditCharacterInput
+
+    with pytest.raises(ValidationError):
+        EditCharacterInput.model_validate({
+            "name": "林舟",
+            "old_description": "",
+            "new_description": "x",
+        })
+
+
 @pytest.mark.asyncio
 async def test_edit_character_replaces_description_text() -> None:
     from app.agent_runtime.tools.impls.context.character import EditCharacterTool
@@ -556,6 +569,19 @@ async def test_create_world_entry_rejects_duplicate_title() -> None:
         result = await tool.ainvoke({"title": "主角", "content": "林舟"})
 
     assert json.loads(result) == {"error": "世界书条目标题已存在: 主角"}
+
+
+def test_edit_world_entry_input_rejects_empty_old_content() -> None:
+    from pydantic import ValidationError
+
+    from app.agent_runtime.tools.impls.context.world_entry import EditWorldEntryInput
+
+    with pytest.raises(ValidationError):
+        EditWorldEntryInput.model_validate({
+            "title": "主角",
+            "old_content": "",
+            "new_content": "x",
+        })
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/tools/test_note_tools.py
+++ b/backend/tests/agent_runtime/tools/test_note_tools.py
@@ -875,3 +875,19 @@ async def test_delete_note_category_rejects_category_from_another_project() -> N
             result = await tool.ainvoke({"category_ref": {"id": "cat-1"}})
 
     assert json.loads(result)["error"] == "分类不属于当前项目"
+
+
+def test_edit_note_input_rejects_empty_old_content() -> None:
+    # Regression: an empty old_content previously passed model validation but
+    # made fuzzy_replace raise. It must be rejected early.
+    import pytest
+    from pydantic import ValidationError
+
+    from app.agent_runtime.tools.impls.note.edit_note import EditNoteInput
+
+    with pytest.raises(ValidationError):
+        EditNoteInput.model_validate({
+            "note_ref": {"id": "note-1"},
+            "old_content": "",
+            "new_content": "x",
+        })

--- a/backend/tests/agent_runtime/tools/test_text_match.py
+++ b/backend/tests/agent_runtime/tools/test_text_match.py
@@ -257,3 +257,76 @@ def test_replace_all_fuzzy_many_matches_is_linear() -> None:
     assert result is not None
     assert result.used_fuzzy_match is True
     assert result.new_content == "\n".join("b" for _ in range(n))
+
+
+# ---------------------------------------------------------------------------
+# fuzzy_replace - stripped trailing whitespace must not match a prefix
+# ---------------------------------------------------------------------------
+
+
+def test_query_trailing_space_does_not_match_prefix() -> None:
+    # Regression: the agent quoted "foo " but the content is "foobar" with no
+    # space after "foo". Stripping the query's trailing space used to turn it
+    # into a prefix match, rewriting "foo" and leaving the dangling "bar"
+    # appended to the new text ("Xbar"). It must now be reported as not found.
+    assert fuzzy_replace("foobar", "foo ", "X") is None
+
+
+def test_query_trailing_space_does_not_match_prefix_cjk() -> None:
+    # The exact scenario from the bug report: "角色代号：foo " (trailing space)
+    # must not match the "角色代号：foo" head of "角色代号：foobar".
+    assert (
+        fuzzy_replace("角色代号：foobar", "角色代号：foo ", "角色代号：已修正") is None
+    )
+
+
+def test_query_trailing_space_aligns_with_content_trailing_ws() -> None:
+    # The content has trailing NBSP after "foo"; the agent used a regular
+    # trailing space. After normalization both collapse, and the match ends at
+    # the end of content -- a genuine boundary, not a prefix artifact -- so the
+    # replacement is allowed. The boundary guard must not over-reject here.
+    result = fuzzy_replace("foo\u00a0", "foo ", "X")
+    assert result == FuzzyReplaceResult("X", used_fuzzy_match=True)
+
+
+def test_query_trailing_space_aligns_with_content_interior_ws() -> None:
+    # The content has an interior NBSP (foo + NBSP + bar); the agent's trailing
+    # space aligns with that whitespace after "foo", so the match is genuine.
+    # Only "foo" is rewritten; the whitespace and "bar" are preserved.
+    result = fuzzy_replace("foo\u00a0bar", "foo ", "X")
+    assert result == FuzzyReplaceResult("X bar", used_fuzzy_match=True)
+
+
+def test_query_trailing_space_skips_prefix_keeps_genuine_single() -> None:
+    # replace_all=False: the leftmost "代号：foo" is a prefix of "代号：foobar"
+    # (artifact) and must be skipped; the genuine occurrence on line 2 (followed
+    # by trailing NBSP, which aligns with the query's trailing space) is matched
+    # instead, and the prefix line is left untouched.
+    content = "角色代号：foobar\n代号：foo\u00a0"
+    result = fuzzy_replace(content, "代号：foo ", "代号：已修正")
+    assert result == FuzzyReplaceResult(
+        "角色代号：foobar\n代号：已修正", used_fuzzy_match=True
+    )
+
+
+def test_query_trailing_space_skips_prefix_keeps_genuine_replace_all() -> None:
+    # replace_all=True: line 1 (interior NBSP) and line 3 (trailing NBSP) are
+    # genuine matches; line 2 ("foobar") is a prefix artifact and is skipped,
+    # so its text is preserved verbatim.
+    content = "foo\u00a0bar\nfoobar\nfoo\u00a0"
+    result = fuzzy_replace(content, "foo ", "X", replace_all=True)
+    assert result == FuzzyReplaceResult("X bar\nfoobar\nX", used_fuzzy_match=True)
+
+
+def test_query_without_trailing_space_still_matches_prefix_normally() -> None:
+    # No trailing whitespace is stripped from the query, so the boundary guard
+    # is not engaged. A genuine fuzzy match (smart quote) still works even
+    # though the normalized query is a prefix of the longer content line.
+    result = fuzzy_replace("a\u201cb\u201drest", '"b"', "X")
+    assert result == FuzzyReplaceResult("aXrest", used_fuzzy_match=True)
+
+
+def test_query_trailing_space_replace_all_all_artifacts_returns_none() -> None:
+    # Every occurrence of "foo" is a prefix of a longer run, so none survive the
+    # boundary guard; the call is "not found" rather than corrupting content.
+    assert fuzzy_replace("foobar\nfoobaz", "foo ", "X", replace_all=True) is None

--- a/backend/tests/agent_runtime/tools/test_text_match.py
+++ b/backend/tests/agent_runtime/tools/test_text_match.py
@@ -1,0 +1,259 @@
+"""Tests for :mod:`app.agent_runtime.tools.text_match`."""
+
+import pytest
+
+from app.agent_runtime.tools.text_match import (
+    FuzzyReplaceResult,
+    fuzzy_replace,
+    normalize_for_fuzzy_match,
+)
+
+
+# ---------------------------------------------------------------------------
+# normalize_for_fuzzy_match
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_strips_trailing_whitespace_per_line() -> None:
+    assert normalize_for_fuzzy_match("hello   \nworld\t\n") == "hello\nworld\n"
+
+
+def test_normalize_converts_smart_single_quotes() -> None:
+    assert normalize_for_fuzzy_match("\u2018a\u2019") == "'a'"
+
+
+def test_normalize_converts_smart_double_quotes() -> None:
+    assert normalize_for_fuzzy_match("\u201ca\u201d") == '"a"'
+
+
+def test_normalize_converts_unicode_dashes_to_hyphen() -> None:
+    for dash in "\u2010\u2011\u2012\u2013\u2014\u2015\u2212":
+        assert normalize_for_fuzzy_match(f"a{dash}b") == "a-b"
+
+
+def test_normalize_converts_special_spaces_to_regular_space() -> None:
+    for space in "\u00a0\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u202f\u205f\u3000":
+        assert normalize_for_fuzzy_match(f"a{space}b") == "a b"
+
+
+def test_normalize_preserves_cjk_fullwidth_punctuation() -> None:
+    # NFKC is intentionally NOT applied so CJK style is preserved.
+    assert normalize_for_fuzzy_match("你好，世界！") == "你好，世界！"
+
+
+def test_normalize_keeps_regular_text_intact() -> None:
+    assert normalize_for_fuzzy_match("plain text\nline two") == "plain text\nline two"
+
+
+# ---------------------------------------------------------------------------
+# fuzzy_replace - exact match path
+# ---------------------------------------------------------------------------
+
+
+def test_exact_match_replaces_first_occurrence_only() -> None:
+    result = fuzzy_replace("a a a", "a", "b")
+    assert result == FuzzyReplaceResult("b a a", used_fuzzy_match=False)
+
+
+def test_exact_match_replace_all_replaces_every_occurrence() -> None:
+    result = fuzzy_replace("a a a", "a", "b", replace_all=True)
+    assert result == FuzzyReplaceResult("b b b", used_fuzzy_match=False)
+
+
+def test_exact_match_takes_precedence_over_fuzzy() -> None:
+    # The old text contains a smart quote but appears verbatim in the content,
+    # so the exact path is used and quotes are left untouched.
+    content = "say \u201chello\u201d"
+    result = fuzzy_replace(content, "\u201chello\u201d", "hi")
+    assert result == FuzzyReplaceResult("say hi", used_fuzzy_match=False)
+
+
+def test_returns_none_when_no_match() -> None:
+    assert fuzzy_replace("hello world", "missing", "x") is None
+
+
+def test_fuzzy_no_match_returns_none() -> None:
+    # Smart-quote normalization cannot bridge a real textual difference.
+    assert fuzzy_replace("hello world", "goodbye", "x") is None
+
+
+def test_empty_old_text_raises() -> None:
+    with pytest.raises(ValueError):
+        fuzzy_replace("content", "", "new")
+
+
+# ---------------------------------------------------------------------------
+# fuzzy_replace - fuzzy match path
+# ---------------------------------------------------------------------------
+
+
+def test_fuzzy_match_smart_quotes() -> None:
+    # Content uses smart quotes; old_text uses ASCII quotes. The fuzzy path
+    # normalizes both for matching and rewrites the touched (single) line from
+    # the normalized base, while ``new_text`` is inserted verbatim.
+    result = fuzzy_replace("前缀\u201c引文\u201d后缀", '"引文"', "X")
+    assert result == FuzzyReplaceResult("前缀X后缀", used_fuzzy_match=True)
+
+
+def test_fuzzy_match_special_spaces() -> None:
+    result = fuzzy_replace("间距\u3000很大", "间距 很大", "no space")
+    assert result == FuzzyReplaceResult("no space", used_fuzzy_match=True)
+
+
+def test_fuzzy_match_dashes() -> None:
+    result = fuzzy_replace("a\u2014b", "a-b", "X")
+    assert result == FuzzyReplaceResult("X", used_fuzzy_match=True)
+
+
+def test_fuzzy_match_used_fuzzy_match_flag_true() -> None:
+    result = fuzzy_replace("a\u00a0b", "a b", "c")
+    assert result == FuzzyReplaceResult("c", used_fuzzy_match=True)
+
+
+def test_fuzzy_match_preserves_unchanged_lines() -> None:
+    # The untouched first line keeps its NBSP and trailing whitespace; only the
+    # touched line (which requires fuzzy matching via its NBSP) is rewritten
+    # from the normalized base.
+    content = "keep\u00a0me   \nchange\u00a0me\n"
+    result = fuzzy_replace(content, "change me", "CHANGED")
+    assert result == FuzzyReplaceResult(
+        "keep\u00a0me   \nCHANGED\n", used_fuzzy_match=True
+    )
+
+
+def test_fuzzy_match_preserves_unchanged_lines_multi_replacement() -> None:
+    content = "line\u00a0one   \ntar\u00a0get\ntwo tar\u00a0get\nend"
+    result = fuzzy_replace(content, "tar get", "T", replace_all=True)
+    assert result == FuzzyReplaceResult(
+        "line\u00a0one   \nT\ntwo T\nend", used_fuzzy_match=True
+    )
+
+
+def test_fuzzy_match_replace_all() -> None:
+    # Two non-overlapping fuzzy matches on a single line.
+    result = fuzzy_replace("x\u00a0x and x\u00a0x", "x x", "y", replace_all=True)
+    assert result == FuzzyReplaceResult("y and y", used_fuzzy_match=True)
+
+
+def test_fuzzy_match_single_when_replace_all_false() -> None:
+    # Only the first occurrence is replaced; the untouched second line keeps
+    # its original NBSP and trailing whitespace.
+    content = "x\u00a0x\u00a0x\nkeep\u00a0me   "
+    result = fuzzy_replace(content, "x x", "y", replace_all=False)
+    assert result == FuzzyReplaceResult(
+        "y x\nkeep\u00a0me   ", used_fuzzy_match=True
+    )
+
+
+def test_fuzzy_match_spans_multiple_lines() -> None:
+    content = "alpha\u00a0beta\n.gamma.\ngamma"
+    result = fuzzy_replace(content, "alpha beta\n.gamma.", "REPLACED")
+    assert result == FuzzyReplaceResult("REPLACED\ngamma", used_fuzzy_match=True)
+
+
+# ---------------------------------------------------------------------------
+# fuzzy_replace - line ending normalization
+# ---------------------------------------------------------------------------
+
+
+def test_crlf_in_content_is_normalized_for_matching() -> None:
+    result = fuzzy_replace("line1\r\nline2", "line1\nline2", "X")
+    assert result == FuzzyReplaceResult("X", used_fuzzy_match=False)
+
+
+def test_cr_in_old_text_is_normalized() -> None:
+    result = fuzzy_replace("a\nb", "a\rb", "X")
+    assert result == FuzzyReplaceResult("X", used_fuzzy_match=False)
+
+
+def test_crlf_normalization_with_fuzzy_match() -> None:
+    content = "a\u00a0b\r\nc"
+    result = fuzzy_replace(content, "a b\nc", "X")
+    assert result == FuzzyReplaceResult("X", used_fuzzy_match=True)
+
+
+# ---------------------------------------------------------------------------
+# fuzzy_replace - edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_match_at_start_of_content() -> None:
+    assert fuzzy_replace("abc rest", "abc", "X") == FuzzyReplaceResult(
+        "X rest", used_fuzzy_match=False
+    )
+
+
+def test_match_at_end_of_content() -> None:
+    assert fuzzy_replace("rest abc", "abc", "X") == FuzzyReplaceResult(
+        "rest X", used_fuzzy_match=False
+    )
+
+
+def test_new_text_can_contain_normalized_chars() -> None:
+    # The replacement text is inserted verbatim, not re-normalized.
+    result = fuzzy_replace("a b", "a b", "\u201cquote\u201d")
+    assert result == FuzzyReplaceResult("\u201cquote\u201d", used_fuzzy_match=False)
+
+
+def test_duplicate_normalized_line_aligned_by_range() -> None:
+    # Two lines that are identical after normalization. ``replace_all=False``
+    # must touch only the first occurrence (aligned by the actual match range,
+    # not by re-scanning), and the second untouched line keeps its smart
+    # quotes verbatim.
+    content = "a\u201cdup\u201d   \na\u201cdup\u201d\n"
+    result = fuzzy_replace(content, 'a"dup"', "X", replace_all=False)
+    assert result == FuzzyReplaceResult(
+        "X\na\u201cdup\u201d\n", used_fuzzy_match=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# fuzzy_replace - whitespace-only old_text collapses to empty (regression)
+# ---------------------------------------------------------------------------
+
+
+def test_tab_old_text_not_in_content_returns_none() -> None:
+    # Regression: "\t" normalizes to ""; find("") must not match the start of
+    # the content and insert new_text before the original text.
+    assert fuzzy_replace("今晚月色很好。", "\t", "月色") is None
+
+
+def test_space_old_text_not_in_content_returns_none() -> None:
+    assert fuzzy_replace("今晚月色很好。", " ", "月色") is None
+
+
+def test_whitespace_only_old_text_replace_all_returns_none() -> None:
+    # Regression: replace_all=True with a whitespace-only query previously
+    # looped forever because start never advanced past idx 0.
+    assert fuzzy_replace("今晚月色很好。", " ", "月色", replace_all=True) is None
+
+
+def test_whitespace_old_text_present_in_content_still_exact_matches() -> None:
+    # A real space in the content is a legitimate exact match and must still
+    # be replaced (first occurrence only); only the normalized-empty path is
+    # rejected.
+    result = fuzzy_replace("a b c", " ", "-")
+    assert result == FuzzyReplaceResult("a-b c", used_fuzzy_match=False)
+
+
+def test_whitespace_old_text_exact_match_replace_all() -> None:
+    result = fuzzy_replace("a b a b", " ", "-", replace_all=True)
+    assert result == FuzzyReplaceResult("a-b-a-b", used_fuzzy_match=False)
+
+
+# ---------------------------------------------------------------------------
+# fuzzy_replace - replace_all fuzzy path must be linear (regression)
+# ---------------------------------------------------------------------------
+
+
+def test_replace_all_fuzzy_many_matches_is_linear() -> None:
+    # Regression: _apply_replacements_preserving_unchanged used to accumulate
+    # via ``result += ...``, making replace_all fuzzy replacement O(n^2). With
+    # ~5000 smart-quoted lines this must finish near-instantly and yield the
+    # exact expected result.
+    n = 5000
+    content = "\n".join("\u201ca\u201d" for _ in range(n))
+    result = fuzzy_replace(content, '"a"', "b", replace_all=True)
+    assert result is not None
+    assert result.used_fuzzy_match is True
+    assert result.new_content == "\n".join("b" for _ in range(n))


### PR DESCRIPTION
## PR 标题

<!-- 格式: <type>(<scope>): <subject>
示例: feat(backend): 添加章节摘要生成功能
类型: feat | fix | docs | style | refactor | perf | test | chore
范围: frontend | backend | agent | storage | api | db | config -->

## 变更说明

<!-- 使用2-5条要点简要描述本次变更的内容和目的 -->

- 问题: 现有的 `edit_chapter` 和 `edit_note` 仅支持严格的精确匹配，当遇到特殊的换行符（CRLF vs LF）、不可见空格或不同的标点符号时，工具调用极易失败。
- 重要性: 提高编辑工具在复杂文本环境下的鲁棒性，显著提升修改操作的成功率。

变化: 

  1. 引入了降级策略：保持精确匹配优先，精确匹配失败后降级执行模糊匹配逻辑。
  2. 增加了文本归一化清洗规则：去除行尾空白，将智能引号/Unicode破折号/特殊空格转为 ASCII 等效字符，统一回车换行符（CRLF 强转 LF）。
  3. 优化了文件写入逻辑：在模糊匹配修改时，保留未修改行的原始字节流，仅重写被触碰的行，防止破坏文件原有格式。

## 关联 Issue / PR (如有)

<!-- 如果有外部相关的 Issue / PR，请在此链接 -->
Closes #163

## 变更类型

- [x] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

<!-- 对于fix类型的问题，需要解释问题发生的原因，如果原因不明，可以填写Unknown -->
原有匹配逻辑过于严苛。大语言模型输出的待替换文本或系统读取的原始文本中，经常夹杂不同的不可见字符、特殊格式符号以及不一致的换行符，导致基于精确字符串比对的修改操作频频失效。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

<!-- 其他需要说明的内容（可选） -->
无。