### PR TITLE
fix(frontend): 新建角色后自动切换标签

### DIFF
--- a/frontend/src/features/characters/pages/characters-page.tsx
+++ b/frontend/src/features/characters/pages/characters-page.tsx
@@ -159,21 +159,14 @@ export function CharactersPage() {
       queryClient.setQueryData(
         ["characters", updated.projectId],
         (old: CharacterListResponse | undefined) => {
-          if (!old) {
-            return {
-              items: [updated],
-              total: 1,
-              page: 1,
-              pageSize: 100,
-            };
-          }
+          if (!old) return old;
           const exists = old.items.some((character) => character.id === updated.id);
           const items = exists
             ? old.items.map((character) => (character.id === updated.id ? updated : character))
             : [updated, ...old.items];
           return {
             ...old,
-            items: sortCharacters(items),
+            items: sortCharacters(items).slice(0, old.pageSize),
             total: exists ? old.total : old.total + 1,
           };
         },

--- a/frontend/src/features/characters/pages/characters-page.tsx
+++ b/frontend/src/features/characters/pages/characters-page.tsx
@@ -159,7 +159,14 @@ export function CharactersPage() {
       queryClient.setQueryData(
         ["characters", updated.projectId],
         (old: CharacterListResponse | undefined) => {
-          if (!old) return old;
+          if (!old) {
+            return {
+              items: [updated],
+              total: 1,
+              page: 1,
+              pageSize: 100,
+            };
+          }
           const exists = old.items.some((character) => character.id === updated.id);
           const items = exists
             ? old.items.map((character) => (character.id === updated.id ? updated : character))
@@ -181,9 +188,13 @@ export function CharactersPage() {
         name: t("characters.untitledCharacter"),
       }),
     onSuccess: (character) => {
+      upsertCharacterCache(toCharacterListItem(character));
+      queryClient.setQueryData(
+        ["character", character.id, selectedCharacterLoadVersion],
+        character,
+      );
       queryClient.invalidateQueries({ queryKey: ["characters", currentProjectId] });
       setCurrentCharacter(character.id);
-      setSelectedCharacterLoadVersion((prev) => prev + 1);
       toast.success(t("characters.created"));
     },
   });


### PR DESCRIPTION
## PR 标题

fix(frontend): 新建角色后自动切换标签

## 变更说明

- 问题: Character 页面新建角色后，当前标签会被旧列表缓存重置，无法自动停留在新角色。
- 重要性: 新建角色是角色管理的核心流程，创建后未切换会造成操作反馈不一致，也与 World Info 页面的行为不同。
- 变化: 创建成功后先将新角色写入列表与详情缓存，再切换当前角色；同时补齐列表缓存尚未初始化时的处理。

## 关联 Issue / PR (如有)

无。

## 变更类型

- [x] 错误修复 (fix)

## 问题原因(如有)

创建成功后，原逻辑仅使角色列表查询失效并立即更新当前角色 ID。此时组件仍在读取旧的列表缓存，所选角色有效性检查发现新 ID 不在旧列表中，便将当前角色重置为已有角色。此次调整为先同步列表和详情缓存，再切换当前角色，从而消除状态更新的竞争条件。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

本次不涉及数据库变更或新增依赖。已在本地通过以下检查：

- oxfmt 格式检查
- pnpm run lint
- pnpm run type-check
- git diff --check