### PR TITLE
fix(desktop): 完善运行环境调试信息处理

### DIFF
--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -1,4 +1,5 @@
-import { dialog, ipcMain, type BrowserWindow } from "electron";
+import { app, dialog, ipcMain, type BrowserWindow } from "electron";
+import path from "node:path";
 import {
   IpcChannels,
   type CheckRemoteRequest,
@@ -21,6 +22,7 @@ import { inspectLocalRuntime, installLocalRuntime, startLocalBackendFromInstall 
 import { getDefaultInstallDir } from "./runtime/python.js";
 import { cancelUpdateDownload, checkForUpdates, downloadUpdate, getUpdateState, installUpdate, openUpdateRelease } from "./updater.js";
 import { createStartupProgressTracker, getStartupProgress } from "./startup-progress.js";
+import { exportLogs } from "./logging.js";
 import type { BackendProcessHandle } from "./process.js";
 import type { DesktopConfig, DesktopInstance } from "../shared/config.js";
 
@@ -54,6 +56,33 @@ export function registerIpc(context: IpcContext): void {
   ipcMain.handle(IpcChannels.cancelUpdateDownload, () => cancelUpdateDownload());
   ipcMain.handle(IpcChannels.installUpdate, () => installUpdate());
   ipcMain.handle(IpcChannels.openUpdateRelease, () => openUpdateRelease());
+  ipcMain.handle(IpcChannels.exportLogs, async () => {
+    const defaultPath = path.join(
+      app.getPath("downloads"),
+      `openfic-backend-logs-${new Date().toISOString().replace(/[:.]/g, "-")}.zip`,
+    );
+    const window = context.shellWindow();
+    const result = window
+      ? await dialog.showSaveDialog(window, {
+          defaultPath,
+          filters: [{ name: "ZIP 压缩包", extensions: ["zip"] }],
+          title: "导出后端日志",
+        })
+      : await dialog.showSaveDialog({
+          defaultPath,
+          filters: [{ name: "ZIP 压缩包", extensions: ["zip"] }],
+          title: "导出后端日志",
+        });
+    if (result.canceled || !result.filePath) return null;
+
+    try {
+      return await exportLogs(result.filePath);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      dialog.showErrorBox("导出后端日志失败", message);
+      throw error;
+    }
+  });
 
   ipcMain.handle(IpcChannels.ensureInstanceSession, (_event, request: EnsureInstanceSessionRequest) => {
     return ensureAppProtocolForPartition(request.partition);

--- a/desktop/src/main/logging.ts
+++ b/desktop/src/main/logging.ts
@@ -1,0 +1,159 @@
+import { app } from "electron";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, statSync, writeFileSync } from "node:fs";
+import { readdir, rename, rm } from "node:fs/promises";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { Writable } from "node:stream";
+
+const MAX_LOG_SIZE_BYTES = 10 * 1024 * 1024;
+const UTF8_BOM = Buffer.from([0xef, 0xbb, 0xbf]);
+
+function getLogsDir(): string {
+  const logsDir = path.join(app.getPath("userData"), "logs");
+  mkdirSync(logsDir, { recursive: true });
+  return logsDir;
+}
+
+function normalizeLogName(name: string): string {
+  return name.endsWith(".log") ? name : `${name}.log`;
+}
+
+function formatLogEntry(message: string): string {
+  const lines = message.replace(/\r\n?/g, "\n").split("\n");
+  if (lines[lines.length - 1] === "") lines.pop();
+  const timestamp = new Date().toISOString();
+  return (lines.length > 0 ? lines : [""]).map((line) => `[${timestamp}] ${line}\n`).join("");
+}
+
+function rotateLogIfNeeded(logPath: string, nextEntrySize: number): void {
+  try {
+    if (statSync(logPath).size + nextEntrySize <= MAX_LOG_SIZE_BYTES) return;
+
+    const parsed = path.parse(logPath);
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    let suffix = 0;
+    let archivedPath = path.join(parsed.dir, `${parsed.name}.${timestamp}${parsed.ext}`);
+    while (existsSync(archivedPath)) {
+      suffix += 1;
+      archivedPath = path.join(parsed.dir, `${parsed.name}.${timestamp}.${suffix}${parsed.ext}`);
+    }
+    renameSync(logPath, archivedPath);
+  } catch (error) {
+    if (error instanceof Error && "code" in error && error.code === "ENOENT") return;
+    throw error;
+  }
+}
+
+function ensureUtf8Bom(logPath: string): void {
+  try {
+    const content = readFileSync(logPath);
+    if (content.subarray(0, UTF8_BOM.length).equals(UTF8_BOM)) return;
+    writeFileSync(logPath, Buffer.concat([UTF8_BOM, content]));
+  } catch (error) {
+    if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") throw error;
+    writeFileSync(logPath, UTF8_BOM);
+  }
+}
+
+export function getLogPath(name: string): string {
+  return path.join(getLogsDir(), normalizeLogName(name));
+}
+
+export function appendLog(name: string, message: string): void {
+  try {
+    const entry = formatLogEntry(message);
+    const logPath = getLogPath(name);
+    rotateLogIfNeeded(logPath, Buffer.byteLength(entry) + UTF8_BOM.length);
+    ensureUtf8Bom(logPath);
+    appendFileSync(logPath, entry, { encoding: "utf8", flag: "a" });
+  } catch {
+    // Logging failures must not interrupt the application flow they diagnose.
+  }
+}
+
+export function createLogStream(name: string): Writable {
+  let buffer = "";
+
+  const flush = (value: string) => {
+    if (value) appendLog(name, value);
+  };
+
+  return new Writable({
+    write(chunk, encoding, callback) {
+      const text = Buffer.isBuffer(chunk) ? chunk.toString("utf8") : Buffer.from(chunk, encoding).toString("utf8");
+      buffer += text.replace(/\r/g, "\n");
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+      for (const line of lines) flush(line);
+      callback();
+    },
+    final(callback) {
+      flush(buffer);
+      buffer = "";
+      callback();
+    },
+  });
+}
+
+function getLogArchiveFileName(): string {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  return `openfic-backend-logs-${timestamp}.zip`;
+}
+
+function quotePowerShellLiteral(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
+}
+
+function createLogArchive(files: string[], archivePath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child =
+      process.platform === "win32"
+        ? spawn(
+            "powershell.exe",
+            [
+              "-NoLogo",
+              "-NoProfile",
+              "-NonInteractive",
+              "-EncodedCommand",
+              Buffer.from(
+                `$ErrorActionPreference = 'Stop'; Compress-Archive -LiteralPath @(${files.map(quotePowerShellLiteral).join(",")}) -DestinationPath ${quotePowerShellLiteral(archivePath)} -Force`,
+                "utf16le",
+              ).toString("base64"),
+            ],
+            { windowsHide: true, stdio: "ignore" },
+          )
+        : spawn("zip", ["-j", "-q", archivePath, ...files], { stdio: "ignore" });
+
+    child.once("error", reject);
+    child.once("exit", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`日志压缩命令退出：${code ?? "未知"}`));
+    });
+  });
+}
+
+export async function exportLogs(destinationPath: string): Promise<string> {
+  const logsDir = getLogsDir();
+  const files = (await readdir(logsDir, { withFileTypes: true }))
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".log"))
+    .map((entry) => path.join(logsDir, entry.name));
+  if (files.length === 0) throw new Error("暂无可导出的后端日志");
+
+  const temporaryArchivePath = path.join(path.dirname(destinationPath), `.${getLogArchiveFileName()}`);
+  appendLog("startup", `开始导出后端日志：${files.length} 个文件`);
+  try {
+    await createLogArchive(files, temporaryArchivePath);
+    await rm(destinationPath, { force: true });
+    await rename(temporaryArchivePath, destinationPath);
+    appendLog("startup", `后端日志导出完成：${destinationPath}`);
+    return destinationPath;
+  } catch (error) {
+    await rm(temporaryArchivePath, { force: true });
+    const message = error instanceof Error ? error.message : String(error);
+    appendLog("startup", `后端日志导出失败：${message}`);
+    throw new Error(`后端日志导出失败：${message}`);
+  }
+}

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -1,6 +1,4 @@
 import { app, dialog, Menu, type BrowserWindow } from "electron";
