### PR TITLE
fix(agent): 修复工具调用触发内容刷新失效的问题

### DIFF
--- a/backend/app/agent_runtime/tools/hooks/chapter_refresh.py
+++ b/backend/app/agent_runtime/tools/hooks/chapter_refresh.py
@@ -56,6 +56,11 @@ async def chapter_refresh_post_hook(context: HookContext) -> HookResult:
     if chapter_id:
         payload["chapter_id"] = chapter_id
 
+    metadata = result.get("metadata")
+    chapter_diff = metadata.get("chapter_diff") if isinstance(metadata, dict) else None
+    if isinstance(chapter_diff, dict) and isinstance(chapter_diff.get("operation"), str):
+        payload["operation"] = chapter_diff["operation"]
+
     await emit(
         "agent:chapter_refresh",
         payload,

--- a/backend/app/agent_runtime/tools/hooks/note_refresh.py
+++ b/backend/app/agent_runtime/tools/hooks/note_refresh.py
@@ -11,6 +11,11 @@ from app.socket.handlers import agent_session_room
 from loguru import logger
 
 NOTE_WRITE_TOOL_NAMES = frozenset(TOOL_CATEGORIES["note_write"])
+NOTE_TOOL_OPERATIONS = {
+    "create_note": "create",
+    "edit_note": "edit",
+    "delete_note": "delete",
+}
 
 
 def _parse_output(output: str | None) -> dict[str, Any] | None:
@@ -58,6 +63,7 @@ async def note_refresh_post_hook(context: HookContext) -> HookResult:
     payload: dict[str, Any] = {
         "session_id": target_session_id,
         "project_id": project_id,
+        "operation": NOTE_TOOL_OPERATIONS.get(context.tool_name, "update"),
         "created_at": datetime.now(UTC).isoformat(),
     }
     note_id = _extract_note_id(result)

--- a/backend/app/agent_runtime/tools/impls/chapter/edit_chapter.py
+++ b/backend/app/agent_runtime/tools/impls/chapter/edit_chapter.py
@@ -1,5 +1,6 @@
 import json
 import re
+from datetime import UTC, datetime
 from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
@@ -147,6 +148,7 @@ class EditChapterTool(AgentTool):
                     raise ToolExecutionError("未在章节内容中找到要替换的文本")
                 match.content = replace_result.new_content
                 match.word_count = count_words(match.content)
+            match.updated_at = datetime.now(UTC)
             await chapter_repo.update_chapter(session, match)
             chapter_diff = build_chapter_diff_preview(
                 before_match,

--- a/backend/app/agent_runtime/tools/impls/note/edit_note.py
+++ b/backend/app/agent_runtime/tools/impls/note/edit_note.py
@@ -4,6 +4,7 @@
 """
 
 import json
+from datetime import UTC, datetime
 from difflib import SequenceMatcher
 from typing import Any
 
@@ -186,6 +187,7 @@ class EditNoteTool(AgentTool):
             if replace_result is None:
                 raise ToolExecutionError("未在笔记内容中找到要替换的文本")
             note.content = replace_result.new_content
+            note.updated_at = datetime.now(UTC)
             await note_repo.update_note(session, note)
             after = note_images_by_id(
                 await note_repo.list_by_project(

--- a/backend/tests/agent_runtime/tools/test_chapter_refresh_hook.py
+++ b/backend/tests/agent_runtime/tools/test_chapter_refresh_hook.py
@@ -84,3 +84,36 @@ async def test_chapter_refresh_hook_ignores_non_mutation_or_failed_output(monkey
     )
 
     assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_chapter_refresh_hook_marks_delete_operation(monkeypatch) -> None:
+    from app.agent_runtime.tools.hooks.chapter_refresh import chapter_refresh_post_hook
+
+    captured: list[tuple[str, dict, str | None]] = []
+
+    async def fake_emit(event: str, data: dict, *, room: str | None = None) -> None:
+        captured.append((event, data, room))
+
+    monkeypatch.setattr("app.agent_runtime.tools.hooks.chapter_refresh.emit", fake_emit)
+
+    await chapter_refresh_post_hook(
+        HookContext(
+            tool_name="delete_chapter",
+            access_level="write",
+            args={},
+            state={"session_id": "session-1", "project_id": "project-1"},
+            output=json.dumps(
+                {
+                    "success": True,
+                    "metadata": {
+                        "chapter_diff": {"operation": "delete", "chapter_id": "chapter-1"}
+                    },
+                },
+                ensure_ascii=False,
+            ),
+        )
+    )
+
+    assert captured[0][1]["operation"] == "delete"
+    assert captured[0][1]["chapter_id"] == "chapter-1"

--- a/backend/tests/agent_runtime/tools/test_chapter_tools.py
+++ b/backend/tests/agent_runtime/tools/test_chapter_tools.py
@@ -1,6 +1,7 @@
 """Tests for Agent chapter and volume tools."""
 
 import json
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -372,6 +373,8 @@ async def test_edit_chapter_resolves_inside_volume() -> None:
         },
     }
     mock_repo.list_by_volume.assert_awaited_once_with(mock_session, "vol-1")
+    assert isinstance(chapter.updated_at, datetime)
+    assert chapter.updated_at.tzinfo is UTC
 
 
 async def test_delete_chapter_delegates_to_chapter_service() -> None:

--- a/backend/tests/agent_runtime/tools/test_note_refresh_hook.py
+++ b/backend/tests/agent_runtime/tools/test_note_refresh_hook.py
@@ -1,0 +1,37 @@
+import json
+
+import pytest
+
+from app.agent_runtime.tools.base import HookContext
+
+
+@pytest.mark.asyncio
+async def test_note_refresh_hook_marks_delete_operation(monkeypatch) -> None:
+    from app.agent_runtime.tools.hooks.note_refresh import note_refresh_post_hook
+
+    captured: list[tuple[str, dict, str | None]] = []
+
+    async def fake_emit(event: str, data: dict, *, room: str | None = None) -> None:
+        captured.append((event, data, room))
+
+    monkeypatch.setattr("app.agent_runtime.tools.hooks.note_refresh.emit", fake_emit)
+
+    await note_refresh_post_hook(
+        HookContext(
+            tool_name="delete_note",
+            access_level="write",
+            args={},
+            state={"session_id": "session-1", "project_id": "project-1"},
+            output=json.dumps(
+                {
+                    "success": True,
+                    "metadata": {"note_diff": {"note_id": "note-1"}},
+                },
+                ensure_ascii=False,
+            ),
+        )
+    )
+
+    assert captured[0][0] == "agent:note_refresh"
+    assert captured[0][1]["operation"] == "delete"
+    assert captured[0][1]["note_id"] == "note-1"

--- a/backend/tests/agent_runtime/tools/test_note_tools.py
+++ b/backend/tests/agent_runtime/tools/test_note_tools.py
@@ -1,6 +1,7 @@
 """Tests for Agent note tools."""
 
 import json
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
@@ -182,6 +183,8 @@ async def test_edit_note_returns_success_and_diff_metadata() -> None:
             }
         },
     }
+    assert isinstance(note.updated_at, datetime)
+    assert note.updated_at.tzinfo is UTC
 
 
 async def test_delete_note_rejects_hidden_note() -> None:

--- a/frontend/src/features/assistant/hooks/use-agent-session.ts
+++ b/frontend/src/features/assistant/hooks/use-agent-session.ts
@@ -8,6 +8,10 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useState, useCallback, useEffect, useRef } from "react";
 
 import { toast } from "@/components";
+import { useCharactersStore } from "@/features/characters/store/use-characters-store";
+import { useWorldInfoStore } from "@/features/world-info/store/use-world-info-store";
+import { invalidateWritingEditorEntityQueries } from "@/features/writing/hooks/use-writing-editor-entity";
+import { useTabsStore } from "@/features/writing/store/use-tabs-store";
 import i18n from "@/i18n";
 import type {
   AgentMessage,
@@ -30,6 +34,8 @@ import {
   cancelAgentSession,
   submitAgentToolApproval,
 } from "@/lib/api-client";
+import type { CharacterListResponse } from "@/lib/character.types";
+import type { WorldInfoEntryBriefListResponse } from "@/lib/world-info.types";
 
 import type { ClarificationAnswerItem } from "../components/agent/message-blocks/messages/special/clarification-flow-state";
 import { joinAgentSession, subscribeAgentSessionEvents } from "../lib/agent-socket";
@@ -47,6 +53,7 @@ import {
   type AgentTranscriptState,
 } from "../lib/agent-transcript-state";
 import { createApprovalPreviewToolMessage } from "../lib/chapter-tool-preview";
+import { removeListItemFromCache } from "../lib/entity-list-cache";
 import {
   applyPendingUserMessageEvent,
   createPendingUserMessage,
@@ -200,22 +207,36 @@ export function useAgentSession({
   }, []);
 
   const invalidateChapterQueries = useCallback(
-    (targetChapterId?: string) => {
+    (targetChapterId?: string, operation?: string) => {
       queryClient.invalidateQueries({ queryKey: ["volume-tree", projectId] });
+      if (operation === "delete") {
+        if (targetChapterId) {
+          void queryClient.cancelQueries({
+            queryKey: ["chapter", targetChapterId],
+            exact: true,
+          });
+        }
+        queryClient.invalidateQueries({ queryKey: ["projects"] });
+        return;
+      }
       if (targetChapterId) {
         queryClient.invalidateQueries({ queryKey: ["chapter", targetChapterId] });
       }
+      invalidateWritingEditorEntityQueries(queryClient, "chapter", targetChapterId);
       queryClient.invalidateQueries({ queryKey: ["projects"] });
     },
     [projectId, queryClient],
   );
 
   const invalidateNoteQueries = useCallback(
-    (targetNoteId?: string) => {
+    (targetNoteId?: string, operation?: string) => {
       queryClient.invalidateQueries({ queryKey: ["note-tree", projectId] });
+      if (operation === "delete") return;
+
       if (targetNoteId) {
         queryClient.invalidateQueries({ queryKey: ["note", targetNoteId] });
       }
+      invalidateWritingEditorEntityQueries(queryClient, "note", targetNoteId);
     },
     [projectId, queryClient],
   );
@@ -230,7 +251,7 @@ export function useAgentSession({
       if (!targetEntryId) return;
 
       if (operation === "delete") {
-        queryClient.removeQueries({
+        void queryClient.cancelQueries({
           queryKey: ["world-info-entry-detail", targetEntryId],
           exact: true,
         });
@@ -257,7 +278,7 @@ export function useAgentSession({
       if (!targetCharacterId) return;
 
       if (operation === "delete") {
-        queryClient.removeQueries({
+        void queryClient.cancelQueries({
           queryKey: ["character", targetCharacterId],
         });
         return;
@@ -457,14 +478,24 @@ export function useAgentSession({
       if (message?.type === "chapter_refresh") {
         const targetChapterId =
           typeof message.payload?.chapter_id === "string" ? message.payload.chapter_id : undefined;
-        invalidateChapterQueries(targetChapterId);
+        const operation =
+          typeof message.payload?.operation === "string" ? message.payload.operation : undefined;
+        if (operation === "delete" && targetChapterId) {
+          useTabsStore.getState().removeTabsByReference("chapter", targetChapterId);
+        }
+        invalidateChapterQueries(targetChapterId, operation);
         return;
       }
 
       if (message?.type === "note_refresh") {
         const targetNoteId =
           typeof message.payload?.note_id === "string" ? message.payload.note_id : undefined;
-        invalidateNoteQueries(targetNoteId);
+        const operation =
+          typeof message.payload?.operation === "string" ? message.payload.operation : undefined;
+        if (operation === "delete" && targetNoteId) {
+          useTabsStore.getState().removeTabsByReference("note", targetNoteId);
+        }
+        invalidateNoteQueries(targetNoteId, operation);
         return;
       }
 
@@ -483,6 +514,20 @@ export function useAgentSession({
           typeof message.payload?.entry_id === "string" ? message.payload.entry_id : undefined;
         const operation =
           typeof message.payload?.operation === "string" ? message.payload.operation : undefined;
+        if (
+          operation === "delete" &&
+          targetEntryId &&
+          useWorldInfoStore.getState().currentEntryId === targetEntryId
+        ) {
+          if (targetWorldInfoId) {
+            queryClient.setQueryData(
+              ["world-info-entries", targetWorldInfoId],
+              (data: WorldInfoEntryBriefListResponse | undefined) =>
+                removeListItemFromCache(data, targetEntryId),
+            );
+          }
+          useWorldInfoStore.getState().setCurrentEntry(null);
+        }
         invalidateWorldEntryQueries(targetWorldInfoId, targetEntryId, operation);
         return;
       }
@@ -494,6 +539,18 @@ export function useAgentSession({
             : undefined;
         const operation =
           typeof message.payload?.operation === "string" ? message.payload.operation : undefined;
+        if (
+          operation === "delete" &&
+          targetCharacterId &&
+          useCharactersStore.getState().currentCharacterId === targetCharacterId
+        ) {
+          queryClient.setQueryData(
+            ["characters", projectId],
+            (data: CharacterListResponse | undefined) =>
+              removeListItemFromCache(data, targetCharacterId),
+          );
+          useCharactersStore.getState().setCurrentCharacter(null);
+        }
         invalidateCharacterQueries(targetCharacterId, operation);
         return;
       }
@@ -526,6 +583,8 @@ export function useAgentSession({
       onTokenUsage,
       onTaskUsageDelta,
       onTaskUsageSnapshot,
+      projectId,
+      queryClient,
       syncCompactingState,
       syncPendingMessageState,
       updateTranscriptState,

--- a/frontend/src/features/assistant/lib/agent-socket-events.ts
+++ b/frontend/src/features/assistant/lib/agent-socket-events.ts
@@ -296,6 +296,7 @@ export function toAgentEvent(
         session_id: getString(data.session_id),
         project_id: getString(data.project_id),
         chapter_id: getString(data.chapter_id),
+        operation: getString(data.operation),
       },
     };
   }
@@ -311,6 +312,7 @@ export function toAgentEvent(
         session_id: getString(data.session_id),
         project_id: getString(data.project_id),
         note_id: getString(data.note_id),
+        operation: getString(data.operation),
       },
     };
   }

--- a/frontend/src/features/assistant/lib/entity-list-cache.ts
+++ b/frontend/src/features/assistant/lib/entity-list-cache.ts
@@ -1,0 +1,20 @@
+interface EntityListCache<TItem> {
+  items: TItem[];
+  total: number;
+}
+
+export function removeListItemFromCache<TItem extends { id: string }>(
+  data: EntityListCache<TItem> | undefined,
+  itemId: string,
+): EntityListCache<TItem> | undefined {
+  if (!data) return data;
+
+  const items = data.items.filter((item) => item.id !== itemId);
+  if (items.length === data.items.length) return data;
+
+  return {
+    ...data,
+    items,
+    total: Math.max(0, data.total - 1),
+  };
+}

--- a/frontend/src/features/characters/pages/character-editor-loading-state.ts
+++ b/frontend/src/features/characters/pages/character-editor-loading-state.ts
@@ -1,0 +1,6 @@
+export function shouldShowCharacterEditorLoading(
+  hasCharacter: boolean,
+  isInitialLoading: boolean,
+): boolean {
+  return !hasCharacter && isInitialLoading;
+}

--- a/frontend/src/features/characters/pages/characters-page.tsx
+++ b/frontend/src/features/characters/pages/characters-page.tsx
@@ -28,6 +28,7 @@ import { CharacterEditor } from "../components/character-editor";
 import { CharacterList } from "../components/character-list";
 import { CharacterProfileDialog } from "../components/character-profile-dialog";
 import { useCharactersStore } from "../store/use-characters-store";
+import { shouldShowCharacterEditorLoading } from "./character-editor-loading-state";
 
 import "./characters-page.css";
 
@@ -145,7 +146,7 @@ export function CharactersPage() {
     }
   }, [characters, currentCharacterId, setCurrentCharacter]);
 
-  const { data: selectedCharacter, isFetching: isCharacterLoading } = useQuery({
+  const { data: selectedCharacter, isLoading: isCharacterLoading } = useQuery({
     queryKey: ["character", currentCharacterId, selectedCharacterLoadVersion],
     queryFn: () => fetchCharacter(currentCharacterId!),
     enabled: !!currentCharacterId,
@@ -321,7 +322,7 @@ export function CharactersPage() {
       key={selectedCharacter?.id ?? "empty"}
       character={selectedCharacter ?? null}
       isSaving={updateMutation.isPending}
-      isLoading={isCharacterLoading}
+      isLoading={shouldShowCharacterEditorLoading(Boolean(selectedCharacter), isCharacterLoading)}
       isAgentLocked={Boolean(currentProjectId && assistantState.isAgentRunning)}
       onSave={async (data) => {
         if (!selectedCharacter) return;

--- a/frontend/src/features/world-info/components/entry-editor-state.ts
+++ b/frontend/src/features/world-info/components/entry-editor-state.ts
@@ -1,0 +1,13 @@
+export interface EntryEditorState {
+  name: string;
+  content: string;
+  tokenCount: number;
+}
+
+export function resolveRemoteEntryEditorState(
+  localState: EntryEditorState,
+  remoteState: EntryEditorState,
+  hasLocalChanges: boolean,
+): EntryEditorState {
+  return hasLocalChanges ? localState : remoteState;
+}

--- a/frontend/src/features/world-info/components/entry-editor.tsx
+++ b/frontend/src/features/world-info/components/entry-editor.tsx
@@ -20,6 +20,8 @@ import type {
   WorldInfoEntryBriefListResponse,
 } from "@/lib/world-info.types";
 
+import { resolveRemoteEntryEditorState } from "./entry-editor-state";
+
 interface EntryEditorProps {
   /** 条目数据 */
   entry: WorldInfoEntry;
@@ -169,6 +171,28 @@ export function EntryEditor({
       }
     };
   }, [flushSave]);
+
+  useEffect(() => {
+    const nextState = resolveRemoteEntryEditorState(
+      {
+        name: savedNameRef.current,
+        content: savedContentRef.current,
+        tokenCount,
+      },
+      {
+        name: entry.name,
+        content: entry.content,
+        tokenCount: entry.tokenCount || 0,
+      },
+      hasChangesRef.current,
+    );
+    if (hasChangesRef.current) return;
+
+    savedNameRef.current = nextState.name;
+    savedContentRef.current = nextState.content;
+    setName(nextState.name);
+    setTokenCount(nextState.tokenCount);
+  }, [entry.content, entry.name, entry.tokenCount, tokenCount]);
 
   useEffect(() => {
     if (scrollToLine == null || scrollToLine < 1 || scrolledRef.current) return;

--- a/frontend/src/features/writing/components/chapter-editor.tsx
+++ b/frontend/src/features/writing/components/chapter-editor.tsx
@@ -23,7 +23,10 @@ import { createToastThrottler } from "@/lib/ui-utils";
 
 import { useAutoSave } from "../hooks/use-auto-save";
 import { useUpdateChapter } from "../hooks/use-chapters";
-import { useWritingEditorEntity } from "../hooks/use-writing-editor-entity";
+import {
+  shouldShowWritingEditorLoading,
+  useWritingEditorEntity,
+} from "../hooks/use-writing-editor-entity";
 import {
   useWritingWorkingCopy,
   type WritingDraft,
@@ -591,7 +594,7 @@ export function ChapterEditor({
   onOpenSummary,
 }: ChapterEditorProps) {
   const { t } = useTranslation();
-  const { data, isFetching, isLoading } = useWritingEditorEntity({
+  const { data } = useWritingEditorEntity({
     type: "chapter",
     entityId: chapterId,
     fetchEntity: fetchChapter,
@@ -614,7 +617,7 @@ export function ChapterEditor({
     );
   }
 
-  if (isLoading || isFetching || !data) {
+  if (shouldShowWritingEditorLoading(data)) {
     return (
       <Flex
         align="center"

--- a/frontend/src/features/writing/components/note-editor.tsx
+++ b/frontend/src/features/writing/components/note-editor.tsx
@@ -10,7 +10,10 @@ import { createToastThrottler } from "@/lib/ui-utils";
 
 import { useAutoSave } from "../hooks/use-auto-save";
 import { useUpdateNote } from "../hooks/use-notes";
-import { useWritingEditorEntity } from "../hooks/use-writing-editor-entity";
+import {
+  shouldShowWritingEditorLoading,
+  useWritingEditorEntity,
+} from "../hooks/use-writing-editor-entity";
 import {
   useWritingWorkingCopy,
   type WritingDraft,
@@ -250,7 +253,7 @@ function NoteEditorContent({
 
 export function NoteEditor(props: NoteEditorProps) {
   const { t } = useTranslation();
-  const { data, isFetching, isLoading } = useWritingEditorEntity({
+  const { data } = useWritingEditorEntity({
     type: "note",
     entityId: props.noteId,
     fetchEntity: fetchNote,
@@ -273,7 +276,7 @@ export function NoteEditor(props: NoteEditorProps) {
     );
   }
 
-  if (isLoading || isFetching || !data) {
+  if (shouldShowWritingEditorLoading(data)) {
     return (
       <Flex
         align="center"

--- a/frontend/src/features/writing/hooks/use-writing-editor-entity.ts
+++ b/frontend/src/features/writing/hooks/use-writing-editor-entity.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, type QueryClient } from "@tanstack/react-query";
 
 import {
   deleteWritingWorkingCopyIfUpdatedAt,
@@ -53,6 +53,22 @@ interface UseWritingEditorEntityOptions<TEntity extends WritingEditorEntity> {
   type: WritingWorkingCopyType;
   entityId: string | null;
   fetchEntity: (entityId: string) => Promise<TEntity>;
+}
+
+export function invalidateWritingEditorEntityQueries(
+  queryClient: QueryClient,
+  type: WritingWorkingCopyType,
+  entityId?: string,
+): void {
+  void queryClient.invalidateQueries({
+    queryKey: entityId ? ["writing-editor", type, entityId] : ["writing-editor", type],
+  });
+}
+
+export function shouldShowWritingEditorLoading<TEntity>(
+  data: TEntity | undefined,
+): data is undefined {
+  return data === undefined;
 }
 
 export function useWritingEditorEntity<TEntity extends WritingEditorEntity>({

--- a/frontend/src/features/writing/store/use-tabs-store.ts
+++ b/frontend/src/features/writing/store/use-tabs-store.ts
@@ -31,11 +31,26 @@ interface TabsActions {
   updateTabTitle: (tabId: string, title: string) => void;
   syncTabsWithChapters: (chapters: { id: string; title: string }[]) => void;
   syncTabs: (items: { id: string; title: string }[], type: "chapter" | "note") => void;
+  removeTabsByReference: (type: "chapter" | "note", refId: string) => void;
   showEmptyTab: () => void;
   reorderTabs: (activeId: string, overId: string) => void;
 }
 
 type TabsStore = TabsState & TabsActions;
+
+export function removeTabsByReference(
+  tabs: EditorTab[],
+  activeTabId: string | null,
+  type: "chapter" | "note",
+  refId: string,
+): { tabs: EditorTab[]; activeTabId: string | null } {
+  const nextTabs = tabs.filter((tab) => tab.type !== type || tab.refId !== refId);
+  const nextActiveTabId = nextTabs.some((tab) => tab.id === activeTabId)
+    ? activeTabId
+    : (nextTabs[0]?.id ?? null);
+
+  return { tabs: nextTabs, activeTabId: nextActiveTabId };
+}
 
 function toRecord(tab: EditorTab): EditorTabRecord {
   return {
@@ -319,6 +334,15 @@ export const useTabsStore = create<TabsStore>()((set, get) => ({
       });
       persistTabs(currentProjectId, newTabs, newActiveId);
     }
+  },
+
+  removeTabsByReference: (type, refId) => {
+    const { tabs, activeTabId, currentProjectId } = get();
+    const next = removeTabsByReference(tabs, activeTabId, type, refId);
+    if (next.tabs.length === tabs.length) return;
+
+    set(next);
+    persistTabs(currentProjectId, next.tabs, next.activeTabId);
   },
 
   reorderTabs: (activeId, overId) => {


### PR DESCRIPTION
## PR 标题

fix(agent): 修复工具调用触发内容刷新失效的问题

## 变更说明

- 问题: Agent 修改或删除章节、笔记等实体后，当前页面的编辑器、标签页和列表状态不能及时同步。
- 重要性: 用户可能继续看到已删除实体或旧内容，后台刷新还会导致编辑器出现全屏加载闪烁。
- 变化: 为章节和笔记刷新事件补充操作类型；删除时关闭对应标签页并更新当前选择和列表缓存；编辑后刷新写作编辑器实体查询。
- 变化: 编辑章节和笔记时更新 `updated_at`；章节、笔记、角色和世界书编辑器仅在首次加载显示全屏加载态。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

刷新事件未携带章节、笔记操作类型，前端无法区分删除场景；写作编辑器和角色编辑器将后台刷新视为首次加载；章节和笔记编辑未更新 `updated_at`，导致本地工作副本无法判断远端实体已更新。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证记录：

- `uv run pytest tests/agent_runtime/tools/test_chapter_refresh_hook.py tests/agent_runtime/tools/test_note_refresh_hook.py tests/agent_runtime/tools/test_chapter_tools.py tests/agent_runtime/tools/test_note_tools.py`（42 passed）
- `uv run ruff check .`
- `uv run ty check app`
- `pnpm type-check`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
