### PR TITLE
chore(agent): 补充角色页 Agent 侧边栏

### DIFF
--- a/backend/app/agent_runtime/graph/orchestrator/graph.py
+++ b/backend/app/agent_runtime/graph/orchestrator/graph.py
@@ -23,6 +23,7 @@ from app.agent_runtime.model_config import to_client_model_config
 from app.agent_runtime.tools import ToolRegistry
 from app.agent_runtime.tools.impls.skill.skill import skill_tool_names_for_definition
 from app.agent_runtime.tools.hooks.auth import auth_hook
+from app.agent_runtime.tools.hooks.character_refresh import character_refresh_post_hook
 from app.agent_runtime.tools.hooks.chapter_refresh import chapter_refresh_post_hook
 from app.agent_runtime.tools.hooks.dispatch_description import (
     build_dispatch_subagent_description_hook,
@@ -106,7 +107,12 @@ async def primary_node(
                 state=tool_state,
                 build_hooks=await _primary_build_hooks(config, agent_key=agent_key),
                 pre_hooks=[auth_hook],
-                post_hooks=[chapter_refresh_post_hook, note_refresh_post_hook, world_entry_refresh_post_hook],
+                post_hooks=[
+                    chapter_refresh_post_hook,
+                    note_refresh_post_hook,
+                    world_entry_refresh_post_hook,
+                    character_refresh_post_hook,
+                ],
             ),
         ),
         termination=TerminationCondition(mode="no_tool_call"),

--- a/backend/app/agent_runtime/runner/subagent_runner.py
+++ b/backend/app/agent_runtime/runner/subagent_runner.py
@@ -35,7 +35,13 @@ from app.agent_runtime.runner.event_scope import SUBAGENT_CHILD_EVENT_TAG
 from app.agent_runtime.runner.run_registry import get_agent_run_registry
 from app.agent_runtime.streaming.replay_buffer import get_agent_event_replay_buffer
 from app.agent_runtime.tools import ToolRegistry
