### PR TITLE
chore(editor): 限制单条正文内容长度

### DIFF
--- a/backend/app/agent_runtime/revisions.py
+++ b/backend/app/agent_runtime/revisions.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.agent_runtime.persistence import compaction_repo, repo as message_repo
 from app.agent_runtime.persistence.child_runs import rollback_child_runs_for_parent_revisions
 from app.agent_runtime.persistence.model import AgentRunMessage
+from app.core.editor_content_limits import validate_editor_content
 from app.core.errors import NotFoundError
 from app.storage.models.chapter import Chapter
 from app.storage.models.character import Character
@@ -873,6 +874,19 @@ async def rollback_revision_for_session(
             restored_message_content = user_message.content
     if not restored_message_content and target.message.startswith("用户消息:"):
         restored_message_content = target.message.removeprefix("用户消息:").strip()
+
+    for snapshot in restore_by_chapter.values():
+        if snapshot.exists:
+            validate_editor_content(snapshot.content or "")
+    for snapshot in restore_by_note.values():
+        if snapshot.exists:
+            validate_editor_content(snapshot.content or "")
+    for snapshot in restore_by_world_entry.values():
+        if snapshot.exists:
+            validate_editor_content(snapshot.content or "")
+    for snapshot in restore_by_character.values():
+        if snapshot.exists:
+            validate_editor_content(snapshot.description or "")
 
     rollback_revision = Revision(
         project_id=target.project_id,

--- a/backend/app/agent_runtime/tools/impls/chapter/edit_chapter.py
+++ b/backend/app/agent_runtime/tools/impls/chapter/edit_chapter.py
@@ -6,6 +6,7 @@ from typing import Any
 from pydantic import BaseModel, Field, field_validator
 
 from app.agent_runtime.tools.base import AgentTool
+from app.core.editor_content_limits import EditorContentLimitError, validate_editor_content
 from app.agent_runtime.revisions import (
     current_revision_id_from_state,
     images_by_id,
@@ -147,6 +148,10 @@ class EditChapterTool(AgentTool):
                 if replace_result is None:
                     raise ToolExecutionError("未在章节内容中找到要替换的文本")
                 match.content = replace_result.new_content
+                try:
+                    validate_editor_content(match.content)
+                except EditorContentLimitError as exc:
+                    raise ToolExecutionError(str(exc)) from exc
                 match.word_count = count_words(match.content)
             match.updated_at = datetime.now(UTC)
             await chapter_repo.update_chapter(session, match)

--- a/backend/app/agent_runtime/tools/impls/chapter/write_chapter.py
+++ b/backend/app/agent_runtime/tools/impls/chapter/write_chapter.py
@@ -5,6 +5,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from app.agent_runtime.tools.base import AgentTool
+from app.core.editor_content_limits import EditorContentLimitError, validate_editor_content
 from app.agent_runtime.revisions import (
     current_revision_id_from_state,
     images_by_id,
@@ -65,6 +66,10 @@ class WriteChapterTool(AgentTool):
         content = args.get("content")
         if not isinstance(title, str) or not isinstance(content, str):
             return None
+        try:
+            validate_editor_content(content)
+        except EditorContentLimitError:
+            return None
         volume_ref = args.get("volume_ref")
         if isinstance(volume_ref, VolumeRef):
             volume_ref = volume_ref.model_dump()
@@ -90,6 +95,10 @@ class WriteChapterTool(AgentTool):
         revision_id = current_revision_id_from_state(self._state)
         if revision_id is None:
             raise ToolExecutionError("缺少当前 revision，无法执行章节写入")
+        try:
+            validate_editor_content(content)
+        except EditorContentLimitError as exc:
+            raise ToolExecutionError(str(exc)) from exc
         session = await create_session()
         try:
             volume = resolve_volume_from_list(

--- a/backend/app/agent_runtime/tools/impls/context/character.py
+++ b/backend/app/agent_runtime/tools/impls/context/character.py
@@ -10,6 +10,7 @@ from app.agent_runtime.revisions import (
     record_character_diffs,
 )
 from app.agent_runtime.tools.base import AgentTool
+from app.core.editor_content_limits import EditorContentLimitError, validate_editor_content
 from app.agent_runtime.tools.errors import ToolExecutionError
 from app.agent_runtime.tools.registry import ToolRegistry
 from app.agent_runtime.tools.text_match import fuzzy_replace
@@ -238,6 +239,10 @@ class CreateCharacterTool(AgentTool):
         if session is None or not isinstance(name, str) or not isinstance(description, str):
             return None
         try:
+            validate_editor_content(description)
+        except EditorContentLimitError:
+            return None
+        try:
             normalized_name = await _ensure_name_available(session, self.project_id, name)
         except ToolExecutionError:
             return None
@@ -252,6 +257,10 @@ class CreateCharacterTool(AgentTool):
 
     async def _execute(self, name: str, description: str) -> str:
         revision_id = _require_revision_id(self._state)
+        try:
+            validate_editor_content(description)
+        except EditorContentLimitError as exc:
+            raise ToolExecutionError(str(exc)) from exc
         session = await create_session()
         try:
             normalized_name = await _ensure_name_available(session, self.project_id, name)
@@ -279,6 +288,8 @@ class CreateCharacterTool(AgentTool):
                 },
                 ensure_ascii=False,
             )
+        except ToolExecutionError:
+            raise
         except Exception:
             await session.rollback()
             raise
@@ -319,6 +330,7 @@ class EditCharacterTool(AgentTool):
                 if replace_result is None:
                     return None
                 description = replace_result.new_content
+                validate_editor_content(description)
             updated_name = (
                 await _ensure_name_available(
                     session,
@@ -329,7 +341,7 @@ class EditCharacterTool(AgentTool):
                 if new_name is not None
                 else before.name
             )
-        except ToolExecutionError:
+        except (EditorContentLimitError, ToolExecutionError):
             return None
         after = CharacterPreview(
             id=before.id,
@@ -366,6 +378,10 @@ class EditCharacterTool(AgentTool):
                 if replace_result is None:
                     raise ToolExecutionError("未在角色描述中找到要替换的文本")
                 description = replace_result.new_content
+                try:
+                    validate_editor_content(description)
+                except EditorContentLimitError as exc:
+                    raise ToolExecutionError(str(exc)) from exc
             normalized_new_name = None
             if new_name is not None:
                 normalized_new_name = await _ensure_name_available(

--- a/backend/app/agent_runtime/tools/impls/context/world_entry.py
+++ b/backend/app/agent_runtime/tools/impls/context/world_entry.py
@@ -10,6 +10,7 @@ from app.agent_runtime.revisions import (
     world_entry_images_by_id,
 )
 from app.agent_runtime.tools.base import AgentTool
+from app.core.editor_content_limits import EditorContentLimitError, validate_editor_content
 from app.agent_runtime.tools.errors import ToolExecutionError
 from app.agent_runtime.tools.registry import ToolRegistry
 from app.agent_runtime.tools.text_match import fuzzy_replace
@@ -255,6 +256,10 @@ class CreateWorldEntryTool(AgentTool):
         if session is None or not isinstance(title, str) or not isinstance(content, str):
             return None
         try:
+            validate_editor_content(content)
+        except EditorContentLimitError:
+            return None
+        try:
             world_info = await _get_project_world_info(session, self.project_id)
             normalized_title = await _ensure_title_available(session, world_info.id, title)
         except ToolExecutionError:
@@ -278,6 +283,10 @@ class CreateWorldEntryTool(AgentTool):
 
     async def _execute(self, title: str, content: str) -> str:
         revision_id = _require_revision_id(self._state)
+        try:
+            validate_editor_content(content)
+        except EditorContentLimitError as exc:
+            raise ToolExecutionError(str(exc)) from exc
         session = await create_session()
         try:
             world_info = await _get_project_world_info(session, self.project_id)
@@ -308,6 +317,8 @@ class CreateWorldEntryTool(AgentTool):
                 },
                 ensure_ascii=False,
             )
+        except ToolExecutionError:
+            raise
         except Exception:
             await session.rollback()
             raise
@@ -349,6 +360,7 @@ class EditWorldEntryTool(AgentTool):
                 if replace_result is None:
                     return None
                 content = replace_result.new_content
+                validate_editor_content(content)
             updated_title = (
                 await _ensure_title_available(
                     session,
@@ -359,7 +371,7 @@ class EditWorldEntryTool(AgentTool):
                 if new_title is not None
                 else before.title
             )
-        except ToolExecutionError:
+        except (EditorContentLimitError, ToolExecutionError):
             return None
         after = WorldEntryPreview(
             id=before.id,
@@ -400,6 +412,10 @@ class EditWorldEntryTool(AgentTool):
                 if replace_result is None:
                     raise ToolExecutionError("未在世界书条目内容中找到要替换的文本")
                 content = replace_result.new_content
+                try:
+                    validate_editor_content(content)
+                except EditorContentLimitError as exc:
+                    raise ToolExecutionError(str(exc)) from exc
             normalized_new_title = None
             if new_title is not None:
                 normalized_new_title = await _ensure_title_available(

--- a/backend/app/agent_runtime/tools/impls/note/edit_note.py
+++ b/backend/app/agent_runtime/tools/impls/note/edit_note.py
@@ -11,6 +11,7 @@ from typing import Any
 from pydantic import BaseModel, Field, field_validator
 
 from app.agent_runtime.tools.base import AgentTool
+from app.core.editor_content_limits import EditorContentLimitError, validate_editor_content
 from app.agent_runtime.revisions import (
     current_revision_id_from_state,
     note_images_by_id,
@@ -123,6 +124,10 @@ class EditNoteTool(AgentTool):
         if preview_result is None:
             return None
         preview_content = preview_result.new_content
+        try:
+            validate_editor_content(preview_content)
+        except EditorContentLimitError:
+            return None
         return {
             "type": "preview",
             "success": True,
@@ -187,6 +192,10 @@ class EditNoteTool(AgentTool):
             if replace_result is None:
                 raise ToolExecutionError("未在笔记内容中找到要替换的文本")
             note.content = replace_result.new_content
+            try:
+                validate_editor_content(note.content)
+            except EditorContentLimitError as exc:
+                raise ToolExecutionError(str(exc)) from exc
             note.updated_at = datetime.now(UTC)
             await note_repo.update_note(session, note)
             after = note_images_by_id(

--- a/backend/app/agent_runtime/tools/impls/note/write_note.py
+++ b/backend/app/agent_runtime/tools/impls/note/write_note.py
@@ -9,6 +9,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from app.agent_runtime.tools.base import AgentTool
+from app.core.editor_content_limits import EditorContentLimitError, validate_editor_content
 from app.agent_runtime.revisions import (
     current_revision_id_from_state,
     note_images_by_id,
@@ -44,6 +45,10 @@ class WriteNoteTool(AgentTool):
         title = args.get("title")
         content = args.get("content")
         if session is None or not isinstance(title, str) or not isinstance(content, str):
+            return None
+        try:
+            validate_editor_content(content)
+        except EditorContentLimitError:
             return None
 
         category_id: str | None = None
@@ -102,6 +107,10 @@ class WriteNoteTool(AgentTool):
         revision_id = current_revision_id_from_state(self._state)
         if revision_id is None:
             raise ToolExecutionError("缺少当前 revision，无法执行笔记写入")
+        try:
+            validate_editor_content(content)
+        except EditorContentLimitError as exc:
+            raise ToolExecutionError(str(exc)) from exc
         session = await create_session()
         try:
             category_id: str | None = None

--- a/backend/app/api/routers/chapters.py
+++ b/backend/app/api/routers/chapters.py
@@ -66,6 +66,8 @@ async def create_chapter(
         return ChapterResponse.model_validate(chapter)
     except NotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
 @router.get(
@@ -172,6 +174,8 @@ async def update_chapter(
         return ChapterResponse.model_validate(chapter)
     except NotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
 @router.delete(

--- a/backend/app/api/routers/characters.py
+++ b/backend/app/api/routers/characters.py
@@ -106,6 +106,8 @@ async def create_character(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except ConflictError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
 @router.get(
@@ -230,6 +232,8 @@ async def update_character(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except ConflictError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
 @router.delete(

--- a/backend/app/api/routers/import_router.py
+++ b/backend/app/api/routers/import_router.py
@@ -166,13 +166,16 @@ async def confirm_import(
         )
 
     # 调用服务层执行导入
-    result = await import_service.confirm_import(
-        session=session,
-        title=title,
-        description=description,
-        cover_file=cover,
-        chapters=parse_result.chapters,
-    )
+    try:
+        result = await import_service.confirm_import(
+            session=session,
+            title=title,
+            description=description,
+            cover_file=cover,
+            chapters=parse_result.chapters,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
 
     return ImportConfirmResponse(
         project_id=result.project_id,

--- a/backend/app/api/routers/notes.py
+++ b/backend/app/api/routers/notes.py
@@ -98,6 +98,8 @@ async def update_category(
         return NoteCategoryResponse.model_validate(category)
     except NotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
 @router.delete(
@@ -238,6 +240,8 @@ async def update_note(
         return NoteResponse.model_validate(note)
     except NotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
 @router.delete(

--- a/backend/app/api/routers/world_info_entries.py
+++ b/backend/app/api/routers/world_info_entries.py
@@ -241,6 +241,8 @@ async def create_entry(
         return _entry_to_response(entry)
     except NotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
 @router.get(
@@ -351,6 +353,8 @@ async def update_entry(
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except world_info_entry_service.WorldInfoEntryNameConflictError as e:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
 @router.delete(

--- a/backend/app/core/editor_content_limits.py
+++ b/backend/app/core/editor_content_limits.py
@@ -1,0 +1,31 @@
+"""Shared limits for persisted editor content."""
+
+MAX_EDITOR_CONTENT_LINES = 2_000
+MAX_EDITOR_CONTENT_CHARACTERS = 100_000
+
+
+class EditorContentLimitError(ValueError):
+    """Raised when persisted editor content exceeds its supported size."""
+
+
+def count_editor_content_lines(content: str) -> int:
+    """Count logical lines without treating a trailing newline as an extra line."""
+    return len(content.splitlines())
+
+
+def validate_editor_content(content: str) -> None:
+    """Raise when content exceeds the supported line or character limit."""
+    line_count = count_editor_content_lines(content)
+    character_count = len(content)
+    if (
+        line_count <= MAX_EDITOR_CONTENT_LINES
+        and character_count <= MAX_EDITOR_CONTENT_CHARACTERS
+    ):
+        return
+
+    raise EditorContentLimitError(
+        "内容超出限制："
+        f"当前 {line_count} 行、{character_count} 字符；"
+        f"单一内容最多允许 {MAX_EDITOR_CONTENT_LINES} 行且 "
+        f"{MAX_EDITOR_CONTENT_CHARACTERS} 字符。请拆分内容后重试。"
+    )

--- a/backend/app/storage/services/chapter_service.py
+++ b/backend/app/storage/services/chapter_service.py
@@ -10,6 +10,7 @@ from typing import Literal
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.editor_content_limits import validate_editor_content
 from app.core.errors import NotFoundError
 from app.storage.models.chapter import Chapter
 from app.storage.models.volume import Volume
@@ -158,6 +159,8 @@ async def create_chapter(
     Raises:
         NotFoundError: 项目不存在。
     """
+    validate_editor_content(content)
+
     # 检查项目是否存在
     project = await project_repo.get_by_id(session, project_id)
     if project is None:
@@ -457,6 +460,7 @@ async def update_chapter(
 
     content_changed = False
     if content is not None and content != chapter.content:
+        validate_editor_content(content)
         chapter.content = content
         # 优先使用前端传递的字数，否则后端计算
         chapter.word_count = (

--- a/backend/app/storage/services/character_service.py
+++ b/backend/app/storage/services/character_service.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from fastapi import UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.editor_content_limits import validate_editor_content
 from app.core.errors import ConflictError, NotFoundError
 from app.core.storage import delete_character_image, save_character_image
 from app.core.utils.tiktoken import get_encoding
@@ -78,6 +79,7 @@ async def create_character(
     image_file: UploadFile | None = None,
 ) -> Character:
     """创建角色。"""
+    validate_editor_content(description)
     project = await project_repo.get_by_id(session, project_id)
     if project is None:
         raise NotFoundError(f"项目不存在: {project_id}")
@@ -181,6 +183,7 @@ async def update_character(
             raise ConflictError("角色名称已存在")
         character.name = next_name
     if description is not None:
+        validate_editor_content(description)
         character.description = description
     if is_favorited is not None:
         character.is_favorited = is_favorited

--- a/backend/app/storage/services/import_service.py
+++ b/backend/app/storage/services/import_service.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from fastapi import UploadFile
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.editor_content_limits import validate_editor_content
 from app.core.storage import save_cover_file
 from app.core.txt_parser import ParsedChapter
 from app.storage.models.chapter import Chapter
@@ -48,6 +49,9 @@ async def confirm_import(
     Returns:
         导入结果。
     """
+    for chapter in chapters:
+        validate_editor_content(chapter.content)
+
     # 计算总字数
     total_word_count = sum(c.word_count for c in chapters)
 

--- a/backend/app/storage/services/note_service.py
+++ b/backend/app/storage/services/note_service.py
@@ -9,6 +9,7 @@ from typing import Literal
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.editor_content_limits import validate_editor_content
 from app.core.errors import NotFoundError
 from app.storage.models.note import Note, NoteCategory
 from app.storage.repos import (
@@ -67,6 +68,7 @@ async def create_note(
     title: str,
     content: str = "",
 ) -> Note:
+    validate_editor_content(content)
     project = await project_repo.get_by_id(session, project_id)
     if project is None:
         raise NotFoundError(f"项目不存在: {project_id}")
@@ -164,6 +166,7 @@ async def update_note(
         changed = True
 
     if content is not None and content != note.content:
+        validate_editor_content(content)
         note.content = content
         changed = True
 

--- a/backend/app/storage/services/world_info_entry_service.py
+++ b/backend/app/storage/services/world_info_entry_service.py
@@ -9,6 +9,7 @@ from datetime import UTC, datetime
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.editor_content_limits import validate_editor_content
 from app.core.errors import NotFoundError
 from app.core.utils.tiktoken import get_encoding
 from app.storage.models.world_info_entry import WorldInfoEntry
@@ -205,6 +206,9 @@ async def import_entries(
     if mode not in {"append", "overwrite"}:
         raise ValueError(f"不支持的导入模式: {mode}")
 
+    for entry in entries:
+        validate_editor_content(entry.content)
+
     if mode == "overwrite":
         await world_info_entry_repo.delete_by_world_info(session, world_info_id)
         existing_entries: list[WorldInfoEntry] = []
@@ -281,6 +285,8 @@ async def create_entry(
     Raises:
         NotFoundError: 世界书不存在。
     """
+    validate_editor_content(content)
+
     # 检查世界书是否存在
     await get_world_info(session, world_info_id)
 
@@ -392,6 +398,7 @@ async def update_entry(
             exclude_entry_id=entry.id,
         )
     if content is not None:
+        validate_editor_content(content)
         entry.content = content
     if token_count is not None:
         entry.token_count = token_count

--- a/backend/tests/agent_runtime/test_agent_revision_rollback.py
+++ b/backend/tests/agent_runtime/test_agent_revision_rollback.py
@@ -11,6 +11,7 @@ from app.storage.models.chapter import Chapter
 from app.storage.models.character import Character
 from app.storage.models.note import Note, NoteCategory
 from app.storage.models.project import Project
+from app.storage.models.revision_chapter_snapshot import RevisionChapterSnapshot
 from app.storage.models.task import Task
 from app.storage.models.volume import Volume
 from app.storage.models.world_info import WorldInfo
@@ -446,6 +447,79 @@ async def test_rollback_revision_restores_chapters_and_messages(revision_db):
     assert rolled_back is not None
     assert rolled_back.status == "rolled_back"
     assert task is not None
+
+
+@pytest.mark.asyncio
+async def test_rollback_rejects_oversized_chapter_snapshot_before_mutating(revision_db):
+    from app.agent_runtime.revisions import (
+        begin_user_revision,
+        rollback_revision_for_session,
+    )
+    from app.storage.repos import chapter_repo, revision_chapter_snapshot_repo, revision_repo
+
+    async with revision_db() as session:
+        user = await message_repo.insert_message(
+            session,
+            session_id="sess-1",
+            task_id="task-1",
+            project_id="proj-1",
+            role="user",
+            status="sent",
+            content="恢复超限章节",
+        )
+        target_revision = await begin_user_revision(
+            session,
+            project_id="proj-1",
+            task_id="task-1",
+            agent_session_id="sess-1",
+            user_message_id=user.id,
+            user_message_seq=user.seq,
+            message="用户消息: 恢复超限章节",
+            pre_run_checkpoint_id="cp-before",
+            graph_thread_id="sess-1",
+        )
+        await revision_chapter_snapshot_repo.create(
+            session,
+            RevisionChapterSnapshot(
+                revision_id=target_revision.id,
+                chapter_id="chap-1",
+                project_id="proj-1",
+                exists=True,
+                title="第一章",
+                content="\n".join("超限内容" for _ in range(2001)),
+                word_count=0,
+                chapter_order=1,
+            ),
+        )
+        chapter = await chapter_repo.get_by_id(session, "chap-1")
+        assert chapter is not None
+        chapter.content = "回滚前内容"
+        await chapter_repo.update_chapter(session, chapter)
+        await session.commit()
+
+    async with revision_db() as session:
+        with pytest.raises(ValueError, match="内容超出限制"):
+            await rollback_revision_for_session(
+                session,
+                agent_session_id="sess-1",
+                revision_id=target_revision.id,
+            )
+        await session.commit()
+
+    async with revision_db() as session:
+        chapter = await chapter_repo.get_by_id(session, "chap-1")
+        target_after = await revision_repo.get_by_id(session, target_revision.id)
+        revisions = await revision_repo.list_by_agent_session_from_seq(
+            session,
+            "sess-1",
+            target_revision.user_message_seq,
+        )
+
+    assert chapter is not None
+    assert chapter.content == "回滚前内容"
+    assert target_after is not None
+    assert target_after.status != "rolled_back"
+    assert all(revision.revision_type != "rollback" for revision in revisions)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/tools/test_chapter_tools.py
+++ b/backend/tests/agent_runtime/tools/test_chapter_tools.py
@@ -5,6 +5,10 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+from app.agent_runtime.tools.errors import ToolExecutionError
+
 
 def _make_state() -> dict:
     return {
@@ -234,6 +238,66 @@ async def test_write_chapter_appends_to_volume_and_returns_volume_id() -> None:
     assert created_chapter.volume_id == "vol-1"
     assert created_chapter.order == 4
     refresh_volume_count.assert_awaited_once_with(mock_session, "vol-1")
+
+
+async def test_write_chapter_rejects_over_limit_content_without_creating() -> None:
+    from app.agent_runtime.tools.impls.chapter.write_chapter import WriteChapterTool
+
+    tool = WriteChapterTool(_state=_make_state())
+
+    with patch(
+        "app.agent_runtime.tools.impls.chapter.write_chapter.chapter_repo.create",
+        AsyncMock(),
+    ) as create_chapter:
+        result = await tool.ainvoke(
+            {
+                "volume_ref": {"type": "order", "value": 1},
+                "title": "超限章节",
+                "content": "\n".join("内容" for _ in range(2001)),
+            }
+        )
+
+    assert "内容超出限制" in json.loads(result)["error"]
+    create_chapter.assert_not_awaited()
+
+
+async def test_edit_chapter_rejects_over_limit_replacement_without_updating_repo() -> None:
+    from app.agent_runtime.tools.impls.chapter.edit_chapter import EditChapterTool
+
+    volume = _make_volume()
+    chapter = _make_chapter(content="原内容")
+    tool = EditChapterTool(_state=_make_state())
+
+    with patch("app.agent_runtime.tools.impls.chapter.edit_chapter.create_session") as mock_cs:
+        mock_session = AsyncMock()
+        mock_cs.return_value = mock_session
+        with (
+            patch(
+                "app.agent_runtime.tools.impls.chapter.edit_chapter.volume_repo.list_by_project",
+                AsyncMock(return_value=[volume]),
+            ),
+            patch(
+                "app.agent_runtime.tools.impls.chapter.edit_chapter.chapter_repo.list_by_project",
+                AsyncMock(return_value=[chapter]),
+            ),
+            patch(
+                "app.agent_runtime.tools.impls.chapter.edit_chapter.chapter_repo.list_by_volume",
+                AsyncMock(return_value=[chapter]),
+            ),
+            patch(
+                "app.agent_runtime.tools.impls.chapter.edit_chapter.chapter_repo.update_chapter",
+                AsyncMock(),
+            ) as update_chapter,
+        ):
+            with pytest.raises(ToolExecutionError, match="内容超出限制"):
+                await tool._execute(
+                    volume_ref={"type": "order", "value": 1},
+                    chapter_ref={"type": "order", "value": 1},
+                    old_content="原内容",
+                    new_content="\n".join("内容" for _ in range(2001)),
+                )
+
+    update_chapter.assert_not_awaited()
 
 
 async def test_write_chapter_insert_order_shifts_within_volume() -> None:

--- a/backend/tests/agent_runtime/tools/test_context_tools.py
+++ b/backend/tests/agent_runtime/tools/test_context_tools.py
@@ -282,6 +282,25 @@ async def test_create_character_returns_diff() -> None:
     }
 
 
+@pytest.mark.asyncio
+async def test_create_character_rejects_over_limit_description_without_creating() -> None:
+    from app.agent_runtime.tools.impls.context.character import CreateCharacterTool
+
+    tool = CreateCharacterTool(_state={**_make_state(), "current_revision_id": "rev-1"})
+
+    with patch(
+        "app.agent_runtime.tools.impls.context.character.character_service"
+    ) as mock_character_service:
+        mock_character_service.create_character = AsyncMock()
+
+        result = await tool.ainvoke(
+            {"name": "林舟", "description": "\n".join("内容" for _ in range(2001))}
+        )
+
+    assert "内容超出限制" in json.loads(result)["error"]
+    mock_character_service.create_character.assert_not_awaited()
+
+
 def test_edit_character_input_rejects_empty_old_description() -> None:
     from pydantic import ValidationError
 
@@ -356,6 +375,42 @@ async def test_edit_character_replaces_description_text() -> None:
             "text": "主角与旧友",
         },
     ]
+
+
+@pytest.mark.asyncio
+async def test_edit_character_rejects_over_limit_replacement_without_updating() -> None:
+    from app.agent_runtime.tools.impls.context.character import EditCharacterTool
+
+    tool = EditCharacterTool(_state={**_make_state(), "current_revision_id": "rev-1"})
+    character = SimpleNamespace(
+        id="char-1",
+        project_id="proj-1",
+        name="林舟",
+        description="旧内容",
+        is_favorited=False,
+    )
+
+    with patch(
+        "app.agent_runtime.tools.impls.context.character.create_session"
+    ) as mock_cs, patch(
+        "app.agent_runtime.tools.impls.context.character.character_repo"
+    ) as mock_character_repo, patch(
+        "app.agent_runtime.tools.impls.context.character.character_service"
+    ) as mock_character_service:
+        mock_cs.return_value = AsyncMock()
+        mock_character_repo.list_by_project = AsyncMock(return_value=([character], 1))
+        mock_character_service.update_character = AsyncMock()
+
+        result = await tool.ainvoke(
+            {
+                "name": "林舟",
+                "old_description": "旧内容",
+                "new_description": "\n".join("内容" for _ in range(2001)),
+            }
+        )
+
+    assert "内容超出限制" in json.loads(result)["error"]
+    mock_character_service.update_character.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -571,6 +626,25 @@ async def test_create_world_entry_rejects_duplicate_title() -> None:
     assert json.loads(result) == {"error": "世界书条目标题已存在: 主角"}
 
 
+@pytest.mark.asyncio
+async def test_create_world_entry_rejects_over_limit_content_without_creating() -> None:
+    from app.agent_runtime.tools.impls.context.world_entry import CreateWorldEntryTool
+
+    tool = CreateWorldEntryTool(_state={**_make_state(), "current_revision_id": "rev-1"})
+
+    with patch(
+        "app.agent_runtime.tools.impls.context.world_entry.world_info_entry_service"
+    ) as mock_entry_service:
+        mock_entry_service.create_entry = AsyncMock()
+
+        result = await tool.ainvoke(
+            {"title": "主角", "content": "\n".join("内容" for _ in range(2001))}
+        )
+
+    assert "内容超出限制" in json.loads(result)["error"]
+    mock_entry_service.create_entry.assert_not_awaited()
+
+
 def test_edit_world_entry_input_rejects_empty_old_content() -> None:
     from pydantic import ValidationError
 
@@ -655,6 +729,48 @@ async def test_edit_world_entry_returns_diff() -> None:
             ],
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_edit_world_entry_rejects_over_limit_replacement_without_updating() -> None:
+    from app.agent_runtime.tools.impls.context.world_entry import EditWorldEntryTool
+
+    tool = EditWorldEntryTool(_state={**_make_state(), "current_revision_id": "rev-1"})
+    entry = SimpleNamespace(
+        id="e1",
+        world_info_id="world-1",
+        name="主角",
+        uid=1,
+        order=1,
+        content="旧内容",
+        token_count=2,
+        is_enabled=True,
+    )
+
+    with patch(
+        "app.agent_runtime.tools.impls.context.world_entry.create_session"
+    ) as mock_cs, patch(
+        "app.agent_runtime.tools.impls.context.world_entry.world_info_repo"
+    ) as mock_world_repo, patch(
+        "app.agent_runtime.tools.impls.context.world_entry.world_info_entry_repo"
+    ) as mock_entry_repo, patch(
+        "app.agent_runtime.tools.impls.context.world_entry.world_info_entry_service"
+    ) as mock_entry_service:
+        mock_cs.return_value = AsyncMock()
+        mock_world_repo.get_by_project_id = AsyncMock(return_value=SimpleNamespace(id="world-1"))
+        mock_entry_repo.list_by_world_info = AsyncMock(return_value=[entry])
+        mock_entry_service.update_entry = AsyncMock()
+
+        result = await tool.ainvoke(
+            {
+                "title": "主角",
+                "old_content": "旧内容",
+                "new_content": "\n".join("内容" for _ in range(2001)),
+            }
+        )
+
+    assert "内容超出限制" in json.loads(result)["error"]
+    mock_entry_service.update_entry.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/tools/test_note_tools.py
+++ b/backend/tests/agent_runtime/tools/test_note_tools.py
@@ -4,6 +4,10 @@ import json
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
+from app.agent_runtime.tools.errors import ToolExecutionError
+
 
 def _make_state() -> dict:
     return {
@@ -131,7 +135,7 @@ async def test_edit_note_returns_success_and_diff_metadata() -> None:
             ),
             patch(
                 "app.agent_runtime.tools.impls.note.edit_note.note_repo.list_by_project",
-                AsyncMock(side_effect=[[note], [note]]),
+                AsyncMock(return_value=[note]),
             ),
             patch(
                 "app.agent_runtime.tools.impls.note.edit_note.note_repo.update_note",
@@ -185,6 +189,39 @@ async def test_edit_note_returns_success_and_diff_metadata() -> None:
     }
     assert isinstance(note.updated_at, datetime)
     assert note.updated_at.tzinfo is UTC
+
+
+async def test_edit_note_rejects_over_limit_replace_all_without_updating_repo() -> None:
+    from app.agent_runtime.tools.impls.note.edit_note import EditNoteTool
+
+    note = _make_note(content="原\n原")
+    tool = EditNoteTool(_state=_make_state())
+
+    with patch("app.agent_runtime.tools.impls.note.edit_note.create_session") as mock_cs:
+        mock_session = AsyncMock()
+        mock_cs.return_value = mock_session
+        with (
+            patch(
+                "app.agent_runtime.tools.impls.note.edit_note.note_repo.get_by_id",
+                AsyncMock(return_value=note),
+            ),
+            patch(
+                "app.agent_runtime.tools.impls.note.edit_note.note_repo.list_by_project",
+                AsyncMock(return_value=[note]),
+            ),
+            patch(
+                "app.agent_runtime.tools.impls.note.edit_note.note_repo.update_note",
+                AsyncMock(),
+            ) as update_note,
+        ):
+            with pytest.raises(ToolExecutionError, match="内容超出限制"):
+                await tool._execute(
+                    note_ref={"id": "note-1"},
+                    old_content="原",
+                    new_content="\n".join("内容" for _ in range(1001)),
+                )
+
+    update_note.assert_not_awaited()
 
 
 async def test_delete_note_rejects_hidden_note() -> None:
@@ -371,6 +408,26 @@ async def test_write_note_creates_note_and_returns_success() -> None:
     assert data["metadata"]["note_diff"]["note_title"] == "新笔记"
     assert data["metadata"]["note_diff"]["category_id"] is None
     assert data["metadata"]["note_diff"]["sections"][0]["type"] == "content"
+
+
+async def test_write_note_rejects_over_limit_content_without_creating() -> None:
+    from app.agent_runtime.tools.impls.note.write_note import WriteNoteTool
+
+    tool = WriteNoteTool(_state=_make_state())
+
+    with patch(
+        "app.agent_runtime.tools.impls.note.write_note.note_repo.create",
+        AsyncMock(),
+    ) as create_note:
+        result = await tool.ainvoke(
+            {
+                "title": "超限笔记",
+                "content": "\n".join("内容" for _ in range(2001)),
+            }
+        )
+
+    assert "内容超出限制" in json.loads(result)["error"]
+    create_note.assert_not_awaited()
 
 
 async def test_write_note_builds_approval_diff_preview() -> None:

--- a/backend/tests/api/test_chapters.py
+++ b/backend/tests/api/test_chapters.py
@@ -86,6 +86,25 @@ async def test_create_chapter_empty_content(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_chapter_rejects_content_over_line_limit(client: AsyncClient) -> None:
+    project_id, volume_id = await _create_project(client)
+
+    response = await client.post(
+        f"/api/v1/projects/{project_id}/chapters",
+        json={
+            "volume_id": volume_id,
+            "title": "超限章节",
+            "content": "\n".join("内容" for _ in range(2001)),
+        },
+    )
+
+    assert response.status_code == 400
+    assert "内容超出限制" in response.json()["detail"]
+    tree = (await client.get(f"/api/v1/projects/{project_id}/chapters")).json()
+    assert tree["total_chapters"] == 0
+
+
+@pytest.mark.asyncio
 async def test_create_chapter_validation_errors(client: AsyncClient) -> None:
     """测试创建章节时的校验错误。"""
     project_id, volume_id = await _create_project(client)
@@ -253,6 +272,28 @@ async def test_get_and_update_chapter(client: AsyncClient) -> None:
     assert data["title"] == "新标题"
     assert data["content"] == "新内容"
     assert data["word_count"] == 200
+
+
+@pytest.mark.asyncio
+async def test_update_chapter_rejects_content_over_line_limit(client: AsyncClient) -> None:
+    project_id, volume_id = await _create_project(client)
+    chapter = await _create_chapter(
+        client,
+        project_id,
+        volume_id,
+        title="原章节",
+        content="原内容",
+    )
+
+    response = await client.patch(
+        f"/api/v1/chapters/{chapter['id']}",
+        json={"content": "\n".join("内容" for _ in range(2001))},
+    )
+
+    assert response.status_code == 400
+    assert "内容超出限制" in response.json()["detail"]
+    unchanged = await client.get(f"/api/v1/chapters/{chapter['id']}")
+    assert unchanged.json()["content"] == "原内容"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_characters.py
+++ b/backend/tests/api/test_characters.py
@@ -74,6 +74,21 @@ async def test_create_character_generates_numbered_name_when_duplicate(client: A
 
 
 @pytest.mark.asyncio
+async def test_create_character_rejects_description_over_line_limit(client: AsyncClient) -> None:
+    project_id = await create_project(client, "角色长度限制项目")
+
+    response = await client.post(
+        f"/api/v1/projects/{project_id}/characters",
+        data={"name": "超限角色", "description": "\n".join("内容" for _ in range(2001))},
+    )
+
+    assert response.status_code == 400
+    assert "内容超出限制" in response.json()["detail"]
+    characters = (await client.get(f"/api/v1/projects/{project_id}/characters")).json()
+    assert characters["total"] == 0
+
+
+@pytest.mark.asyncio
 async def test_update_character_rejects_duplicate_name(client: AsyncClient) -> None:
     project_id = await create_project(client, "重名更新项目")
     first = await create_character(client, project_id, "林夏")
@@ -86,6 +101,24 @@ async def test_update_character_rejects_duplicate_name(client: AsyncClient) -> N
 
     assert response.status_code == 409
     assert response.json()["detail"] == "角色名称已存在"
+
+
+@pytest.mark.asyncio
+async def test_update_character_rejects_description_over_line_limit(
+    client: AsyncClient,
+) -> None:
+    project_id = await create_project(client, "角色更新长度限制项目")
+    character = await create_character(client, project_id, "原角色", "原描述")
+
+    response = await client.patch(
+        f"/api/v1/characters/{character['id']}",
+        data={"description": "\n".join("内容" for _ in range(2001))},
+    )
+
+    assert response.status_code == 400
+    assert "内容超出限制" in response.json()["detail"]
+    unchanged = await client.get(f"/api/v1/characters/{character['id']}")
+    assert unchanged.json()["description"] == "原描述"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_import.py
+++ b/backend/tests/api/test_import.py
@@ -3,6 +3,8 @@
 Import API 测试。
 """
 
+import json
+
 import pytest
 from httpx import AsyncClient
 
@@ -165,6 +167,56 @@ async def test_confirm_import_empty_title(client: AsyncClient) -> None:
     response = await client.post("/api/v1/import/confirm", files=files, data=data)
     # 422 是 Pydantic 验证错误，400 是业务验证错误，两者都可接受
     assert response.status_code in (400, 422)
+
+
+@pytest.mark.asyncio
+async def test_confirm_import_rejects_over_limit_content_before_project_creation(
+    client: AsyncClient,
+) -> None:
+    projects_before = (await client.get("/api/v1/projects")).json()["total"]
+    files = {
+        "file": (
+            "over-limit.txt",
+            ("内容" * 100001).encode("utf-8"),
+            "text/plain",
+        )
+    }
+
+    response = await client.post(
+        "/api/v1/import/confirm",
+        files=files,
+        data={"title": "超限导入"},
+    )
+
+    assert response.status_code == 400
+    assert "内容超出限制" in response.json()["detail"]
+    projects_after = (await client.get("/api/v1/projects")).json()["total"]
+    assert projects_after == projects_before
+
+
+@pytest.mark.asyncio
+async def test_confirm_import_stream_rejects_over_limit_chapter_before_project_creation(
+    client: AsyncClient,
+) -> None:
+    projects_before = (await client.get("/api/v1/projects")).json()["total"]
+    content = "\n".join(["内容" * 51, *("内容" for _ in range(2000))])
+
+    response = await client.post(
+        "/api/v1/import/confirm-stream",
+        files={"file": ("over-limit.txt", content.encode("utf-8"), "text/plain")},
+        data={"title": "超限流式导入"},
+    )
+
+    events = [
+        json.loads(line.removeprefix("data: "))
+        for line in response.text.splitlines()
+        if line.startswith("data: ")
+    ]
+    error_event = next(event for event in events if event["type"] == "error")
+    assert error_event["type"] == "error"
+    assert "内容超出限制" in error_event["message"]
+    projects_after = (await client.get("/api/v1/projects")).json()["total"]
+    assert projects_after == projects_before
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_notes.py
+++ b/backend/tests/api/test_notes.py
@@ -34,6 +34,21 @@ async def test_create_note(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_note_rejects_content_over_line_limit(client: AsyncClient) -> None:
+    project_id, _ = await _create_project(client)
+
+    response = await client.post(
+        f"/api/v1/projects/{project_id}/notes",
+        json={"title": "超限笔记", "content": "\n".join("内容" for _ in range(2001))},
+    )
+
+    assert response.status_code == 400
+    assert "内容超出限制" in response.json()["detail"]
+    notes = (await client.get(f"/api/v1/projects/{project_id}/notes")).json()
+    assert notes["total_notes"] == 0
+
+
+@pytest.mark.asyncio
 async def test_create_note_in_category(client: AsyncClient) -> None:
     project_id, _ = await _create_project(client)
     cat_resp = await client.post(
@@ -85,6 +100,26 @@ async def test_update_note(client: AsyncClient) -> None:
     assert resp.status_code == 200
     assert resp.json()["title"] == "新标题"
     assert resp.json()["content"] == "旧内容"
+
+
+@pytest.mark.asyncio
+async def test_update_note_rejects_content_over_line_limit(client: AsyncClient) -> None:
+    project_id, _ = await _create_project(client)
+    create = await client.post(
+        f"/api/v1/projects/{project_id}/notes",
+        json={"title": "原笔记", "content": "原内容"},
+    )
+    note_id = create.json()["id"]
+
+    response = await client.patch(
+        f"/api/v1/notes/{note_id}",
+        json={"content": "\n".join("内容" for _ in range(2001))},
+    )
+
+    assert response.status_code == 400
+    assert "内容超出限制" in response.json()["detail"]
+    unchanged = await client.get(f"/api/v1/notes/{note_id}")
+    assert unchanged.json()["content"] == "原内容"
 
 
 @pytest.mark.asyncio
@@ -187,6 +222,19 @@ async def test_create_category_third_level_rejected(client: AsyncClient) -> None
         json={"title": "三级", "parent_id": c2_id},
     )
     assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_category_rejects_missing_parent(client: AsyncClient) -> None:
+    project_id, _ = await _create_project(client)
+
+    response = await client.post(
+        f"/api/v1/projects/{project_id}/note-categories",
+        json={"title": "无效父分类", "parent_id": "missing-parent"},
+    )
+
+    assert response.status_code == 400
+    assert "父分类不存在" in response.json()["detail"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_world_info_entries.py
+++ b/backend/tests/api/test_world_info_entries.py
@@ -3,6 +3,8 @@
 WorldInfo Entry API 测试。
 """
 
+import json
+
 import pytest
 from httpx import AsyncClient
 
@@ -39,6 +41,21 @@ async def test_create_entry(client: AsyncClient, world_info_id: str) -> None:
     assert data["is_enabled"] is True
     assert data["uid"] == 1
     assert data["order"] == 1
+
+
+@pytest.mark.asyncio
+async def test_create_entry_rejects_content_over_line_limit(
+    client: AsyncClient, world_info_id: str
+) -> None:
+    response = await client.post(
+        f"/api/v1/world-info/{world_info_id}/entries",
+        json={"name": "超限条目", "content": "\n".join("内容" for _ in range(2001))},
+    )
+
+    assert response.status_code == 400
+    assert "内容超出限制" in response.json()["detail"]
+    entries = (await client.get(f"/api/v1/world-info/{world_info_id}/entries")).json()
+    assert entries["total"] == 0
 
 
 @pytest.mark.asyncio
@@ -154,6 +171,27 @@ async def test_update_entry(client: AsyncClient, world_info_id: str) -> None:
 
 
 @pytest.mark.asyncio
+async def test_update_entry_rejects_content_over_line_limit(
+    client: AsyncClient, world_info_id: str
+) -> None:
+    create_response = await client.post(
+        f"/api/v1/world-info/{world_info_id}/entries",
+        json={"name": "原条目", "content": "原内容"},
+    )
+    entry_id = create_response.json()["id"]
+
+    response = await client.patch(
+        f"/api/v1/world-info-entries/{entry_id}",
+        json={"content": "\n".join("内容" for _ in range(2001))},
+    )
+
+    assert response.status_code == 400
+    assert "内容超出限制" in response.json()["detail"]
+    unchanged = await client.get(f"/api/v1/world-info-entries/{entry_id}")
+    assert unchanged.json()["content"] == "原内容"
+
+
+@pytest.mark.asyncio
 async def test_delete_entry(client: AsyncClient, world_info_id: str) -> None:
     """测试删除条目。"""
     create_resp = await client.post(
@@ -256,6 +294,51 @@ async def test_import_world_info_entries_stream_overwrite_clears_existing_entrie
     list_response = await client.get(f"/api/v1/world-info/{world_info_id}/entries")
     items = list_response.json()["items"]
     assert [item["name"] for item in items] == ["背景"]
+
+
+@pytest.mark.asyncio
+async def test_import_world_info_entries_stream_overwrite_rejects_oversized_content(
+    client: AsyncClient, world_info_id: str
+) -> None:
+    await client.post(
+        f"/api/v1/world-info/{world_info_id}/entries",
+        json={"name": "原有条目", "content": "原有内容"},
+    )
+    content = json.dumps(
+        {
+            "entries": {
+                "0": {
+                    "uid": 0,
+                    "comment": "超限条目",
+                    "content": "\n".join("内容" for _ in range(2001)),
+                    "disable": False,
+                    "order": 100,
+                }
+            }
+        }
+    ).encode("utf-8")
+
+    response = await client.post(
+        f"/api/v1/world-info/{world_info_id}/entries/import-stream?mode=overwrite",
+        files={"file": ("worldbook.json", content, "application/json")},
+    )
+
+    assert response.status_code == 200
+    events = [
+        json.loads(line.removeprefix("data: "))
+        for line in response.text.splitlines()
+        if line.startswith("data: ")
+    ]
+    assert any(
+        event["type"] == "error" and "内容超出限制" in event["message"]
+        for event in events
+    )
+    assert all(event["type"] != "complete" for event in events)
+    list_response = await client.get(f"/api/v1/world-info/{world_info_id}/entries")
+    items = list_response.json()["items"]
+    assert [item["name"] for item in items] == ["原有条目"]
+    entry_response = await client.get(f"/api/v1/world-info-entries/{items[0]['id']}")
+    assert entry_response.json()["content"] == "原有内容"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/core/test_editor_content_limits.py
+++ b/backend/tests/core/test_editor_content_limits.py
@@ -1,0 +1,37 @@
+import pytest
+
+from app.core.editor_content_limits import (
+    MAX_EDITOR_CONTENT_CHARACTERS,
+    MAX_EDITOR_CONTENT_LINES,
+    EditorContentLimitError,
+    count_editor_content_lines,
+    validate_editor_content,
+)
+
+
+def test_count_editor_content_lines_treats_empty_text_as_zero_lines() -> None:
+    assert count_editor_content_lines("") == 0
+
+
+@pytest.mark.parametrize("newline", ["\n", "\r\n", "\r"])
+def test_count_editor_content_lines_uses_consistent_newline_semantics(newline: str) -> None:
+    assert count_editor_content_lines(f"first{newline}second{newline}") == 2
+
+
+def test_validate_editor_content_accepts_limit_boundaries() -> None:
+    validate_editor_content("\n".join("x" for _ in range(MAX_EDITOR_CONTENT_LINES)))
+    validate_editor_content("x" * MAX_EDITOR_CONTENT_CHARACTERS)
+
+
+def test_validate_editor_content_rejects_content_exceeding_line_limit() -> None:
+    content = "\n".join("x" for _ in range(MAX_EDITOR_CONTENT_LINES + 1))
+
+    with pytest.raises(EditorContentLimitError, match="2001 行"):
+        validate_editor_content(content)
+
+
+def test_validate_editor_content_rejects_content_exceeding_character_limit() -> None:
+    content = "😀" * (MAX_EDITOR_CONTENT_CHARACTERS + 1)
+
+    with pytest.raises(EditorContentLimitError, match="100001 字符"):
+        validate_editor_content(content)

--- a/backend/tests/storage/test_world_info_entry_service.py
+++ b/backend/tests/storage/test_world_info_entry_service.py
@@ -1,0 +1,38 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.core.editor_content_limits import EditorContentLimitError
+from app.storage.services.world_info_entry_service import (
+    WorldInfoImportEntry,
+    import_entries,
+)
+
+
+@pytest.mark.asyncio
+async def test_overwrite_import_validates_all_entries_before_deleting_existing_entries() -> None:
+    session = AsyncMock()
+    entries = [
+        WorldInfoImportEntry(
+            uid=1,
+            name="超限条目",
+            content="\n".join("内容" for _ in range(2001)),
+            is_enabled=True,
+            order=1,
+        )
+    ]
+
+    with (
+        patch(
+            "app.storage.services.world_info_entry_service.get_world_info",
+            AsyncMock(),
+        ),
+        patch(
+            "app.storage.services.world_info_entry_service.world_info_entry_repo.delete_by_world_info",
+            AsyncMock(),
+        ) as delete_entries,
+    ):
+        with pytest.raises(EditorContentLimitError, match="内容超出限制"):
+            await import_entries(session, "world-1", entries, mode="overwrite")
+
+    delete_entries.assert_not_awaited()

--- a/frontend/src/features/characters/components/character-editor.tsx
+++ b/frontend/src/features/characters/components/character-editor.tsx
@@ -4,7 +4,13 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { MarkdownEditor, Spinner } from "@/components";
+import { toast } from "@/components/toast";
 import type { Character } from "@/lib/character.types";
+import {
+  getEditorContentLimit,
+  MAX_EDITOR_CONTENT_CHARACTERS,
+  MAX_EDITOR_CONTENT_LINES,
+} from "@/lib/editor-content-limits";
 import { countTokens } from "@/lib/tiktoken-utils";
 
 const AUTO_SAVE_DELAY = 1500;
@@ -37,15 +43,40 @@ export function CharacterEditor({
   });
   const hasChangesRef = useRef(false);
   const isSavingRef = useRef(false);
+  const rejectedContentRef = useRef<string | null>(null);
+
+  const showContentLimitToast = useCallback(
+    (content: string) => {
+      if (rejectedContentRef.current === content) return;
+      rejectedContentRef.current = content;
+      const { lineCount, characterCount } = getEditorContentLimit(content);
+      toast.error(
+        t("common.editorContentTooLarge", {
+          lineCount,
+          characterCount,
+          maxLines: MAX_EDITOR_CONTENT_LINES,
+          maxCharacters: MAX_EDITOR_CONTENT_CHARACTERS,
+        }),
+      );
+    },
+    [t],
+  );
 
   const flushSave = useCallback(async () => {
     if (!character || isSavingRef.current || !hasChangesRef.current) return;
     const nextName = latestValueRef.current.name.trim();
     if (!nextName) return;
+    const description = latestValueRef.current.description;
+    const contentLimit = getEditorContentLimit(description);
+    if (!contentLimit.isWithinLimit) {
+      showContentLimitToast(description);
+      return;
+    }
+    rejectedContentRef.current = null;
 
     isSavingRef.current = true;
     try {
-      await onSave({ name: nextName, description: latestValueRef.current.description });
+      await onSave({ name: nextName, description });
       hasChangesRef.current = false;
       setHasChanges(false);
     } catch {
@@ -54,7 +85,7 @@ export function CharacterEditor({
     } finally {
       isSavingRef.current = false;
     }
-  }, [character, onSave]);
+  }, [character, onSave, showContentLimitToast]);
 
   const scheduleSave = useCallback(() => {
     if (saveTimerRef.current) clearTimeout(saveTimerRef.current);

--- a/frontend/src/features/world-info/components/entry-editor.tsx
+++ b/frontend/src/features/world-info/components/entry-editor.tsx
@@ -13,6 +13,11 @@ import { useTranslation } from "react-i18next";
 import { MarkdownEditor } from "@/components";
 import { toast } from "@/components/toast";
 import { updateWorldInfoEntry } from "@/lib/api-client";
+import {
+  getEditorContentLimit,
+  MAX_EDITOR_CONTENT_CHARACTERS,
+  MAX_EDITOR_CONTENT_LINES,
+} from "@/lib/editor-content-limits";
 import { countTokens } from "@/lib/tiktoken-utils";
 import type {
   WorldInfoEntry,
@@ -63,6 +68,24 @@ export function EntryEditor({
   const isSavingRef = useRef(false);
   const editorRef = useRef<Editor | null>(null);
   const scrolledRef = useRef(false);
+  const rejectedContentRef = useRef<string | null>(null);
+
+  const showContentLimitToast = useCallback(
+    (content: string) => {
+      if (rejectedContentRef.current === content) return;
+      rejectedContentRef.current = content;
+      const { lineCount, characterCount } = getEditorContentLimit(content);
+      toast.error(
+        t("common.editorContentTooLarge", {
+          lineCount,
+          characterCount,
+          maxLines: MAX_EDITOR_CONTENT_LINES,
+          maxCharacters: MAX_EDITOR_CONTENT_CHARACTERS,
+        }),
+      );
+    },
+    [t],
+  );
 
   const updateCaches = useCallback(
     (updated: WorldInfoEntry) => {
@@ -96,6 +119,14 @@ export function EntryEditor({
 
     const content = savedContentRef.current;
     const newName = savedNameRef.current.trim();
+    const contentLimit = getEditorContentLimit(content);
+    if (!contentLimit.isWithinLimit) {
+      showContentLimitToast(content);
+      isSavingRef.current = false;
+      setIsSaving(false);
+      return;
+    }
+    rejectedContentRef.current = null;
     const hasDuplicateName = entries.some((item) => item.id !== entry.id && item.name === newName);
     if (hasDuplicateName) {
       toast.error(t("worldInfo.duplicateEntryName"));
@@ -120,7 +151,7 @@ export function EntryEditor({
       isSavingRef.current = false;
       setIsSaving(false);
     }
-  }, [entries, entry.id, t, updateCaches]);
+  }, [entries, entry.id, showContentLimitToast, t, updateCaches]);
 
   const triggerAutoSave = useCallback(() => {
     if (saveTimerRef.current) {

--- a/frontend/src/features/writing/components/chapter-editor.tsx
+++ b/frontend/src/features/writing/components/chapter-editor.tsx
@@ -18,6 +18,11 @@ import {
 import { useScrollbarAutoHide } from "@/hooks/use-scrollbar-auto-hide";
 import { fetchChapter } from "@/lib/api-client";
 import type { Chapter } from "@/lib/chapter.types";
+import {
+  getEditorContentLimit,
+  MAX_EDITOR_CONTENT_CHARACTERS,
+  MAX_EDITOR_CONTENT_LINES,
+} from "@/lib/editor-content-limits";
 import { htmlToNewlines, newlinesToHtml } from "@/lib/html-utils";
 import { createToastThrottler } from "@/lib/ui-utils";
 
@@ -111,6 +116,25 @@ function ChapterEditorContent({
 
   const showLockedToast = useMemo(
     () => createToastThrottler(t("writing.agentLockedChapterEdit")),
+    [t],
+  );
+  const rejectedContentRef = useRef<string | null>(null);
+
+  const showContentLimitToast = useCallback(
+    (content: string) => {
+      if (rejectedContentRef.current === content) return false;
+      rejectedContentRef.current = content;
+      const { lineCount, characterCount } = getEditorContentLimit(content);
+      toast.error(
+        t("common.editorContentTooLarge", {
+          lineCount,
+          characterCount,
+          maxLines: MAX_EDITOR_CONTENT_LINES,
+          maxCharacters: MAX_EDITOR_CONTENT_CHARACTERS,
+        }),
+      );
+      return true;
+    },
     [t],
   );
 
@@ -240,6 +264,15 @@ function ChapterEditorContent({
 
       const draftToSave = latestDraftRef.current;
       const draftUpdatedAt = latestDraftUpdatedAtRef.current;
+      const contentLimit = getEditorContentLimit(draftToSave.content);
+      if (!contentLimit.isWithinLimit) {
+        persistWorkingCopy(draftToSave, baseUpdatedAtRef.current, draftUpdatedAt);
+        hasChangesRef.current = true;
+        setHasChanges(true);
+        showContentLimitToast(draftToSave.content);
+        return;
+      }
+      rejectedContentRef.current = null;
       const currentWordCount = wordsCount(draftToSave.content);
 
       setIsSaving(true);
@@ -282,6 +315,7 @@ function ChapterEditorContent({
       updateMutation,
       clearWorkingCopy,
       persistWorkingCopy,
+      showContentLimitToast,
     ],
   );
 

--- a/frontend/src/features/writing/components/note-editor.tsx
+++ b/frontend/src/features/writing/components/note-editor.tsx
@@ -4,7 +4,13 @@ import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import { MarkdownEditor, Spinner } from "@/components";
+import { toast } from "@/components/toast";
 import { fetchNote } from "@/lib/api-client";
+import {
+  getEditorContentLimit,
+  MAX_EDITOR_CONTENT_CHARACTERS,
+  MAX_EDITOR_CONTENT_LINES,
+} from "@/lib/editor-content-limits";
 import type { Note } from "@/lib/note.types";
 import { createToastThrottler } from "@/lib/ui-utils";
 
@@ -76,6 +82,24 @@ function NoteEditorContent({
     content: note.content,
   });
   const baseUpdatedAtRef = useRef(note.updatedAt);
+  const rejectedContentRef = useRef<string | null>(null);
+
+  const showContentLimitToast = useCallback(
+    (content: string) => {
+      if (rejectedContentRef.current === content) return;
+      rejectedContentRef.current = content;
+      const { lineCount, characterCount } = getEditorContentLimit(content);
+      toast.error(
+        t("common.editorContentTooLarge", {
+          lineCount,
+          characterCount,
+          maxLines: MAX_EDITOR_CONTENT_LINES,
+          maxCharacters: MAX_EDITOR_CONTENT_CHARACTERS,
+        }),
+      );
+    },
+    [t],
+  );
 
   const persistDraft = useCallback(
     (draft: WritingDraft) => {
@@ -95,6 +119,15 @@ function NoteEditorContent({
 
     const draftToSave = latestDraftRef.current;
     const draftUpdatedAt = latestDraftUpdatedAtRef.current;
+    const contentLimit = getEditorContentLimit(draftToSave.content);
+    if (!contentLimit.isWithinLimit) {
+      persistWorkingCopy(draftToSave, baseUpdatedAtRef.current, draftUpdatedAt);
+      hasChangesRef.current = true;
+      setHasChanges(true);
+      showContentLimitToast(draftToSave.content);
+      return;
+    }
+    rejectedContentRef.current = null;
 
     setIsSaving(true);
     try {
@@ -131,6 +164,7 @@ function NoteEditorContent({
     note.id,
     persistWorkingCopy,
     showLockedToast,
+    showContentLimitToast,
     updateMutation,
     updateTabTitle,
   ]);

--- a/frontend/src/features/writing/hooks/use-auto-save.ts
+++ b/frontend/src/features/writing/hooks/use-auto-save.ts
@@ -70,6 +70,10 @@ export function useAutoSave({
     return clearTimer;
   }, [resetTimer, clearTimer]);
 
+  useEffect(() => {
+    if (lastSaveTime !== null) resetTimer();
+  }, [lastSaveTime, resetTimer]);
+
   // 页面离开前保存
   useEffect(() => {
     const handleBeforeUnload = (e: BeforeUnloadEvent) => {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -20,6 +20,7 @@
     "copied": "Copied",
     "saveSuccess": "Saved successfully",
     "saveFailed": "Save failed",
+    "editorContentTooLarge": "Content exceeds the limit: {{lineCount}} lines and {{characterCount}} characters. The maximum is {{maxLines}} lines and {{maxCharacters}} characters. Split the content and try again.",
     "deleteSuccess": "Deleted",
     "deleteFailed": "Delete failed",
     "optional": "Optional",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -20,6 +20,7 @@
     "copied": "已复制",
     "saveSuccess": "保存成功",
     "saveFailed": "保存失败",
+    "editorContentTooLarge": "内容超出限制：当前 {{lineCount}} 行、{{characterCount}} 字符；最多允许 {{maxLines}} 行且 {{maxCharacters}} 字符。请拆分内容后重试。",
     "deleteSuccess": "已删除",
     "deleteFailed": "删除失败",
     "optional": "可选",

--- a/frontend/src/lib/editor-content-limits.ts
+++ b/frontend/src/lib/editor-content-limits.ts
@@ -1,0 +1,53 @@
+export const MAX_EDITOR_CONTENT_LINES = 2_000;
+export const MAX_EDITOR_CONTENT_CHARACTERS = 100_000;
+
+const LINE_SEPARATORS = new Set([
+  "\n",
+  "\r",
+  "\u000B",
+  "\u000C",
+  "\u001C",
+  "\u001D",
+  "\u001E",
+  "\u0085",
+  "\u2028",
+  "\u2029",
+]);
+
+export interface EditorContentLimit {
+  lineCount: number;
+  characterCount: number;
+  isWithinLimit: boolean;
+}
+
+function countEditorContentLines(content: string): number {
+  if (content === "") return 0;
+
+  let separatorCount = 0;
+  let endsWithSeparator = false;
+  for (let index = 0; index < content.length; index += 1) {
+    const character = content[index] ?? "";
+    if (!LINE_SEPARATORS.has(character)) {
+      endsWithSeparator = false;
+      continue;
+    }
+
+    separatorCount += 1;
+    if (character === "\r" && content[index + 1] === "\n") index += 1;
+    endsWithSeparator = index === content.length - 1;
+  }
+
+  return endsWithSeparator ? separatorCount : separatorCount + 1;
+}
+
+export function getEditorContentLimit(content: string): EditorContentLimit {
+  const lineCount = countEditorContentLines(content);
+  const characterCount = Array.from(content).length;
+
+  return {
+    lineCount,
+    characterCount,
+    isWithinLimit:
+      lineCount <= MAX_EDITOR_CONTENT_LINES && characterCount <= MAX_EDITOR_CONTENT_CHARACTERS,
+  };
+}


### PR DESCRIPTION
## PR 标题

chore(editor): 限制单条正文内容长度

## 变更说明

- 问题: Agent 的批量替换、异常输出或用户一次性粘贴超长正文时，单条内容没有长度限制，后续读取和编辑器渲染可能卡死。
- 重要性: 需要在内容进入持久化层前统一限制单条正文大小，避免异常内容写入后影响项目可用性。
- 变化: 后端为章节、笔记、世界书条目和角色描述增加 2,000 行、100,000 个 Unicode 字符的统一校验，并覆盖 API、导入、Agent 工具和 revision 回滚。
- 变化: 前端在章节、笔记、世界书和角色编辑器保存前拦截超限内容，保留草稿和未保存状态，避免重复自动保存提示。
- 变化: 补充创建、更新、批量替换、普通与流式导入、覆盖导入、回滚及 Unicode 换行符边界测试。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因(如有)

不适用。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证结果：

- `uv run pytest -q`：1,246 passed
- `uv run ruff check app tests`：通过
- `uv run ty check app`：通过
- `pnpm type-check`、`pnpm lint`、`pnpm format:check`、`pnpm build`：通过
