### PR TITLE
fix(desktop): 修复系统缺失 tar 导致运行环境安装失败的问题

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -25,13 +25,15 @@
     "react-markdown": "^10.1.0",
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
-    "scheduler": "^0.27.0"
+    "scheduler": "^0.27.0",
+    "tar-stream": "^3.2.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@types/tar-stream": "^3.1.4",
     "@typescript-eslint/eslint-plugin": "^8.59.2",
     "@typescript-eslint/parser": "^8.59.2",
     "@vitejs/plugin-react": "^6.0.3",

--- a/desktop/pnpm-lock.yaml
+++ b/desktop/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       scheduler:
         specifier: ^0.27.0
         version: 0.27.0
+      tar-stream:
+        specifier: ^3.2.0
+        version: 3.2.0
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.4
@@ -48,6 +51,9 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
+      '@types/tar-stream':
+        specifier: ^3.1.4
+        version: 3.1.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.59.2
         version: 8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
@@ -1450,6 +1456,9 @@ packages:
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
+  '@types/tar-stream@3.1.4':
+    resolution: {integrity: sha512-921gW0+g29mCJX0fRvqeHzBlE/XclDaAG0Ousy1LCghsOhvaKacDeRGEVzQP9IPfKn8Vysy7FEXAIxycpc/CMg==}
+
   '@types/unist@2.0.11':
     resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
@@ -1822,6 +1831,14 @@ packages:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
 
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -1831,6 +1848,43 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  bare-fs@4.7.4:
+    resolution: {integrity: sha512-y1kC+ffIx/tPLdTE693uNjHfzTfr+ravR5tvWlMXe25nELbkqV400S71qHDwbkAQ1FVEZobB1NFRzFbCCcyBCQ==}
+    engines: {bare: '>=1.16.0'}
+    peerDependencies:
+      bare-buffer: '*'
+    peerDependenciesMeta:
+      bare-buffer:
+        optional: true
+
+  bare-path@3.1.1:
+    resolution: {integrity: sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==}
+
+  bare-stream@2.13.3:
+    resolution: {integrity: sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==}
+    peerDependencies:
+      bare-abort-controller: '*'
+      bare-buffer: '*'
+      bare-events: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+      bare-buffer:
+        optional: true
+      bare-events:
+        optional: true
+
+  bare-url@2.4.6:
+    resolution: {integrity: sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -2256,6 +2310,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
@@ -2271,6 +2328,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
@@ -3498,6 +3558,9 @@ packages:
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
+
   string-width@4.2.0:
     resolution: {integrity: sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==}
     engines: {node: '>=8'}
@@ -3553,12 +3616,21 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  tar-stream@3.2.0:
+    resolution: {integrity: sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==}
+
   tar@6.1.12:
     resolution: {integrity: sha512-jU4TdemS31uABHd+Lt5WEYJuzn+TJTCBLljvIAHZOz6M9Os5pJ4dD+vRFLxPa/n3T0iEFzpi+0x1UfuDZYbRMw==}
     engines: {node: '>=10'}
 
+  teex@1.0.1:
+    resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
+
   temp-file@3.4.0:
     resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   tiny-typed-emitter@2.1.0:
     resolution: {integrity: sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==}
@@ -5209,6 +5281,10 @@ snapshots:
     dependencies:
       '@types/node': 24.13.2
 
+  '@types/tar-stream@3.1.4':
+    dependencies:
+      '@types/node': 24.13.2
+
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
@@ -5594,11 +5670,42 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
+  b4a@1.8.1: {}
+
   bail@2.0.2: {}
 
   balanced-match@1.0.0: {}
 
   balanced-match@4.0.4: {}
+
+  bare-events@2.9.1: {}
+
+  bare-fs@4.7.4:
+    dependencies:
+      bare-events: 2.9.1
+      bare-path: 3.1.1
+      bare-stream: 2.13.3(bare-events@2.9.1)
+      bare-url: 2.4.6
+      fast-fifo: 1.3.2
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  bare-path@3.1.1: {}
+
+  bare-stream@2.13.3(bare-events@2.9.1):
+    dependencies:
+      b4a: 1.8.1
+      streamx: 2.28.0
+      teex: 1.0.1
+    optionalDependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  bare-url@2.4.6:
+    dependencies:
+      bare-path: 3.1.1
 
   base64-js@1.5.1: {}
 
@@ -6128,6 +6235,12 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   expect-type@1.4.0: {}
 
   extract-zip@2.0.1:
@@ -6144,6 +6257,8 @@ snapshots:
     optional: true
 
   fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-json-stable-stringify@2.1.0: {}
 
@@ -7657,6 +7772,15 @@ snapshots:
 
   std-env@4.2.0: {}
 
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   string-width@4.2.0:
     dependencies:
       emoji-regex: 8.0.0
@@ -7728,6 +7852,17 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  tar-stream@3.2.0:
+    dependencies:
+      b4a: 1.8.1
+      bare-fs: 4.7.4
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - react-native-b4a
+
   tar@6.1.12:
     dependencies:
       chownr: 2.0.0
@@ -7737,10 +7872,23 @@ snapshots:
       mkdirp: 1.0.4
       yallist: 4.0.0
 
+  teex@1.0.1:
+    dependencies:
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   temp-file@3.4.0:
     dependencies:
       async-exit-hook: 2.0.1
       fs-extra: 10.1.0
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   tiny-typed-emitter@2.1.0: {}
 

--- a/desktop/src/main/runtime/archive.ts
+++ b/desktop/src/main/runtime/archive.ts
@@ -3,8 +3,8 @@ import { createWriteStream } from "node:fs";
 import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { pipeline } from "node:stream/promises";
-import { spawn } from "node:child_process";
 import { Transform } from "node:stream";
+export { extractTarGz } from "./tar-extract.js";
 
 const FIRST_BYTE_TIMEOUT_MS = 8_000;
 
@@ -69,33 +69,4 @@ export async function downloadFile(
     }
   }
   throw lastError instanceof Error ? lastError : new Error(String(lastError));
