### PR TITLE
chore(backend): 为 OpenAI Compatible 提供商添加思考强度支持

### DIFF
--- a/backend/app/api/routers/agent_runtime.py
+++ b/backend/app/api/routers/agent_runtime.py
@@ -67,7 +67,6 @@ from app.core.encryption import EncryptionService
 from app.core.errors import NotFoundError
 from app.core.ids import generate_id
 from app.models.repos import model_provider_repo, model_repo
-from app.models.catalog import ModelProviderCatalogService
 from app.settings import settings
 from app.background.jobs.session_title_jobs import enqueue_session_title_job
 from app.background.jobs import service as background_service
@@ -317,9 +316,7 @@ async def _build_model_config(
         "presence_penalty": model.presence_penalty,
         "repetition_penalty": model.repetition_penalty,
     }
-    if reasoning_effort and await ModelProviderCatalogService().supports_provider_model_reasoning(
-        provider.provider_type, provider.url, model.model_id
-    ):
+    if reasoning_effort and reasoning_effort != "off":
         model_config["reasoning_effort"] = reasoning_effort
     return model_config
 
@@ -1149,7 +1146,11 @@ async def fork_agent_session(
 
     fork_session_id: str | None = None
     try:
-        model_config = await _resolve_model_config(session, request.model_id)
+        model_config = await _resolve_model_config(
+            session,
+            request.model_id,
+            request.reasoning_effort,
+        )
         result = await fork_agent_session_at_revision(
             session,
             source_session_id=session_id,

--- a/backend/app/api/schemas/agent.py
+++ b/backend/app/api/schemas/agent.py
@@ -234,6 +234,10 @@ class AgentForkRequest(BaseModel):
 
     source_revision_id: str = Field(..., description="分叉来源用户消息 revision ID")
     model_id: str = Field(..., description="Fork 会话后续使用的模型 ID")
+    reasoning_effort: ReasoningEffort | None = Field(
+        default=None,
+        description="Fork 会话后续使用的推理强度",
+    )
 
     model_config = {"extra": "forbid"}
 

--- a/backend/app/models/clients/llm_client.py
+++ b/backend/app/models/clients/llm_client.py
@@ -10,15 +10,16 @@ import time
 from dataclasses import dataclass
 import json
 import re
-from typing import AsyncGenerator, Any, Mapping, cast
+from typing import AsyncGenerator, Any, Mapping, Protocol, cast
 
-from langchain_core.language_models import BaseChatModel
+from langchain_core.language_models import LanguageModelInput
 from langchain_core.messages import (
     AIMessage,
     HumanMessage,
     SystemMessage,
     BaseMessage,
 )
+from langchain_core.runnables import Runnable
 from langchain_core.tools import BaseTool
 from loguru import logger
 
@@ -29,6 +30,13 @@ from app.models.clients.model_factory import ModelConfig, ReasoningEffort, creat
 
 DEFAULT_LLM_TIMEOUT = 120
 _patch_deepseek_reasoning_payload = patch_deepseek_reasoning_payload
+
+
+class ToolBindableModel(Protocol):
+    def bind_tools(
+        self,
+        tools: list[BaseTool],
+    ) -> Runnable[LanguageModelInput, AIMessage]: ...
 
 
 @dataclass
@@ -86,10 +94,10 @@ class LLMClient:
             config: LLM配置。
         """
         self.config = config
-        self._llm: BaseChatModel | None = None
-        self._llm_with_tools: BaseChatModel | None = None
+        self._llm: Runnable[LanguageModelInput, BaseMessage] | None = None
+        self._llm_with_tools: Runnable[LanguageModelInput, AIMessage] | None = None
 
-    def _get_llm(self) -> BaseChatModel:
+    def _get_llm(self) -> Runnable[LanguageModelInput, BaseMessage]:
         """获取或创建LangChain LLM实例。"""
         if self._llm is not None:
             return self._llm
@@ -560,6 +568,6 @@ class LLMClient:
             返回self以支持链式调用。
         """
         llm = self._get_llm()
-        self._llm_with_tools = cast(BaseChatModel, llm.bind_tools(tools))
+        self._llm_with_tools = cast(ToolBindableModel, llm).bind_tools(tools)
         logger.info(f"已绑定 {len(tools)} 个工具到LLM")
         return self

--- a/backend/app/models/clients/model_factory.py
+++ b/backend/app/models/clients/model_factory.py
@@ -1,7 +1,9 @@
 from dataclasses import dataclass
 from typing import Any
 
-from langchain_core.language_models import BaseChatModel
+from langchain_core.language_models import LanguageModelInput
+from langchain_core.messages import BaseMessage
+from langchain_core.runnables import Runnable
 
 from app.core.utils.tiktoken import seed_bundled_encodings
 from app.models.clients.deepseek_payload import patch_deepseek_reasoning_payload
@@ -63,6 +65,18 @@ def _non_default(value: Any, default: Any) -> Any | None:
     return value if is_non_default(value, default) else None
 
 
+def _enabled_reasoning_effort(config: ModelConfig) -> ReasoningEffort | None:
+    return config.reasoning_effort if config.reasoning_effort != "off" else None
+
+
+def _three_level_reasoning_effort(
+    reasoning_effort: ReasoningEffort | None,
+) -> str | None:
+    if reasoning_effort is None:
+        return None
+    return "high" if reasoning_effort in {"xhigh", "max"} else reasoning_effort
+
+
 def _openai_compatible_kwargs(config: ModelConfig) -> dict[str, Any]:
     kwargs = _compact_kwargs(
         model=config.model_id,
@@ -75,7 +89,7 @@ def _openai_compatible_kwargs(config: ModelConfig) -> dict[str, Any]:
             config.frequency_penalty, DEFAULT_FREQUENCY_PENALTY
         ),
         presence_penalty=_non_default(config.presence_penalty, DEFAULT_PRESENCE_PENALTY),
-        reasoning_effort=config.reasoning_effort,
+        reasoning_effort=_enabled_reasoning_effort(config),
         max_retries=0,
         stream_usage=True,
     )
@@ -94,9 +108,10 @@ def _openai_compatible_kwargs(config: ModelConfig) -> dict[str, Any]:
     return kwargs
 
 
-def create_chat_model(config: ModelConfig) -> BaseChatModel:
+def create_chat_model(config: ModelConfig) -> Runnable[LanguageModelInput, BaseMessage]:
     seed_bundled_encodings()
     provider = config.provider_type
+    reasoning_effort = _enabled_reasoning_effort(config)
 
     if provider == "anthropic":
         from langchain_anthropic import ChatAnthropic
@@ -109,6 +124,7 @@ def create_chat_model(config: ModelConfig) -> BaseChatModel:
             top_p=_non_default(config.top_p, DEFAULT_TOP_P),
             top_k=_non_default(config.top_k, DEFAULT_TOP_K),
             max_tokens=config.max_tokens or 4096,
+            effort=reasoning_effort,
             max_retries=0,
         ))
 
