### PR TITLE
fix(providers): 避免图标请求阻塞连接操作

### DIFF
--- a/backend/app/api/routers/model_icons.py
+++ b/backend/app/api/routers/model_icons.py
@@ -6,7 +6,7 @@ from typing import Annotated
 from fastapi import APIRouter, Depends, HTTPException, Request
 from starlette.responses import Response
 
-from app.models.catalog.icon_proxy import CatalogIconProxyError, CatalogIconProxyService
+from app.models.catalog.icon_proxy import CatalogIconProxyService
 
 router = APIRouter(prefix="/icons/model", tags=["model-icons"])
 
@@ -29,10 +29,7 @@ async def get_catalog_provider_icon(
     if not provider_id:
         raise HTTPException(status_code=404, detail="Catalog provider icon not found")
 
-    try:
-        payload = await service.fetch_icon(provider_id)
-    except CatalogIconProxyError as exc:
-        raise HTTPException(status_code=exc.status_code, detail=exc.detail) from exc
+    payload = await service.fetch_icon(provider_id)
 
     return Response(
         content=payload.content,

--- a/backend/app/models/catalog/icon_proxy.py
+++ b/backend/app/models/catalog/icon_proxy.py
@@ -1,15 +1,20 @@
 # -*- coding: utf-8 -*-
-"""Catalog icon proxy with in-memory source selection."""
+"""Catalog icon proxy with per-icon source fallback."""
 
 from __future__ import annotations
 
 import asyncio
+import time
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, Protocol
 
 import httpx
 
-CatalogIconSource = Literal["models_dev", "jsdelivr"]
+CatalogIconSource = Literal["models_dev", "jsdelivr", "default"]
+
+_MAX_CONCURRENT_UPSTREAM_REQUESTS = 8
+_MODELS_DEV_RETRY_DELAY_SECONDS = 30.0
+_DEFAULT_ICON_SVG = b"""<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg"><path shape-rendering="geometricPrecision" d="M9.8132 15.9038L9 18.75L8.1868 15.9038C7.75968 14.4089 6.59112 13.2403 5.09619 12.8132L2.25 12L5.09619 11.1868C6.59113 10.7597 7.75968 9.59112 8.1868 8.09619L9 5.25L9.8132 8.09619C10.2403 9.59113 11.4089 10.7597 12.9038 11.1868L15.75 12L12.9038 12.8132C11.4089 13.2403 10.2403 14.4089 9.8132 15.9038Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path d="M18.2589 8.71454L18 9.75L17.7411 8.71454C17.4388 7.50533 16.4947 6.56117 15.2855 6.25887L14.25 6L15.2855 5.74113C16.4947 5.43883 17.4388 4.49467 17.7411 3.28546L18 2.25L18.2589 3.28546C18.5612 4.49467 19.5053 5.43883 20.7145 5.74113L21.75 6L20.7145 6.25887C19.5053 6.56117 18.5612 7.50533 18.2589 8.71454Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path d="M16.8942 20.5673L16.5 21.75L16.1058 20.5673C15.8818 19.8954 15.3546 19.3682 14.6827 19.1442L13.5 18.75L14.6827 18.3558C15.3546 18.1318 15.8818 17.6046 16.1058 16.9327L16.5 15.75L16.8942 16.9327C17.1182 17.6046 17.6454 18.1318 18.3173 18.3558L19.5 18.75L18.3173 19.1442C17.6454 19.3682 17.1182 19.8954 16.8942 20.5673Z" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>"""
 
 
 @dataclass(frozen=True)
@@ -20,143 +25,96 @@ class CatalogIconPayload:
 
 @dataclass(frozen=True)
 class _IconSourceConfig:
-    name: CatalogIconSource
+    name: Literal["models_dev", "jsdelivr"]
     url_template: str
 
 
 @dataclass(frozen=True)
 class _IconSourceError(Exception):
-    source: CatalogIconSource
     status_code: int | None
-    should_switch_winner: bool
+    marks_source_unavailable: bool
 
 
-class CatalogIconProxyError(Exception):
-    """Raised when no upstream source can serve the requested icon."""
+class _IconHttpClient(Protocol):
+    async def get(self, url: str) -> httpx.Response: ...
 
-    def __init__(self, status_code: int, detail: str) -> None:
-        super().__init__(detail)
-        self.status_code = status_code
-        self.detail = detail
+    async def aclose(self) -> None: ...
 
 
-_ICON_SOURCES: tuple[_IconSourceConfig, ...] = (
-    _IconSourceConfig("models_dev", "https://models.dev/logos/{provider_id}.svg"),
-    _IconSourceConfig(
-        "jsdelivr",
-        "https://cdn.jsdelivr.net/gh/sst/models.dev@dev/providers/{provider_id}/logo.svg",
-    ),
+_MODELS_DEV_SOURCE = _IconSourceConfig(
+    "models_dev", "https://models.dev/logos/{provider_id}.svg"
 )
-_SOURCE_BY_NAME = {source.name: source for source in _ICON_SOURCES}
+_JSDELIVR_SOURCE = _IconSourceConfig(
+    "jsdelivr",
+    "https://cdn.jsdelivr.net/gh/sst/models.dev@dev/providers/{provider_id}/logo.svg",
+)
 
 
 class CatalogIconProxyService:
     """Serve catalog icons through a single backend entrypoint."""
 
-    def __init__(self, timeout: float = 5.0) -> None:
-        self._client = httpx.AsyncClient(timeout=timeout, follow_redirects=True)
-        self._winner: CatalogIconSource | None = None
-        self._probe_lock = asyncio.Lock()
-        self._switch_lock = asyncio.Lock()
-
-    @property
-    def winner(self) -> CatalogIconSource | None:
-        return self._winner
+    def __init__(
+        self, timeout: float = 5.0, client: _IconHttpClient | None = None
+    ) -> None:
+        self._client = client or httpx.AsyncClient(timeout=timeout, follow_redirects=True)
+        self._request_semaphore = asyncio.Semaphore(_MAX_CONCURRENT_UPSTREAM_REQUESTS)
+        self._models_dev_unavailable_until = 0.0
 
     async def aclose(self) -> None:
         await self._client.aclose()
 
     async def fetch_icon(self, provider_id: str) -> CatalogIconPayload:
         if not provider_id:
-            raise CatalogIconProxyError(404, "Catalog provider icon not found")
-
-        if self._winner is None:
-            async with self._probe_lock:
-                if self._winner is None:
-                    result = await self._probe_sources(provider_id)
-                    self._winner = result.source
-                    return result
-
-        primary_source = self._winner
-        if primary_source is None:
-            raise CatalogIconProxyError(502, "Catalog icon source is unavailable")
-        return await self._fetch_with_fallback(provider_id, primary_source)
-
-    async def _probe_sources(self, provider_id: str) -> CatalogIconPayload:
-        tasks = [
-            asyncio.create_task(self._fetch_from_source(source, provider_id))
-            for source in _ICON_SOURCES
-        ]
-        errors: list[_IconSourceError] = []
+            return self._default_icon()
 
         try:
-            for task in asyncio.as_completed(tasks):
-                try:
-                    result = await task
-                except _IconSourceError as exc:
-                    errors.append(exc)
-                    continue
+            return await self._fetch_jsdelivr_icon(provider_id)
+        except _IconSourceError:
+            return await self._fetch_models_dev_or_default(provider_id)
 
-                for pending in tasks:
-                    if pending is not task and not pending.done():
-                        pending.cancel()
-                await asyncio.gather(*tasks, return_exceptions=True)
-                return result
-        finally:
-            await asyncio.gather(*tasks, return_exceptions=True)
+    async def _fetch_jsdelivr_icon(self, provider_id: str) -> CatalogIconPayload:
+        async with self._request_semaphore:
+            return await self._request_icon(_JSDELIVR_SOURCE, provider_id)
 
-        raise self._terminal_error(provider_id, errors)
+    async def _fetch_models_dev_or_default(self, provider_id: str) -> CatalogIconPayload:
+        if self._is_models_dev_unavailable():
+            return self._default_icon()
 
-    async def _fetch_with_fallback(
-        self, provider_id: str, primary_source_name: CatalogIconSource
-    ) -> CatalogIconPayload:
-        primary_source = _SOURCE_BY_NAME[primary_source_name]
-        fallback_source = next(
-            source for source in _ICON_SOURCES if source.name != primary_source_name
-        )
+        async with self._request_semaphore:
+            if self._is_models_dev_unavailable():
+                return self._default_icon()
 
-        try:
-            return await self._fetch_from_source(primary_source, provider_id)
-        except _IconSourceError as primary_error:
             try:
-                fallback_result = await self._fetch_from_source(fallback_source, provider_id)
-            except _IconSourceError as fallback_error:
-                raise self._terminal_error(provider_id, [primary_error, fallback_error])
+                return await self._request_icon(_MODELS_DEV_SOURCE, provider_id)
+            except _IconSourceError as exc:
+                if exc.marks_source_unavailable:
+                    self._models_dev_unavailable_until = (
+                        time.monotonic() + _MODELS_DEV_RETRY_DELAY_SECONDS
+                    )
+                return self._default_icon()
 
-            if primary_error.should_switch_winner:
-                async with self._switch_lock:
-                    if self._winner == primary_source_name:
-                        self._winner = fallback_source.name
-            return fallback_result
-
-    async def _fetch_from_source(
+    async def _request_icon(
         self, source: _IconSourceConfig, provider_id: str
     ) -> CatalogIconPayload:
         url = source.url_template.format(provider_id=provider_id)
         try:
             response = await self._client.get(url)
         except httpx.TimeoutException as exc:
-            raise _IconSourceError(source.name, None, True) from exc
+            raise _IconSourceError(None, True) from exc
         except httpx.RequestError as exc:
-            raise _IconSourceError(source.name, None, True) from exc
+            raise _IconSourceError(None, True) from exc
 
         if response.status_code == 200:
             return CatalogIconPayload(content=response.content, source=source.name)
         if response.status_code == 404:
-            raise _IconSourceError(source.name, 404, False)
+            raise _IconSourceError(404, False)
         if 500 <= response.status_code <= 599:
-            raise _IconSourceError(source.name, response.status_code, True)
-        raise _IconSourceError(source.name, response.status_code, False)
+            raise _IconSourceError(response.status_code, True)
+        raise _IconSourceError(response.status_code, False)
 
-    def _terminal_error(
-        self, provider_id: str, errors: list[_IconSourceError]
-    ) -> CatalogIconProxyError:
-        if errors and all(error.status_code == 404 for error in errors):
-            return CatalogIconProxyError(
-                404,
-                f"Catalog provider icon '{provider_id}' was not found",
-            )
-        return CatalogIconProxyError(
-            502,
-            f"Failed to fetch catalog provider icon '{provider_id}'",
-        )
+    def _is_models_dev_unavailable(self) -> bool:
+        return time.monotonic() < self._models_dev_unavailable_until
+
+    @staticmethod
+    def _default_icon() -> CatalogIconPayload:
+        return CatalogIconPayload(content=_DEFAULT_ICON_SVG, source="default")

--- a/backend/tests/api/test_model_icons.py
+++ b/backend/tests/api/test_model_icons.py
@@ -3,8 +3,6 @@
 Catalog model icon API tests.
 """
 
-import asyncio
-
 import httpx
 import pytest
 import respx
@@ -13,7 +11,7 @@ from httpx import AsyncClient
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_catalog_icon_route_proxies_svg_with_backend_entrypoint(
+async def test_catalog_icon_route_prefers_jsdelivr_without_probing_models_dev(
     client: AsyncClient,
 ) -> None:
     jsdelivr_route = respx.get(
@@ -26,31 +24,21 @@ async def test_catalog_icon_route_proxies_svg_with_backend_entrypoint(
             request=request,
         )
     )
-    modelsdev_route = respx.get("https://models.dev/logos/openai.svg").mock(
-        side_effect=lambda request: httpx.Response(
-            200,
-            text="<svg>modelsdev</svg>",
-            headers={"content-type": "image/svg+xml"},
-            request=request,
-        )
-    )
-
     response = await client.get("/icons/model/catalog/openai.svg")
 
     assert response.status_code == 200
     assert response.headers["content-type"].startswith("image/svg+xml")
-    assert response.text in {"<svg>jsdelivr</svg>", "<svg>modelsdev</svg>"}
+    assert response.text == "<svg>jsdelivr</svg>"
     assert jsdelivr_route.called
-    assert modelsdev_route.called
 
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_catalog_icon_route_fails_over_and_switches_cached_source(
+async def test_catalog_icon_route_falls_back_per_icon_without_changing_jsdelivr_priority(
     client: AsyncClient,
 ) -> None:
     jsdelivr_calls = {"openai": 0, "anthropic": 0, "deepseek": 0}
-    modelsdev_calls = {"openai": 0, "anthropic": 0, "deepseek": 0}
+    modelsdev_calls = {"anthropic": 0}
 
     async def jsdelivr_openai(request: httpx.Request) -> httpx.Response:
         jsdelivr_calls["openai"] += 1
@@ -61,21 +49,11 @@ async def test_catalog_icon_route_fails_over_and_switches_cached_source(
             request=request,
         )
 
-    async def modelsdev_openai(request: httpx.Request) -> httpx.Response:
-        modelsdev_calls["openai"] += 1
-        await asyncio.sleep(0.02)
-        return httpx.Response(
-            200,
-            text="<svg>modelsdev-openai</svg>",
-            headers={"content-type": "image/svg+xml"},
-            request=request,
-        )
-
     async def jsdelivr_anthropic(request: httpx.Request) -> httpx.Response:
         jsdelivr_calls["anthropic"] += 1
         return httpx.Response(
-            503,
-            text="upstream error",
+            404,
+            text="not found",
             headers={"content-type": "text/plain"},
             request=request,
         )
@@ -110,7 +88,6 @@ async def test_catalog_icon_route_fails_over_and_switches_cached_source(
     respx.get(
         "https://cdn.jsdelivr.net/gh/sst/models.dev@dev/providers/openai/logo.svg"
     ).mock(side_effect=jsdelivr_openai)
-    respx.get("https://models.dev/logos/openai.svg").mock(side_effect=modelsdev_openai)
     respx.get(
         "https://cdn.jsdelivr.net/gh/sst/models.dev@dev/providers/anthropic/logo.svg"
     ).mock(side_effect=jsdelivr_anthropic)
@@ -133,6 +110,6 @@ async def test_catalog_icon_route_fails_over_and_switches_cached_source(
     assert second.status_code == 200
     assert second.text == "<svg>modelsdev-anthropic</svg>"
     assert third.status_code == 200
-    assert third.text == "<svg>modelsdev-deepseek</svg>"
-    assert jsdelivr_calls == {"openai": 1, "anthropic": 1, "deepseek": 0}
-    assert modelsdev_calls == {"openai": 1, "anthropic": 1, "deepseek": 1}
+    assert third.text == "<svg>jsdelivr-deepseek</svg>"
+    assert jsdelivr_calls == {"openai": 1, "anthropic": 1, "deepseek": 1}
+    assert modelsdev_calls == {"anthropic": 1}

--- a/backend/tests/models/test_catalog_icon_proxy.py
+++ b/backend/tests/models/test_catalog_icon_proxy.py
@@ -3,8 +3,6 @@
 Catalog icon proxy service tests.
 """
 
-import asyncio
-
 import httpx
 import pytest
 
@@ -23,53 +21,103 @@ class _FakeClient:
 
 
 @pytest.mark.asyncio
-async def test_concurrent_first_requests_share_single_probe() -> None:
-    service = CatalogIconProxyService()
-    calls = {"openai": {"models": 0, "js": 0}, "anthropic": {"models": 0, "js": 0}}
+async def test_fetches_jsdelivr_before_models_dev_for_each_icon() -> None:
+    calls: list[str] = []
 
     async def responder(url: str) -> httpx.Response:
         if "providers/openai/logo.svg" in url:
-            calls["openai"]["js"] += 1
+            calls.append("jsdelivr:openai")
             return httpx.Response(200, text="<svg>openai-js</svg>")
         if "models.dev/logos/openai.svg" in url:
-            calls["openai"]["models"] += 1
-            await asyncio.sleep(0.02)
-            return httpx.Response(200, text="<svg>openai-models</svg>")
+            raise AssertionError("jsDelivr success must not probe Models.dev")
         if "providers/anthropic/logo.svg" in url:
-            calls["anthropic"]["js"] += 1
-            return httpx.Response(200, text="<svg>anthropic-js</svg>")
+            calls.append("jsdelivr:anthropic")
+            return httpx.Response(404, text="not found")
         if "models.dev/logos/anthropic.svg" in url:
-            calls["anthropic"]["models"] += 1
-            return httpx.Response(200, text="<svg>anthropic-models</svg>")
+            calls.append("models_dev:anthropic")
+            return httpx.Response(200, text="<svg>anthropic-default</svg>")
+        if "providers/deepseek/logo.svg" in url:
+            calls.append("jsdelivr:deepseek")
+            return httpx.Response(200, text="<svg>deepseek-js</svg>")
+        if "models.dev/logos/deepseek.svg" in url:
+            raise AssertionError("each icon must use its own source decision")
         raise AssertionError(f"Unexpected URL {url}")
 
-    service._client = _FakeClient(responder)  # type: ignore[assignment]
+    service = CatalogIconProxyService(client=_FakeClient(responder))
 
-    first, second = await asyncio.gather(
-        service.fetch_icon("openai"),
-        service.fetch_icon("anthropic"),
-    )
+    openai = await service.fetch_icon("openai")
+    anthropic = await service.fetch_icon("anthropic")
+    deepseek = await service.fetch_icon("deepseek")
 
-    assert first.source == "jsdelivr"
-    assert second.source == "jsdelivr"
-    assert service.winner == "jsdelivr"
-    assert calls == {
-        "openai": {"models": 1, "js": 1},
-        "anthropic": {"models": 0, "js": 1},
-    }
+    assert openai.source == "jsdelivr"
+    assert anthropic.source == "models_dev"
+    assert deepseek.source == "jsdelivr"
+    assert calls == [
+        "jsdelivr:openai",
+        "jsdelivr:anthropic",
+        "models_dev:anthropic",
+        "jsdelivr:deepseek",
+    ]
 
 
 @pytest.mark.asyncio
-async def test_404_falls_back_without_switching_global_winner() -> None:
-    service = CatalogIconProxyService()
+async def test_unavailable_icon_sources_return_local_default_icon() -> None:
+    calls: list[str] = []
+
+    async def responder(url: str) -> httpx.Response:
+        if "providers/chutes/logo.svg" in url:
+            calls.append("jsdelivr")
+            return httpx.Response(404, text="not found")
+        if "models.dev/logos/chutes.svg" in url:
+            calls.append("models_dev")
+            raise httpx.ConnectTimeout("Models.dev is unreachable")
+        raise AssertionError(f"Unexpected URL {url}")
+
+    service = CatalogIconProxyService(client=_FakeClient(responder))
+
+    result = await service.fetch_icon("chutes")
+
+    assert result.source == "default"
+    assert b'viewBox="0 0 24 24"' in result.content
+    assert b'M9.8132 15.9038L9 18.75L8.1868 15.9038' in result.content
+    assert calls == ["jsdelivr", "models_dev"]
+
+
+@pytest.mark.asyncio
+async def test_models_dev_failure_skips_later_fallback_requests() -> None:
+    calls: list[str] = []
+
+    async def responder(url: str) -> httpx.Response:
+        if "providers/chutes/logo.svg" in url:
+            calls.append("jsdelivr:chutes")
+            return httpx.Response(404, text="not found")
+        if "providers/clarifai/logo.svg" in url:
+            calls.append("jsdelivr:clarifai")
+            return httpx.Response(404, text="not found")
+        if "models.dev/logos/chutes.svg" in url:
+            calls.append("models_dev:chutes")
+            raise httpx.ConnectTimeout("Models.dev is unreachable")
+        if "models.dev/logos/clarifai.svg" in url:
+            raise AssertionError("unavailable Models.dev source must be skipped")
+        raise AssertionError(f"Unexpected URL {url}")
+
+    service = CatalogIconProxyService(client=_FakeClient(responder))
+
+    first = await service.fetch_icon("chutes")
+    second = await service.fetch_icon("clarifai")
+
+    assert first.source == "default"
+    assert second.source == "default"
+    assert calls == ["jsdelivr:chutes", "models_dev:chutes", "jsdelivr:clarifai"]
+
+
+@pytest.mark.asyncio
+async def test_404_falls_back_to_models_dev_without_affecting_other_icons() -> None:
     calls = {"anthropic": {"models": 0, "js": 0}, "deepseek": {"models": 0, "js": 0}}
 
     async def responder(url: str) -> httpx.Response:
         if "providers/openai/logo.svg" in url:
             return httpx.Response(200, text="<svg>openai-js</svg>")
-        if "models.dev/logos/openai.svg" in url:
-            await asyncio.sleep(0.02)
-            return httpx.Response(200, text="<svg>openai-models</svg>")
         if "providers/anthropic/logo.svg" in url:
             calls["anthropic"]["js"] += 1
             return httpx.Response(404, text="not found")
@@ -84,7 +132,7 @@ async def test_404_falls_back_without_switching_global_winner() -> None:
             return httpx.Response(200, text="<svg>deepseek-models</svg>")
         raise AssertionError(f"Unexpected URL {url}")
 
-    service._client = _FakeClient(responder)  # type: ignore[assignment]
+    service = CatalogIconProxyService(client=_FakeClient(responder))
 
     first = await service.fetch_icon("openai")
     second = await service.fetch_icon("anthropic")
@@ -93,7 +141,6 @@ async def test_404_falls_back_without_switching_global_winner() -> None:
     assert first.source == "jsdelivr"
     assert second.source == "models_dev"
     assert third.source == "jsdelivr"
-    assert service.winner == "jsdelivr"
     assert calls == {
         "anthropic": {"models": 1, "js": 1},
         "deepseek": {"models": 0, "js": 1},

--- a/frontend/src/features/settings/lib/provider-icon-request-queue.ts
+++ b/frontend/src/features/settings/lib/provider-icon-request-queue.ts
@@ -1,0 +1,42 @@
+const MAX_CONCURRENT_PROVIDER_ICON_REQUESTS = 2;
+
+const pendingRequests: Array<() => void> = [];
+let activeRequestCount = 0;
+
+export function scheduleProviderIconRequest(request: () => Promise<void>): () => void {
+  let hasStarted = false;
+  let isCancelled = false;
+
+  const start = () => {
+    hasStarted = true;
+    if (isCancelled) {
+      startPendingRequests();
+      return;
+    }
+
+    activeRequestCount += 1;
+    void request().finally(() => {
+      activeRequestCount -= 1;
+      startPendingRequests();
+    });
+  };
+
+  pendingRequests.push(start);
+  startPendingRequests();
+
+  return () => {
+    isCancelled = true;
+    if (!hasStarted) {
+      const index = pendingRequests.indexOf(start);
+      if (index >= 0) pendingRequests.splice(index, 1);
+    }
+  };
+}
+
+function startPendingRequests(): void {
+  while (activeRequestCount < MAX_CONCURRENT_PROVIDER_ICON_REQUESTS) {
+    const request = pendingRequests.shift();
+    if (!request) return;
+    request();
+  }
+}

--- a/frontend/src/features/settings/lib/provider-icons.tsx
+++ b/frontend/src/features/settings/lib/provider-icons.tsx
@@ -4,10 +4,11 @@
  * 提供商图标工具。
  */
 
-import { ReactSVG } from "react-svg";
+import { useEffect, useRef, useState } from "react";
 
 import { Spinner } from "@/components";
 
+import { scheduleProviderIconRequest } from "./provider-icon-request-queue";
 import { getProviderIconUrl } from "./provider-icon-url";
 
 /**
@@ -19,6 +20,8 @@ interface ProviderIconProps {
 }
 
 function prepareProviderSvg(svg: SVGSVGElement, size: number): void {
+  const inheritsNoFill = svg.getAttribute("fill") === "none";
+
   svg
     .querySelectorAll("script, foreignObject, image, use, iframe, object, embed, link, style")
     .forEach((element) => element.remove());
@@ -33,7 +36,10 @@ function prepareProviderSvg(svg: SVGSVGElement, size: number): void {
       }
     }
 
-    if (element.getAttribute("fill") !== "none") {
+    if (
+      element.getAttribute("fill") !== "none" &&
+      (element.hasAttribute("fill") || !inheritsNoFill)
+    ) {
       element.setAttribute("fill", "currentColor");
     }
     if (element.hasAttribute("stroke")) {
@@ -50,6 +56,45 @@ function prepareProviderSvg(svg: SVGSVGElement, size: number): void {
 
 export function ProviderIcon({ iconPath, size = 20 }: ProviderIconProps) {
   const iconUrl = getProviderIconUrl(iconPath);
+  const svgContainerRef = useRef<HTMLSpanElement>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    if (!iconUrl) return;
+
+    const abortController = new AbortController();
+    const svgContainer = svgContainerRef.current;
+
+    svgContainer?.replaceChildren();
+    setIsLoading(true);
+
+    const cancelRequest = scheduleProviderIconRequest(async () => {
+      try {
+        const response = await fetch(iconUrl, { signal: abortController.signal });
+        if (!response.ok) throw new Error(`Failed to load provider icon: ${response.status}`);
+
+        const document = new DOMParser().parseFromString(await response.text(), "image/svg+xml");
+        const svg = document.documentElement;
+        if (!(svg instanceof SVGSVGElement)) throw new Error("Provider icon is not an SVG");
+
+        prepareProviderSvg(svg, size);
+        if (!abortController.signal.aborted) {
+          svgContainerRef.current?.replaceChildren(svg);
+        }
+      } catch (error) {
+        if (!(error instanceof DOMException && error.name === "AbortError")) {
+          svgContainerRef.current?.replaceChildren();
+        }
+      } finally {
+        if (!abortController.signal.aborted) setIsLoading(false);
+      }
+    });
+
+    return () => {
+      abortController.abort();
+      cancelRequest();
+    };
+  }, [iconUrl, size]);
 
   if (!iconUrl) {
     return null;
@@ -67,20 +112,16 @@ export function ProviderIcon({ iconPath, size = 20 }: ProviderIconProps) {
         flexShrink: 0,
       }}
     >
-      <ReactSVG
-        beforeInjection={(svg) => prepareProviderSvg(svg, size)}
-        evalScripts="never"
-        fallback={() => null}
-        loading={() => <Spinner size={12} />}
-        src={iconUrl}
+      {isLoading ? <Spinner size={12} /> : null}
+      <span
+        ref={svgContainerRef}
         style={{
-          display: "inline-flex",
-          width: size,
-          height: size,
+          display: isLoading ? "none" : "inline-flex",
+          width: isLoading ? undefined : size,
+          height: isLoading ? undefined : size,
           alignItems: "center",
           justifyContent: "center",
         }}
-        wrapper="span"
       />
     </span>
   );


### PR DESCRIPTION
## PR 标题

fix(providers): 避免图标请求阻塞连接操作

## 变更说明

- 问题: 提供商选择器会同时请求大量图标，浏览器同源连接被占满后，连接验证和新建提供商请求会排队。
- 重要性: 图标加载不应影响设置页的核心操作。
- 变化: 前端将图标请求限制为最多 2 个并发请求，组件卸载或图标地址变化时取消排队或中止请求。
- 变化: 后端取消进程级图标源竞速选主，改为每个图标独立按 jsDelivr、Models.dev、内置星形 SVG 的顺序降级。
- 变化: Models.dev 发生网络错误或 5xx 后暂时跳过，避免缺失图标重复等待不可达上游；后端图标请求也限制并发数。
- 变化: 修复 SVG 根节点 `fill="none"` 被前端清理逻辑覆盖、以及加载 Spinner 被压缩为椭圆的问题。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [x] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

`ReactSVG` 会在下拉列表打开时同时为所有图标发起同源 XHR，等待上游响应的图标请求占用了浏览器有限的连接槽。后端原有的双源竞速与全局 winner 还会让一个图标的选源结果影响其它图标，并在缺失图标时产生额外上游请求和超时。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令：

- `pnpm format:check`
- `pnpm type-check`
- `pnpm lint`
- `node --experimental-strip-types --test /tmp/kilo/provider-icon-request-queue.test.ts`
- `uv run ruff check app/models/catalog/icon_proxy.py app/api/routers/model_icons.py tests/models/test_catalog_icon_proxy.py tests/api/test_model_icons.py`
- `uv run ty check app/models/catalog/icon_proxy.py app/api/routers/model_icons.py tests/models/test_catalog_icon_proxy.py tests/api/test_model_icons.py`
- `uv run pytest tests/models/test_catalog_icon_proxy.py tests/api/test_model_icons.py tests/api/test_model_providers.py -q`