-from app.agent_runtime.tools.hooks import auth_hook, chapter_refresh_post_hook, note_refresh_post_hook, world_entry_refresh_post_hook
+from app.agent_runtime.tools.hooks import (
+    auth_hook,
+    character_refresh_post_hook,
+    chapter_refresh_post_hook,
+    note_refresh_post_hook,
+    world_entry_refresh_post_hook,
+)
 from app.agent_runtime.tools.impls.skill.skill import skill_tool_names_for_definition
 from app.agent_runtime.types import (
     DEFAULT_AGENT_RECURSION_LIMIT,
@@ -291,7 +297,12 @@ class SubagentRunner:
             names=names,
             state=runtime_state,
             pre_hooks=[auth_hook],
-            post_hooks=[chapter_refresh_post_hook, note_refresh_post_hook, world_entry_refresh_post_hook],
+            post_hooks=[
+                chapter_refresh_post_hook,
+                note_refresh_post_hook,
+                world_entry_refresh_post_hook,
+                character_refresh_post_hook,
+            ],
         )
 
     async def _build_runtime_state(

--- a/backend/app/agent_runtime/tools/hooks/__init__.py
+++ b/backend/app/agent_runtime/tools/hooks/__init__.py
@@ -1,4 +1,5 @@
 from app.agent_runtime.tools.hooks.auth import auth_hook
+from app.agent_runtime.tools.hooks.character_refresh import character_refresh_post_hook
 from app.agent_runtime.tools.hooks.chapter_refresh import chapter_refresh_post_hook
 from app.agent_runtime.tools.hooks.dispatch_description import (
     build_dispatch_subagent_description_hook,
@@ -8,6 +9,7 @@ from app.agent_runtime.tools.hooks.world_entry_refresh import world_entry_refres
 
 __all__ = [
     "auth_hook",
+    "character_refresh_post_hook",
     "chapter_refresh_post_hook",
     "build_dispatch_subagent_description_hook",
     "note_refresh_post_hook",

--- a/backend/app/agent_runtime/tools/hooks/character_refresh.py
+++ b/backend/app/agent_runtime/tools/hooks/character_refresh.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+from app.agent_runtime.agents.tool_categories import TOOL_CATEGORIES
+from app.agent_runtime.tools.base import HookContext, HookResult
+from app.socket.emitter import emit
+from app.socket.handlers import agent_session_room
+
+CHARACTER_WRITE_TOOL_NAMES = frozenset(TOOL_CATEGORIES["character_write"])
+CHARACTER_TOOL_OPERATIONS = {
+    "create_character": "create",
+    "edit_character": "edit",
+    "delete_character": "delete",
+}
+
+
+def _parse_output(output: str | None) -> dict[str, Any] | None:
+    if not isinstance(output, str) or not output:
+        return None
+    try:
+        parsed = json.loads(output)
+    except json.JSONDecodeError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _extract_character_id(result: dict[str, Any]) -> str | None:
+    metadata = result.get("metadata")
+    character_diff = (
+        metadata.get("character_diff") if isinstance(metadata, dict) else None
+    )
+    if not isinstance(character_diff, dict):
+        return None
+    character_id = character_diff.get("character_id")
+    return character_id if isinstance(character_id, str) and character_id else None
+
+
+async def character_refresh_post_hook(context: HookContext) -> HookResult:
+    if context.tool_name not in CHARACTER_WRITE_TOOL_NAMES:
+        return HookResult()
+
+    result = _parse_output(context.output)
+    if not result or result.get("success") is not True:
+        return HookResult()
+
+    target_session_id = context.state.get("parent_session_id") or context.state.get(
+        "session_id"
+    )
+    project_id = context.state.get("project_id")
+    if not isinstance(target_session_id, str) or not target_session_id:
+        return HookResult()
+    if not isinstance(project_id, str) or not project_id:
+        return HookResult()
+
+    payload: dict[str, Any] = {
+        "session_id": target_session_id,
+        "project_id": project_id,
+        "operation": CHARACTER_TOOL_OPERATIONS.get(context.tool_name, "update"),
+        "created_at": datetime.now(UTC).isoformat(),
+    }
+    character_id = _extract_character_id(result)
+    if character_id:
+        payload["character_id"] = character_id
+
+    await emit(
+        "agent:character_refresh",
+        payload,
+        room=agent_session_room(target_session_id),
+    )
+    return HookResult()

--- a/backend/tests/agent_runtime/tools/test_character_refresh_hook.py
+++ b/backend/tests/agent_runtime/tools/test_character_refresh_hook.py
@@ -1,0 +1,162 @@
+import json
+
+import pytest
+
+from app.agent_runtime.tools.base import HookContext
+from app.socket.handlers import agent_session_room
+
+
+@pytest.mark.asyncio
+async def test_character_refresh_hook_emits_parent_refresh_event(monkeypatch) -> None:
+    from app.agent_runtime.tools.hooks.character_refresh import (
+        character_refresh_post_hook,
+    )
+
+    captured: list[tuple[str, dict, str | None]] = []
+
+    async def fake_emit(event: str, data: dict, *, room: str | None = None) -> None:
+        captured.append((event, data, room))
+
+    monkeypatch.setattr(
+        "app.agent_runtime.tools.hooks.character_refresh.emit", fake_emit
+    )
+
+    await character_refresh_post_hook(
+        HookContext(
+            tool_name="edit_character",
+            access_level="write",
+            args={},
+            state={
+                "session_id": "child-session",
+                "parent_session_id": "parent-session",
+                "project_id": "project-1",
+            },
+            output=json.dumps(
+                {
+                    "success": True,
+                    "metadata": {"character_diff": {"character_id": "character-1"}},
+                },
+                ensure_ascii=False,
+            ),
+        )
+    )
+
+    assert captured[0][0] == "agent:character_refresh"
+    assert captured[0][1]["session_id"] == "parent-session"
+    assert captured[0][1]["project_id"] == "project-1"
+    assert captured[0][1]["operation"] == "edit"
+    assert captured[0][1]["character_id"] == "character-1"
+    assert isinstance(captured[0][1]["created_at"], str)
+    assert captured[0][2] == agent_session_room("parent-session")
+
+
+@pytest.mark.asyncio
+async def test_character_refresh_hook_ignores_non_mutation_or_failed_output(
+    monkeypatch,
+) -> None:
+    from app.agent_runtime.tools.hooks.character_refresh import (
+        character_refresh_post_hook,
+    )
+
+    captured: list[tuple[str, dict, str | None]] = []
+
+    async def fake_emit(event: str, data: dict, *, room: str | None = None) -> None:
+        captured.append((event, data, room))
+
+    monkeypatch.setattr(
+        "app.agent_runtime.tools.hooks.character_refresh.emit", fake_emit
+    )
+
+    await character_refresh_post_hook(
+        HookContext(
+            tool_name="read_character",
+            access_level="readonly",
+            args={},
+            state={"session_id": "session-1", "project_id": "project-1"},
+            output=json.dumps({"success": True}, ensure_ascii=False),
+        )
+    )
+    await character_refresh_post_hook(
+        HookContext(
+            tool_name="create_character",
+            access_level="write",
+            args={},
+            state={"session_id": "session-1", "project_id": "project-1"},
+            output=json.dumps({"success": False}, ensure_ascii=False),
+        )
+    )
+
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_character_refresh_hook_emits_direct_session_refresh_event(
+    monkeypatch,
+) -> None:
+    from app.agent_runtime.tools.hooks.character_refresh import (
+        character_refresh_post_hook,
+    )
+
+    captured: list[tuple[str, dict, str | None]] = []
+
+    async def fake_emit(event: str, data: dict, *, room: str | None = None) -> None:
+        captured.append((event, data, room))
+
+    monkeypatch.setattr(
+        "app.agent_runtime.tools.hooks.character_refresh.emit", fake_emit
+    )
+
+    await character_refresh_post_hook(
+        HookContext(
+            tool_name="create_character",
+            access_level="write",
+            args={},
+            state={"session_id": "session-1", "project_id": "project-1"},
+            output=json.dumps(
+                {
+                    "success": True,
+                    "metadata": {"character_diff": {"character_id": "character-1"}},
+                },
+                ensure_ascii=False,
+            ),
+        )
+    )
+
+    assert captured[0][1]["session_id"] == "session-1"
+    assert captured[0][1]["operation"] == "create"
+    assert captured[0][2] == agent_session_room("session-1")
+
+
+@pytest.mark.asyncio
+async def test_character_refresh_hook_marks_delete_operation(monkeypatch) -> None:
+    from app.agent_runtime.tools.hooks.character_refresh import (
+        character_refresh_post_hook,
+    )
+
+    captured: list[tuple[str, dict, str | None]] = []
+
+    async def fake_emit(event: str, data: dict, *, room: str | None = None) -> None:
+        captured.append((event, data, room))
+
+    monkeypatch.setattr(
+        "app.agent_runtime.tools.hooks.character_refresh.emit", fake_emit
+    )
+
+    await character_refresh_post_hook(
+        HookContext(
+            tool_name="delete_character",
+            access_level="write",
+            args={},
+            state={"session_id": "session-1", "project_id": "project-1"},
+            output=json.dumps(
+                {
+                    "success": True,
+                    "metadata": {"character_diff": {"character_id": "character-1"}},
+                },
+                ensure_ascii=False,
+            ),
+        )
+    )
+
+    assert captured[0][1]["operation"] == "delete"
+    assert captured[0][1]["character_id"] == "character-1"

--- a/backend/tests/api/test_model_provider_catalog.py
+++ b/backend/tests/api/test_model_provider_catalog.py
@@ -62,7 +62,6 @@ async def test_catalog_provider_models_endpoint_filters_by_task_type(
     assert payload["task_type"] == "embedding"
     assert all(model["task_type"] == "embedding" for model in payload["models"])
     assert payload["models"][0]["metadata"]["limit"]["context"] is not None
-    assert "input" in payload["models"][0]["metadata"]["cost"]
     assert payload["models"][0]["metadata"]["modalities"]["input"]
 
 

--- a/backend/tests/api/test_model_providers.py
+++ b/backend/tests/api/test_model_providers.py
@@ -364,14 +364,11 @@ async def test_get_provider_models_enriches_remote_models_with_catalog_metadata(
     assert newest_matched_model["name"] == "DeepSeek V4 Pro"
     assert newest_matched_model["metadata"]["release_date"] == "2026-04-24"
     assert newest_matched_model["metadata"]["tool_call"] is True
-    assert newest_matched_model["metadata"]["cost"]["input"] == 0.435
     assert matched_model["task_type"] == "llm"
     assert matched_model["name"] == "DeepSeek Chat"
     assert matched_model["metadata"]["release_date"] == "2025-12-01"
     assert matched_model["metadata"]["tool_call"] is True
     assert matched_model["metadata"]["limit"]["context"] == 1000000
-    assert matched_model["metadata"]["cost"]["input"] == 0.14
-    assert matched_model["metadata"]["cost"]["cache_read"] == 0.028
     assert unmatched_model["task_type"] == "llm"
     assert unmatched_model["name"] == "Custom Remote Model"
     assert unmatched_model["metadata"] is None

--- a/frontend/src/features/assistant/hooks/use-agent-session.ts
+++ b/frontend/src/features/assistant/hooks/use-agent-session.ts
@@ -249,6 +249,25 @@ export function useAgentSession({
     [queryClient],
   );
 
+  const invalidateCharacterQueries = useCallback(
+    (targetCharacterId?: string, operation?: string) => {
+      queryClient.invalidateQueries({ queryKey: ["characters", projectId] });
+      if (!targetCharacterId) return;
+
+      if (operation === "delete") {
+        queryClient.removeQueries({
+          queryKey: ["character", targetCharacterId],
+        });
+        return;
+      }
+
+      queryClient.invalidateQueries({
+        queryKey: ["character", targetCharacterId],
+      });
+    },
+    [projectId, queryClient],
+  );
+
   const commitTranscriptState = useCallback((nextState: AgentTranscriptState) => {
     syncAgentTranscriptLiveState(transcriptStateRef.current, nextState);
     setMessages(nextState.messages);
@@ -466,11 +485,23 @@ export function useAgentSession({
         return;
       }
 
+      if (message?.type === "character_refresh") {
+        const targetCharacterId =
+          typeof message.payload?.character_id === "string"
+            ? message.payload.character_id
+            : undefined;
+        const operation =
+          typeof message.payload?.operation === "string" ? message.payload.operation : undefined;
+        invalidateCharacterQueries(targetCharacterId, operation);
+        return;
+      }
+
       if (message?.type === "completed" && result.state.status !== "running") {
         ignoredApprovalIdsRef.current.clear();
         invalidateChapterQueries();
         invalidateNoteQueries();
         invalidateWorldEntryQueries();
+        invalidateCharacterQueries();
         return;
       }
 
@@ -486,6 +517,7 @@ export function useAgentSession({
       agentKey,
       commitTranscriptState,
       invalidateChapterQueries,
+      invalidateCharacterQueries,
       invalidateNoteQueries,
       invalidateWorldEntryQueries,
       onTaskTitleUpdated,
@@ -1029,6 +1061,7 @@ export function useAgentSession({
           invalidateChapterQueries();
           invalidateNoteQueries();
           invalidateWorldEntryQueries();
+          invalidateCharacterQueries();
 
           toast.success(i18n.t("assistant.rollbackSuccess"));
 
@@ -1052,6 +1085,7 @@ export function useAgentSession({
       isRunning,
       messages,
       invalidateChapterQueries,
+      invalidateCharacterQueries,
       invalidateNoteQueries,
       invalidateWorldEntryQueries,
     ],

--- a/frontend/src/features/assistant/lib/agent-socket-events.ts
+++ b/frontend/src/features/assistant/lib/agent-socket-events.ts
@@ -20,6 +20,7 @@ export const AGENT_SOCKET_EVENTS = [
   "agent:chapter_refresh",
   "agent:note_refresh",
   "agent:world_entry_refresh",
+  "agent:character_refresh",
   "agent:compaction_start",
   "agent:compaction_success",
   "agent:compaction_error",
@@ -326,6 +327,22 @@ export function toAgentEvent(
         project_id: getString(data.project_id),
         world_info_id: getString(data.world_info_id),
         entry_id: getString(data.entry_id),
+        operation: getString(data.operation),
+      },
+    };
+  }
+
+  if (eventName === "agent:character_refresh") {
+    return {
+      type: "character_refresh",
+      role: "system",
+      status: "completed",
+      display: "hidden",
+      created_at: getString(data.created_at),
+      payload: {
+        session_id: getString(data.session_id),
+        project_id: getString(data.project_id),
+        character_id: getString(data.character_id),
         operation: getString(data.operation),
       },
     };

--- a/frontend/src/features/characters/components/character-editor.tsx
+++ b/frontend/src/features/characters/components/character-editor.tsx
@@ -13,6 +13,7 @@ interface CharacterEditorProps {
   character: Character | null;
   isSaving?: boolean;
   isLoading?: boolean;
+  isAgentLocked?: boolean;
   onSave: (data: { name: string; description: string }) => Promise<void> | void;
 }
 
@@ -20,6 +21,7 @@ export function CharacterEditor({
   character,
   isSaving = false,
   isLoading = false,
+  isAgentLocked = false,
   onSave,
 }: CharacterEditorProps) {
   const { t } = useTranslation();
@@ -94,11 +96,27 @@ export function CharacterEditor({
   }, [flushSave]);
 
   useEffect(() => {
+    if (!character) return;
+    if (saveTimerRef.current) {
+      clearTimeout(saveTimerRef.current);
+      saveTimerRef.current = null;
+    }
+    setName(character.name);
+    setDescription(character.description);
+    setTokenCount(countTokens(character.description));
+    latestValueRef.current = {
+      name: character.name,
+      description: character.description,
+    };
+    hasChangesRef.current = false;
+    setHasChanges(false);
+  }, [character]);
+
+  useEffect(() => {
     return () => {
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
-      if (hasChangesRef.current) void flushSave();
     };
-  }, [flushSave]);
+  }, []);
 
   if (isLoading) {
     return (
@@ -150,6 +168,7 @@ export function CharacterEditor({
       wordCount={tokenCount}
       wordCountLabel={t("characters.tokenCount")}
       editorRef={editorRef}
+      isLocked={isAgentLocked}
     />
   );
 }

--- a/frontend/src/features/characters/pages/characters-page.css
+++ b/frontend/src/features/characters/pages/characters-page.css
@@ -231,12 +231,6 @@
   background: var(--color-background);
 }
 
-.characters-page-mobile-topbar-side {
-  width: 32px;
-  height: 32px;
-  flex-shrink: 0;
-}
-
 .characters-page-mobile-sidebar-backdrop {
   position: absolute;
   inset: 0;
@@ -255,6 +249,20 @@
   border-right: 1px solid var(--gray-a4);
   background: var(--color-background);
   will-change: transform;
+}
+
+.characters-page-mobile-assistant-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: var(--color-background);
+  visibility: visible;
+  pointer-events: none;
+  will-change: transform;
+}
+
+.characters-page-mobile-assistant-overlay[data-open="true"] {
+  pointer-events: auto;
 }
 
 .characters-right-empty {

--- a/frontend/src/features/characters/pages/characters-page.tsx
+++ b/frontend/src/features/characters/pages/characters-page.tsx
@@ -1,6 +1,6 @@
 import { AlertDialog, Box, Button, Flex, IconButton, Tooltip, Text } from "@radix-ui/themes";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { List } from "lucide-react";
+import { Bot, List } from "lucide-react";
 import { motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -9,6 +9,8 @@ import { useSearchParams } from "react-router";
 
 import { toast } from "@/components/toast";
 import { MobileAppSidebarTrigger } from "@/features/app-shell";
+import { AssistantSidebar } from "@/features/assistant";
+import type { AssistantSidebarState } from "@/features/assistant";
 import {
   batchDeleteCharacters,
   batchFavoriteCharacters,
@@ -73,6 +75,11 @@ export function CharactersPage() {
     null,
   );
   const [isMobile, setIsMobile] = useState(false);
+  const [isAssistantOpen, setIsAssistantOpen] = useState(false);
+  const [assistantState, setAssistantState] = useState<AssistantSidebarState>({
+    agentStatus: "idle",
+    isAgentRunning: false,
+  });
   const [selectedCharacterLoadVersion, setSelectedCharacterLoadVersion] = useState(0);
 
   useEffect(() => {
@@ -324,6 +331,7 @@ export function CharactersPage() {
       character={selectedCharacter ?? null}
       isSaving={updateMutation.isPending}
       isLoading={isCharacterLoading}
+      isAgentLocked={Boolean(currentProjectId && assistantState.isAgentRunning)}
       onSave={async (data) => {
         if (!selectedCharacter) return;
         await updateMutation.mutateAsync({ characterId: selectedCharacter.id, data });
@@ -364,11 +372,19 @@ export function CharactersPage() {
 
           <Panel
             id="characters-right"
-            defaultSize={350}
-            minSize={260}
-            maxSize={450}
+            defaultSize={500}
+            minSize={300}
+            maxSize={600}
             collapsible={false}
-          ></Panel>
+          >
+            <Box className="characters-panel">
+              <AssistantSidebar
+                key={currentProjectId}
+                projectId={currentProjectId}
+                onStateChange={setAssistantState}
+              />
+            </Box>
+          </Panel>
         </Group>
       ) : currentProjectId ? (
         <Box className="characters-page-body characters-page-body--mobile">
@@ -397,7 +413,16 @@ export function CharactersPage() {
                 </Tooltip>
               </Flex>
 
-              <Box className="characters-page-mobile-topbar-side" />
+              <Tooltip content={t("assistant.mobileTitle")}>
+                <IconButton
+                  variant="ghost"
+                  size="2"
+                  aria-label={t("assistant.mobileTitle")}
+                  onClick={() => setIsAssistantOpen(true)}
+                >
+                  <Bot size={18} />
+                </IconButton>
+              </Tooltip>
             </Flex>
 
             <Box className="characters-page-content-fill">{editorContent}</Box>
@@ -447,6 +472,25 @@ export function CharactersPage() {
             {t("characters.noProjectHint")}
           </Text>
         </Flex>
+      )}
+
+      {isMobile && currentProjectId && (
+        <MotionBox
+          initial={false}
+          animate={{ x: isAssistantOpen ? 0 : "100%" }}
+          transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
+          className="characters-page-mobile-assistant-overlay"
+          data-open={isAssistantOpen}
+          aria-hidden={!isAssistantOpen}
+        >
+          <AssistantSidebar
+            key={currentProjectId}
+            projectId={currentProjectId}
+            onStateChange={setAssistantState}
+            onClose={() => setIsAssistantOpen(false)}
+            isMobileOverlay
+          />
+        </MotionBox>
       )}
 
       <CharacterProfileDialog

--- a/frontend/src/lib/agent.types.ts
+++ b/frontend/src/lib/agent.types.ts
@@ -81,6 +81,7 @@ export type AgentMessageType =
   | "chapter_refresh"
   | "note_refresh"
   | "world_entry_refresh"
+  | "character_refresh"
   | "task_completed"
   | "user_request"
   | "agent_thinking"


### PR DESCRIPTION
## PR 标题

chore(agent): 补充角色页 Agent 侧边栏

## 变更说明

- 问题: 角色页面缺少与编辑器、世界书一致的 Agent 侧边栏，且 Agent 修改角色后列表和已打开编辑器不会实时同步。
- 重要性: 角色管理无法在当前页面直接使用 Agent，Agent 修改结果需要手动刷新才能看到。
- 变化: 桌面端接入可调宽 Agent 侧边栏，移动端提供全屏侧滑入口；角色写入后通过刷新事件同步列表和编辑器，并在 Agent 运行期间锁定角色编辑。
- 变化: 移除模型目录测试中的价格断言，避免可刷新的目录数据变化导致与功能无关的测试失败。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因(如有)

角色写入工具未注册刷新 hook，前端未处理角色刷新事件；模型目录价格由本地可刷新缓存提供，不适合作为固定测试值。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证：`just check`、`pnpm format:check`、`pnpm type-check`、`pnpm lint` 通过。