@@ -122,6 +138,7 @@ def create_chat_model(config: ModelConfig) -> BaseChatModel:
             top_p=_non_default(config.top_p, DEFAULT_TOP_P),
             top_k=_non_default(config.top_k, DEFAULT_TOP_K),
             max_output_tokens=config.max_tokens,
+            thinking_level=_three_level_reasoning_effort(reasoning_effort),
             max_retries=1,
         )
         if config.base_url:
@@ -149,7 +166,7 @@ def create_chat_model(config: ModelConfig) -> BaseChatModel:
             base_url=config.base_url or None,
             temperature=_non_default(config.temperature, DEFAULT_TEMPERATURE),
             max_tokens=config.max_tokens,
-            reasoning_effort=config.reasoning_effort,
+            reasoning_effort=reasoning_effort,
             max_retries=0,
             stream_usage=True,
         ))
@@ -157,14 +174,18 @@ def create_chat_model(config: ModelConfig) -> BaseChatModel:
     if provider == "mistral":
         from langchain_mistralai import ChatMistralAI
 
-        return ChatMistralAI(**_compact_kwargs(
+        mistral_kwargs = _compact_kwargs(
             model=config.model_id,
             api_key=config.api_key,
+            base_url=config.base_url or None,
             temperature=_non_default(config.temperature, DEFAULT_TEMPERATURE),
             top_p=_non_default(config.top_p, DEFAULT_TOP_P),
             max_tokens=config.max_tokens,
             max_retries=0,
-        ))
+        )
+        if reasoning_effort:
+            mistral_kwargs["model_kwargs"] = {"reasoning_effort": reasoning_effort}
+        return ChatMistralAI(**mistral_kwargs)
 
     if provider == "openrouter":
         from langchain_openrouter import ChatOpenRouter
