### PR TITLE
fix(ci): 移除 PR 自查清单的强制校验

### DIFF
--- a/.github/workflows/pr-template.yml
+++ b/.github/workflows/pr-template.yml
@@ -29,7 +29,7 @@ jobs:
             errors+=("PR 标题必须符合 Conventional Commits 格式")
           fi
 
-          body=$(printf '%s\n' "$PR_BODY" | sed '/<!--/,/-->/d')
+          body=$(printf '%s\n' "$PR_BODY" | tr -d '\r' | sed '/<!--/,/-->/d')
           change_description=$(printf '%s\n' "$body" | sed -n '/^## 变更说明$/,/^## /{ /^## /!p }' | sed '/^[[:space:]]*-[[:space:]]*\(问题\|重要性\|变化\):[[:space:]]*$/d' | sed '/^[[:space:]]*\.\.\.[[:space:]]*$/d' | tr -d '[:space:]')
 
           if [ -z "$change_description" ]; then
@@ -39,15 +39,6 @@ jobs:
           if ! printf '%s\n' "$body" | grep -Eq '^- \[[xX]\] (新功能|错误修复|文档更新|代码格式调整|代码重构|性能优化|测试相关|杂项)'; then
             errors+=("必须选择至少一种变更类型")
           fi
-
-          for item in \
-            '变更范围合理，未包含无关修改' \
-            '未暴露敏感信息（API Key、密码等）' \
-            '提交信息符合规范'; do
-            if ! printf '%s\n' "$body" | grep -Fqx -- "- [x] ${item}" && ! printf '%s\n' "$body" | grep -Fqx -- "- [X] ${item}"; then
-              errors+=("自查清单未确认：${item}")
-            fi
-          done
 
           if [ "${#errors[@]}" -gt 0 ]; then
             printf '::error::%s\n' "$(IFS='；'; echo "${errors[*]}")"


### PR DESCRIPTION
## PR 标题

fix(ci): 移除 PR 自查清单强制校验

## 变更说明

- 问题: PR 模板检查会因 CRLF 换行误判自查清单未勾选，且不应将人工自查状态作为 CI 阻塞条件。
- 重要性: 防止格式正常的 PR 被无关的自查清单状态阻塞。
- 变化: 正文解析时统一移除 CRLF 的回车字符，并移除对三项自查清单勾选状态的强制校验；标题、变更说明和变更类型检查保持不变。

## 关联 Issue / PR (如有)

无。

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

检查脚本使用整行精确匹配，CRLF 正文的行尾回车会使已勾选条目无法匹配。同时，自查清单用于人工确认，不适合作为自动化校验条件。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 已使用 CRLF 格式的 PR 正文验证：变更说明和变更类型仍可正确识别，未勾选的自查项不会阻塞检查。
