### PR TITLE
fix(frontend): 修复编辑器剪贴板换行处理

### DIFF
--- a/frontend/src/components/editor-clipboard.ts
+++ b/frontend/src/components/editor-clipboard.ts
@@ -1,0 +1,30 @@
+import { getTextBetween, getTextSerializersFromSchema, type JSONContent } from "@tiptap/core";
+import type { MarkdownManager } from "@tiptap/markdown";
+import type { Fragment, Schema } from "@tiptap/pm/model";
+
+export function serializeClipboardText(content: Fragment, schema: Schema): string {
+  const document = schema.topNodeType.create(null, content);
+
+  return getTextBetween(
+    document,
+    { from: 0, to: document.content.size },
+    { blockSeparator: "\n", textSerializers: getTextSerializersFromSchema(schema) },
+  );
+}
+
+export function serializeClipboardMarkdown(
+  markdown: MarkdownManager,
+  content: JSONContent,
+): string {
+  const nodes = content.content ?? [];
+
+  return nodes
+    .map((node, index) => {
+      const separator =
+        index === 0 || (node.type === "paragraph" && nodes[index - 1]?.type === "paragraph")
+          ? ""
+          : "\n";
+      return `${separator}${markdown.serialize({ type: "doc", content: [node] })}`;
+    })
+    .join("\n");
+}

--- a/frontend/src/components/markdown-editor-config.ts
+++ b/frontend/src/components/markdown-editor-config.ts
@@ -9,6 +9,7 @@ import { Plugin } from "@tiptap/pm/state";
 import StarterKit from "@tiptap/starter-kit";
 import { createLowlight, common } from "lowlight";
 
+import { serializeClipboardMarkdown } from "./editor-clipboard";
 import { createEditorShortcuts, type EditorShortcutCallbacks } from "./editor-shortcuts";
 
 export type { EditorShortcutCallbacks } from "./editor-shortcuts";
@@ -81,7 +82,7 @@ const MarkdownClipboard = Extension.create({
               return "";
             }
             const content = slice.content.toJSON() as JSONContent[];
-            return editor.markdown.serialize({ type: "doc", content });
+            return serializeClipboardMarkdown(editor.markdown, { type: "doc", content });
           },
         },
       }),
@@ -103,7 +104,7 @@ export function createMarkdownEditorExtensions(options: MarkdownEditorExtensions
     }),
     TableKit,
     TaskList,
-    TaskItem,
+    TaskItem.configure({ nested: true }),
     CodeBlockLowlight.configure({
       lowlight: createLowlight(common),
     }),

--- a/frontend/src/features/writing/lib/editor-config.ts
+++ b/frontend/src/features/writing/lib/editor-config.ts
@@ -4,14 +4,17 @@
  * Tiptap 编辑器扩展配置 - 纯文本模式。
  */
 
+import type { JSONContent } from "@tiptap/core";
 import CharacterCount from "@tiptap/extension-character-count";
 import Document from "@tiptap/extension-document";
 import History from "@tiptap/extension-history";
 import Paragraph from "@tiptap/extension-paragraph";
 import Placeholder from "@tiptap/extension-placeholder";
 import Text from "@tiptap/extension-text";
+import { Plugin } from "@tiptap/pm/state";
 import { Extension } from "@tiptap/react";
 
+import { serializeClipboardText } from "@/components/editor-clipboard";
 import { createEditorShortcuts, type EditorShortcutCallbacks } from "@/components/editor-shortcuts";
 
 import { SearchAndReplace } from "./search-and-replace";
@@ -30,6 +33,45 @@ const TabIndent = Extension.create({
     };
   },
 });
+
+const PlainTextClipboard = Extension.create({
+  name: "plainTextClipboard",
+
+  addProseMirrorPlugins() {
+    const editor = this.editor;
+
+    return [
+      new Plugin({
+        props: {
+          handlePaste(_view, event) {
+            const text = event.clipboardData?.getData("text/plain");
+            if (text === undefined) {
+              return false;
+            }
+
+            editor.commands.insertContent(createPlainTextPasteContent(text));
+            return true;
+          },
+          clipboardTextSerializer(slice) {
+            return serializeClipboardText(slice.content, editor.schema);
+          },
+        },
+      }),
+    ];
+  },
+});
+
+export function createPlainTextPasteContent(text: string): JSONContent[] {
+  return text
+    .replace(/\r\n?/g, "\n")
+    .split("\n")
+    .map((line) => {
+      if (!line) {
+        return { type: "paragraph" };
+      }
+      return { type: "paragraph", content: [{ type: "text", text: line }] };
+    });
+}
 
 /**
  * 编辑器扩展配置选项
@@ -68,6 +110,7 @@ export function createEditorExtensions(options: EditorExtensionsOptions = {}) {
     }),
     CharacterCount,
     TabIndent,
+    PlainTextClipboard,
     SearchAndReplace,
   ];
 


### PR DESCRIPTION
## PR 标题

fix(frontend): 修复编辑器剪贴板换行处理

## 变更说明

- 问题: 编辑器复制与章节粘贴时的段落分隔不一致，导致多余空行或空行丢失。
- 重要性: 模型生成内容和纯文本在编辑器内外流转时无法保持预期排版。
- 变化: Markdown 编辑器按块类型保留必要空行并支持嵌套任务列表；章节编辑器按纯文本逐行粘贴并保留空段落。

## 关联 Issue / PR

Closes #181

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因

Tiptap 默认以双换行序列化块节点，章节编辑器依赖浏览器 HTML 粘贴解析，二者与项目按单换行保存段落的语义不一致；任务项默认不允许嵌套任务列表。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范