@@ -182,6 +203,7 @@ def create_chat_model(config: ModelConfig) -> BaseChatModel:
             presence_penalty=_non_default(
                 config.presence_penalty, DEFAULT_PRESENCE_PENALTY
             ),
+            reasoning={"effort": reasoning_effort} if reasoning_effort else None,
             max_retries=0,
         ))
 
@@ -194,6 +216,7 @@ def create_chat_model(config: ModelConfig) -> BaseChatModel:
             base_url=config.base_url or None,
             temperature=_non_default(config.temperature, DEFAULT_TEMPERATURE),
             max_tokens=config.max_tokens,
+            reasoning_effort=_three_level_reasoning_effort(reasoning_effort),
             max_retries=0,
         )
         if config.top_p is not None:
@@ -203,6 +226,23 @@ def create_chat_model(config: ModelConfig) -> BaseChatModel:
     if provider == "cohere":
         from langchain_cohere import ChatCohere
 
+        class ChatCohereWithThinking(ChatCohere):
+            @property
+            def _default_params(self) -> dict[str, Any]:
+                params = super()._default_params
+                if reasoning_effort:
+                    params["thinking"] = {
+                        "type": "enabled",
+                        "token_budget": {
+                            "low": 1024,
+                            "medium": 4096,
+                            "high": 8192,
+                            "xhigh": 16384,
+                            "max": 16384,
+                        }[reasoning_effort],
+                    }
+                return params
+
         cohere_kwargs = _compact_kwargs(
             model=config.model_id,
             cohere_api_key=config.api_key,
@@ -211,7 +251,7 @@ def create_chat_model(config: ModelConfig) -> BaseChatModel:
         )
         if config.max_tokens is not None:
             cohere_kwargs["model_kwargs"] = {"max_tokens": config.max_tokens}
-        return ChatCohere(**cohere_kwargs)
+        return ChatCohereWithThinking(**cohere_kwargs)
 
     if provider == "amazon-nova":
         from langchain_amazon_nova import ChatAmazonNova
@@ -223,20 +263,23 @@ def create_chat_model(config: ModelConfig) -> BaseChatModel:
             temperature=_non_default(config.temperature, DEFAULT_TEMPERATURE),
             top_p=_non_default(config.top_p, DEFAULT_TOP_P),
             max_tokens=config.max_tokens,
+            reasoning_effort=_three_level_reasoning_effort(reasoning_effort),
             max_retries=0,
         ))
 
     if provider == "nvidia-ai-endpoints":
         from langchain_nvidia_ai_endpoints import ChatNVIDIA
 
-        return ChatNVIDIA(**_compact_kwargs(
+        nvidia_kwargs = _compact_kwargs(
             model=config.model_id,
             api_key=config.api_key,
             base_url=config.base_url or None,
             temperature=_non_default(config.temperature, DEFAULT_TEMPERATURE),
             top_p=_non_default(config.top_p, DEFAULT_TOP_P),
             max_completion_tokens=config.max_tokens,
-        ))
+        )
+        model = ChatNVIDIA(**nvidia_kwargs)
+        return model.with_thinking_mode(enabled=True) if reasoning_effort else model
 
     # OpenAI-compatible fallback (openai, huggingface, openai-compatible, unknown)
     from langchain_openai import ChatOpenAI

--- a/backend/app/models/clients/model_params.py
+++ b/backend/app/models/clients/model_params.py
@@ -1,7 +1,7 @@
 from typing import Final, Literal, TypeVar
 
 
-ReasoningEffort = Literal["low", "medium", "high", "xhigh", "max"]
+ReasoningEffort = Literal["off", "low", "medium", "high", "xhigh", "max"]
 
 DEFAULT_TEMPERATURE: Final = 1.0
 DEFAULT_TOP_P: Final = 1.0