-}
-
-export async function extractTarGz(
-  archivePath: string,
-  outputDir: string,
-  onProgress?: (entryName: string) => void,
-): Promise<void> {
-  await rm(outputDir, { recursive: true, force: true });
-  await mkdir(outputDir, { recursive: true });
-  await new Promise<void>((resolve, reject) => {
-    const child = spawn("tar", ["-xzf", archivePath, "-C", outputDir], {
-      windowsHide: true,
-      stdio: ["ignore", "pipe", "inherit"],
-    });
-    child.on("error", reject);
-    child.on("exit", (code) => {
-      if (code === 0) resolve();
-      else reject(new Error(`tar exited with code ${code}`));
-    });
-    if (onProgress && child.stdout) {
-      child.stdout.on("data", (chunk: Buffer) => {
-        const lines = chunk.toString("utf8").split("\n");
-        for (const line of lines) {
-          const trimmed = line.trim();
-          if (trimmed) onProgress(trimmed);
-        }
-      });
-    }
-  });
 }

--- a/desktop/src/main/runtime/tar-extract.ts
+++ b/desktop/src/main/runtime/tar-extract.ts
@@ -1,0 +1,84 @@
+import { spawn } from "node:child_process";
+import { createReadStream, createWriteStream } from "node:fs";
+import { mkdir, rm, symlink } from "node:fs/promises";
+import path from "node:path";
+import { pipeline } from "node:stream/promises";
+import { createGunzip } from "node:zlib";
+import { extract } from "tar-stream";
+
+function resolveArchiveEntryPath(outputDir: string, entryName: string): string {
+  const outputRoot = path.resolve(outputDir);
+  const entryPath = path.resolve(outputRoot, entryName);
+  if (entryPath === outputRoot || !entryPath.startsWith(`${outputRoot}${path.sep}`)) {
+    throw new Error(`archive entry escapes output directory: ${entryName}`);
+  }
+  return entryPath;
+}
+
+function resolveArchiveLinkPath(outputDir: string, entryPath: string, linkName: string): void {
+  if (path.isAbsolute(linkName)) throw new Error(`archive link escapes output directory: ${linkName}`);
+  const outputRoot = path.resolve(outputDir);
+  const linkTarget = path.resolve(path.dirname(entryPath), linkName);
+  if (!linkTarget.startsWith(`${outputRoot}${path.sep}`)) {
+    throw new Error(`archive link escapes output directory: ${linkName}`);
+  }
+}
+
+async function extractWithSystemTar(archivePath: string, outputDir: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn("tar", ["-xzf", archivePath, "-C", outputDir], {
+      windowsHide: true,
+      stdio: ["ignore", "ignore", "inherit"],
+    });
+    child.once("error", reject);
+    child.once("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`tar exited with code ${code}`));
+    });
+  });
+}
+
+async function extractWithBuiltInTar(archivePath: string, outputDir: string): Promise<void> {
+  const archive = extract();
+  archive.on("entry", (header, stream, next) => {
+    const extractEntry = async () => {
+      const entryPath = resolveArchiveEntryPath(outputDir, header.name);
+      if (header.type === "directory") {
+        await mkdir(entryPath, { recursive: true });
+        stream.resume();
+        return;
+      }
+      if (header.type === "file") {
+        await mkdir(path.dirname(entryPath), { recursive: true });
+        await pipeline(stream, createWriteStream(entryPath, { mode: header.mode }));
+        return;
+      }
+      if (header.type === "symlink" && header.linkname) {
+        resolveArchiveLinkPath(outputDir, entryPath, header.linkname);
+        await mkdir(path.dirname(entryPath), { recursive: true });
+        await symlink(header.linkname, entryPath);
+        stream.resume();
+        return;
+      }
+      stream.resume();
+    };
+
+    void extractEntry().then(() => next(), next);
+  });
+
+  await pipeline(createReadStream(archivePath), createGunzip(), archive);
+}
+
+export async function extractTarGz(archivePath: string, outputDir: string): Promise<void> {
+  await rm(outputDir, { recursive: true, force: true });
+  await mkdir(outputDir, { recursive: true });
+
+  try {
+    await extractWithSystemTar(archivePath, outputDir);
+  } catch (error) {
+    if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") throw error;
+    await rm(outputDir, { recursive: true, force: true });
+    await mkdir(outputDir, { recursive: true });
+    await extractWithBuiltInTar(archivePath, outputDir);
+  }
+}

