### PR TITLE
fix(agent): 修复跨页面切换导致的侧边栏状态丢失问题

### DIFF
--- a/frontend/src/features/app-shell/components/app-layout.css
+++ b/frontend/src/features/app-shell/components/app-layout.css
@@ -20,3 +20,35 @@
   overflow: hidden;
   transition: padding-left 0.24s cubic-bezier(0.22, 1, 0.36, 1);
 }
+
+.app-layout-assistant-sidebar {
+  position: fixed;
+  z-index: 11;
+  min-width: 0;
+  min-height: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+
+.app-layout-assistant-sidebar-host {
+  width: 100%;
+  height: 100%;
+}
+
+.app-layout-assistant-sidebar[data-active="true"] {
+  visibility: visible;
+  pointer-events: auto;
+}
+
+.app-layout-assistant-sidebar[data-mobile-overlay="true"] {
+  inset: 0;
+  z-index: 60;
+  background: var(--color-background);
+  overflow: hidden;
+  transform: translateX(100%);
+  transition: transform 0.24s cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.app-layout-assistant-sidebar[data-mobile-overlay="true"][data-open="true"] {
+  transform: translateX(0);
+}

--- a/frontend/src/features/app-shell/components/app-layout.tsx
+++ b/frontend/src/features/app-shell/components/app-layout.tsx
@@ -1,11 +1,23 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { Outlet } from "react-router";
 
+import { AssistantSidebar } from "@/features/assistant";
+import type { AssistantSidebarHandle } from "@/features/assistant";
 import { SettingsDialog } from "@/features/settings";
 import type { SettingsDialogRoute } from "@/features/settings/lib/settings-route";
 
 import { AppShellContext } from "./app-shell-context";
 import { AppSidebar } from "./app-sidebar";
+import {
+  clearAssistantSidebarHost as clearAssistantSidebarHostState,
+  registerAssistantSidebarHost as registerAssistantSidebarHostState,
+  type AssistantSidebarHostRegistration,
+  type AssistantSidebarHostState,
+} from "./assistant-sidebar-host-state";
+import {
+  clearAssistantSidebarPosition,
+  syncAssistantSidebarPosition,
+} from "./assistant-sidebar-position";
 
 import "./app-layout.css";
 import { StatusBar } from "./status-bar";
@@ -27,6 +39,12 @@ export function AppLayout({
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [settingsRoute, setSettingsRoute] = useState<SettingsDialogRoute | undefined>(undefined);
+  const [assistantSidebarHost, setAssistantSidebarHost] =
+    useState<AssistantSidebarHostState | null>(null);
+  const [isAssistantSidebarOpen, setIsAssistantSidebarOpen] = useState(false);
+  const assistantSidebarRef = useRef<AssistantSidebarHandle | null>(null);
+  const assistantSidebarContainerRef = useRef<HTMLDivElement | null>(null);
+  const assistantSidebarProjectIdRef = useRef<string | null>(null);
 
   useEffect(() => {
     function handleResize() {
@@ -43,6 +61,65 @@ export function AppLayout({
     return () => window.removeEventListener("resize", handleResize);
   }, []);
 
+  const registerAssistantSidebarHost = useCallback(
+    (registration: AssistantSidebarHostRegistration) => {
+      setAssistantSidebarHost((current) =>
+        registerAssistantSidebarHostState(current, registration),
+      );
+    },
+    [],
+  );
+
+  const clearAssistantSidebarHost = useCallback((id: string) => {
+    setAssistantSidebarHost((current) => clearAssistantSidebarHostState(current, id));
+  }, []);
+
+  const appendToAssistant = useCallback((markup: string) => {
+    assistantSidebarRef.current?.appendToComposer(markup);
+  }, []);
+
+  const openAssistantSidebar = useCallback(() => setIsAssistantSidebarOpen(true), []);
+  const closeAssistantSidebar = useCallback(() => setIsAssistantSidebarOpen(false), []);
+
+  useLayoutEffect(() => {
+    const host = assistantSidebarHost?.host;
+    if (!host || assistantSidebarHost.isMobileOverlay) {
+      const sidebar = assistantSidebarContainerRef.current;
+      if (sidebar) clearAssistantSidebarPosition(sidebar);
+      return;
+    }
+
+    let frameId: number | null = null;
+    const updateBounds = () => {
+      const sidebar = assistantSidebarContainerRef.current;
+      if (!sidebar) return;
+      syncAssistantSidebarPosition(sidebar, host);
+      if (host.getBoundingClientRect().width > 0 || frameId !== null) return;
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null;
+        const nextSidebar = assistantSidebarContainerRef.current;
+        if (nextSidebar) syncAssistantSidebarPosition(nextSidebar, host);
+      });
+    };
+    const resizeObserver = new ResizeObserver(updateBounds);
+    resizeObserver.observe(host);
+    window.addEventListener("resize", updateBounds);
+    updateBounds();
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener("resize", updateBounds);
+      if (frameId !== null) window.cancelAnimationFrame(frameId);
+    };
+  }, [assistantSidebarHost?.host, assistantSidebarHost?.isMobileOverlay]);
+
+  useLayoutEffect(() => {
+    const projectId = assistantSidebarHost?.projectId;
+    if (projectId && assistantSidebarProjectIdRef.current !== projectId) {
+      if (assistantSidebarProjectIdRef.current) setIsAssistantSidebarOpen(false);
+      assistantSidebarProjectIdRef.current = projectId;
+    }
+  }, [assistantSidebarHost?.projectId]);
+
   const contextValue = useMemo(
     () => ({
       isMobile,
@@ -56,9 +133,27 @@ export function AppLayout({
         setIsSettingsOpen(true);
       },
       closeSettings: () => setIsSettingsOpen(false),
+      appendToAssistant,
+      isAssistantSidebarOpen,
+      openAssistantSidebar,
+      closeAssistantSidebar,
+      registerAssistantSidebarHost,
+      clearAssistantSidebarHost,
     }),
-    [isMobile, isSidebarOpen, isSettingsOpen],
+    [
+      appendToAssistant,
+      closeAssistantSidebar,
+      clearAssistantSidebarHost,
+      isAssistantSidebarOpen,
+      isMobile,
+      isSettingsOpen,
+      isSidebarOpen,
+      openAssistantSidebar,
+      registerAssistantSidebarHost,
+    ],
   );
+
+  const isAssistantSidebarVisible = Boolean(assistantSidebarHost?.isActive);
 
   return (
     <AppShellContext.Provider value={contextValue}>
@@ -72,6 +167,30 @@ export function AppLayout({
           <div className="app-layout-content">
             <Outlet />
           </div>
+          {assistantSidebarHost ? (
+            <div
+              ref={assistantSidebarContainerRef}
+              className="app-layout-assistant-sidebar"
+              data-active={isAssistantSidebarVisible}
+              data-mobile-overlay={String(assistantSidebarHost.isMobileOverlay)}
+              data-open={String(assistantSidebarHost.isOpen)}
+            >
+              <AssistantSidebar
+                ref={assistantSidebarRef}
+                projectId={assistantSidebarHost.projectId}
+                onStateChange={
+                  assistantSidebarHost.isActive ? assistantSidebarHost.onStateChange : undefined
+                }
+                onOpenMentionChapter={
+                  assistantSidebarHost.isActive
+                    ? assistantSidebarHost.onOpenMentionChapter
+                    : undefined
+                }
+                onClose={assistantSidebarHost.isActive ? assistantSidebarHost.onClose : undefined}
+                isMobileOverlay={assistantSidebarHost.isMobileOverlay}
+              />
+            </div>
+          ) : null}
         </div>
 
         <StatusBar version={version} />

--- a/frontend/src/features/app-shell/components/app-shell-context.tsx
+++ b/frontend/src/features/app-shell/components/app-shell-context.tsx
@@ -2,6 +2,8 @@ import { createContext, useContext } from "react";
 
 import type { SettingsDialogRoute } from "@/features/settings/lib/settings-route";
 
+import type { AssistantSidebarHostRegistration } from "./assistant-sidebar-host-state";
+
 interface AppShellContextValue {
   isMobile: boolean;
   isSidebarOpen: boolean;
@@ -11,6 +13,12 @@ interface AppShellContextValue {
   toggleSidebar: () => void;
   openSettings: (route?: SettingsDialogRoute) => void;
   closeSettings: () => void;
+  appendToAssistant: (markup: string) => void;
+  isAssistantSidebarOpen: boolean;
+  openAssistantSidebar: () => void;
+  closeAssistantSidebar: () => void;
+  registerAssistantSidebarHost: (registration: AssistantSidebarHostRegistration) => void;
+  clearAssistantSidebarHost: (id: string) => void;
 }
 
 export const AppShellContext = createContext<AppShellContextValue | null>(null);

--- a/frontend/src/features/app-shell/components/assistant-sidebar-host-state.ts
+++ b/frontend/src/features/app-shell/components/assistant-sidebar-host-state.ts
@@ -1,0 +1,44 @@
+import type { AssistantSidebarState } from "@/features/assistant/lib/assistant-state.types";
+
+export interface AssistantSidebarHostRegistration {
+  id: string;
+  host: HTMLElement | null;
+  projectId: string;
+  isMobileOverlay: boolean;
+  isOpen: boolean;
+  onStateChange?: (state: AssistantSidebarState) => void;
+  onOpenMentionChapter?: (chapterId: string, chapterTitle: string) => void;
+  onClose?: () => void;
+}
+
+export interface AssistantSidebarHostState extends AssistantSidebarHostRegistration {
+  isActive: boolean;
+}
+
+export function registerAssistantSidebarHost(
+  current: AssistantSidebarHostState | null,
+  registration: AssistantSidebarHostRegistration,
+): AssistantSidebarHostState {
+  if (
+    current &&
+    current.id === registration.id &&
+    current.host === registration.host &&
+    current.projectId === registration.projectId &&
+    current.isMobileOverlay === registration.isMobileOverlay &&
+    current.isOpen === registration.isOpen &&
+    current.onStateChange === registration.onStateChange &&
+    current.onOpenMentionChapter === registration.onOpenMentionChapter &&
+    current.onClose === registration.onClose
+  ) {
+    return current;
+  }
+  return { ...registration, isActive: true };
+}
+
+export function clearAssistantSidebarHost(
+  current: AssistantSidebarHostState | null,
+  id: string,
+): AssistantSidebarHostState | null {
+  if (!current || current.id !== id) return current;
+  return { ...current, host: null, isActive: false };
+}

--- a/frontend/src/features/app-shell/components/assistant-sidebar-host.tsx
+++ b/frontend/src/features/app-shell/components/assistant-sidebar-host.tsx
@@ -1,0 +1,68 @@
+import { useId, useLayoutEffect, useRef } from "react";
+
+import { useAppShell } from "./app-shell-context";
+import type { AssistantSidebarHostRegistration } from "./assistant-sidebar-host-state";
+
+interface AssistantSidebarHostProps extends Omit<
+  AssistantSidebarHostRegistration,
+  "id" | "host" | "isOpen" | "onClose"
+> {
+  className?: string;
+}
+
+export function AssistantSidebarHost({
+  className,
+  isMobileOverlay,
+  onOpenMentionChapter,
+  onStateChange,
+  projectId,
+}: AssistantSidebarHostProps) {
+  const id = useId();
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const {
+    clearAssistantSidebarHost,
+    closeAssistantSidebar,
+    isAssistantSidebarOpen,
+    registerAssistantSidebarHost,
+  } = useAppShell();
+  const callbacksRef = useRef({ onOpenMentionChapter, onStateChange });
+  callbacksRef.current = { onOpenMentionChapter, onStateChange };
+
+  useLayoutEffect(() => {
+    return () => clearAssistantSidebarHost(id);
+  }, [clearAssistantSidebarHost, id]);
+
+  useLayoutEffect(() => {
+    registerAssistantSidebarHost({
+      id,
+      host: isMobileOverlay ? null : hostRef.current,
+      projectId,
+      isMobileOverlay,
+      isOpen: isMobileOverlay ? isAssistantSidebarOpen : true,
+      onStateChange: (state) => callbacksRef.current.onStateChange?.(state),
+      onOpenMentionChapter: (chapterId, chapterTitle) =>
+        callbacksRef.current.onOpenMentionChapter?.(chapterId, chapterTitle),
+      onClose: closeAssistantSidebar,
+    });
+  }, [
+    id,
+    isMobileOverlay,
+    isAssistantSidebarOpen,
+    projectId,
+    closeAssistantSidebar,
+    registerAssistantSidebarHost,
+  ]);
+
+  if (isMobileOverlay) return null;
+  return (
+    <div
+      ref={hostRef}
+      className={
+        className
+          ? `app-layout-assistant-sidebar-host ${className}`
+          : "app-layout-assistant-sidebar-host"
+      }
+      data-slot="assistant-sidebar-host"
+    />
+  );
+}

--- a/frontend/src/features/app-shell/components/assistant-sidebar-position.ts
+++ b/frontend/src/features/app-shell/components/assistant-sidebar-position.ts
@@ -1,0 +1,14 @@
+export function syncAssistantSidebarPosition(sidebar: HTMLElement, host: HTMLElement): void {
+  const bounds = host.getBoundingClientRect();
+  sidebar.style.left = `${bounds.left}px`;
+  sidebar.style.top = `${bounds.top}px`;
+  sidebar.style.width = `${bounds.width}px`;
+  sidebar.style.height = `${bounds.height}px`;
+}
+
+export function clearAssistantSidebarPosition(sidebar: HTMLElement): void {
+  sidebar.style.removeProperty("left");
+  sidebar.style.removeProperty("top");
+  sidebar.style.removeProperty("width");
+  sidebar.style.removeProperty("height");
+}

--- a/frontend/src/features/app-shell/index.ts
+++ b/frontend/src/features/app-shell/index.ts
@@ -1,4 +1,5 @@
 export { AppLayout } from "./components/app-layout";
 export { AppSidebar } from "./components/app-sidebar";
+export { AssistantSidebarHost } from "./components/assistant-sidebar-host";
 export { MobileAppSidebarTrigger } from "./components/mobile-app-sidebar-trigger";
 export { useAppShell } from "./components/app-shell-context";

--- a/frontend/src/features/assistant/components/agent/agent-input.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-input.tsx
@@ -169,11 +169,7 @@ export function AgentInput({
 
   return (
     <Box className="ai-sidebar-input-area">
-      <motion.div
-        layout
-        className="ai-sidebar-input-stage"
-        transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
-      >
+      <div className="ai-sidebar-input-stage">
         <AnimatePresence initial={false}>
           {mentionSuggestions ? (
             <AgentMentionSuggestions
@@ -202,12 +198,10 @@ export function AgentInput({
           ) : null}
         </AnimatePresence>
 
-        <motion.div
+        <div
           ref={inputContainerRef}
-          layout
           className="ai-sidebar-input-container"
           data-mode={bodyMode}
-          transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
         >
           <AnimatePresence
             initial={false}
@@ -271,8 +265,8 @@ export function AgentInput({
               </motion.div>
             )}
           </AnimatePresence>
-        </motion.div>
-      </motion.div>
+        </div>
+      </div>
 
       {readOnly ? null : (
         <Flex

--- a/frontend/src/features/assistant/components/agent/agent-message-blocks.css
+++ b/frontend/src/features/assistant/components/agent/agent-message-blocks.css
@@ -110,6 +110,10 @@
   width: min(100%, 85vw);
 }
 
+.agent-message-user-shell-row[data-width="100%"] .agent-user-message-shell {
+  width: 100%;
+}
+
 .agent-user-message-preview {
   position: relative;
   overflow: hidden;

--- a/frontend/src/features/assistant/components/agent/message-blocks/shared/message-shell.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/shared/message-shell.tsx
@@ -3,6 +3,8 @@ import { ChevronDown } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 
+import { useAppShell } from "@/features/app-shell/components/app-shell-context";
+
 import "./message-shell.css";
 import { joinClassNames } from "./message-shell-utils";
 
@@ -243,10 +245,13 @@ export function MessageBlockContent({
 }
 
 export function UserMessageShell({ children, className }: UserMessageShellProps) {
+  const { isMobile } = useAppShell();
+
   return (
     <Flex
       justify="end"
       className={joinClassNames("agent-message-user-shell-row", className)}
+      data-width={isMobile ? "100%" : undefined}
     >
       <Box className="agent-user-message-shell">{children}</Box>
     </Flex>

--- a/frontend/src/features/assistant/components/assistant-sidebar.tsx
+++ b/frontend/src/features/assistant/components/assistant-sidebar.tsx
@@ -668,6 +668,13 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
       let cancelled = false;
       queueMicrotask(() => {
         if (cancelled) return;
+        setInputValue("");
+        setView("tasks");
+        setIsLoadingTask(false);
+        setCurrentTaskId(null);
+        setCurrentTaskTitle("");
+        setSummaryWarningOpen(false);
+        pendingSendActionRef.current = null;
         setConversationState(createConversationStackState(""));
         setActiveSubagents([]);
         setSessionTotalUsage(createSessionTotalUsageState());

--- a/frontend/src/features/assistant/hooks/use-agent-session.ts
+++ b/frontend/src/features/assistant/hooks/use-agent-session.ts
@@ -181,6 +181,8 @@ export function useAgentSession({
   const suppressNextErrorAfterCompactionErrorRef = useRef(false);
   const transcriptStateRef = useRef(createAgentTranscriptLiveState());
   const transportRetryAttemptRef = useRef(0);
+  const projectIdRef = useRef(projectId);
+  projectIdRef.current = projectId;
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [messages, setMessages] = useState<AgentMessage[]>([]);
   const [pendingMessage, setPendingMessage] = useState<AgentPendingMessage | null>(null);
@@ -631,6 +633,7 @@ export function useAgentSession({
           ...(agentKey ? { agent_key: agentKey } : {}),
         });
 
+        if (projectIdRef.current !== projectId) return;
         onSessionCreated?.(createResponse);
         sessionIdRef.current = createResponse.session_id;
         activeModelIdRef.current = modelId;
@@ -638,8 +641,10 @@ export function useAgentSession({
         queryClient.invalidateQueries({ queryKey: ["tasks", projectId], exact: false });
         attachAgentSocket(createResponse.session_id);
         await joinAgentSession(createResponse.session_id);
+        if (projectIdRef.current !== projectId) return;
         await sendAgentMessage(createResponse.session_id, userRequest);
       } catch (error) {
+        if (projectIdRef.current !== projectId) return;
         console.error("Failed to start agent session:", error);
         updateTranscriptState((current) => ({
           ...current,
@@ -900,13 +905,20 @@ export function useAgentSession({
     suppressSocketEventsAfterAbortRef.current = false;
     transportRetryAttemptRef.current = 0;
     suppressNextErrorAfterCompactionErrorRef.current = false;
+    ignoredApprovalIdsRef.current.clear();
+    manualCompactionPreviousStateRef.current = null;
     syncPendingMessageState(null);
     syncCompactingState(false);
+    setIsRollbacking(false);
     setSessionId(null);
     commitTranscriptState(createAgentTranscriptLiveState());
     socketUnsubscribeRef.current?.();
     socketUnsubscribeRef.current = null;
   }, [commitTranscriptState, syncCompactingState, syncPendingMessageState]);
+
+  useEffect(() => {
+    resetSession();
+  }, [projectId, resetSession]);
 
   const abortSession = useCallback(async () => {
     const activeSessionId = sessionId;

--- a/frontend/src/features/characters/pages/characters-page.tsx
+++ b/frontend/src/features/characters/pages/characters-page.tsx
@@ -8,8 +8,7 @@ import { Group, Panel, Separator } from "react-resizable-panels";
 import { useSearchParams } from "react-router";
 
 import { toast } from "@/components/toast";
-import { MobileAppSidebarTrigger } from "@/features/app-shell";
-import { AssistantSidebar } from "@/features/assistant";
+import { AssistantSidebarHost, MobileAppSidebarTrigger, useAppShell } from "@/features/app-shell";
 import type { AssistantSidebarState } from "@/features/assistant";
 import {
   batchDeleteCharacters,
@@ -62,6 +61,7 @@ export function CharactersPage() {
   const { t } = useTranslation();
   const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
+  const { isMobile, openAssistantSidebar } = useAppShell();
   const {
     currentProjectId,
     currentCharacterId,
@@ -74,20 +74,11 @@ export function CharactersPage() {
   const [deleteCharacterTarget, setDeleteCharacterTarget] = useState<CharacterListItem | null>(
     null,
   );
-  const [isMobile, setIsMobile] = useState(false);
-  const [isAssistantOpen, setIsAssistantOpen] = useState(false);
   const [assistantState, setAssistantState] = useState<AssistantSidebarState>({
     agentStatus: "idle",
     isAgentRunning: false,
   });
   const [selectedCharacterLoadVersion, setSelectedCharacterLoadVersion] = useState(0);
-
-  useEffect(() => {
-    const checkMobile = () => setIsMobile(window.innerWidth < 768);
-    checkMobile();
-    window.addEventListener("resize", checkMobile);
-    return () => window.removeEventListener("resize", checkMobile);
-  }, []);
 
   const { data: projectsData } = useQuery({
     queryKey: ["projects", "characters-page"],
@@ -378,10 +369,10 @@ export function CharactersPage() {
             collapsible={false}
           >
             <Box className="characters-panel">
-              <AssistantSidebar
-                key={currentProjectId}
+              <AssistantSidebarHost
                 projectId={currentProjectId}
                 onStateChange={setAssistantState}
+                isMobileOverlay={false}
               />
             </Box>
           </Panel>
@@ -418,7 +409,7 @@ export function CharactersPage() {
                   variant="ghost"
                   size="2"
                   aria-label={t("assistant.mobileTitle")}
-                  onClick={() => setIsAssistantOpen(true)}
+                  onClick={openAssistantSidebar}
                 >
                   <Bot size={18} />
                 </IconButton>
@@ -475,22 +466,11 @@ export function CharactersPage() {
       )}
 
       {isMobile && currentProjectId && (
-        <MotionBox
-          initial={false}
-          animate={{ x: isAssistantOpen ? 0 : "100%" }}
-          transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
-          className="characters-page-mobile-assistant-overlay"
-          data-open={isAssistantOpen}
-          aria-hidden={!isAssistantOpen}
-        >
-          <AssistantSidebar
-            key={currentProjectId}
-            projectId={currentProjectId}
-            onStateChange={setAssistantState}
-            onClose={() => setIsAssistantOpen(false)}
-            isMobileOverlay
-          />
-        </MotionBox>
+        <AssistantSidebarHost
+          projectId={currentProjectId}
+          onStateChange={setAssistantState}
+          isMobileOverlay
+        />
       )}
 
       <CharacterProfileDialog

--- a/frontend/src/features/world-info/pages/world-info-page.tsx
+++ b/frontend/src/features/world-info/pages/world-info-page.tsx
@@ -16,8 +16,7 @@ import { useSearchParams } from "react-router";
 import "./world-info-page.css";
 
 import { toast } from "@/components/toast";
-import { MobileAppSidebarTrigger } from "@/features/app-shell";
-import { AssistantSidebar } from "@/features/assistant";
+import { AssistantSidebarHost, MobileAppSidebarTrigger, useAppShell } from "@/features/app-shell";
 import type { AssistantSidebarState } from "@/features/assistant";
 import {
   fetchWorldInfoByProject,
@@ -69,9 +68,12 @@ export function WorldInfoPage() {
   const { t } = useTranslation();
   const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
+  const { closeAssistantSidebar, isMobile, openAssistantSidebar } = useAppShell();
 
   const {
     currentWorldInfoId,
+    currentProjectId,
+    setCurrentProject,
     setCurrentWorldInfo,
     currentEntryId,
     setCurrentEntry,
@@ -96,16 +98,6 @@ export function WorldInfoPage() {
     agentStatus: "idle",
     isAgentRunning: false,
   });
-  const [isMobile, setIsMobile] = useState(false);
-  const [isAssistantOpen, setIsAssistantOpen] = useState(false);
-  const [currentProjectId, setCurrentProjectId] = useState<string | null>(null);
-
-  useEffect(() => {
-    const checkMobile = () => setIsMobile(window.innerWidth < 768);
-    checkMobile();
-    window.addEventListener("resize", checkMobile);
-    return () => window.removeEventListener("resize", checkMobile);
-  }, []);
 
   // 从 URL 参数初始化状态
   useEffect(() => {
@@ -138,11 +130,11 @@ export function WorldInfoPage() {
           : null) ??
         projects[0]?.id ??
         null;
-      setCurrentProjectId(nextProjectId);
+      setCurrentProject(nextProjectId);
     };
 
     void initProject();
-  }, [currentProjectId, projectIdFromUrl, projects]);
+  }, [currentProjectId, projectIdFromUrl, projects, setCurrentProject]);
 
   useEffect(() => {
     if (currentProjectId) void setPreference(LAST_PROJECT_KEY, currentProjectId);
@@ -175,7 +167,6 @@ export function WorldInfoPage() {
     queryFn: () => fetchWorldInfoEntries(currentWorldInfoId!, { page: 1, pageSize: 500 }),
     enabled: !!currentWorldInfoId,
     staleTime: 0,
-    gcTime: 0,
   });
 
   // 获取当前选中条目的完整数据
@@ -184,7 +175,6 @@ export function WorldInfoPage() {
     queryFn: () => fetchWorldInfoEntry(currentEntryId!),
     enabled: !!currentEntryId,
     staleTime: 0,
-    gcTime: 0,
   });
 
   const entries = useMemo(() => entriesData?.items ?? [], [entriesData?.items]);
@@ -324,13 +314,12 @@ export function WorldInfoPage() {
 
   const handleSelectProject = useCallback(
     (projectId: string) => {
-      setCurrentProjectId(projectId || null);
-      setCurrentEntry(null);
+      setCurrentProject(projectId || null);
       setIsCreatingEntry(false);
       setSidebarOpen(false);
-      setIsAssistantOpen(false);
+      closeAssistantSidebar();
     },
-    [setCurrentEntry, setSidebarOpen],
+    [closeAssistantSidebar, setCurrentProject, setSidebarOpen],
   );
 
   /** 处理创建条目 */
@@ -584,10 +573,9 @@ export function WorldInfoPage() {
   );
 
   const agentSidebarContent = currentProjectId ? (
-    <AssistantSidebar
+    <AssistantSidebarHost
       projectId={currentProjectId}
       onStateChange={setAssistantState}
-      onClose={() => setIsAssistantOpen(false)}
       isMobileOverlay={isMobile}
     />
   ) : (
@@ -802,7 +790,7 @@ export function WorldInfoPage() {
                       variant="ghost"
                       size="2"
                       aria-label={t("assistant.mobileTitle")}
-                      onClick={() => setIsAssistantOpen(true)}
+                      onClick={openAssistantSidebar}
                     >
                       <Bot size={18} />
                     </IconButton>
@@ -865,18 +853,7 @@ export function WorldInfoPage() {
         </Flex>
       </Flex>
 
-      {isMobile && currentProjectId && (
-        <MotionBox
-          initial={false}
-          animate={{ x: isAssistantOpen ? 0 : "100%" }}
-          transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
-          className="world-info-page-mobile-assistant-overlay"
-          data-open={isAssistantOpen}
-          aria-hidden={!isAssistantOpen}
-        >
-          {agentSidebarContent}
-        </MotionBox>
-      )}
+      {isMobile && currentProjectId ? agentSidebarContent : null}
 
       <ImportWorldInfoDialog
         open={importDialogOpen}

--- a/frontend/src/features/world-info/store/use-world-info-store.ts
+++ b/frontend/src/features/world-info/store/use-world-info-store.ts
@@ -7,6 +7,8 @@
 import { create } from "zustand";
 
 interface WorldInfoStoreState {
+  /** 当前项目 ID */
+  currentProjectId: string | null;
   /** 当前选中的世界书 ID */
   currentWorldInfoId: string | null;
   /** 当前选中的条目 ID */
@@ -32,6 +34,8 @@ interface WorldInfoStoreState {
 }
 
 interface WorldInfoStoreActions {
+  /** 设置当前项目 */
+  setCurrentProject: (projectId: string | null) => void;
   /** 设置当前世界书 */
   setCurrentWorldInfo: (worldInfoId: string | null) => void;
   /** 设置当前选中的条目 */
@@ -60,6 +64,7 @@ interface WorldInfoStoreActions {
 type WorldInfoStore = WorldInfoStoreState & WorldInfoStoreActions;
 
 const initialState: WorldInfoStoreState = {
+  currentProjectId: null,
   currentWorldInfoId: null,
   currentEntryId: null,
   searchQuery: "",
@@ -75,6 +80,7 @@ const initialState: WorldInfoStoreState = {
 export const useWorldInfoStore = create<WorldInfoStore>((set, get) => ({
   ...initialState,
 
+  setCurrentProject: (projectId) => set({ currentProjectId: projectId, currentEntryId: null }),
   setCurrentWorldInfo: (worldInfoId) => set({ currentWorldInfoId: worldInfoId }),
   setCurrentEntry: (entryId) => set({ currentEntryId: entryId }),
   setSearchQuery: (query) => set({ searchQuery: query }),

--- a/frontend/src/features/writing/pages/writing-page.tsx
+++ b/frontend/src/features/writing/pages/writing-page.tsx
@@ -8,9 +8,8 @@ import { useParams } from "react-router";
 
 import "./writing-page.css";
 
-import { MobileAppSidebarTrigger } from "@/features/app-shell";
-import { AssistantSidebar } from "@/features/assistant";
-import type { AssistantSidebarHandle, AssistantSidebarState } from "@/features/assistant";
+import { AssistantSidebarHost, MobileAppSidebarTrigger, useAppShell } from "@/features/app-shell";
+import type { AssistantSidebarState } from "@/features/assistant";
 import { getLastChapterId, setLastChapterId } from "@/lib/local-db";
 
 import { ChapterEditor } from "../components/chapter-editor";
@@ -34,6 +33,8 @@ const SummaryPanel = lazy(() =>
 export function WritingPage() {
   const { t } = useTranslation();
   const { projectId } = useParams<{ projectId: string }>();
+  const { appendToAssistant, isAssistantSidebarOpen, isMobile, openAssistantSidebar } =
+    useAppShell();
 
   const { setCurrentChapter, hydrateSidebarView } = useWritingStore();
   const {
@@ -67,16 +68,13 @@ export function WritingPage() {
 
   const isPageLoading = !isTabsLoaded || isChaptersLoading;
 
-  const [isMobile, setIsMobile] = useState(false);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-  const [isAssistantOpen, setIsAssistantOpen] = useState(false);
   const [isSummaryOpen, setIsSummaryOpen] = useState(false);
   const [hasOpenedSummary, setHasOpenedSummary] = useState(false);
   const [assistantState, setAssistantState] = useState<AssistantSidebarState>({
     agentStatus: "idle",
     isAgentRunning: false,
   });
-  const assistantSidebarRef = useRef<AssistantSidebarHandle | null>(null);
 
   const isAgentLocked = useMemo(
     () => assistantState.isAgentRunning,
@@ -87,16 +85,6 @@ export function WritingPage() {
   useEffect(() => {
     void hydrateSidebarView();
   }, [hydrateSidebarView]);
-
-  useEffect(() => {
-    const checkMobile = () => {
-      setIsMobile(window.innerWidth < 768);
-    };
-
-    checkMobile();
-    window.addEventListener("resize", checkMobile);
-    return () => window.removeEventListener("resize", checkMobile);
-  }, []);
 
   const allChapters = useMemo(
     () => chaptersData?.volumes.flatMap((volume) => volume.chapters) ?? [],
@@ -316,17 +304,17 @@ export function WritingPage() {
     (markup: string) => {
       if (!markup.trim()) return;
 
-      if (isMobile && !isAssistantOpen) {
-        setIsAssistantOpen(true);
+      if (isMobile && !isAssistantSidebarOpen) {
+        openAssistantSidebar();
         window.requestAnimationFrame(() => {
-          assistantSidebarRef.current?.appendToComposer(markup);
+          appendToAssistant(markup);
         });
         return;
       }
 
-      assistantSidebarRef.current?.appendToComposer(markup);
+      appendToAssistant(markup);
     },
-    [isAssistantOpen, isMobile],
+    [appendToAssistant, isAssistantSidebarOpen, isMobile, openAssistantSidebar],
   );
 
   const handleOpenSummary = useCallback(() => {
@@ -428,11 +416,11 @@ export function WritingPage() {
               collapsible={false}
             >
               <Box className="writing-page-sidebar writing-page-sidebar--right">
-                <AssistantSidebar
-                  ref={assistantSidebarRef}
+                <AssistantSidebarHost
                   projectId={projectId}
                   onStateChange={setAssistantState}
                   onOpenMentionChapter={handleChapterSelect}
+                  isMobileOverlay={false}
                 />
               </Box>
             </Panel>
@@ -469,7 +457,7 @@ export function WritingPage() {
                     variant="ghost"
                     size="2"
                     aria-label={t("assistant.mobileTitle")}
-                    onClick={() => setIsAssistantOpen(true)}
+                    onClick={openAssistantSidebar}
                   >
                     <Bot size={18} />
                   </IconButton>
@@ -539,23 +527,12 @@ export function WritingPage() {
       </Box>
 
       {isMobile && (
-        <MotionBox
-          initial={false}
-          animate={{ x: isAssistantOpen ? 0 : "100%" }}
-          transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
-          className="writing-page-mobile-assistant-overlay"
-          data-open={isAssistantOpen}
-          aria-hidden={!isAssistantOpen}
-        >
-          <AssistantSidebar
-            ref={assistantSidebarRef}
-            projectId={projectId}
-            onStateChange={setAssistantState}
-            onOpenMentionChapter={handleChapterSelect}
-            onClose={() => setIsAssistantOpen(false)}
-            isMobileOverlay
-          />
-        </MotionBox>
+        <AssistantSidebarHost
+          projectId={projectId}
+          onStateChange={setAssistantState}
+          onOpenMentionChapter={handleChapterSelect}
+          isMobileOverlay
+        />
       )}
 
       {hasOpenedSummary && (


### PR DESCRIPTION
## PR 标题

fix(agent): 修复跨页面切换导致的侧边栏状态丢失问题

## 变更说明

- 问题: 在写作、世界书和角色页之间切换时，Agent 侧边栏会因页面卸载而丢失会话、输入和移动端打开状态；跨项目切换时还可能显示旧会话。
- 重要性: Agent 会话属于长时间交互，页面导航不应中断同一项目的会话上下文。
- 变化: 将 Agent 侧边栏提升为 app-shell 常驻实例，页面仅注册显示宿主；同项目切换保留状态，项目变更时清理会话和旧 Socket 订阅。
- 变化: 优化桌面拖拽分割线、移动端用户消息宽度、输入区挂载动画和世界书重复进入时的加载体验。

## 关联 Issue / PR (如有)

Closes #168 

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

Agent 侧边栏由各页面分别渲染，路由切换会卸载对应实例。世界书页面的项目选择使用局部状态，且条目查询在页面卸载时立即回收缓存。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令：`pnpm type-check`、`pnpm lint`、`pnpm format:check`、`git diff --check`。