@@ -16,7 +16,7 @@ MAX_CONTEXT_LENGTH: Final = 2_000_000
 DEFAULT_REASONING_EFFORT: Final[ReasoningEffort] = "medium"
 
 REASONING_EFFORT_VALUES: Final[frozenset[str]] = frozenset(
-    {"low", "medium", "high", "xhigh", "max"}
+    {"off", "low", "medium", "high", "xhigh", "max"}
 )
 
 T = TypeVar("T")

--- a/backend/tests/agent_runtime/test_model_factory.py
+++ b/backend/tests/agent_runtime/test_model_factory.py
@@ -123,6 +123,158 @@ def test_create_chat_model_sends_non_default_advanced_params():
     }
 
 
+def test_create_chat_model_omits_disabled_reasoning_effort():
+    model = create_chat_model(
+        ModelConfig(
+            provider_type="openai-compatible",
+            base_url="https://custom.api/v1",
+            api_key="sk-test",
+            model_id="new-reasoning-model",
+            reasoning_effort="off",
+        )
+    )
+
+    assert model._default_params == {  # type: ignore[attr-defined]
+        "model": "new-reasoning-model",
+        "stream": False,
+    }
+
+
+def test_create_chat_model_deepseek_omits_disabled_reasoning_effort():
+    model = create_chat_model(
+        ModelConfig(
+            provider_type="deepseek",
+            base_url="https://api.deepseek.com",
+            api_key="sk-test",
+            model_id="deepseek-reasoner",
+            reasoning_effort="off",
+        )
+    )
+
+    assert "reasoning_effort" not in model._default_params  # type: ignore[attr-defined]
+
+
+def test_create_chat_model_maps_anthropic_reasoning_effort():
+    model = create_chat_model(
+        ModelConfig(
+            provider_type="anthropic",
+            base_url="",
+            api_key="sk-ant-test",
+            model_id="claude-sonnet-4-6",
+            reasoning_effort="xhigh",
+        )
+    )
+
+    assert model.effort == "xhigh"
+
+
+def test_create_chat_model_maps_google_reasoning_effort():
+    model = create_chat_model(
+        ModelConfig(
+            provider_type="google-genai",
+            base_url="",
+            api_key="sk-google-test",
+            model_id="gemini-3-pro-preview",
+            reasoning_effort="max",
+        )
+    )
+
+    assert model.thinking_level == "high"
+
+
+def test_create_chat_model_maps_openrouter_reasoning_effort():
+    model = create_chat_model(
+        ModelConfig(
+            provider_type="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_key="sk-or-test",
+            model_id="openai/gpt-5.2",
+            reasoning_effort="high",
+        )
+    )
+
+    assert model._default_params["reasoning"] == {"effort": "high"}  # type: ignore[attr-defined]
+
+
+def test_create_chat_model_maps_groq_reasoning_effort():
+    model = create_chat_model(
+        ModelConfig(
+            provider_type="groq",
+            base_url="https://api.groq.com/openai/v1",
+            api_key="gsk_test",
+            model_id="openai/gpt-oss-120b",
+            reasoning_effort="max",
+        )
+    )
+
+    assert model._default_params["reasoning_effort"] == "high"  # type: ignore[attr-defined]
+
+
+def test_create_chat_model_maps_cohere_reasoning_effort():
+    model = create_chat_model(
+        ModelConfig(
+            provider_type="cohere",
+            base_url="https://api.cohere.com/v2",
+            api_key="cohere-test",
+            model_id="command-a-reasoning-08-2025",
+            reasoning_effort="medium",
+        )
+    )
+
+    assert model._default_params["thinking"] == {  # type: ignore[attr-defined]
+        "type": "enabled",
+        "token_budget": 4096,
+    }
+
+
+def test_create_chat_model_maps_amazon_nova_reasoning_effort():
+    model = create_chat_model(
+        ModelConfig(
+            provider_type="amazon-nova",
+            base_url="https://api.nova.amazon.com/v1",
+            api_key="nova-test",
+            model_id="nova-2-pro-v1",
+            reasoning_effort="max",
+        )
+    )
+
+    assert model._default_params["reasoning_effort"] == "high"  # type: ignore[attr-defined]
+
+
+def test_create_chat_model_passes_reasoning_effort_to_mistral():
+    mistral_model = create_chat_model(
+        ModelConfig(
+            provider_type="mistral",
+            base_url="https://api.mistral.ai",
+            api_key="sk-mistral-test",
+            model_id="magistral-medium",
+            reasoning_effort="high",
+        )
+    )
+    assert mistral_model._default_params["reasoning_effort"] == "high"  # type: ignore[attr-defined]
+
+
+def test_create_chat_model_enables_nvidia_thinking_mode():
+    nvidia_model = create_chat_model(
+        ModelConfig(
+            provider_type="nvidia-ai-endpoints",
+            base_url="https://integrate.api.nvidia.com/v1",
+            api_key="nvapi-test",
+            model_id="moonshotai/kimi-k2.5",
+            reasoning_effort="high",
+        )
+    )
+
+    assert getattr(nvidia_model, "kwargs") == {"thinking_mode": True}
+    bound_model = getattr(nvidia_model, "bound")
+    payload = bound_model._get_payload(  # type: ignore[no-untyped-call]
+        [{"role": "user", "content": "test"}],
+        stop=None,
+        **getattr(nvidia_model, "kwargs"),
+    )
+    assert payload["chat_template_kwargs"] == {"thinking": True}
+
+
 def test_create_chat_model_disables_provider_internal_retries_for_openai_like_models():
     config = ModelConfig(
         provider_type="openai",

--- a/backend/tests/api/test_agent.py
+++ b/backend/tests/api/test_agent.py
@@ -24,7 +24,7 @@ from app.agent_runtime.runner.checkpointer import get_checkpointer, reset_checkp
 from app.agent_runtime.runner.run_registry import get_agent_run_registry
 from app.agent_runtime.runner.session_runner import SessionRunner
 from app.agent_runtime.streaming.replay_buffer import get_agent_event_replay_buffer
-from app.api.routers.agent_runtime import _SESSION_RUNNERS
+from app.api.routers.agent_runtime import _SESSION_RUNNERS, _build_model_config
 from app.socket.handlers import agent_session_room, agent_subagents_room
 from app.storage.models.chapter import Chapter
 from app.storage.models.commit import Commit
@@ -106,6 +106,54 @@ async def _seed_agent_target(client: AsyncClient) -> dict[str, str]:
 
 @pytest.mark.asyncio
 class TestAgentAPI:
+    async def test_build_model_config_allows_reasoning_effort_for_uncataloged_model(self) -> None:
+        model = SimpleNamespace(
+            id="uncataloged-model-record",
+            model_id="new-reasoning-model",
+            context_length=128000,
+            temperature=1.0,
+            top_p=1.0,
+            top_k=0,
+            min_p=0.0,
+            top_a=0.0,
+            max_tokens=None,
+            frequency_penalty=0.0,
+            presence_penalty=0.0,
+            repetition_penalty=1.0,
+        )
+        provider = SimpleNamespace(
+            provider_type="anthropic",
+            url="https://api.anthropic.com",
+        )
+
+        config = await _build_model_config(model, provider, "sk-test", "high")
+
+        assert config["reasoning_effort"] == "high"
+
+    async def test_build_model_config_omits_disabled_reasoning_effort(self) -> None:
+        model = SimpleNamespace(
+            id="reasoning-model-record",
+            model_id="reasoning-model",
+            context_length=128000,
+            temperature=1.0,
+            top_p=1.0,
+            top_k=0,
+            min_p=0.0,
+            top_a=0.0,
+            max_tokens=None,
+            frequency_penalty=0.0,
+            presence_penalty=0.0,
+            repetition_penalty=1.0,
+        )
+        provider = SimpleNamespace(
+            provider_type="openai-compatible",
+            url="https://custom.api/v1",
+        )
+
+        config = await _build_model_config(model, provider, "sk-test", "off")
+
+        assert "reasoning_effort" not in config
+
     async def test_list_agent_tools_success(self, client: AsyncClient) -> None:
         response = await client.get("/api/v1/agent/tools")
 
@@ -390,6 +438,57 @@ class TestAgentAPI:
             response = await client.post(
                 "/api/v1/agent/sessions/session-reasoning-effort/message",
                 json={"message": "提高推理强度", "reasoning_effort": "high"},
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        resolve_model_config.assert_awaited_once_with(session, target["model_id"], "high")
+        assert runner.model_config == resolved_config
+
+    async def test_send_agent_message_allows_reasoning_effort_for_uncataloged_model(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session.add(
+            Task(
+                id="task-uncataloged-reasoning-effort",
+                project_id=target["project_id"],
+                title="目录外推理强度",
+                mode="agent",
+                agent_session_id="session-uncataloged-reasoning-effort",
+            )
+        )
+        await session.commit()
+
+        runner = SessionRunner(
+            session_id="session-uncataloged-reasoning-effort",
+            task_id="task-uncataloged-reasoning-effort",
+            model_config={
+                "max_context_tokens": 8000,
+                "model_id": "uncataloged-model",
+                "model_record_id": target["model_id"],
+            },
+            project_id=target["project_id"],
+        )
+        runner.run = MagicMock(return_value=object())
+        _SESSION_RUNNERS["session-uncataloged-reasoning-effort"] = runner
+
+        resolved_config = {
+            "max_context_tokens": 8000,
+            "model_id": "uncataloged-model",
+            "reasoning_effort": "high",
+        }
+        with patch(
+            "app.api.routers.agent_runtime._resolve_model_config",
+            AsyncMock(return_value=resolved_config),
+        ) as resolve_model_config, patch(
+            "app.api.routers.agent_runtime._launch_task",
+            AsyncMock(),
+        ):
+            response = await client.post(
+                "/api/v1/agent/sessions/session-uncataloged-reasoning-effort/message",
+                json={"message": "使用新模型推理", "reasoning_effort": "high"},
             )
 
         assert response.status_code == status.HTTP_200_OK
@@ -2533,14 +2632,23 @@ class TestAgentAPI:
 
         with patch(
             "app.api.routers.agent_runtime._resolve_model_config",
-            AsyncMock(return_value={"max_context_tokens": 128000}),
-        ), patch(
+            AsyncMock(
+                return_value={
+                    "max_context_tokens": 128000,
+                    "reasoning_effort": "high",
+                }
+            ),
+        ) as resolve_model_config, patch(
             "app.agent_runtime.runner.session_runner.SessionRunner.materialize_state",
             AsyncMock(return_value="fork-cp"),
         ) as materialize_state:
             response = await client.post(
                 "/api/v1/agent/sessions/sess-fork-source/fork",
-                json={"source_revision_id": revision.id, "model_id": "model-fork"},
+                json={
+                    "source_revision_id": revision.id,
+                    "model_id": "model-fork",
+                    "reasoning_effort": "high",
+                },
             )
 
         assert response.status_code == status.HTTP_200_OK
@@ -2552,5 +2660,7 @@ class TestAgentAPI:
         state_values = materialize_state.await_args.args[0]
         assert state_values["session_id"] == data["session_id"]
         assert state_values["current_revision_id"] is None
+        assert state_values["model_config"]["reasoning_effort"] == "high"
+        resolve_model_config.assert_awaited_once_with(session, "model-fork", "high")
         fork_task = await session.get(Task, data["task_id"])
         assert fork_task is not None

--- a/frontend/src/features/assistant/components/agent/agent-input.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-input.tsx
@@ -114,8 +114,9 @@ export function AgentInput({
       iconPath={selectedModel.providerIconPath}
     />
   ) : null;
-  const shouldShowReasoningEffort = selectedModel?.reasoning === true;
+  const shouldShowReasoningEffort = Boolean(selectedModel);
   const reasoningEffortOptions: SelectOption[] = [
+    { value: "off", label: "Off" },
     { value: "low", label: "Low" },
     { value: "medium", label: "Medium" },
     { value: "high", label: "High" },

--- a/frontend/src/features/assistant/components/assistant-sidebar.tsx
+++ b/frontend/src/features/assistant/components/assistant-sidebar.tsx
@@ -149,7 +149,7 @@ function getStoredReasoningEffort(modelId: string): ReasoningEffort {
       window.localStorage.getItem(ASSISTANT_REASONING_EFFORT_STORAGE_KEY) ?? "{}",
     ) as Record<string, string>;
     const value = stored[modelId];
-    return ["low", "medium", "high", "xhigh", "max"].includes(value)
+    return ["off", "low", "medium", "high", "xhigh", "max"].includes(value)
       ? (value as ReasoningEffort)
       : "medium";
   } catch {
@@ -563,7 +563,7 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
       projectId,
       scrollToBottomKey: currentTaskId,
       modelId: effectiveModelId,
-      reasoningEffort: currentModel?.reasoning === true ? reasoningEffort : undefined,
+      reasoningEffort,
       agentKey: effectiveAgentKey,
       inputValue,
       onClearInput: () => setInputValue(""),
@@ -1538,7 +1538,7 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
               projectId={projectId}
               modelId={effectiveModelId}
               models={llmModelOptions}
-              reasoningEffort={currentModel?.reasoning === true ? reasoningEffort : undefined}
+              reasoningEffort={reasoningEffort}
               isSending={isSendingMessage}
               disabled={isViewingSubagent || isLoadingTask}
               pendingMessage={isViewingSubagent ? null : agentSidebar.pendingMessage}

--- a/frontend/src/features/assistant/hooks/use-agent-session.ts
+++ b/frontend/src/features/assistant/hooks/use-agent-session.ts
@@ -1179,7 +1179,12 @@ export function useAgentSession({
       }
 
       try {
-        const result = await forkAgentSession(activeSessionId, sourceRevisionId, modelId);
+        const result = await forkAgentSession(
+          activeSessionId,
+          sourceRevisionId,
+          modelId,
+          reasoningEffort,
+        );
         queryClient.invalidateQueries({ queryKey: ["tasks", projectId], exact: false });
         toast.success(i18n.t("assistant.forkSuccess"));
         return result;
@@ -1189,7 +1194,7 @@ export function useAgentSession({
         return null;
       }
     },
-    [isRollbacking, isRunning, modelId, projectId, queryClient, sessionId],
+    [isRollbacking, isRunning, modelId, projectId, queryClient, reasoningEffort, sessionId],
   );
 
   return {

--- a/frontend/src/lib/agent.types.ts
+++ b/frontend/src/lib/agent.types.ts
@@ -262,7 +262,7 @@ export interface AgentSendMessageRequest {
   reasoning_effort?: ReasoningEffort;
 }
 
-export type ReasoningEffort = "low" | "medium" | "high" | "xhigh" | "max";
+export type ReasoningEffort = "off" | "low" | "medium" | "high" | "xhigh" | "max";
 
 export type AgentPendingMessageAction = "queued" | "cancelled" | "consumed";
 

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -2312,10 +2312,12 @@ export async function forkAgentSession(
   sessionId: string,
   sourceRevisionId: string,
   modelId: string,
+  reasoningEffort?: ReasoningEffort,
 ): Promise<AgentForkResponse> {
   const response = await apiClient.post(`/agent/sessions/${sessionId}/fork`, {
     source_revision_id: sourceRevisionId,
     model_id: modelId,
+    ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
   });
   return response.data;
 }


### PR DESCRIPTION
## PR 标题

chore(backend): 为 OpenAI Compatible 提供商添加思考强度支持

## 变更说明

- 问题: 手动拉取但目录未收录的模型无法选择或传递思考强度，OpenAI Compatible 提供商尤其受影响。
- 重要性: 提供商更新模型后，用户无法在目录同步前启用模型支持的推理能力。
- 变化: Agent 模型选择器始终提供思考强度和关闭选项；后端不再以目录能力阻断用户显式设置的强度。
- 变化: 为各原生提供商映射对应的思考参数，Fork 会话继承当前强度，并补充模型工厂与 Agent API 回归测试。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因(如有)

模型目录元数据同时作为界面展示和后端参数校验依据，导致目录外的手动拉取模型无法设置思考强度。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证结果：

- 后端：`uv run pytest`，1230 passed
- 后端：`uv run ruff check .`、`uv run ty check app`
- 前端：`pnpm type-check`、`pnpm lint`、`pnpm format:check`、`pnpm build`