--- a/desktop/tests/main/archive.test.mjs
+++ b/desktop/tests/main/archive.test.mjs
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import { gzipSync } from "node:zlib";
+import { mkdtemp, readFile, readlink, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { extractTarGz } from "../../dist/main/runtime/tar-extract.js";
+
+function writeOctal(buffer, offset, length, value) {
+  buffer.write(`${value.toString(8).padStart(length - 1, "0")}\0`, offset, length, "ascii");
+}
+
+function createTarGz(entries) {
+  const blocks = [];
+
+  for (const { content = "", linkname = "", name, type = "file" } of entries) {
+    const contentBuffer = Buffer.isBuffer(content) ? content : Buffer.from(content);
+    const header = Buffer.alloc(512);
+    header.write(name, 0, 100, "utf8");
+    writeOctal(header, 100, 8, type === "directory" ? 0o755 : 0o644);
+    writeOctal(header, 108, 8, 0);
+    writeOctal(header, 116, 8, 0);
+    writeOctal(header, 124, 12, type === "file" ? contentBuffer.length : 0);
+    writeOctal(header, 136, 12, 0);
+    header.fill(0x20, 148, 156);
+    header[156] = type === "symlink" ? 0x32 : 0x30;
+    if (linkname) header.write(linkname, 157, 100, "utf8");
+    header.write("ustar\0", 257, 6, "ascii");
+    header.write("00", 263, 2, "ascii");
+    writeOctal(header, 148, 8, header.reduce((sum, byte) => sum + byte, 0));
+
+    const padding = Buffer.alloc((512 - (contentBuffer.length % 512)) % 512);
+    blocks.push(header, contentBuffer, padding);
+  }
+
+  return gzipSync(Buffer.concat([...blocks, Buffer.alloc(1024)]));
+}
+
+function createPythonArchive() {
+  return createTarGz([{ name: "python/python.exe", content: "portable python\n" }]);
+}
+
+function createPythonArchiveWithSymlink() {
+  return createTarGz([
+    { name: "python/python3.13", content: "portable python\n" },
+    { name: "python/python3", type: "symlink", linkname: "python3.13" },
+  ]);
+}
+
+test("falls back to the built-in extractor when tar is unavailable", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "openfic-archive-"));
+  const archivePath = path.join(directory, "python.tar.gz");
+  const outputDir = path.join(directory, "output");
+  const originalPath = process.env.PATH;
+
+  try {
+    await writeFile(archivePath, createPythonArchive());
+    process.env.PATH = "";
+
+    await extractTarGz(archivePath, outputDir);
+
+    assert.equal(await readFile(path.join(outputDir, "python", "python.exe"), "utf8"), "portable python\n");
+  } finally {
+    process.env.PATH = originalPath;
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("preserves relative symbolic links when falling back to the built-in extractor", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "openfic-archive-"));
+  const archivePath = path.join(directory, "python.tar.gz");
+  const outputDir = path.join(directory, "output");
+  const originalPath = process.env.PATH;
+
+  try {
+    await writeFile(archivePath, createPythonArchiveWithSymlink());
+    process.env.PATH = "";
+
+    await extractTarGz(archivePath, outputDir);
+
+    assert.equal(await readlink(path.join(outputDir, "python", "python3")), "python3.13");
+  } finally {
+    process.env.PATH = originalPath;
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("rejects archive entries outside the output directory", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "openfic-archive-"));
+  const archivePath = path.join(directory, "python.tar.gz");
+  const outputDir = path.join(directory, "output");
+  const originalPath = process.env.PATH;
+
+  try {
+    await writeFile(archivePath, createTarGz([{ name: "../escape", content: "unsafe" }]));
+    process.env.PATH = "";
+
+    await assert.rejects(extractTarGz(archivePath, outputDir), /archive entry escapes output directory/);
+  } finally {
+    process.env.PATH = originalPath;
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("uses the system tar when it is available", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "openfic-archive-"));
+  const archivePath = path.join(directory, "python.tar.gz");
+  const outputDir = path.join(directory, "output");
+
+  try {
+    await writeFile(archivePath, createPythonArchive());
+
+    await extractTarGz(archivePath, outputDir);
+
+    assert.equal(await readFile(path.join(outputDir, "python", "python.exe"), "utf8"), "portable python\n");
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
+
+test("does not fall back when the system tar rejects an invalid archive", async () => {
+  const directory = await mkdtemp(path.join(os.tmpdir(), "openfic-archive-"));
+  const archivePath = path.join(directory, "invalid.tar.gz");
+  const outputDir = path.join(directory, "output");
+
+  try {
+    await writeFile(archivePath, "not a gzip archive");
+
+    await assert.rejects(extractTarGz(archivePath, outputDir), /tar exited with code/);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## PR 标题

fix(desktop): 修复系统缺失 tar 导致运行环境安装失败的问题

## 变更说明

- 问题: Windows 桌面端安装运行环境时，系统缺少或无法解析 `tar` 命令会在解压 Python 阶段报 `spawn tar ENOENT`
- 重要性: 初次安装无法继续，用户无法使用桌面端
- 变化: 保留系统 `tar` 优先路径，仅在启动失败且错误为 `ENOENT` 时使用内置 `.tar.gz` 解压
- 变化: 内置解压保留相对符号链接，并拒绝归档路径或链接目标逃逸输出目录
- 测试: 新增系统 tar 可用、缺失回退、非 ENOENT 不回退、符号链接和目录穿越场景测试

## 关联 Issue / PR (如有)

Related to #179

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [x] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

运行环境安装直接依赖系统 `tar`。当 Windows 进程环境中不存在该可执行命令时，子进程启动会抛出 `ENOENT`，且没有可继续安装的解压回退路径。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令：

- `pnpm type-check`
- `pnpm lint`
- `pnpm build`
- `node --test tests/main/archive.test.mjs`（5/5 通过）

构建存在既有的 UI chunk 大小提示，不影响本次主进程改动。
