### PR TITLE
fix(agent): 清理不可达的会话检查点

### DIFF
--- a/backend/app/agent_runtime/runner/checkpointer.py
+++ b/backend/app/agent_runtime/runner/checkpointer.py
@@ -1,14 +1,20 @@
 import os
 import shutil
 from pathlib import Path
+
 import aiosqlite
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import Checkpoint, copy_checkpoint
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
 
 import app.settings as app_settings
 from app.agent_runtime.model_config import without_api_key
+from app.agent_runtime.persistence.model import AgentChildRun
+from app.storage.models.task import Task
 
 _checkpointer: AsyncSqliteSaver | None = None
 
@@ -16,6 +22,9 @@ _ALLOWED_MSGPACK_MODULES = (
     ("app.agent_runtime.tools.impls.interaction.ask_user", "Question"),
     ("app.agent_runtime.tools.impls.interaction.ask_user", "QuestionOption"),
 )
+_LEGACY_API_KEY_MARKER = b"api_key"
+_LEGACY_API_KEY_MIGRATION = "remove_plaintext_api_keys_v1"
+_CHECKPOINT_CLEANUP_BATCH_SIZE = 500
 
 
 def _default_db_path() -> Path:
@@ -74,8 +83,14 @@ async def _remove_api_keys_from_existing_checkpoints(
     checkpointer: AsyncSqliteSaver,
 ) -> None:
     """Rewrite legacy Agent checkpoints that persisted plaintext API keys."""
+    if await _has_completed_legacy_api_key_migration(checkpointer):
+        return
+
     checkpoints: list[tuple[RunnableConfig, Checkpoint]] = []
-    async for item in checkpointer.alist(None):
+    for config in await _list_legacy_api_key_checkpoint_configs(checkpointer):
+        item = await checkpointer.aget_tuple(config)
+        if item is None:
+            continue
         channel_values = item.checkpoint.get("channel_values")
         if not isinstance(channel_values, dict):
             continue
@@ -95,6 +110,70 @@ async def _remove_api_keys_from_existing_checkpoints(
             {},
             checkpoint.get("channel_versions", {}),
         )
