### PR TITLE
feat(import): 支持 TXT 分卷导入

### DIFF
--- a/backend/app/api/routers/import_router.py
+++ b/backend/app/api/routers/import_router.py
@@ -15,6 +15,7 @@ from app.api.schemas.import_schema import (
     ImportConfirmResponse,
     ImportPreviewResponse,
     PreviewChapter,
+    PreviewVolume,
 )
 from app.core.txt_parser import parse_txt_content
 from app.storage.database import get_session
@@ -76,17 +77,24 @@ async def preview_txt_file(
     result = parse_txt_content(content)
 
     # 转换为预览响应
-    preview_chapters = [
-        PreviewChapter(
-            title=chapter.title,
-            word_count=chapter.word_count,
-            content_preview=chapter.content[:200] if chapter.content else "",
+    preview_volumes = [
+        PreviewVolume(
+            title=volume.title,
+            chapter_count=len(volume.chapters),
+            chapters=[
+                PreviewChapter(
+                    title=chapter.title,
+                    word_count=chapter.word_count,
+                    content_preview=chapter.content[:200] if chapter.content else "",
+                )
+                for chapter in volume.chapters
+            ],
         )
-        for chapter in result.chapters
+        for volume in result.volumes
     ]
 
     return ImportPreviewResponse(
-        chapters=preview_chapters,
+        volumes=preview_volumes,
         total_word_count=result.total_word_count,
         chapter_count=result.chapter_count,
         detected_encoding=result.detected_encoding,
@@ -159,7 +167,7 @@ async def confirm_import(
     # 解析文件
     parse_result = parse_txt_content(content)
 
-    if not parse_result.chapters:
+    if not parse_result.volumes:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="文件解析失败，未能识别任何章节",
@@ -172,7 +180,7 @@ async def confirm_import(
             title=title,
             description=description,
             cover_file=cover,
-            chapters=parse_result.chapters,
+            volumes=parse_result.volumes,
         )
     except ValueError as exc:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
@@ -237,11 +245,11 @@ async def confirm_import_stream(
 
             parse_result = parse_txt_content(content)
 
-            if not parse_result.chapters:
+            if not parse_result.volumes:
                 yield f"data: {json.dumps({'type': 'error', 'message': '文件解析失败，未能识别任何章节'})}\n\n"
                 return
 
-            total_chapters = len(parse_result.chapters)
+            total_chapters = parse_result.chapter_count
 
             # 进度：创建项目
             yield f"data: {json.dumps({'type': 'progress', 'stage': 'creating_project', 'progress': 25})}\n\n"
@@ -252,7 +260,7 @@ async def confirm_import_stream(
                 title=title_clean,
                 description=description,
                 cover_file=cover,
-                chapters=parse_result.chapters,
+                volumes=parse_result.volumes,
             )
 
             # 进度：保存章节（模拟进度，实际已在批量插入中完成）

--- a/backend/app/api/schemas/import_schema.py
+++ b/backend/app/api/schemas/import_schema.py
@@ -14,10 +14,18 @@ class PreviewChapter(BaseModel):
     content_preview: str = Field(description="内容预览（前 200 字）")
 
 
+class PreviewVolume(BaseModel):
+    """预览卷信息。"""
+
+    title: str = Field(description="卷标题")
+    chapter_count: int = Field(description="卷内章节数")
+    chapters: list[PreviewChapter] = Field(description="卷内章节列表")
+
+
 class ImportPreviewResponse(BaseModel):
     """导入预览响应。"""
 
-    chapters: list[PreviewChapter] = Field(description="章节列表")
+    volumes: list[PreviewVolume] = Field(description="卷列表")
     total_word_count: int = Field(description="总字数")
     chapter_count: int = Field(description="章节数")
     detected_encoding: str = Field(description="检测到的编码")

--- a/backend/app/core/txt_parser.py
+++ b/backend/app/core/txt_parser.py
@@ -25,10 +25,18 @@ class ParsedChapter:
 
 
 @dataclass
+class ParsedVolume:
+    """解析后的单个卷。"""
+
+    title: str
+    chapters: list[ParsedChapter] = field(default_factory=list)
+
+
+@dataclass
 class ParseResult:
     """TXT 解析结果。"""
 
-    chapters: list[ParsedChapter] = field(default_factory=list)
+    volumes: list[ParsedVolume] = field(default_factory=list)
     total_word_count: int = 0
     chapter_count: int = 0
     detected_encoding: str = "utf-8"
@@ -139,6 +147,12 @@ TOC_RULES: list[tuple[str, re.Pattern[str]]] = [
     ),
 ]
 
+VOLUME_TITLE_PATTERN = re.compile(
+    r"^[ \t　]{0,4}(?:第\s{0,4}[\d〇零一二两三四五六七八九十百千万壹贰叁肆伍陆柒捌玖拾佰仟]+?"
+    r"\s{0,4}卷|卷[\d〇零一二两三四五六七八九十百千万壹贰叁肆伍陆柒捌玖拾佰仟]{1,8}).{0,30}$",
+    re.MULTILINE,
+)
+
 
 def _detect_encoding(content: bytes) -> str:
     """
@@ -188,6 +202,25 @@ def _count_words(text: str) -> int:
     numbers = len(re.findall(r"\d+", text))
 
     return chinese_chars + english_words + numbers
+
+
+def _create_fallback_chapter(content: str) -> ParsedChapter | None:
+    """将未识别的文本按首行标题回退为单个章节。"""
+    content = content.strip()
+    if not content:
+        return None
+
+    lines = content.split("\n", 1)
+    title = lines[0].strip() if len(lines[0].strip()) <= 50 else "正文"
+    chapter_content = (
+        lines[1].strip() if title != "正文" and len(lines) > 1 else content
+    )
+
+    return ParsedChapter(
+        title=title or "正文",
+        content=re.sub(r"^[\n\s]+", "　　", chapter_content),
+        word_count=_count_words(chapter_content),
+    )
 
 
 # _text_to_html 函数已移除
@@ -266,9 +299,35 @@ def parse_txt_content(content: bytes) -> ParseResult:
     # 选择最佳目录规则
     toc_pattern = _select_best_toc_rule(text)
 
-    chapters: list[ParsedChapter] = []
+    volumes: list[ParsedVolume] = []
+    default_volume: ParsedVolume | None = None
 
-    if toc_pattern is None:
+    def get_default_volume() -> ParsedVolume:
+        nonlocal default_volume
+        if default_volume is None:
+            default_volume = ParsedVolume(title="第一卷")
+            volumes.append(default_volume)
+        return default_volume
+
+    toc_matches = list(toc_pattern.finditer(text)) if toc_pattern else []
+    volume_matches = list(VOLUME_TITLE_PATTERN.finditer(text))
+    toc_matches = [
+        match
+        for match in toc_matches
+        if not any(
+            match.start() < volume_match.end() and volume_match.start() < match.end()
+            for volume_match in volume_matches
+        )
+    ]
+    matches = sorted(
+        [
+            *[(match, False) for match in toc_matches],
+            *[(match, True) for match in volume_matches],
+        ],
+        key=lambda item: item[0].start(),
+    )
+
+    if not matches:
         # 没有识别到章节，整个内容作为一个章节
         content_stripped = text.strip()
         if content_stripped:
@@ -282,7 +341,7 @@ def parse_txt_content(content: bytes) -> ParseResult:
                 title = "正文"
                 chapter_content = content_stripped
 
-            chapters.append(
+            get_default_volume().chapters.append(
                 ParsedChapter(
                     title=title,
                     content=chapter_content,  # 直接使用换行符格式，不转换为 HTML
@@ -290,72 +349,70 @@ def parse_txt_content(content: bytes) -> ParseResult:
                 )
             )
     else:
-        # 使用正则切分章节
-        matches = list(toc_pattern.finditer(text))
+        # 处理第一个目录标题之前的内容（可能是序言/简介）
+        first_match_start = matches[0][0].start()
+        if first_match_start > 100:  # 前面内容超过 100 字符才作为序言
+            preface_content = text[:first_match_start].strip()
+            if preface_content:
+                word_count = _count_words(preface_content)
+                if word_count > 50:  # 序言至少 50 字
+                    get_default_volume().chapters.append(
+                        ParsedChapter(
+                            title="前言",
+                            content=preface_content,  # 直接使用换行符格式，不转换为 HTML
+                            word_count=word_count,
+                        )
+                    )
 
-        if not matches:
-            # 没有匹配，整个内容作为一个章节
-            content_stripped = text.strip()
-            if content_stripped:
-                word_count = _count_words(content_stripped)
-            chapters.append(
+        current_volume: ParsedVolume | None = None
+
+        # 处理每个目录标题
+        for i, (match, is_explicit_volume) in enumerate(matches):
+            title = match.group().strip()
+
+            # 获取标题内容（从标题结束到下一个目录标题开始）
+            content_start = match.end()
+            if i + 1 < len(matches):
+                content_end = matches[i + 1][0].start()
+            else:
+                content_end = len(text)
+
+            chapter_content = text[content_start:content_end].strip()
+
+            if is_explicit_volume or not chapter_content:
+                current_volume = ParsedVolume(title=title)
+                volumes.append(current_volume)
+                fallback_chapter = _create_fallback_chapter(chapter_content)
+                if fallback_chapter:
+                    current_volume.chapters.append(fallback_chapter)
+                continue
+
+            # 移除内容开头的标题重复
+            if chapter_content.startswith(title):
+                chapter_content = chapter_content[len(title) :].strip()
+
+            # 清理内容开头的空白和换行
+            chapter_content = re.sub(r"^[\n\s]+", "　　", chapter_content)
+
+            word_count = _count_words(chapter_content)
+
+            if current_volume is None:
+                current_volume = get_default_volume()
+
+            current_volume.chapters.append(
                 ParsedChapter(
-                    title="正文",
-                    content=content_stripped,  # 直接使用换行符格式，不转换为 HTML
+                    title=title,
+                    content=chapter_content,  # 直接使用换行符格式，不转换为 HTML
                     word_count=word_count,
                 )
             )
-        else:
-            # 处理第一个章节之前的内容（可能是序言/简介）
-            first_match_start = matches[0].start()
-            if first_match_start > 100:  # 前面内容超过 100 字符才作为序言
-                preface_content = text[:first_match_start].strip()
-                if preface_content:
-                    word_count = _count_words(preface_content)
-                    if word_count > 50:  # 序言至少 50 字
-                        chapters.append(
-                            ParsedChapter(
-                                title="前言",
-                                content=preface_content,  # 直接使用换行符格式，不转换为 HTML
-                                word_count=word_count,
-                            )
-                        )
-
-            # 处理每个章节
-            for i, match in enumerate(matches):
-                title = match.group().strip()
-
-                # 获取章节内容（从标题结束到下一个章节开始）
-                content_start = match.end()
-                if i + 1 < len(matches):
-                    content_end = matches[i + 1].start()
-                else:
-                    content_end = len(text)
-
-                chapter_content = text[content_start:content_end].strip()
-
-                # 移除内容开头的标题重复
-                if chapter_content.startswith(title):
-                    chapter_content = chapter_content[len(title) :].strip()
-
-                # 清理内容开头的空白和换行
-                chapter_content = re.sub(r"^[\n\s]+", "　　", chapter_content)
-
-                word_count = _count_words(chapter_content)
-
-                chapters.append(
-                    ParsedChapter(
-                        title=title,
-                        content=chapter_content,  # 直接使用换行符格式，不转换为 HTML
-                        word_count=word_count,
-                    )
-                )
 
     # 计算总字数
-    total_word_count = sum(c.word_count for c in chapters)
+    chapters = [chapter for volume in volumes for chapter in volume.chapters]
+    total_word_count = sum(chapter.word_count for chapter in chapters)
 
     return ParseResult(
-        chapters=chapters,
+        volumes=volumes,
         total_word_count=total_word_count,
         chapter_count=len(chapters),
         detected_encoding=encoding,

--- a/backend/app/storage/services/import_service.py
+++ b/backend/app/storage/services/import_service.py
@@ -10,13 +10,12 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.editor_content_limits import validate_editor_content
 from app.core.storage import save_cover_file
-from app.core.txt_parser import ParsedChapter
+from app.core.txt_parser import ParsedVolume
 from app.storage.models.chapter import Chapter
 from app.storage.models.project import Project
 from app.storage.models.volume import Volume
 from app.storage.repos import project_repo
 from app.storage.services import writing_activity_service
-from app.storage.services.volume_service import DEFAULT_VOLUME_TITLE
 
 
 @dataclass
@@ -34,7 +33,7 @@ async def confirm_import(
     title: str,
     description: str | None,
     cover_file: UploadFile | None,
-    chapters: list[ParsedChapter],
+    volumes: list[ParsedVolume],
 ) -> ImportResult:
     """
     确认导入，创建项目和所有章节。
@@ -44,16 +43,18 @@ async def confirm_import(
         title: 书名。
         description: 简介，可选。
         cover_file: 封面文件，可选。
-        chapters: 解析后的章节列表。
+        volumes: 解析后的卷列表。
 
     Returns:
         导入结果。
     """
-    for chapter in chapters:
-        validate_editor_content(chapter.content)
+    for parsed_volume in volumes:
+        for chapter in parsed_volume.chapters:
+            validate_editor_content(chapter.content)
 
     # 计算总字数
-    total_word_count = sum(c.word_count for c in chapters)
+    chapters = [chapter for volume in volumes for chapter in volume.chapters]
+    total_word_count = sum(chapter.word_count for chapter in chapters)
 
     # 创建项目
     project = Project(
@@ -64,14 +65,17 @@ async def confirm_import(
     )
     project = await project_repo.create(session, project)
 
-    volume = Volume(
-        project_id=project.id,
-        title=DEFAULT_VOLUME_TITLE,
-        description=None,
-        order=1,
-        chapter_count=len(chapters),
-    )
-    session.add(volume)
+    volume_objects = [
+        Volume(
+            project_id=project.id,
+            title=parsed_volume.title,
+            description=None,
+            order=order,
+            chapter_count=len(parsed_volume.chapters),
+        )
+        for order, parsed_volume in enumerate(volumes, start=1)
+    ]
+    session.add_all(volume_objects)
     await session.flush()
 
     # 如果提供了封面文件，保存封面
@@ -88,9 +92,10 @@ async def confirm_import(
             title=parsed_chapter.title,
             content=parsed_chapter.content,
             word_count=parsed_chapter.word_count,
-            order=order,
+            order=chapter_order,
         )
-        for order, parsed_chapter in enumerate(chapters, start=1)
+        for volume, parsed_volume in zip(volume_objects, volumes, strict=True)
+        for chapter_order, parsed_chapter in enumerate(parsed_volume.chapters, start=1)
     ]
 
     # 批量插入所有章节

--- a/backend/tests/api/test_import.py
+++ b/backend/tests/api/test_import.py
@@ -22,7 +22,8 @@ async def test_preview_txt_simple(client: AsyncClient) -> None:
     assert data["chapter_count"] >= 1
     assert data["total_word_count"] > 0
     assert data["detected_encoding"] == "utf-8"
-    assert len(data["chapters"]) >= 1
+    assert len(data["volumes"]) == 1
+    assert len(data["volumes"][0]["chapters"]) >= 1
 
 
 @pytest.mark.asyncio
@@ -53,7 +54,9 @@ async def test_preview_txt_with_chapters(client: AsyncClient) -> None:
     assert data["chapter_count"] >= 2  # 至少解析出 2 个章节
     assert data["total_word_count"] > 0
     # 验证章节标题包含关键字
-    titles = [ch["title"] for ch in data["chapters"]]
+    titles = [
+        chapter["title"] for volume in data["volumes"] for chapter in volume["chapters"]
+    ]
     assert any("第一章" in t for t in titles)
     assert any("第二章" in t for t in titles)
 
@@ -158,6 +161,105 @@ async def test_confirm_import(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_import_txt_with_volume_titles(client: AsyncClient) -> None:
+    """卷标题与下一目录标题之间没有正文时，应按卷导入章节。"""
+    first_chapter = "第一卷的第一章正文。" * 60
+    second_chapter = "第一卷的第二章正文。" * 60
+    third_chapter = "第二卷的第一章正文。" * 60
+    content = f"""第一卷 初入江湖
+第一章 出山
+
+{first_chapter}
+
+第二章 相逢
+
+{second_chapter}
+
+第二卷 风云再起
+第一章 入城
+
+{third_chapter}
+"""
+    files = {"file": ("volumes.txt", content.encode("utf-8"), "text/plain")}
+
+    preview_response = await client.post("/api/v1/import/preview", files=files)
+
+    assert preview_response.status_code == 200
+    preview = preview_response.json()
+    assert [volume["title"] for volume in preview["volumes"]] == [
+        "第一卷 初入江湖",
+        "第二卷 风云再起",
+    ]
+    assert [chapter["title"] for chapter in preview["volumes"][0]["chapters"]] == [
+        "第一章 出山",
+        "第二章 相逢",
+    ]
+    assert [chapter["title"] for chapter in preview["volumes"][1]["chapters"]] == [
+        "第一章 入城",
+    ]
+    assert preview["chapter_count"] == 3
+
+    import_response = await client.post(
+        "/api/v1/import/confirm",
+        files=files,
+        data={"title": "分卷测试小说"},
+    )
+
+    assert import_response.status_code == 201
+    project_id = import_response.json()["project_id"]
+    tree_response = await client.get(f"/api/v1/projects/{project_id}/chapters")
+
+    assert tree_response.status_code == 200
+    volumes = tree_response.json()["volumes"]
+    assert [volume["title"] for volume in volumes] == [
+        "第一卷 初入江湖",
+        "第二卷 风云再起",
+    ]
+    assert [volume["chapter_count"] for volume in volumes] == [2, 1]
+    assert [chapter["order"] for chapter in volumes[0]["chapters"]] == [1, 2]
+    assert [chapter["order"] for chapter in volumes[1]["chapters"]] == [1]
+
+
+@pytest.mark.asyncio
+async def test_preview_creates_explicit_volume_when_following_chapter_is_unrecognized(
+    client: AsyncClient,
+) -> None:
+    """显式卷标题后的未识别章节也应归入新卷。"""
+    first_chapter = "第一章正文。" * 200
+    second_chapter = "未命名章节正文。" * 200
+    content = f"""第一卷 第一卷
+前言
+作品简介
+
+第一章 灵眸少年（一）
+
+{first_chapter}
+
+第二卷 未命名卷
+未命名章节
+
+{second_chapter}
+"""
+    files = {"file": ("explicit-volumes.txt", content.encode("utf-8"), "text/plain")}
+
+    response = await client.post("/api/v1/import/preview", files=files)
+
+    assert response.status_code == 200
+    preview = response.json()
+    assert [volume["title"] for volume in preview["volumes"]] == [
+        "第一卷 第一卷",
+        "第二卷 未命名卷",
+    ]
+    assert [chapter["title"] for chapter in preview["volumes"][0]["chapters"]] == [
+        "前言",
+        "第一章 灵眸少年（一）",
+    ]
+    assert [chapter["title"] for chapter in preview["volumes"][1]["chapters"]] == [
+        "未命名章节",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_confirm_import_empty_title(client: AsyncClient) -> None:
     """测试导入时标题为空。"""
     content = "简单内容"
@@ -249,5 +351,5 @@ async def test_preview_gb18030_preserves_original_text(client: AsyncClient) -> N
     data = response.json()
 
     assert data["detected_encoding"].lower() == "gb18030"
-    assert data["chapters"][0]["title"] == "第一章 扩展字符测试"
-    assert data["chapters"][0]["content_preview"] == "这里有扩展字：𠮷。"
+    assert data["volumes"][0]["chapters"][0]["title"] == "第一章 扩展字符测试"
+    assert data["volumes"][0]["chapters"][0]["content_preview"] == "这里有扩展字：𠮷。"

--- a/frontend/src/features/projects/components/import-dialog.css
+++ b/frontend/src/features/projects/components/import-dialog.css
@@ -26,10 +26,92 @@
   display: block;
 }
 
-.import-dialog-preview-scroll {
-  height: 240px;
+.import-dialog-preview-panel {
+  height: clamp(260px, 42vh, 336px);
   border: 1px solid var(--gray-5);
   border-radius: var(--radius-2);
+  overflow: hidden;
+}
+
+.import-dialog-volume-list {
+  height: 100%;
+}
+
+.import-dialog-volume-group + .import-dialog-volume-group {
+  border-top: 1px solid var(--gray-4);
+}
+
+.import-dialog-volume-header {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr) auto;
+  align-items: center;
+  column-gap: 8px;
+  width: 100%;
+  padding: 10px 12px;
+  border: 0;
+  background: var(--color-panel);
+  color: var(--gray-12);
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  transition: background-color 0.15s;
+}
+
+.import-dialog-volume-header:hover {
+  background: var(--gray-3);
+}
+
+.import-dialog-volume-header:focus-visible {
+  outline: 2px solid var(--accent-8);
+  outline-offset: -2px;
+}
+
+.import-dialog-volume-group[data-expanded="true"] .import-dialog-volume-header {
+  background: var(--gray-2);
+}
+
+.import-dialog-volume-chevron {
+  color: var(--gray-9);
+  transition: transform 0.15s;
+}
+
+.import-dialog-volume-chevron[data-expanded="false"] {
+  transform: rotate(-90deg);
+}
+
+.import-dialog-volume-index {
+  color: var(--gray-9);
+  font-size: var(--font-size-1);
+  font-variant-numeric: tabular-nums;
+}
+
+.import-dialog-volume-title,
+.import-dialog-volume-meta,
+.import-dialog-preview-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.import-dialog-volume-title {
+  font-size: var(--font-size-2);
+  font-weight: var(--font-weight-medium);
+}
+
+.import-dialog-volume-meta {
+  color: var(--gray-10);
+  font-size: var(--font-size-1);
+  white-space: nowrap;
+}
+
+.import-dialog-volume-chapters {
+  border-top: 1px solid var(--gray-4);
+  background: var(--gray-1);
+}
+
+.import-dialog-chapter-index {
+  flex: 0 0 2ch;
+  font-variant-numeric: tabular-nums;
 }
 
 .import-dialog-preview-row--bordered {

--- a/frontend/src/features/projects/components/import-dialog.tsx
+++ b/frontend/src/features/projects/components/import-dialog.tsx
@@ -13,14 +13,22 @@ import {
   Box,
   TextField,
   TextArea,
-  ScrollArea,
   Badge,
   Progress,
   Card,
 } from "@radix-ui/themes";
-import { Upload, FileText, ChevronLeft, ChevronRight, Check, AlertCircle } from "lucide-react";
-import { useState, useCallback, useRef } from "react";
+import {
+  Upload,
+  FileText,
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  Check,
+  AlertCircle,
+} from "lucide-react";
+import { useState, useCallback, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import { GroupedVirtuoso } from "react-virtuoso";
 
 import { Spinner } from "@/components";
 
@@ -50,6 +58,7 @@ export function ImportDialog({ open, onOpenChange, onSuccess }: ImportDialogProp
   // 文件和解析结果
   const [file, setFile] = useState<File | null>(null);
   const [previewData, setPreviewData] = useState<ImportPreviewResponse | null>(null);
+  const [expandedVolumeIndexes, setExpandedVolumeIndexes] = useState<number[]>([0]);
 
   // 项目信息
   const [title, setTitle] = useState("");
@@ -77,6 +86,7 @@ export function ImportDialog({ open, onOpenChange, onSuccess }: ImportDialogProp
     setError(null);
     setFile(null);
     setPreviewData(null);
+    setExpandedVolumeIndexes([0]);
     setTitle("");
     setDescription("");
     setCover(null);
@@ -115,6 +125,7 @@ export function ImportDialog({ open, onOpenChange, onSuccess }: ImportDialogProp
       try {
         const result = await previewTxtFile(selectedFile);
         setPreviewData(result);
+        setExpandedVolumeIndexes([0]);
         setTitle(selectedFile.name.replace(/\.txt$/i, ""));
         setStep("preview");
       } catch (err) {
@@ -190,6 +201,31 @@ export function ImportDialog({ open, onOpenChange, onSuccess }: ImportDialogProp
       maximumFractionDigits: count >= 10000 ? 1 : 0,
     }).format(count);
   };
+
+  const handleToggleVolume = (volumeIndex: number) => {
+    setExpandedVolumeIndexes((currentIndexes) =>
+      currentIndexes.includes(volumeIndex)
+        ? currentIndexes.filter((index) => index !== volumeIndex)
+        : [...currentIndexes, volumeIndex],
+    );
+  };
+
+  const previewGroupCounts = useMemo(
+    () =>
+      previewData?.volumes.map((volume, volumeIndex) =>
+        expandedVolumeIndexes.includes(volumeIndex) ? volume.chapters.length : 0,
+      ) ?? [],
+    [expandedVolumeIndexes, previewData?.volumes],
+  );
+  const previewChapters = useMemo(
+    () =>
+      previewData?.volumes.flatMap((volume, volumeIndex) =>
+        expandedVolumeIndexes.includes(volumeIndex)
+          ? volume.chapters.map((chapter, chapterIndex) => ({ chapter, chapterIndex, volumeIndex }))
+          : [],
+      ) ?? [],
+    [expandedVolumeIndexes, previewData?.volumes],
+  );
 
   const getImportStageText = () => {
     switch (importStage) {
@@ -334,7 +370,7 @@ export function ImportDialog({ open, onOpenChange, onSuccess }: ImportDialogProp
                   </Card>
                 </Flex>
 
-                {/* 章节预览列表 */}
+                {/* 分卷章节预览 */}
                 <Text
                   size="2"
                   weight="medium"
@@ -343,42 +379,107 @@ export function ImportDialog({ open, onOpenChange, onSuccess }: ImportDialogProp
                 >
                   {t("import.chapterPreview")}
                 </Text>
-                <ScrollArea className="import-dialog-preview-scroll">
-                  <Box p="2">
-                    {previewData.chapters.map((chapter, index) => (
-                      <Flex
-                        key={index}
-                        align="center"
-                        gap="2"
-                        py="2"
-                        px="2"
-                        className={
-                          index < previewData.chapters.length - 1
-                            ? "import-dialog-preview-row--bordered"
-                            : undefined
-                        }
-                      >
-                        <FileText
-                          size={16}
-                          color="var(--gray-9)"
-                        />
-                        <Text
-                          size="2"
-                          className="import-dialog-preview-title"
-                          truncate
+                <Box className="import-dialog-preview-panel">
+                  <GroupedVirtuoso
+                    className="import-dialog-volume-list"
+                    groupCounts={previewGroupCounts}
+                    overscan={6}
+                    groupContent={(volumeIndex) => {
+                      const volume = previewData.volumes[volumeIndex];
+                      if (!volume) return null;
+
+                      const wordCount = volume.chapters.reduce(
+                        (total, chapter) => total + chapter.word_count,
+                        0,
+                      );
+                      const isExpanded = expandedVolumeIndexes.includes(volumeIndex);
+
+                      return (
+                        <Box
+                          className="import-dialog-volume-group"
+                          data-expanded={isExpanded ? "true" : "false"}
                         >
-                          {chapter.title}
-                        </Text>
-                        <Badge
-                          size="1"
-                          color="gray"
+                          <button
+                            type="button"
+                            className="import-dialog-volume-header"
+                            aria-expanded={isExpanded}
+                            aria-controls={`import-volume-${volumeIndex}`}
+                            onClick={() => handleToggleVolume(volumeIndex)}
+                          >
+                            <ChevronDown
+                              size={16}
+                              className="import-dialog-volume-chevron"
+                              data-expanded={isExpanded ? "true" : "false"}
+                            />
+                            <span className="import-dialog-volume-index">{volumeIndex + 1}</span>
+                            <span
+                              className="import-dialog-volume-title"
+                              title={volume.title}
+                            >
+                              {volume.title}
+                            </span>
+                            <span className="import-dialog-volume-meta">
+                              {volume.chapter_count} {t("projects.chapters")} ·{" "}
+                              {formatWordCount(wordCount)} {t("projects.words")}
+                            </span>
+                          </button>
+                        </Box>
+                      );
+                    }}
+                    itemContent={(chapterListIndex) => {
+                      const previewChapter = previewChapters[chapterListIndex];
+                      if (!previewChapter) return null;
+
+                      const { chapter, chapterIndex, volumeIndex } = previewChapter;
+                      const volume = previewData.volumes[volumeIndex];
+                      if (!volume) return null;
+
+                      return (
+                        <Box
+                          px="3"
+                          className="import-dialog-volume-chapters"
                         >
-                          {chapter.word_count} {t("projects.words")}
-                        </Badge>
-                      </Flex>
-                    ))}
-                  </Box>
-                </ScrollArea>
+                          <Flex
+                            align="center"
+                            gap="2"
+                            py="2"
+                            className={
+                              chapterIndex < volume.chapters.length - 1
+                                ? "import-dialog-preview-row--bordered"
+                                : undefined
+                            }
+                          >
+                            <Text
+                              size="1"
+                              color="gray"
+                              className="import-dialog-chapter-index"
+                            >
+                              {chapterIndex + 1}
+                            </Text>
+                            <FileText
+                              size={15}
+                              color="var(--gray-9)"
+                            />
+                            <Text
+                              size="2"
+                              className="import-dialog-preview-title"
+                              truncate
+                              title={chapter.title}
+                            >
+                              {chapter.title}
+                            </Text>
+                            <Badge
+                              size="1"
+                              color="gray"
+                            >
+                              {formatWordCount(chapter.word_count)} {t("projects.words")}
+                            </Badge>
+                          </Flex>
+                        </Box>
+                      );
+                    }}
+                  />
+                </Box>
 
                 {previewData.chapter_count === 1 && (
                   <Flex

--- a/frontend/src/features/projects/lib/import-api.ts
+++ b/frontend/src/features/projects/lib/import-api.ts
@@ -12,9 +12,16 @@ export interface PreviewChapter {
   content_preview: string;
 }
 
+/** 预览卷信息 */
+export interface PreviewVolume {
+  title: string;
+  chapter_count: number;
+  chapters: PreviewChapter[];
+}
+
 /** 导入预览响应 */
 export interface ImportPreviewResponse {
-  chapters: PreviewChapter[];
+  volumes: PreviewVolume[];
   total_word_count: number;
   chapter_count: number;
   detected_encoding: string;


### PR DESCRIPTION
## PR 标题

feat(import): 支持 TXT 分卷导入

## 变更说明

- 问题: TXT 导入会将所有章节写入默认卷，明确卷标题在后续章节无法识别时也会被误当作章节。
- 重要性: 长篇小说的卷结构丢失，且大量章节预览会造成较高的渲染开销。
- 变化: 解析器识别显式卷标题并保留未识别章节文本，导入时按卷创建与排序章节。
- 变化: 导入预览按可收起卷组展示章节，并使用虚拟列表限制大量章节的 DOM 渲染。

## 关联 Issue / PR (如有)

无

## 变更类型

- [x] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

无

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 验证命令: `uv run pytest tests/api/test_import.py`、`uv run ruff check ...`、`pnpm type-check`、`pnpm lint`、`pnpm format:check`。