-import { appendFileSync, mkdirSync } from "node:fs";
-import path from "node:path";
 import { registerAppScheme, handleAppProtocol, setRuntimeConfig } from "./protocol.js";
 import { createMainWindow } from "./windows.js";
 import { readDesktopConfig, writeDesktopConfig } from "./config.js";
@@ -13,17 +11,12 @@ import { initializeUpdater } from "./updater.js";
 import { configureDefaultSystemProxy } from "./proxy.js";
 import { createStartupProgressTracker, type StartupProgressTracker } from "./startup-progress.js";
 import { IpcChannels } from "../shared/ipc.js";
+import { appendLog } from "./logging.js";
 import type { InitializeAppResult } from "../shared/ipc.js";
 import type { DesktopConfig, DesktopInstance } from "../shared/config.js";
 
 function writeStartupLog(message: string): void {
-  try {
-    const logDir = path.join(process.env.APPDATA ?? app.getPath("userData"), "openfic-desktop");
-    mkdirSync(logDir, { recursive: true });
-    appendFileSync(path.join(logDir, "startup.log"), `[${new Date().toISOString()}] ${message}\n`, "utf8");
-  } catch {
-    // Ignore logging failures during startup diagnostics.
-  }
+  appendLog("startup", message);
 }
 
 let mainWindow: BrowserWindow | null = null;
@@ -185,7 +178,12 @@ async function activateInstance(
     return `远程实例版本为 ${health.version ?? "未知"}，桌面端版本为 ${app.getVersion()}，部分功能可能不兼容。`;
   }
 
-  await startLocalBackend(instance.installDir, startupProgress);
+  try {
+    await startLocalBackend(instance.installDir, startupProgress);
+  } catch (error) {
+    appendLog("runtime", `本地运行环境更新或启动失败：${error instanceof Error ? error.message : String(error)}`);
+    throw error;
+  }
   return null;
 }
 

--- a/desktop/src/main/process.ts
+++ b/desktop/src/main/process.ts
@@ -1,7 +1,6 @@
 import { app } from "electron";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { createWriteStream, mkdirSync } from "node:fs";
