### PR TITLE
fix(ci): 跳过发布 PR 检查

### DIFF
--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -20,6 +20,7 @@ env:
 jobs:
   frontend:
     name: Frontend package
+    if: "!startsWith(github.event.pull_request.head.ref, 'release-please--')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -44,6 +45,7 @@ jobs:
 
   python:
     name: Python package
+    if: "!startsWith(github.event.pull_request.head.ref, 'release-please--')"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -68,6 +70,7 @@ jobs:
 
   docker:
     name: Docker (${{ matrix.platform }})
+    if: "!startsWith(github.event.pull_request.head.ref, 'release-please--')"
     strategy:
       fail-fast: false
       matrix:
@@ -91,6 +94,7 @@ jobs:
   desktop:
     name: Desktop (${{ matrix.os }} ${{ matrix.arch }})
     needs: frontend
+    if: "!startsWith(github.event.pull_request.head.ref, 'release-please--')"
     strategy:
       fail-fast: false
       matrix:
@@ -145,7 +149,7 @@ jobs:
 
   summary:
     name: Summary
-    if: always()
+    if: "always() && !startsWith(github.event.pull_request.head.ref, 'release-please--')"
     needs: [frontend, python, docker, desktop]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -21,6 +21,7 @@ env:
 jobs:
   changes:
     name: Detect changes
+    if: "!startsWith(github.event.pull_request.head.ref, 'release-please--')"
     runs-on: ubuntu-latest
     outputs:
       backend: ${{ steps.filter.outputs.backend }}
@@ -65,7 +66,7 @@ jobs:
   backend:
     name: Backend
     needs: changes
-    if: needs.changes.outputs.backend == 'true'
+    if: "!startsWith(github.event.pull_request.head.ref, 'release-please--') && needs.changes.outputs.backend == 'true'"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -103,7 +104,7 @@ jobs:
   frontend:
     name: Frontend
     needs: changes
-    if: needs.changes.outputs.frontend == 'true'
+    if: "!startsWith(github.event.pull_request.head.ref, 'release-please--') && needs.changes.outputs.frontend == 'true'"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -134,7 +135,7 @@ jobs:
   desktop:
     name: Desktop
     needs: changes
-    if: needs.changes.outputs.desktop == 'true'
+    if: "!startsWith(github.event.pull_request.head.ref, 'release-please--') && needs.changes.outputs.desktop == 'true'"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -166,7 +167,7 @@ jobs:
 
   summary:
     name: Summary
-    if: always()
+    if: "always() && !startsWith(github.event.pull_request.head.ref, 'release-please--')"
     needs: [changes, backend, frontend, desktop]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-template.yml
+++ b/.github/workflows/pr-template.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   validate:
     name: Validate template
+    if: "!startsWith(github.event.pull_request.head.ref, 'release-please--')"
     runs-on: ubuntu-latest
     steps:
       - name: Validate title and description


### PR DESCRIPTION
## PR 标题

fix(ci): 跳过发布 PR 检查

## 变更说明

- 问题: Release Please 创建发布 PR 时，会重复执行普通 PR 的模板、质量和打包检查。
- 重要性: 发布 PR 的提交已在原始功能 PR 中完成校验，重复执行会额外占用 CI 资源并延长发布流程。
- 变化: 对 `release-please--` 前缀的源分支，跳过 `PR Template Check`、`PR Check` 与 `Package Check` 的全部 job。

## 关联 Issue / PR (如有)

无。

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

Release Please 使用 `GITHUB_TOKEN` 创建 PR，作者与普通 PR 一致，无法通过机器人账户区分；其源分支固定使用 `release-please--` 前缀。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

已运行 `actionlint` 检查全部 PR 工作流，并运行 `git diff --check`。