+
+    await _mark_legacy_api_key_migration_completed(checkpointer)
+
+
+async def _has_completed_legacy_api_key_migration(
+    checkpointer: AsyncSqliteSaver,
+) -> bool:
+    cursor = await checkpointer.conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS openfic_checkpoint_migrations (
+            name TEXT PRIMARY KEY
+        )
+        """
+    )
+    await cursor.close()
+    cursor = await checkpointer.conn.execute(
+        "SELECT 1 FROM openfic_checkpoint_migrations WHERE name = ?",
+        (_LEGACY_API_KEY_MIGRATION,),
+    )
+    try:
+        return await cursor.fetchone() is not None
+    finally:
+        await cursor.close()
+
+
+async def _list_legacy_api_key_checkpoint_configs(
+    checkpointer: AsyncSqliteSaver,
+) -> list[RunnableConfig]:
+    cursor = await checkpointer.conn.execute(
+        """
+        SELECT thread_id, checkpoint_ns, checkpoint_id
+        FROM checkpoints
+        WHERE instr(checkpoint, ?) > 0
+        """,
+        (_LEGACY_API_KEY_MARKER,),
+    )
+    try:
+        rows = await cursor.fetchall()
+    finally:
+        await cursor.close()
+
+    return [
+        {
+            "configurable": {
+                "thread_id": thread_id,
+                "checkpoint_ns": checkpoint_ns,
+                "checkpoint_id": checkpoint_id,
+            }
+        }
+        for thread_id, checkpoint_ns, checkpoint_id in rows
+    ]
+
+
+async def _mark_legacy_api_key_migration_completed(
+    checkpointer: AsyncSqliteSaver,
+) -> None:
+    cursor = await checkpointer.conn.execute(
+        "INSERT INTO openfic_checkpoint_migrations (name) VALUES (?)",
+        (_LEGACY_API_KEY_MIGRATION,),
+    )
+    try:
+        await checkpointer.conn.commit()
+    finally:
+        await cursor.close()
 
 
 async def delete_checkpoints_for_thread(thread_id: str) -> int:
@@ -142,6 +221,84 @@ async def delete_checkpoints_after_for_thread(
         return conn.total_changes - before
     finally:
         await conn.close()
+
+
+async def cleanup_unreachable_checkpoints(
+    session: AsyncSession,
+    checkpointer: AsyncSqliteSaver,
+) -> int:
+    reachable_thread_ids = await _list_reachable_checkpoint_thread_ids(session)
+    checkpoint_thread_ids = await _list_checkpoint_thread_ids(checkpointer)
+    unreachable_thread_ids = checkpoint_thread_ids - reachable_thread_ids
+    if not unreachable_thread_ids:
+        return 0
+
+    deleted_rows = 0
+    thread_ids = list(unreachable_thread_ids)
+    for index in range(0, len(thread_ids), _CHECKPOINT_CLEANUP_BATCH_SIZE):
+        batch = thread_ids[index : index + _CHECKPOINT_CLEANUP_BATCH_SIZE]
+        placeholders = ", ".join("?" for _ in batch)
+        before = checkpointer.conn.total_changes
+        await checkpointer.conn.execute(
+            f"DELETE FROM writes WHERE thread_id IN ({placeholders})",
+            tuple(batch),
+        )
+        await checkpointer.conn.execute(
+            f"DELETE FROM checkpoints WHERE thread_id IN ({placeholders})",
+            tuple(batch),
+        )
+        deleted_rows += checkpointer.conn.total_changes - before
+    await checkpointer.conn.commit()
+    return deleted_rows
+
+
+async def _list_reachable_checkpoint_thread_ids(session: AsyncSession) -> set[str]:
+    task_result = await session.execute(
+        select(col(Task.agent_session_id)).where(
+            col(Task.agent_session_id).is_not(None),
+            col(Task.agent_session_id) != "",
+        )
+    )
+    reachable_thread_ids = {
+        session_id
+        for session_id in task_result.scalars().all()
+        if isinstance(session_id, str) and session_id
+    }
+    if not reachable_thread_ids:
+        return reachable_thread_ids
+
+    child_run_result = await session.execute(
+        select(
+            col(AgentChildRun.parent_session_id),
+            col(AgentChildRun.child_thread_id),
+        )
+    )
+    children_by_parent: dict[str, set[str]] = {}
+    for parent_session_id, child_thread_id in child_run_result.all():
+        if not parent_session_id or not child_thread_id:
+            continue
+        children_by_parent.setdefault(parent_session_id, set()).add(child_thread_id)
+
+    pending_thread_ids = list(reachable_thread_ids)
+    while pending_thread_ids:
+        parent_session_id = pending_thread_ids.pop()
+        for child_thread_id in children_by_parent.get(parent_session_id, set()):
+            if child_thread_id in reachable_thread_ids:
+                continue
+            reachable_thread_ids.add(child_thread_id)
+            pending_thread_ids.append(child_thread_id)
+
+    return reachable_thread_ids
+
+
+async def _list_checkpoint_thread_ids(checkpointer: AsyncSqliteSaver) -> set[str]:
+    cursor = await checkpointer.conn.execute(
+        "SELECT thread_id FROM checkpoints UNION SELECT thread_id FROM writes"
+    )
+    try:
+        return {row[0] for row in await cursor.fetchall() if row[0]}
+    finally:
+        await cursor.close()
 
 
 async def latest_checkpoint_id_for_thread(thread_id: str) -> str | None:

--- a/backend/app/agent_runtime/tools/impls/orchestration/recycle_subagent.py
+++ b/backend/app/agent_runtime/tools/impls/orchestration/recycle_subagent.py
@@ -5,6 +5,7 @@ import json
 from pydantic import BaseModel, Field
 
 from app.agent_runtime.persistence.child_runs import recycle_child_run
+from app.agent_runtime.runner.checkpointer import delete_checkpoints_for_thread
 from app.agent_runtime.runner.run_registry import get_agent_run_registry
 from app.agent_runtime.tools.base import AgentTool
 from app.agent_runtime.tools.impls.orchestration.common import (
@@ -79,6 +80,7 @@ class RecycleSubagentTool(AgentTool):
             )
         finally:
             await close_session(session)
+        await delete_checkpoints_for_thread(recycled.child_thread_id)
 
         runner = make_subagent_runner(state=self._state, configurable=configurable)
         await runner.publish_parent_subagent_status(recycled.id)

--- a/backend/app/api/routers/tasks.py
+++ b/backend/app/api/routers/tasks.py
@@ -8,6 +8,7 @@ from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.modes import AgentMode
+from app.agent_runtime.persistence.child_runs import list_child_runs_for_parent
 from app.agent_runtime.persistence.task_projection import load_task_messages_for_agent_session
 from app.agent_runtime.runner.checkpointer import delete_checkpoints_for_thread
 
@@ -30,14 +31,32 @@ def _require_agent_mode(mode: str) -> AgentMode:
     return cast(AgentMode, mode)
 
 
-async def _cleanup_task_checkpoints(session_id: str | None) -> None:
+async def _list_descendant_child_thread_ids(
+    session: AsyncSession,
+    parent_session_id: str,
+) -> list[str]:
+    child_thread_ids: list[str] = []
+    for child_run in await list_child_runs_for_parent(session, parent_session_id):
+        child_thread_ids.extend(
+            await _list_descendant_child_thread_ids(session, child_run.child_thread_id)
+        )
+        child_thread_ids.append(child_run.child_thread_id)
+    return child_thread_ids
+
+
+async def _cleanup_task_checkpoints(
+    session: AsyncSession,
+    session_id: str | None,
+) -> None:
     if not session_id:
         return
-    deleted_rows = await delete_checkpoints_for_thread(session_id)
-    logger.bind(session_id=session_id).info(
-        "Deleted {} checkpoint rows for task cleanup",
-        deleted_rows,
-    )
+    thread_ids = [*await _list_descendant_child_thread_ids(session, session_id), session_id]
+    for thread_id in thread_ids:
+        deleted_rows = await delete_checkpoints_for_thread(thread_id)
+        logger.bind(session_id=session_id, thread_id=thread_id).info(
+            "Deleted {} checkpoint rows for task cleanup",
+            deleted_rows,
+        )
 
 
 @router.get("/tasks/{task_id}", response_model=TaskResponse)
@@ -191,7 +210,7 @@ async def delete_task(
             )
         await task_service.delete_task(session, task_id)
         await session.commit()
-        await _cleanup_task_checkpoints(task.agent_session_id)
+        await _cleanup_task_checkpoints(session, task.agent_session_id)
     except HTTPException:
         raise
     except NotFoundError as e:
@@ -220,7 +239,7 @@ async def delete_all_tasks(
 
         await session.commit()
         for task in deletable_tasks:
-            await _cleanup_task_checkpoints(task.agent_session_id)
+            await _cleanup_task_checkpoints(session, task.agent_session_id)
         deleted_count = len(deletable_tasks)
         logger.info(
             f"已删除项目 {project_id} 下的 {deleted_count} 个任务，跳过 {skipped_running_count} 个运行中任务"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -52,7 +52,12 @@ from app.api.routers import (
 )
 from app.audit import start_audit_queue, stop_audit_queue
 from app.audit.queue import load_audit_details_persistence
-from app.agent_runtime.runner.checkpointer import close_checkpointer, init_checkpointer
+from app.agent_runtime.runner.checkpointer import (
+    cleanup_unreachable_checkpoints,
+    close_checkpointer,
+    get_checkpointer,
+    init_checkpointer,
+)
 from app.agent_runtime.runner.run_registry import get_agent_run_registry
 from app.background.runtime.supervisor import (
     start_background_runtime,
@@ -120,6 +125,20 @@ async def _seed_builtin_models() -> None:
         await seed_builtin_models(session)
     finally:
         await session.close()
+
+
+async def _cleanup_unreachable_checkpoints() -> None:
+    session = await create_session()
+    try:
+        deleted_rows = await cleanup_unreachable_checkpoints(
+            session,
+            await get_checkpointer(),
+        )
+    finally:
+        await session.close()
+
+    if deleted_rows:
+        logger.info(f"Deleted {deleted_rows} unreachable checkpoint rows at startup")
 
 
 def _get_server_bind() -> tuple[str, int]:
@@ -275,6 +294,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         logger.warning(f"已重置 {cleared_tasks} 个遗留的运行中任务状态")
     await _seed_builtin_models()
     await init_checkpointer()
+    await _cleanup_unreachable_checkpoints()
     await load_audit_details_persistence()
     start_audit_queue()
     await start_background_runtime()

--- a/backend/tests/agent_runtime/test_checkpointer.py
+++ b/backend/tests/agent_runtime/test_checkpointer.py
@@ -3,13 +3,17 @@ import sqlite3
 import tempfile
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 from unittest.mock import AsyncMock
 
 import app.agent_runtime.runner.checkpointer as checkpointer_mod
 import aiosqlite
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import Checkpoint
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 import pytest
 from app.agent_runtime.runner.checkpointer import (
+    cleanup_unreachable_checkpoints,
     close_checkpointer,
     delete_checkpoints_after_for_thread,
     delete_checkpoints_for_thread,
@@ -18,6 +22,8 @@ from app.agent_runtime.runner.checkpointer import (
     reset_checkpointer,
 )
 from app.agent_runtime.tools.impls.interaction.ask_user import Question, QuestionOption
+from app.agent_runtime.persistence.child_runs import create_child_run
+from app.storage.models.task import Task
 
 
 @pytest.mark.asyncio
@@ -30,30 +36,36 @@ async def test_get_checkpointer_restores_legacy_question_checkpoint(monkeypatch,
         conn = await aiosqlite.connect(db_path)
         legacy_checkpointer = AsyncSqliteSaver(conn)
         await legacy_checkpointer.setup()
-        config = {
-            "configurable": {
-                "thread_id": "legacy-question-session",
-                "checkpoint_ns": "",
-            }
-        }
-        checkpoint = {
-            "v": 2,
-            "id": "legacy-question-checkpoint",
-            "ts": "2026-07-12T00:00:00+00:00",
-            "channel_values": {
-                "pending_question": Question(
-                    title="继续方式",
-                    description="请选择后续处理方式。",
-                    options=[
-                        QuestionOption(label="继续", description="继续执行"),
-                        QuestionOption(label="暂停", description="暂停执行"),
-                    ],
-                )
+        config = cast(
+            RunnableConfig,
+            {
+                "configurable": {
+                    "thread_id": "legacy-question-session",
+                    "checkpoint_ns": "",
+                }
             },
-            "channel_versions": {},
-            "versions_seen": {},
-            "pending_sends": [],
-        }
+        )
+        checkpoint = cast(
+            Checkpoint,
+            {
+                "v": 2,
+                "id": "legacy-question-checkpoint",
+                "ts": "2026-07-12T00:00:00+00:00",
+                "channel_values": {
+                    "pending_question": Question(
+                        title="继续方式",
+                        description="请选择后续处理方式。",
+                        options=[
+                            QuestionOption(label="继续", description="继续执行"),
+                            QuestionOption(label="暂停", description="暂停执行"),
+                        ],
+                    )
+                },
+                "channel_versions": {},
+                "versions_seen": {},
+                "pending_sends": [],
+            },
+        )
         await legacy_checkpointer.aput(config, checkpoint, {}, {})
         await conn.close()
 
@@ -70,7 +82,9 @@ async def test_get_checkpointer_restores_legacy_question_checkpoint(monkeypatch,
 
 
 @pytest.mark.asyncio
-async def test_get_checkpointer_removes_api_keys_from_legacy_checkpoints():
+async def test_get_checkpointer_removes_api_keys_from_legacy_checkpoints(
+    monkeypatch: pytest.MonkeyPatch,
+):
     with tempfile.TemporaryDirectory() as tmpdir:
         db_path = os.path.join(tmpdir, "test_checkpoints.db")
         os.environ["AGENT_CHECKPOINT_DB"] = db_path
@@ -79,30 +93,41 @@ async def test_get_checkpointer_removes_api_keys_from_legacy_checkpoints():
         conn = await aiosqlite.connect(db_path)
         legacy_checkpointer = AsyncSqliteSaver(conn)
         await legacy_checkpointer.setup()
-        config = {
-            "configurable": {
-                "thread_id": "legacy-session",
-                "checkpoint_ns": "",
-            }
-        }
-        checkpoint = {
-            "v": 2,
-            "id": "legacy-checkpoint",
-            "ts": "2026-07-12T00:00:00+00:00",
-            "channel_values": {
-                "model_config": {
-                    "model_record_id": "model-1",
-                    "model_id": "gpt-test",
-                    "api_key": "legacy-secret",
+        config = cast(
+            RunnableConfig,
+            {
+                "configurable": {
+                    "thread_id": "legacy-session",
+                    "checkpoint_ns": "",
                 }
             },
-            "channel_versions": {},
-            "versions_seen": {},
-            "pending_sends": [],
-        }
+        )
+        checkpoint = cast(
+            Checkpoint,
+            {
+                "v": 2,
+                "id": "legacy-checkpoint",
+                "ts": "2026-07-12T00:00:00+00:00",
+                "channel_values": {
+                    "model_config": {
+                        "model_record_id": "model-1",
+                        "model_id": "gpt-test",
+                        "api_key": "legacy-secret",
+                    }
+                },
+                "channel_versions": {},
+                "versions_seen": {},
+                "pending_sends": [],
+            },
+        )
         await legacy_checkpointer.aput(config, checkpoint, {}, {})
         await conn.close()
 
+        async def fail_full_checkpoint_scan(*args, **kwargs):
+            raise AssertionError("full checkpoint scan should not run")
+            yield
+
+        monkeypatch.setattr(AsyncSqliteSaver, "alist", fail_full_checkpoint_scan)
         checkpointer = await get_checkpointer()
         persisted = await checkpointer.aget_tuple(config)
 
@@ -110,6 +135,55 @@ async def test_get_checkpointer_removes_api_keys_from_legacy_checkpoints():
         assert "api_key" not in persisted.checkpoint["channel_values"]["model_config"]
 
         del os.environ["AGENT_CHECKPOINT_DB"]
+        await reset_checkpointer()
+
+
+@pytest.mark.asyncio
+async def test_get_checkpointer_runs_legacy_api_key_migration_once(
+    monkeypatch,
+    tmp_path,
+):
+    db_path = tmp_path / "test_checkpoints.db"
+    monkeypatch.setenv("AGENT_CHECKPOINT_DB", str(db_path))
+    await reset_checkpointer()
+
+    try:
+        await get_checkpointer()
+        await reset_checkpointer()
+        list_legacy_configs = AsyncMock()
+        monkeypatch.setattr(
+            checkpointer_mod,
+            "_list_legacy_api_key_checkpoint_configs",
+            list_legacy_configs,
+        )
+
+        await get_checkpointer()
+
+        list_legacy_configs.assert_not_awaited()
+    finally:
+        await reset_checkpointer()
+
+
+@pytest.mark.asyncio
+async def test_get_checkpointer_does_not_scan_all_checkpoints_without_legacy_api_keys(
+    monkeypatch,
+    tmp_path,
+):
+    db_path = tmp_path / "test_checkpoints.db"
+    monkeypatch.setenv("AGENT_CHECKPOINT_DB", str(db_path))
+    await reset_checkpointer()
+
+    async def fail_full_checkpoint_scan(*args, **kwargs):
+        raise AssertionError("full checkpoint scan should not run")
+        yield
+
+    monkeypatch.setattr(AsyncSqliteSaver, "alist", fail_full_checkpoint_scan)
+
+    try:
+        checkpointer = await get_checkpointer()
+
+        assert checkpointer is not None
+    finally:
         await reset_checkpointer()
 
 
@@ -312,6 +386,115 @@ async def test_delete_checkpoints_after_for_thread_keeps_cutoff_and_clears_subgr
 async def test_delete_checkpoints_after_for_thread_noops_on_empty_args():
     assert await delete_checkpoints_after_for_thread("", "cp-001") == 0
     assert await delete_checkpoints_after_for_thread("session-a", "") == 0
+
+
+async def test_cleanup_unreachable_checkpoints_preserves_reachable_session_tree(
+    client,
+    session,
+    monkeypatch,
+    tmp_path,
+):
+    db_path = tmp_path / "test_checkpoints.db"
+    monkeypatch.setenv("AGENT_CHECKPOINT_DB", str(db_path))
+    await reset_checkpointer()
+    parent_session_id = "agent-root"
+    task = Task(
+        id="task-root",
+        project_id="project-root",
+        title="Root session",
+        mode="agent",
+        agent_session_id=parent_session_id,
+    )
+    session.add(task)
+    await session.commit()
+    child = await create_child_run(
+        session,
+        parent_session_id=parent_session_id,
+        parent_task_id=task.id,
+        parent_thread_id=parent_session_id,
+        child_thread_id="agent-root:child:completed",
+        agent_key="writer",
+        dispatch_id="completed",
+        tool_call_id="tool-completed",
+        request={"task": "write", "input": {}, "metadata": {}},
+        status="completed",
+    )
+    nested_child = await create_child_run(
+        session,
+        parent_session_id=child.child_thread_id,
+        parent_task_id=task.id,
+        parent_thread_id=child.child_thread_id,
+        child_thread_id="agent-root:child:completed:child:nested",
+        agent_key="reviewer",
+        dispatch_id="nested",
+        tool_call_id="tool-nested",
+        request={"task": "review", "input": {}, "metadata": {}},
+        status="completed",
+    )
+    await create_child_run(
+        session,
+        parent_session_id="deleted-agent-root",
+        parent_task_id="deleted-task",
+        parent_thread_id="deleted-agent-root",
+        child_thread_id="deleted-agent-root:child:orphan",
+        agent_key="writer",
+        dispatch_id="orphan",
+        tool_call_id="tool-orphan",
+        request={"task": "write", "input": {}, "metadata": {}},
+        status="completed",
+    )
+
+    checkpointer = await get_checkpointer()
+    reachable_thread_ids = {
+        parent_session_id,
+        child.child_thread_id,
+        nested_child.child_thread_id,
+    }
+    orphan_thread_ids = {
+        "deleted-agent-root",
+        "deleted-agent-root:child:orphan",
+        "unrelated-thread",
+    }
+    for index, thread_id in enumerate([*reachable_thread_ids, *orphan_thread_ids]):
+        checkpoint_id = f"checkpoint-{index}"
+        await checkpointer.conn.execute(
+            "INSERT INTO checkpoints(thread_id, checkpoint_ns, checkpoint_id) VALUES (?, ?, ?)",
+            (thread_id, "", checkpoint_id),
+        )
+        await checkpointer.conn.execute(
+            "INSERT INTO writes(thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel) VALUES (?, ?, ?, ?, ?, ?)",
+            (thread_id, "", checkpoint_id, "task", 0, "messages"),
+        )
+    await checkpointer.conn.commit()
+
+    deleted_rows = await cleanup_unreachable_checkpoints(session, checkpointer)
+
+    assert deleted_rows == 6
+    cursor = await checkpointer.conn.execute(
+        "SELECT thread_id FROM checkpoints UNION SELECT thread_id FROM writes"
+    )
+    try:
+        remaining_thread_ids = {row[0] for row in await cursor.fetchall()}
+    finally:
+        await cursor.close()
+    assert remaining_thread_ids == reachable_thread_ids
+    await reset_checkpointer()
+
+
+async def test_cleanup_unreachable_checkpoints_noops_for_empty_checkpoint_store(
+    client,
+    session,
+    monkeypatch,
+    tmp_path,
+):
+    db_path = tmp_path / "test_checkpoints.db"
+    monkeypatch.setenv("AGENT_CHECKPOINT_DB", str(db_path))
+    await reset_checkpointer()
+
+    try:
+        assert await cleanup_unreachable_checkpoints(session, await get_checkpointer()) == 0
+    finally:
+        await reset_checkpointer()
 
 
 async def test_reset_checkpointer_closes_existing_connection(monkeypatch):

--- a/backend/tests/agent_runtime/tools/test_recycle_subagent.py
+++ b/backend/tests/agent_runtime/tools/test_recycle_subagent.py
@@ -1,5 +1,7 @@
 import json
 from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -18,6 +20,7 @@ async def test_recycle_subagent_returns_subagent_identity(
 
     row = SimpleNamespace(
         id="child-run-1",
+        child_thread_id="parent:child:writer",
         dispatch_id="dispatch-writer",
         agent_key="writer",
         metadata_json={"agent_number": "#1001"},
@@ -49,16 +52,21 @@ async def test_recycle_subagent_returns_subagent_identity(
     monkeypatch.setattr(recycle_module, "open_session", open_session)
     monkeypatch.setattr(recycle_module, "close_session", noop)
     monkeypatch.setattr(recycle_module, "recycle_child_run", recycle_child_run)
+    delete_checkpoints = AsyncMock(return_value=2)
+    monkeypatch.setattr(recycle_module, "delete_checkpoints_for_thread", delete_checkpoints)
     monkeypatch.setattr(recycle_module, "get_agent_run_registry", lambda: Registry())
     monkeypatch.setattr(
         recycle_module, "make_subagent_runner", lambda **_kwargs: Runner()
     )
-    tool = RecycleSubagentTool(
-        _state={
-            "session_id": "parent",
-            "project_id": "project-1",
-            "active_agent": "primary",
-        }
+    tool = cast(
+        Any,
+        RecycleSubagentTool(
+            _state={
+                "session_id": "parent",
+                "project_id": "project-1",
+                "active_agent": "primary",
+            }
+        ),
     )
 
     result = json.loads(
@@ -72,3 +80,7 @@ async def test_recycle_subagent_returns_subagent_identity(
         "metadata": {"agent_number": "#1001"},
         "recycled": True,
     }
+    if is_active:
+        delete_checkpoints.assert_awaited_once_with(row.child_thread_id)
+    else:
+        delete_checkpoints.assert_not_awaited()

--- a/backend/tests/api/test_tasks.py
+++ b/backend/tests/api/test_tasks.py
@@ -9,6 +9,7 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.modes import AgentMode
+from app.agent_runtime.persistence.child_runs import create_child_run
 from app.agent_runtime.persistence import repo as agent_run_repo
 from app.storage.services import task_service
 
@@ -268,6 +269,50 @@ class TestTaskAPI:
 
         get_response = await client.get(f"/api/v1/tasks/{task.id}")
         assert get_response.status_code == status.HTTP_404_NOT_FOUND
+
+    async def test_delete_task_deletes_descendant_subagent_checkpoints(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+    ) -> None:
+        task, _project_id, _chapter_id = await self.create_agent_task(client, session)
+        parent_session_id = task.agent_session_id or ""
+        child = await create_child_run(
+            session,
+            parent_session_id=parent_session_id,
+            parent_task_id=task.id,
+            parent_thread_id=parent_session_id,
+            child_thread_id=f"{parent_session_id}:child:writer",
+            agent_key="writer",
+            dispatch_id="dispatch-writer",
+            tool_call_id="tool-call-writer",
+            request={"task": "write", "input": {}, "metadata": {}},
+        )
+        grandchild = await create_child_run(
+            session,
+            parent_session_id=child.child_thread_id,
+            parent_task_id=task.id,
+            parent_thread_id=child.child_thread_id,
+            child_thread_id=f"{child.child_thread_id}:child:reviewer",
+            agent_key="reviewer",
+            dispatch_id="dispatch-reviewer",
+            tool_call_id="tool-call-reviewer",
+            request={"task": "review", "input": {}, "metadata": {}},
+        )
+        await session.commit()
+
+        with patch(
+            "app.api.routers.tasks.delete_checkpoints_for_thread",
+            new=AsyncMock(return_value=2),
+        ) as delete_checkpoints:
+            response = await client.delete(f"/api/v1/tasks/{task.id}")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert delete_checkpoints.await_args_list == [
+            ((grandchild.child_thread_id,), {}),
+            ((child.child_thread_id,), {}),
+            ((parent_session_id,), {}),
+        ]
 
     async def test_delete_task_rejects_running_task(
         self,

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -58,6 +58,7 @@ async def test_lifespan_refreshes_catalog_in_background_and_cancels_on_shutdown(
     monkeypatch.setattr(main, "_reset_task_running_state", reset_task_state)
     monkeypatch.setattr(main, "_seed_builtin_models", do_nothing)
     monkeypatch.setattr(main, "init_checkpointer", do_nothing)
+    monkeypatch.setattr(main, "_cleanup_unreachable_checkpoints", do_nothing)
     monkeypatch.setattr(main, "load_audit_details_persistence", do_nothing)
     monkeypatch.setattr(main, "start_audit_queue", lambda: None)
     monkeypatch.setattr(main, "start_background_runtime", do_nothing)


### PR DESCRIPTION
## PR 标题

fix(agent): 清理不可达的会话检查点

## 变更说明

- 问题: 删除任务或回收 subagent 后，关联 checkpoint 可能残留；历史遗留的无主 checkpoint 也会持续占用存储并拖慢初始化。
- 重要性: 避免无效 checkpoint 累积，同时确保仍可继续的主会话和 subagent 会话状态不会被误删。
- 变化: 删除任务时递归清理后代 subagent checkpoint；回收 subagent 时清理其 checkpoint；启动时以现存 Task 会话树为根清理不可达 checkpoint，并优化旧明文 API Key checkpoint 的一次性迁移扫描。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [x] 性能优化 (perf)
- [x] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

checkpoint 存储独立于主业务数据库。此前仅部分业务路径清理单个 thread，任务删除未递归覆盖子会话，回收 subagent 未删除 checkpoint，启动阶段也不会清理已经失去 Task 根节点的 checkpoint。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

已执行 `just check`，并额外执行 `uv run pytest -q`，结果为 `1207 passed`。