-import path from "node:path";
+import { appendLog, createLogStream, getLogPath } from "./logging.js";
 
 export interface BackendProcessHandle {
   process: ChildProcessWithoutNullStreams;
@@ -19,9 +18,7 @@ export interface StartBackendOptions {
 }
 
 export function getBackendLogPath(): string {
-  const logsDir = path.join(app.getPath("userData"), "logs");
-  mkdirSync(logsDir, { recursive: true });
-  return path.join(logsDir, "backend.log");
+  return getLogPath("backend");
 }
 
 function observeOutputLines(stream: NodeJS.ReadableStream, onLine: (line: string) => void): void {
@@ -44,7 +41,18 @@ function observeOutputLines(stream: NodeJS.ReadableStream, onLine: (line: string
 export function startBackendProcess(options: StartBackendOptions): BackendProcessHandle {
   const dataDir = options.dataDir ?? app.getPath("userData");
   const logPath = getBackendLogPath();
-  const logStream = createWriteStream(logPath, { flags: "w" });
+  const stdoutLog = createLogStream("backend");
+  const stderrLog = createLogStream("backend");
+  let logsClosed = false;
+
+  const closeLogs = () => {
+    if (logsClosed) return;
+    logsClosed = true;
+    stdoutLog.end();
+    stderrLog.end();
+  };
+
+  appendLog("backend", `启动后端命令：${options.command} ${options.args.join(" ")}`);
 
   const child = spawn(options.command, options.args, {
     cwd: dataDir,
@@ -53,17 +61,27 @@ export function startBackendProcess(options: StartBackendOptions): BackendProces
       OPENFIC_SERVER_HOST: "127.0.0.1",
       OPENFIC_SERVER_PORT: String(options.port),
       OPENFIC_DATA_DIR: dataDir,
+      PYTHONIOENCODING: "utf-8",
+      PYTHONUTF8: "1",
       ...options.environment,
     },
     windowsHide: true,
   });
 
-  child.stdout.pipe(logStream);
-  child.stderr.pipe(logStream);
+  child.stdout.pipe(stdoutLog, { end: false });
+  child.stderr.pipe(stderrLog, { end: false });
   if (options.onOutputLine) {
     observeOutputLines(child.stdout, options.onOutputLine);
     observeOutputLines(child.stderr, options.onOutputLine);
   }
+  child.once("error", (error) => {
+    appendLog("backend", `后端进程启动失败：${error.message}`);
+    closeLogs();
+  });
+  child.once("close", (code, signal) => {
+    appendLog("backend", `后端进程已退出：code=${code ?? "null"} signal=${signal ?? "none"}`);
+    closeLogs();
+  });
 
   return {
     process: child,
@@ -74,6 +92,8 @@ export function startBackendProcess(options: StartBackendOptions): BackendProces
 
 export function stopBackendProcess(handle: BackendProcessHandle | null): void {
   if (!handle || handle.process.killed) return;
+
+  appendLog("backend", `请求停止后端进程：pid=${handle.process.pid ?? "unknown"}`);
 
   if (process.platform === "win32") {
     spawn("taskkill", ["/F", "/T", "/PID", String(handle.process.pid)], {

--- a/desktop/src/main/proxy.ts
+++ b/desktop/src/main/proxy.ts
@@ -1,4 +1,5 @@
 import { session, type Session } from "electron";
+import { appendLog } from "./logging.js";
 
 const configuredSessions = new WeakMap<Session, Promise<void>>();
 const LOCAL_BYPASS_HOSTS = ["localhost", "127.0.0.1"];
@@ -9,7 +10,7 @@ export function configureSystemProxy(targetSession: Session): Promise<void> {
   if (configured) return configured;
 
   const configuration = targetSession.setProxy({ mode: "system" }).catch((error: unknown) => {
-    console.warn("Unable to configure the system proxy:", error);
+    appendLog("startup", `配置系统代理失败：${error instanceof Error ? error.message : String(error)}`);
   });
   configuredSessions.set(targetSession, configuration);
   return configuration;

--- a/desktop/src/main/runtime/archive.ts
+++ b/desktop/src/main/runtime/archive.ts
@@ -52,6 +52,7 @@ export async function downloadFile(
   urls: string[],
   outputPath: string,
   onProgress?: (received: number, total: number) => void,
+  onLog?: (message: string) => void,
 ): Promise<void> {
   if (urls.length === 0) throw new Error("no download urls provided");
   await mkdir(path.dirname(outputPath), { recursive: true });
@@ -59,11 +60,14 @@ export async function downloadFile(
   let lastError: unknown;
   for (const url of urls) {
     try {
+      onLog?.(`下载文件：${url}`);
       const response = await fetchWithFirstByteTimeout(url);
       await streamResponseToPath(response, outputPath, onProgress);
+      onLog?.(`文件下载完成：${url}`);
       return;
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      onLog?.(`文件下载失败：${url}：${message}`);
       lastError = new Error(`failed to download ${url}: ${message}`);
       await rm(outputPath, { force: true });
     }

--- a/desktop/src/main/runtime/openfic.ts
+++ b/desktop/src/main/runtime/openfic.ts
@@ -14,6 +14,7 @@ import {
   resolveOpenFicCliPath,
 } from "./openfic-commands.js";
 import type { StartupProgressTracker } from "../startup-progress.js";
+import { appendLog, createLogStream } from "../logging.js";
 
 export type OpenFicRuntimeStep = "create-venv" | "install-uv" | "install-openfic";
 
@@ -22,6 +23,10 @@ const DEFAULT_PYPI_INDEX_URL = "https://pypi.org/simple/";
 const TSINGHUA_PYPI_INDEX_URL = "https://pypi.tuna.tsinghua.edu.cn/simple/";
 const PYPI_INDEX_PROBE_TIMEOUT_MS = 5_000;
 const PYPI_INDEX_PROBE_PACKAGE = "openfic";
+const UTF8_PYTHON_ENVIRONMENT = {
+  PYTHONIOENCODING: "utf-8",
+  PYTHONUTF8: "1",
+};
 
 interface PypiIndexProbe {
   indexUrl: string;
@@ -61,7 +66,7 @@ async function pathExists(filePath: string): Promise<boolean> {
 
 function forwardLines(
   stream: NodeJS.ReadableStream | null,
-  writer: NodeJS.WriteStream,
+  logStream: NodeJS.WritableStream,
   onLine?: (line: string) => void,
 ): void {
   if (!stream) return;
@@ -69,7 +74,7 @@ function forwardLines(
   let buffer = "";
   stream.on("data", (chunk: Buffer | string) => {
     const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
-    writer.write(text);
+    logStream.write(text);
     buffer += text.replace(/\r/g, "\n");
 
     const lines = buffer.split("\n");
@@ -83,6 +88,7 @@ function forwardLines(
   stream.on("end", () => {
     const trimmed = buffer.trim();
     if (trimmed) onLine?.(trimmed);
+    logStream.end();
   });
 }
 
@@ -95,16 +101,25 @@ async function probePypiIndex(indexUrl: string, expectedVersion: string): Promis
   const timeout = setTimeout(() => controller.abort(), PYPI_INDEX_PROBE_TIMEOUT_MS);
   const startedAt = performance.now();
   try {
+    appendLog("runtime", `探测 Python 包索引：${indexUrl}`);
     const response = await net.fetch(`${indexUrl}${PYPI_INDEX_PROBE_PACKAGE}/`, {
       cache: "no-store",
       signal: controller.signal,
     });
-    if (!response.ok) return null;
+    if (!response.ok) {
+      appendLog("runtime", `Python 包索引响应异常：${indexUrl}，状态码 ${response.status}`);
+      return null;
+    }
     const packageIndex = await response.text();
     const elapsedMs = performance.now() - startedAt;
-    if (!packageIndex.includes(`openfic-${expectedVersion}`)) return null;
+    if (!packageIndex.includes(`openfic-${expectedVersion}`)) {
+      appendLog("runtime", `Python 包索引未找到 OpenFic ${expectedVersion}：${indexUrl}`);
+      return null;
+    }
+    appendLog("runtime", `Python 包索引可用：${indexUrl}，耗时 ${Math.round(elapsedMs)}ms`);
     return { indexUrl, elapsedMs };
-  } catch {
+  } catch (error) {
+    appendLog("runtime", `Python 包索引探测失败：${indexUrl}：${error instanceof Error ? error.message : String(error)}`);
     return null;
   } finally {
     clearTimeout(timeout);
@@ -122,6 +137,7 @@ async function getFastestPypiEnvironment(expectedVersion: string): Promise<NodeJ
   }
 
   const indexUrl = fastestProbe?.indexUrl ?? DEFAULT_PYPI_INDEX_URL;
+  appendLog("runtime", `使用 Python 包索引：${indexUrl}`);
   const proxyEnvironment = await getSystemProxyEnvironment(indexUrl);
   return {
     ...proxyEnvironment,
@@ -136,54 +152,96 @@ function run(
   command: string,
   args: string[],
   cwd: string,
-  onStdoutLine?: (line: string) => void,
+  onOutputLine?: (line: string) => void,
   environment?: NodeJS.ProcessEnv,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
+    appendLog("runtime", `执行命令：${command} ${args.join(" ")}`);
+    let lastOutputLine = "";
     const child = spawn(command, args, {
       cwd,
-      env: { ...process.env, ...environment },
+      env: { ...process.env, ...UTF8_PYTHON_ENVIRONMENT, ...environment },
       windowsHide: true,
       stdio: ["ignore", "pipe", "pipe"],
     });
-    forwardLines(child.stdout, process.stdout, (line) => {
+    const handleOutput = (line: string) => {
       const text = stripAnsi(line).trim();
-      if (text) onStdoutLine?.(text);
+      if (!text) return;
+      lastOutputLine = text;
+      onOutputLine?.(text);
+    };
+    forwardLines(child.stdout, createLogStream("runtime"), handleOutput);
+    forwardLines(child.stderr, createLogStream("runtime"), handleOutput);
+    child.on("error", (error) => {
+      appendLog("runtime", `命令启动失败：${error.message}`);
+      reject(error);
     });
-    forwardLines(child.stderr, process.stderr);
-    child.on("error", reject);
     child.on("exit", (code) => {
-      if (code === 0) resolve();
-      else reject(new Error(`${command} ${args.join(" ")} exited with code ${code}`));
+      if (code === 0) {
+        appendLog("runtime", "命令执行完成");
+        resolve();
+        return;
+      }
+      const outputDetail = lastOutputLine ? `：${lastOutputLine}` : "";
+      const error = new Error(`${command} ${args.join(" ")} exited with code ${code}${outputDetail}`);
+      appendLog("runtime", `命令执行失败：${error.message}`);
+      reject(error);
     });
   });
 }
 
 function readOutput(command: string, args: string[], cwd: string): Promise<string | null> {
   return new Promise((resolve) => {
+    appendLog("runtime", `检查命令：${command} ${args.join(" ")}`);
     const child = spawn(command, args, {
       cwd,
+      env: { ...process.env, ...UTF8_PYTHON_ENVIRONMENT },
       windowsHide: true,
-      stdio: ["ignore", "pipe", "ignore"],
+      stdio: ["ignore", "pipe", "pipe"],
     });
     let output = "";
-    child.stdout.on("data", (chunk: Buffer | string) => {
-      output += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+    const collectOutput = (chunk: Buffer | string) => {
+      const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      output += text;
+    };
+    child.stdout.on("data", collectOutput);
+    child.stdout.pipe(createLogStream("runtime"));
+    child.stderr.pipe(createLogStream("runtime"));
+    child.on("error", (error) => {
+      appendLog("runtime", `检查命令启动失败：${error.message}`);
+      resolve(null);
     });
-    child.on("error", () => resolve(null));
-    child.on("exit", (code) => resolve(code === 0 ? output.trim() || null : null));
+    child.on("exit", (code) => {
+      if (code === 0) {
+        appendLog("runtime", "检查命令执行完成");
+        resolve(output.trim() || null);
+        return;
+      }
+      appendLog("runtime", `检查命令执行失败：退出码 ${code}`);
+      resolve(null);
+    });
   });
 }
 
 function succeeds(command: string, args: string[], cwd: string): Promise<boolean> {
   return new Promise((resolve) => {
+    appendLog("runtime", `检查命令：${command} ${args.join(" ")}`);
     const child = spawn(command, args, {
       cwd,
+      env: { ...process.env, ...UTF8_PYTHON_ENVIRONMENT },
       windowsHide: true,
-      stdio: "ignore",
+      stdio: ["ignore", "pipe", "pipe"],
     });
-    child.on("error", () => resolve(false));
-    child.on("exit", (code) => resolve(code === 0));
+    child.stdout.pipe(createLogStream("runtime"));
+    child.stderr.pipe(createLogStream("runtime"));
+    child.on("error", (error) => {
+      appendLog("runtime", `检查命令启动失败：${error.message}`);
+      resolve(false);
+    });
+    child.on("exit", (code) => {
+      appendLog("runtime", code === 0 ? "检查命令执行完成" : `检查命令执行失败：退出码 ${code}`);
+      resolve(code === 0);
+    });
   });
 }
 
@@ -232,13 +290,18 @@ export async function ensureOpenFicRuntime(
   let pypiEnvironment: Promise<NodeJS.ProcessEnv> | null = null;
   const getPypiEnvironment = () => (pypiEnvironment ??= getFastestPypiEnvironment(expectedVersion));
 
+  appendLog("runtime", `开始检查 OpenFic 运行环境：${runtimeDir}`);
   await mkdir(runtimeDir, { recursive: true });
 
-  if (python.wasReplaced) await rm(venvDir, { recursive: true, force: true });
+  if (python.wasReplaced) {
+    appendLog("runtime", "便携式 Python 已更新，删除现有虚拟环境");
+    await rm(venvDir, { recursive: true, force: true });
+  }
 
   const venvIsUsable =
     (await pathExists(venvPythonPath)) && Boolean(await readOutput(venvPythonPath, ["--version"], runtimeDir));
   if (!venvIsUsable) {
+    appendLog("runtime", "虚拟环境不存在或不可用，开始创建");
     await rm(venvDir, { recursive: true, force: true });
     onProgress("create-venv", "创建 OpenFic 运行环境");
     await run(python.pythonPath, ["-m", "venv", venvDir], runtimeDir);
@@ -246,6 +309,7 @@ export async function ensureOpenFicRuntime(
 
   const uvIsUsable = (await pathExists(uvPath)) && Boolean(await readOutput(uvPath, ["--version"], runtimeDir));
   if (!uvIsUsable) {
+    appendLog("runtime", "uv 不存在或不可用，开始安装");
     onProgress("install-uv", "安装 uv");
     const packageIndexEnvironment = await getPypiEnvironment();
     await run(
@@ -263,6 +327,10 @@ export async function ensureOpenFicRuntime(
   const openFicCliIsUsable =
     (await pathExists(openFicCliPath)) && (await succeeds(openFicCliPath, ["--help"], runtimeDir));
   if (installedVersion !== expectedVersion || !openFicCliIsUsable) {
+    appendLog(
+      "runtime",
+      installedVersion ? `OpenFic 后端需要更新：${installedVersion} -> ${expectedVersion}` : "OpenFic 后端尚未安装",
+    );
     onProgress("install-openfic", installedVersion ? "更新 OpenFic 后端" : "安装 OpenFic 后端");
     const packageIndexEnvironment = await getPypiEnvironment();
     const installCommand = createOpenFicInstallCommand(
@@ -279,6 +347,7 @@ export async function ensureOpenFicRuntime(
     );
   }
 
+  appendLog("runtime", "OpenFic 运行环境检查完成");
   return { uvPath, venvPythonPath };
 }
 

--- a/desktop/src/main/runtime/python.ts
+++ b/desktop/src/main/runtime/python.ts
@@ -2,6 +2,7 @@ import { app } from "electron";
 import { spawn } from "node:child_process";
 import { access, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
+import { appendLog } from "../logging.js";
 import { downloadFile, extractTarGz } from "./archive.js";
 import { resolvePythonAsset } from "./python-assets.js";
 import { matchesPortablePythonVersion } from "./python-version.js";
@@ -59,18 +60,28 @@ function formatBytes(bytes: number): string {
 
 function readPythonVersion(pythonPath: string): Promise<string | null> {
   return new Promise((resolve) => {
+    appendLog("runtime", `检查 Python 版本：${pythonPath} --version`);
     const child = spawn(pythonPath, ["--version"], {
+      env: { ...process.env, PYTHONIOENCODING: "utf-8", PYTHONUTF8: "1" },
       windowsHide: true,
       stdio: ["ignore", "pipe", "pipe"],
     });
     let output = "";
     const appendOutput = (chunk: Buffer | string) => {
-      output += typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      const text = typeof chunk === "string" ? chunk : chunk.toString("utf8");
+      output += text;
+      appendLog("runtime", text);
     };
     child.stdout.on("data", appendOutput);
     child.stderr.on("data", appendOutput);
-    child.on("error", () => resolve(null));
-    child.on("exit", (code) => resolve(code === 0 ? output.trim() || null : null));
+    child.on("error", (error) => {
+      appendLog("runtime", `检查 Python 版本失败：${error.message}`);
+      resolve(null);
+    });
+    child.on("exit", (code) => {
+      appendLog("runtime", code === 0 ? "检查 Python 版本完成" : `检查 Python 版本失败：退出码 ${code}`);
+      resolve(code === 0 ? output.trim() || null : null);
+    });
   });
 }
 
@@ -96,11 +107,14 @@ export async function ensurePortablePython(
   const rootDir = getPortablePythonRoot(runtimeDir);
   const pythonPath = getPortablePythonPath(rootDir);
   const asset = resolvePythonAsset();
+  appendLog("runtime", `开始检查便携式 Python：${rootDir}`);
   if (await pathExists(pythonPath)) {
     const installedVersion = await readPythonVersion(pythonPath);
     if (installedVersion && matchesPortablePythonVersion(installedVersion, asset.version)) {
+      appendLog("runtime", `便携式 Python 已就绪：${installedVersion}`);
       return { pythonPath, rootDir, wasReplaced: false };
     }
+    appendLog("runtime", "便携式 Python 版本不匹配或不可用，删除现有文件");
     await rm(rootDir, { recursive: true, force: true });
   }
 
@@ -111,10 +125,17 @@ export async function ensurePortablePython(
   await mkdir(runtimeDir, { recursive: true });
 
   onPhase("download", `下载 Python ${asset.version}`);
-  await downloadFile(asset.urls, archivePath, (received, total) => onDownload({ received, total }));
+  appendLog("runtime", `开始下载 Python ${asset.version}`);
+  await downloadFile(
+    asset.urls,
+    archivePath,
+    (received, total) => onDownload({ received, total }),
+    (message) => appendLog("runtime", message),
+  );
 
   onPhase("extract", "解压 Python");
-  await extractTarGz(archivePath, rootDir);
+  appendLog("runtime", "开始解压 Python");
+  await extractTarGz(archivePath, rootDir, (message) => appendLog("runtime", message));
 
   if (!(await pathExists(pythonPath))) {
     throw new Error(`portable Python not found after extraction: ${pythonPath}`);
@@ -122,6 +143,7 @@ export async function ensurePortablePython(
 
   await rm(archivePath, { force: true });
 
+  appendLog("runtime", "便携式 Python 安装完成");
   return { pythonPath, rootDir, wasReplaced: true };
 }
 

--- a/desktop/src/main/runtime/setup-runner.ts
+++ b/desktop/src/main/runtime/setup-runner.ts
@@ -10,6 +10,7 @@ import {
 } from "./openfic.js";
 import type { BackendProcessHandle } from "../process.js";
 import type { StartupProgressTracker } from "../startup-progress.js";
+import { appendLog, getLogPath } from "../logging.js";
 
 function emitProgress(webContents: WebContents, event: SetupProgressEvent): void {
   webContents.send(IpcChannels.setupProgress, event);
@@ -37,25 +38,34 @@ export async function installLocalRuntime(webContents: WebContents, installDir: 
     emitProgress(webContents, { step, status: "running", message });
   };
 
-  const python = await ensurePortablePython(
-    runtimeDir,
-    (phase, message) => beginStep(phase === "download" ? "download-python" : "extract-python", message),
-    ({ received, total }) => {
-      const fraction = total > 0 ? received / total : undefined;
-      emitProgress(webContents, {
-        step: "download-python",
-        status: "running",
-        message: `下载 Python · ${describeDownloadProgress({ received, total })}`,
-        progress: fraction,
-      });
-    },
-  );
+  appendLog("runtime", `开始安装运行环境：${runtimeDir}`);
+  try {
+    const python = await ensurePortablePython(
+      runtimeDir,
+      (phase, message) => beginStep(phase === "download" ? "download-python" : "extract-python", message),
+      ({ received, total }) => {
+        const fraction = total > 0 ? received / total : undefined;
+        emitProgress(webContents, {
+          step: "download-python",
+          status: "running",
+          message: `下载 Python · ${describeDownloadProgress({ received, total })}`,
+          progress: fraction,
+        });
+      },
+    );
 
-  await ensureOpenFicRuntime(python, runtimeDir, app.getVersion(), (step, message) => beginStep(step, message));
+    await ensureOpenFicRuntime(python, runtimeDir, app.getVersion(), (step, message) => beginStep(step, message));
 
-  if (currentStep) markDone(webContents, currentStep);
-
-  return runtimeDir;
+    if (currentStep) markDone(webContents, currentStep);
+    appendLog("runtime", "运行环境安装完成");
+    return runtimeDir;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const logPath = getLogPath("runtime");
+    appendLog("runtime", `运行环境安装失败：${message}`);
+    if (currentStep) emitProgress(webContents, { step: currentStep, status: "failed", message });
+    throw new Error(`${message}。运行环境日志：${logPath}`);
+  }
 }
 
 export interface LocalRuntimeInspection {

--- a/desktop/src/main/runtime/tar-extract.ts
+++ b/desktop/src/main/runtime/tar-extract.ts
@@ -24,16 +24,43 @@ function resolveArchiveLinkPath(outputDir: string, entryPath: string, linkName: 
   }
 }
 
-async function extractWithSystemTar(archivePath: string, outputDir: string): Promise<void> {
+function logProcessOutput(stream: NodeJS.ReadableStream, onLog?: (message: string) => void): void {
+  let buffer = "";
+  stream.on("data", (chunk: Buffer | string) => {
+    buffer += (typeof chunk === "string" ? chunk : chunk.toString("utf8")).replace(/\r/g, "\n");
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      if (line.trim()) onLog?.(line);
+    }
+  });
+  stream.on("end", () => {
+    if (buffer.trim()) onLog?.(buffer);
+  });
+}
+
+async function extractWithSystemTar(archivePath: string, outputDir: string, onLog?: (message: string) => void): Promise<void> {
   await new Promise<void>((resolve, reject) => {
+    onLog?.(`执行解压命令：tar -xzf ${archivePath} -C ${outputDir}`);
     const child = spawn("tar", ["-xzf", archivePath, "-C", outputDir], {
       windowsHide: true,
-      stdio: ["ignore", "ignore", "inherit"],
+      stdio: ["ignore", "pipe", "pipe"],
     });
-    child.once("error", reject);
+    logProcessOutput(child.stdout, onLog);
+    logProcessOutput(child.stderr, onLog);
+    child.once("error", (error) => {
+      onLog?.(`解压命令启动失败：${error.message}`);
+      reject(error);
+    });
     child.once("exit", (code) => {
-      if (code === 0) resolve();
-      else reject(new Error(`tar exited with code ${code}`));
+      if (code === 0) {
+        onLog?.("解压命令执行完成");
+        resolve();
+        return;
+      }
+      const error = new Error(`tar exited with code ${code}`);
+      onLog?.(`解压命令执行失败：${error.message}`);
+      reject(error);
     });
   });
 }
@@ -69,14 +96,15 @@ async function extractWithBuiltInTar(archivePath: string, outputDir: string): Pr
   await pipeline(createReadStream(archivePath), createGunzip(), archive);
 }
 
-export async function extractTarGz(archivePath: string, outputDir: string): Promise<void> {
+export async function extractTarGz(archivePath: string, outputDir: string, onLog?: (message: string) => void): Promise<void> {
   await rm(outputDir, { recursive: true, force: true });
   await mkdir(outputDir, { recursive: true });
 
   try {
-    await extractWithSystemTar(archivePath, outputDir);
+    await extractWithSystemTar(archivePath, outputDir, onLog);
   } catch (error) {
     if (!(error instanceof Error) || !("code" in error) || error.code !== "ENOENT") throw error;
+    onLog?.("未找到系统 tar，改用内置解压器");
     await rm(outputDir, { recursive: true, force: true });
     await mkdir(outputDir, { recursive: true });
     await extractWithBuiltInTar(archivePath, outputDir);

--- a/desktop/src/main/windows.ts
+++ b/desktop/src/main/windows.ts
@@ -1,8 +1,7 @@
-import { app, BrowserWindow, screen, shell } from "electron";
-import { appendFileSync, mkdirSync } from "node:fs";
-import path from "node:path";
+import { BrowserWindow, screen, shell } from "electron";
 import { fileURLToPath } from "node:url";
 import { readWindowState, saveWindowStateSync, type WindowState } from "./window-state.js";
+import { appendLog } from "./logging.js";
 
 const preloadPath = fileURLToPath(new URL("../preload/preload.mjs", import.meta.url));
 
@@ -13,13 +12,7 @@ const MIN_HEIGHT = 640;
 const SAVE_DEBOUNCE_MS = 500;
 
 function writeWindowLog(message: string): void {
-  try {
-    const logDir = path.join(process.env.APPDATA ?? app.getPath("userData"), "openfic-desktop");
-    mkdirSync(logDir, { recursive: true });
-    appendFileSync(path.join(logDir, "startup.log"), `[${new Date().toISOString()}] ${message}\n`, "utf8");
-  } catch {
-    // Ignore diagnostics logging failures.
-  }
+  appendLog("startup", message);
 }
 
 function attachWindowDiagnostics(window: BrowserWindow, name: string): void {

--- a/desktop/src/preload/preload.mts
+++ b/desktop/src/preload/preload.mts
@@ -53,6 +53,7 @@ const desktopApi = {
   cancelUpdateDownload: (): Promise<void> => ipcRenderer.invoke(IpcChannels.cancelUpdateDownload),
   installUpdate: (): Promise<void> => ipcRenderer.invoke(IpcChannels.installUpdate),
   openUpdateRelease: (): Promise<void> => ipcRenderer.invoke(IpcChannels.openUpdateRelease),
+  exportLogs: (): Promise<string | null> => ipcRenderer.invoke(IpcChannels.exportLogs),
   onSetupProgress: (handler: (event: SetupProgressEvent) => void): (() => void) => {
     const listener = (_event: Electron.IpcRendererEvent, payload: SetupProgressEvent) => handler(payload);
     ipcRenderer.on(IpcChannels.setupProgress, listener);

--- a/desktop/src/shared/ipc.ts
+++ b/desktop/src/shared/ipc.ts
@@ -28,6 +28,7 @@ export const IpcChannels = {
   installUpdate: "update:install",
   openUpdateRelease: "update:open-release",
   updateState: "update:state",
+  exportLogs: "logs:export",
 } as const;
 
 export type SetupStep =

--- a/desktop/src/ui/components/header.tsx
+++ b/desktop/src/ui/components/header.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type CSSProperties, type MouseEvent } from "react";
-import { Link2, Link2Off, Minus, Plus, RefreshCw, Square, Star, Trash2, X } from "lucide-react";
+import { Bug, Link2, Link2Off, LoaderCircle, Minus, Plus, RefreshCw, Square, Star, Trash2, X } from "lucide-react";
 import type { DesktopConfig, DesktopInstance } from "../../shared/config";
 import type { UpdateState } from "../../shared/ipc";
 
@@ -55,6 +55,7 @@ export function DesktopHeader({
   const [panelVisible, setPanelVisible] = useState(false);
   const [pingStates, setPingStates] = useState<Record<string, PingState>>({});
   const [switchingId, setSwitchingId] = useState<string | null>(null);
+  const [isExportingLogs, setIsExportingLogs] = useState(false);
   const instances = sortInstances(config?.instances ?? []);
   const hasUsableRuntime = instances.some((instance) => pingStates[instance.id]?.status === "ok") || Boolean(activeInstanceId);
   const updateProgress = Math.min(Math.max(updateState.progress ?? 0, 0), 1);
@@ -165,10 +166,33 @@ export function DesktopHeader({
     }
   };
 
+  const handleExportLogs = async () => {
+    if (isExportingLogs) return;
+    setIsExportingLogs(true);
+    try {
+      await window.openficDesktop.exportLogs();
+    } catch {
+      // The main process presents an actionable error dialog.
+    } finally {
+      setIsExportingLogs(false);
+    }
+  };
+
   return (
     <header className="desktop-header">
       <div className="desktop-titlebar-brand">OpenFic</div>
       <div className="desktop-titlebar-actions">
+        <button
+          className="titlebar-button"
+          aria-label="导出调试日志"
+          aria-busy={isExportingLogs}
+          title="导出调试日志"
+          type="button"
+          disabled={isExportingLogs}
+          onClick={() => void handleExportLogs()}
+        >
+          {isExportingLogs ? <LoaderCircle className="titlebar-exporting" size={15} strokeWidth={2} /> : <Bug size={15} strokeWidth={2} />}
+        </button>
         <button
           className="titlebar-button titlebar-update-button"
           data-update-state={updateIconState}

--- a/desktop/src/ui/global.d.ts
+++ b/desktop/src/ui/global.d.ts
@@ -37,6 +37,7 @@ declare global {
       cancelUpdateDownload: () => Promise<void>;
       installUpdate: () => Promise<void>;
       openUpdateRelease: () => Promise<void>;
+      exportLogs: () => Promise<string | null>;
       onSetupProgress: (handler: (event: SetupProgressEvent) => void) => () => void;
       onStartupProgress: (handler: (event: StartupProgressEvent) => void) => () => void;
       onUpdateState: (handler: (state: UpdateState) => void) => () => void;

--- a/desktop/src/ui/styles.css
+++ b/desktop/src/ui/styles.css
@@ -537,6 +537,10 @@ body {
   animation: titlebar-update-spin 820ms linear infinite;
 }
 
+.titlebar-exporting {
+  animation: titlebar-update-spin 820ms linear infinite;
+}
+
 .titlebar-update-progress {
   width: 17px;
   height: 17px;
@@ -1011,6 +1015,10 @@ h1 {
   }
 
   .titlebar-update-checking {
+    animation: none;
+  }
+
+  .titlebar-exporting {
     animation: none;
   }
 }


### PR DESCRIPTION
## fix(desktop): 完善运行环境调试信息处理

## 变更说明

- 问题: 桌面端运行环境安装、更新与后端启动的日志分散且会被覆盖，OpenFic 安装命令的错误输出无法完整展示。
- 重要性: 安装或启动失败时，用户和维护者难以保留与定位错误信息。
- 变化: 统一将启动、运行环境与后端日志追加写入 `logs` 目录，按行记录时间戳、使用 UTF-8 BOM，并在文件超过 10 MiB 时轮转归档。
- 变化: 捕获 Python、uv、OpenFic 与 tar 子进程的标准输出和错误输出，同步更新安装进度并在失败提示中附带运行环境日志路径。
- 变化: 顶部栏新增调试日志导出按钮，可将全部当前及轮转日志压缩为 ZIP 文件。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

后端日志以覆盖模式打开；运行环境子进程输出只定向至标准流，且仅标准输出用于安装进度，导致错误输出未被完整记录或展示。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 验证命令：`pnpm type-check`、`pnpm lint`、`pnpm build`。
