### PR TITLE
fix(desktop): 优化运行时连接流程

### DIFF
--- a/desktop/src/main/health.ts
+++ b/desktop/src/main/health.ts
@@ -11,6 +11,14 @@ export interface BackendHealth {
 interface WaitForBackendOptions {
   process?: ChildProcess;
   timeoutMs?: number;
+  signal?: AbortSignal;
+}
+
+export function throwIfAborted(signal?: AbortSignal): void {
+  if (!signal?.aborted) return;
+  const error = new Error("连接已取消");
+  error.name = "AbortError";
+  throw error;
 }
 
 export function parseBackendHealth(value: unknown): BackendHealth | null {
@@ -41,6 +49,7 @@ export async function waitForBackend(
 ): Promise<BackendHealth> {
   const timeoutMs = typeof options === "number" ? options : (options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
   const backendProcess = typeof options === "number" ? undefined : options.process;
+  const externalSignal = typeof options === "number" ? undefined : options.signal;
   const healthUrl = `${baseUrl.replace(/\/+$/, "")}/api/v1/health`;
   const controller = new AbortController();
   let processError: Error | null = null;
@@ -58,6 +67,9 @@ export async function waitForBackend(
     throw createBackendExitError(healthUrl, backendProcess.exitCode, backendProcess.signalCode);
   }
 
+  const abortWait = () => controller.abort();
+  throwIfAborted(externalSignal);
+  externalSignal?.addEventListener("abort", abortWait, { once: true });
   backendProcess?.once("exit", onExit);
   backendProcess?.once("error", onError);
   const timeout = setTimeout(() => controller.abort(), timeoutMs);
@@ -91,10 +103,12 @@ export async function waitForBackend(
       });
     }
 
+    throwIfAborted(externalSignal);
     if (processError) throw processError;
     throw new Error(`backend health check timeout: ${healthUrl}`);
   } finally {
     clearTimeout(timeout);
+    externalSignal?.removeEventListener("abort", abortWait);
     backendProcess?.off("exit", onExit);
     backendProcess?.off("error", onError);
   }

--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -2,7 +2,6 @@ import { app, dialog, ipcMain, type BrowserWindow } from "electron";
 import path from "node:path";
 import {
   IpcChannels,
-  type CheckRemoteRequest,
   type EnsureInstanceSessionRequest,
   type InitializeAppResult,
   type InspectLocalRuntimeRequest,
@@ -15,7 +14,6 @@ import {
   type SwitchInstanceRequest,
 } from "../shared/ipc.js";
 import { readDesktopConfig, writeDesktopConfig } from "./config.js";
-import { waitForBackend } from "./health.js";
 import { ensureAppProtocolForPartition } from "./protocol.js";
 import { findLocalInstanceByInstallDir, normalizeInstallDir } from "./local-instance.js";
 import { inspectLocalRuntime, installLocalRuntime, startLocalBackendFromInstall } from "./runtime/setup-runner.js";
@@ -30,7 +28,10 @@ export interface IpcContext {
   shellWindow: () => BrowserWindow | null;
   setBackend: (handle: BackendProcessHandle) => void;
   setBackendBaseUrl: (url: string) => void;
+  beginStartupOperation: () => AbortController;
+  finishStartupOperation: (controller: AbortController) => void;
   initializeApp: () => Promise<InitializeAppResult>;
+  cancelStartup: () => void;
   switchInstance: (instanceId: string) => Promise<InitializeAppResult>;
   pingInstance: (instance: DesktopInstance) => Promise<number>;
   onConfigSaved: (config: DesktopConfig) => void;
@@ -49,6 +50,7 @@ export function registerIpc(context: IpcContext): void {
   });
 
   ipcMain.handle(IpcChannels.initializeApp, () => context.initializeApp());
+  ipcMain.handle(IpcChannels.cancelStartup, () => context.cancelStartup());
   ipcMain.handle(IpcChannels.getStartupProgress, () => getStartupProgress());
   ipcMain.handle(IpcChannels.getUpdateState, () => getUpdateState());
   ipcMain.handle(IpcChannels.checkForUpdate, () => checkForUpdates());
@@ -89,31 +91,6 @@ export function registerIpc(context: IpcContext): void {
   });
 
   ipcMain.handle(IpcChannels.getDefaultInstallDir, () => getDefaultInstallDir());
-
-  ipcMain.handle(IpcChannels.checkRemote, async (_event, request: CheckRemoteRequest) => {
-    const startupProgress = createStartupProgressTracker((progress) => {
-      _event.sender.send(IpcChannels.startupProgress, progress);
-    });
-    startupProgress.begin({
-      step: "connect-remote",
-      title: "连接 OpenFic 服务",
-      message: `正在连接 ${request.url}`,
-      progress: 0.3,
-    });
-    try {
-      await waitForBackend(request.url, 10_000);
-      startupProgress.begin({
-        step: "verify-remote",
-        title: "验证服务状态",
-        message: "远程服务已响应",
-        progress: 0.7,
-      });
-      startupProgress.complete();
-    } catch (error) {
-      startupProgress.fail(error);
-      throw error;
-    }
-  });
 
   ipcMain.handle(IpcChannels.switchInstance, (_event, request: SwitchInstanceRequest) =>
     context.switchInstance(request.instanceId),
@@ -156,11 +133,12 @@ export function registerIpc(context: IpcContext): void {
   ipcMain.handle(IpcChannels.startLocalBackend, async (_event, request: StartLocalBackendRequest) => {
     const window = context.shellWindow();
     if (!window) throw new Error("shell window is not available");
+    const controller = context.beginStartupOperation();
     const startupProgress = createStartupProgressTracker((progress) => {
       window.webContents.send(IpcChannels.startupProgress, progress);
     });
     try {
-      const backend = await startLocalBackendFromInstall(request.installDir, startupProgress);
+      const backend = await startLocalBackendFromInstall(request.installDir, startupProgress, controller.signal);
       context.setBackend(backend);
       context.setBackendBaseUrl(backend.baseUrl);
       const previousConfig = await readDesktopConfig();
@@ -196,13 +174,14 @@ export function registerIpc(context: IpcContext): void {
       });
       startupProgress.complete();
     } catch (error) {
-      startupProgress.fail(error);
+      if (controller.signal.aborted) startupProgress.complete("已取消连接");
+      else startupProgress.fail(error);
       throw error;
+    } finally {
+      context.finishStartupOperation(controller);
     }
   });
 
-  ipcMain.handle(IpcChannels.closeSetup, async () => undefined);
-  ipcMain.handle(IpcChannels.showSetup, async () => undefined);
   ipcMain.handle(IpcChannels.minimizeWindow, async () => {
     context.shellWindow()?.minimize();
   });

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -3,7 +3,7 @@ import { registerAppScheme, handleAppProtocol, setRuntimeConfig } from "./protoc
 import { createMainWindow } from "./windows.js";
 import { readDesktopConfig, writeDesktopConfig } from "./config.js";
 import { registerIpc } from "./ipc.js";
-import { waitForBackend } from "./health.js";
+import { throwIfAborted, waitForBackend } from "./health.js";
 import { ensurePortablePython, resolveRuntimeDir } from "./runtime/python.js";
 import { ensureOpenFicRuntime, startLocalOpenFicBackend } from "./runtime/openfic.js";
 import { stopBackendProcess, type BackendProcessHandle } from "./process.js";
@@ -23,6 +23,7 @@ let mainWindow: BrowserWindow | null = null;
 let backendHandle: BackendProcessHandle | null = null;
 let activeInstanceId: string | null = null;
 let isQuitting = false;
+let startupAbortController: AbortController | null = null;
 
 writeStartupLog("process start");
 registerAppScheme();
@@ -78,7 +79,27 @@ function createStartupProgress(): StartupProgressTracker {
   });
 }
 
-async function startLocalBackend(installDir: string | null, startupProgress: StartupProgressTracker): Promise<void> {
+function beginStartupOperation(): AbortController {
+  startupAbortController?.abort();
+  const controller = new AbortController();
+  startupAbortController = controller;
+  return controller;
+}
+
+function finishStartupOperation(controller: AbortController): void {
+  if (startupAbortController === controller) startupAbortController = null;
+}
+
+function cancelStartup(): void {
+  startupAbortController?.abort();
+}
+
+async function startLocalBackend(
+  installDir: string | null,
+  startupProgress: StartupProgressTracker,
+  signal: AbortSignal,
+): Promise<void> {
+  throwIfAborted(signal);
   const runtimeDir = resolveRuntimeDir(installDir);
   startupProgress.begin({
     step: "check-runtime",
@@ -108,6 +129,7 @@ async function startLocalBackend(installDir: string | null, startupProgress: Sta
       });
     },
   );
+  throwIfAborted(signal);
   if (!pythonWasUpdated) {
     startupProgress.update({
       step: "check-runtime",
@@ -127,6 +149,7 @@ async function startLocalBackend(installDir: string | null, startupProgress: Sta
       progress: step === "install-openfic" ? 0.45 : 0.38,
     });
   });
+  throwIfAborted(signal);
   if (!runtimeWasUpdated) {
     startupProgress.update({
       step: "check-runtime",
@@ -136,7 +159,7 @@ async function startLocalBackend(installDir: string | null, startupProgress: Sta
     });
   }
 
-  const backend = await startLocalOpenFicBackend(runtime.venvPythonPath, app.getVersion(), startupProgress);
+  const backend = await startLocalOpenFicBackend(runtime.venvPythonPath, app.getVersion(), startupProgress, signal);
   setBackend(backend);
   setBackendBaseUrl(backend.baseUrl);
 }
@@ -149,7 +172,9 @@ async function activateInstance(
   config: DesktopConfig,
   instance: DesktopInstance,
   startupProgress: StartupProgressTracker,
+  signal: AbortSignal,
 ): Promise<string | null> {
+  throwIfAborted(signal);
   activeInstanceId = instance.id;
   if (instance.mode === "remote") {
     if (!instance.remoteUrl) throw new Error("远程实例缺少后端地址");
@@ -159,7 +184,8 @@ async function activateInstance(
       message: `正在连接 ${instance.remoteUrl}`,
       progress: 0.3,
     });
-    const health = await waitForBackend(instance.remoteUrl, 10_000);
+    const health = await waitForBackend(instance.remoteUrl, { timeoutMs: 10_000, signal });
+    throwIfAborted(signal);
     startupProgress.begin({
       step: "verify-remote",
       title: "验证服务状态",
@@ -167,6 +193,7 @@ async function activateInstance(
       progress: 0.7,
     });
     clearBackend();
+    throwIfAborted(signal);
     setBackendBaseUrl(instance.remoteUrl);
     startupProgress.begin({
       step: "check-compatibility",
@@ -179,7 +206,7 @@ async function activateInstance(
   }
 
   try {
-    await startLocalBackend(instance.installDir, startupProgress);
+    await startLocalBackend(instance.installDir, startupProgress, signal);
   } catch (error) {
     appendLog("runtime", `本地运行环境更新或启动失败：${error instanceof Error ? error.message : String(error)}`);
     throw error;
@@ -188,6 +215,7 @@ async function activateInstance(
 }
 
 async function switchInstance(instanceId: string): Promise<InitializeAppResult> {
+  const controller = beginStartupOperation();
   const startupProgress = createStartupProgress();
   startupProgress.begin({
     step: "load-config",
@@ -206,8 +234,10 @@ async function switchInstance(instanceId: string): Promise<InitializeAppResult> 
       message: `正在切换到 ${instance.name}`,
       progress: 0.1,
     });
-    const compatibilityWarning = await activateInstance(config, instance, startupProgress);
+    const compatibilityWarning = await activateInstance(config, instance, startupProgress, controller.signal);
+    throwIfAborted(controller.signal);
     await writeDesktopConfig({ ...config, activeInstanceId: instance.id });
+    throwIfAborted(controller.signal);
     startupProgress.begin({
       step: "ready",
       title: "服务已就绪",
@@ -217,8 +247,11 @@ async function switchInstance(instanceId: string): Promise<InitializeAppResult> 
     startupProgress.complete();
     return { status: "ready", activeInstanceId: instance.id, compatibilityWarning: compatibilityWarning ?? undefined };
   } catch (error) {
-    startupProgress.fail(error);
+    if (controller.signal.aborted) startupProgress.complete("已取消连接");
+    else startupProgress.fail(error);
     throw error;
+  } finally {
+    finishStartupOperation(controller);
   }
 }
 
@@ -240,6 +273,7 @@ function installMenu(): void {
 }
 
 async function initializeApp(): Promise<InitializeAppResult> {
+  const controller = beginStartupOperation();
   const startupProgress = createStartupProgress();
   startupProgress.begin({
     step: "load-config",
@@ -259,7 +293,8 @@ async function initializeApp(): Promise<InitializeAppResult> {
       startupProgress.complete("尚未找到活动实例");
       return { status: "needs-setup" };
     }
-    const compatibilityWarning = await activateInstance(config, instance, startupProgress);
+    const compatibilityWarning = await activateInstance(config, instance, startupProgress, controller.signal);
+    throwIfAborted(controller.signal);
     if (config.activeInstanceId !== instance.id) {
       await writeDesktopConfig({ ...config, activeInstanceId: instance.id });
     }
@@ -272,6 +307,10 @@ async function initializeApp(): Promise<InitializeAppResult> {
     startupProgress.complete();
     return { status: "ready", activeInstanceId: instance.id, compatibilityWarning: compatibilityWarning ?? undefined };
   } catch (err) {
+    if (controller.signal.aborted) {
+      startupProgress.complete("已取消连接");
+      return { status: "needs-setup" };
+    }
     writeStartupLog(`backend failed: ${err instanceof Error ? err.message : String(err)}`);
     startupProgress.fail(err);
     return {
@@ -279,6 +318,8 @@ async function initializeApp(): Promise<InitializeAppResult> {
       activeInstanceId: null,
       message: err instanceof Error ? err.message : String(err),
     };
+  } finally {
+    finishStartupOperation(controller);
   }
 }
 
@@ -294,7 +335,10 @@ async function bootstrap(): Promise<void> {
     shellWindow: () => mainWindow,
     setBackend,
     setBackendBaseUrl,
+    beginStartupOperation,
+    finishStartupOperation,
     initializeApp,
+    cancelStartup,
     switchInstance,
     pingInstance,
     onConfigSaved,

--- a/desktop/src/main/runtime/openfic.ts
+++ b/desktop/src/main/runtime/openfic.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { findFreePort } from "../ports.js";
 import { startBackendProcess, stopBackendProcess, type BackendProcessHandle } from "../process.js";
 import { configureDefaultSystemProxy, getSystemProxyEnvironment } from "../proxy.js";
-import { waitForBackend } from "../health.js";
+import { throwIfAborted, waitForBackend } from "../health.js";
 import type { PortablePython, RuntimeIntegrityCheck } from "./python.js";
 import {
   createOpenFicInstallCommand,
@@ -353,24 +353,45 @@ export async function ensureOpenFicRuntime(
 
 const STARTUP_LOG_MILESTONES = [
   {
+    text: "Loaded ENCRYPTION_KEY from .key file",
+    step: "start-backend",
+    title: "启动 OpenFic 服务",
+    message: "正在启动服务器进程...",
+    progress: 0.64,
+  },
+  {
     text: "Starting OpenFic",
     step: "initialize-backend",
-    title: "初始化应用服务",
-    message: "正在加载 OpenFic 服务",
+    title: "启动 OpenFic 服务",
+    message: "正在启动 OpenFic 服务...",
     progress: 0.7,
+  },
+  {
+    text: "Database initialization or migration started",
+    step: "initialize-database",
+    title: "启动 OpenFic 服务",
+    message: "正在初始化数据库...",
+    progress: 0.76,
   },
   {
     text: "Database initialization or migration completed",
     step: "initialize-database",
-    title: "初始化数据库",
-    message: "数据库初始化或迁移已完成",
+    title: "启动 OpenFic 服务",
+    message: "已完成数据库初始化及迁移",
     progress: 0.82,
+  },
+  {
+    text: "Background supervisor started",
+    step: "complete-backend-startup",
+    title: "启动 OpenFic 服务",
+    message: "正在启动内部后台任务服务...",
+    progress: 0.88,
   },
   {
     text: "Application startup complete",
     step: "complete-backend-startup",
-    title: "完成应用启动",
-    message: "应用服务已完成初始化",
+    title: "启动 OpenFic 服务",
+    message: "OpenFic 服务已完成初始化",
     progress: 0.92,
   },
 ] as const;
@@ -379,7 +400,9 @@ export async function startLocalOpenFicBackend(
   venvPythonPath: string,
   expectedVersion: string,
   startupProgress?: StartupProgressTracker,
+  signal?: AbortSignal,
 ): Promise<BackendProcessHandle> {
+  throwIfAborted(signal);
   startupProgress?.begin({
     step: "start-backend",
     title: "启动 OpenFic 服务",
@@ -387,24 +410,30 @@ export async function startLocalOpenFicBackend(
     progress: 0.6,
   });
   const port = await findFreePort();
+  throwIfAborted(signal);
   const command = createOpenFicServeCommand(venvPythonPath, port);
   const proxyEnvironment = await getSystemProxyEnvironment("https://pypi.org/");
-  let healthFallbackStarted = false;
+  throwIfAborted(signal);
   let healthFallbackTimer: NodeJS.Timeout | null = null;
+  let latestMilestone: (typeof STARTUP_LOG_MILESTONES)[number] | null = null;
 
   const beginHealthFallback = () => {
-    if (healthFallbackStarted) return;
-    healthFallbackStarted = true;
-    startupProgress?.begin({
-      step: "check-health",
-      title: "检查服务状态",
-      message: "启动阶段停留较久，正在主动检查服务响应",
-      progress: 0.96,
+    if (latestMilestone) {
+      startupProgress?.update({
+        ...latestMilestone,
+        message: "启动时间较长，仍在等待应用服务响应",
+      });
+      return;
+    }
+    startupProgress?.update({
+      step: "start-backend",
+      title: "启动 OpenFic 服务",
+      message: "启动时间较长，仍在等待应用服务响应",
+      progress: 0.6,
     });
   };
 
   const scheduleHealthFallback = () => {
-    if (healthFallbackStarted) return;
     if (healthFallbackTimer) clearTimeout(healthFallbackTimer);
     healthFallbackTimer = setTimeout(beginHealthFallback, 5_000);
   };
@@ -415,9 +444,9 @@ export async function startLocalOpenFicBackend(
     port,
     environment: proxyEnvironment,
     onOutputLine: (line) => {
-      if (healthFallbackStarted) return;
       const milestone = STARTUP_LOG_MILESTONES.find((candidate) => line.includes(candidate.text));
       if (!milestone) return;
+      latestMilestone = milestone;
       startupProgress?.begin(milestone);
       scheduleHealthFallback();
     },
@@ -425,11 +454,11 @@ export async function startLocalOpenFicBackend(
 
   scheduleHealthFallback();
   try {
-    const health = await waitForBackend(handle.baseUrl, { process: handle.process });
+    const health = await waitForBackend(handle.baseUrl, { process: handle.process, signal });
     if (healthFallbackTimer) clearTimeout(healthFallbackTimer);
     startupProgress?.begin({
       step: "check-health",
-      title: "检查服务状态",
+      title: "启动 OpenFic 服务",
       message: "服务已响应，正在验证版本",
       progress: 0.98,
     });

--- a/desktop/src/main/runtime/setup-runner.ts
+++ b/desktop/src/main/runtime/setup-runner.ts
@@ -11,6 +11,7 @@ import {
 import type { BackendProcessHandle } from "../process.js";
 import type { StartupProgressTracker } from "../startup-progress.js";
 import { appendLog, getLogPath } from "../logging.js";
+import { throwIfAborted } from "../health.js";
 
 function emitProgress(webContents: WebContents, event: SetupProgressEvent): void {
   webContents.send(IpcChannels.setupProgress, event);
@@ -95,11 +96,14 @@ export async function inspectLocalRuntime(installDir: string): Promise<LocalRunt
 export async function startLocalBackendFromInstall(
   installDir: string,
   startupProgress?: StartupProgressTracker,
+  signal?: AbortSignal,
 ): Promise<BackendProcessHandle> {
+  throwIfAborted(signal);
   const inspection = await inspectLocalRuntime(installDir);
   if (inspection.status !== "ready") {
     throw new Error(`本地运行环境不完整：${inspection.message}。请先修复运行环境。`);
   }
+  throwIfAborted(signal);
   const runtimeDir = resolveRuntimeDir(installDir);
-  return startLocalOpenFicBackend(resolveVenvPythonPath(runtimeDir), app.getVersion(), startupProgress);
+  return startLocalOpenFicBackend(resolveVenvPythonPath(runtimeDir), app.getVersion(), startupProgress, signal);
 }

--- a/desktop/src/preload/preload.mts
+++ b/desktop/src/preload/preload.mts
@@ -2,7 +2,6 @@ import { contextBridge, ipcRenderer } from "electron";
 import { fileURLToPath } from "node:url";
 import {
   IpcChannels,
-  type CheckRemoteRequest,
   type EnsureInstanceSessionRequest,
   type InitializeAppResult,
   type InspectLocalRuntimeRequest,
@@ -24,6 +23,7 @@ const desktopApi = {
   saveConfig: (config: DesktopConfig): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.saveConfig, { config } satisfies SaveConfigRequest),
   initializeApp: (): Promise<InitializeAppResult> => ipcRenderer.invoke(IpcChannels.initializeApp),
+  cancelStartup: (): Promise<void> => ipcRenderer.invoke(IpcChannels.cancelStartup),
   ensureInstanceSession: (partition: string): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.ensureInstanceSession, { partition } satisfies EnsureInstanceSessionRequest),
   getDefaultInstallDir: (): Promise<string> => ipcRenderer.invoke(IpcChannels.getDefaultInstallDir),
@@ -31,8 +31,6 @@ const desktopApi = {
     ipcRenderer.invoke(IpcChannels.installRuntime, { installDir } satisfies InstallRuntimeRequest),
   startLocalBackend: (installDir: string): Promise<void> =>
     ipcRenderer.invoke(IpcChannels.startLocalBackend, { installDir } satisfies StartLocalBackendRequest),
-  checkRemote: (url: string): Promise<void> =>
-    ipcRenderer.invoke(IpcChannels.checkRemote, { url } satisfies CheckRemoteRequest),
   switchInstance: (instanceId: string): Promise<InitializeAppResult> =>
     ipcRenderer.invoke(IpcChannels.switchInstance, { instanceId } satisfies SwitchInstanceRequest),
   pingInstance: (instance: DesktopInstance): Promise<PingInstanceResult> =>
@@ -40,8 +38,6 @@ const desktopApi = {
   selectDirectory: (): Promise<string | null> => ipcRenderer.invoke(IpcChannels.selectDirectory),
   inspectLocalRuntime: (installDir: string): Promise<InspectLocalRuntimeResult> =>
     ipcRenderer.invoke(IpcChannels.inspectLocalRuntime, { installDir } satisfies InspectLocalRuntimeRequest),
-  closeSetup: (): Promise<void> => ipcRenderer.invoke(IpcChannels.closeSetup),
-  showSetup: (): Promise<void> => ipcRenderer.invoke(IpcChannels.showSetup),
   frontendHostPreloadPath: fileURLToPath(new URL("./frontend-host-preload.cjs", import.meta.url)),
   minimizeWindow: (): Promise<void> => ipcRenderer.invoke(IpcChannels.minimizeWindow),
   toggleMaximizeWindow: (): Promise<void> => ipcRenderer.invoke(IpcChannels.toggleMaximizeWindow),

--- a/desktop/src/shared/ipc.ts
+++ b/desktop/src/shared/ipc.ts
@@ -4,11 +4,11 @@ export const IpcChannels = {
   getConfig: "config:get",
   saveConfig: "config:save",
   initializeApp: "app:initialize",
+  cancelStartup: "app:cancel-startup",
   ensureInstanceSession: "app:ensure-instance-session",
   getDefaultInstallDir: "app:default-install-dir",
   installRuntime: "setup:install-runtime",
   startLocalBackend: "setup:start-local-backend",
-  checkRemote: "setup:check-remote",
   switchInstance: "instance:switch",
   pingInstance: "instance:ping",
   selectDirectory: "dialog:select-directory",
@@ -16,8 +16,6 @@ export const IpcChannels = {
   setupProgress: "setup:progress",
   getStartupProgress: "app:get-startup-progress",
   startupProgress: "app:startup-progress",
-  closeSetup: "setup:close",
-  showSetup: "shell:show-setup",
   minimizeWindow: "window:minimize",
   toggleMaximizeWindow: "window:toggle-maximize",
   closeWindow: "window:close",
@@ -48,10 +46,6 @@ export interface SetupProgressEvent {
 
 export interface SaveConfigRequest {
   config: DesktopConfig;
-}
-
-export interface CheckRemoteRequest {
-  url: string;
 }
 
 export interface EnsureInstanceSessionRequest {

--- a/desktop/src/ui/app.tsx
+++ b/desktop/src/ui/app.tsx
@@ -82,6 +82,7 @@ export function App() {
   const [frontendWebview, setFrontendWebview] = useState<HTMLElement | null>(null);
   const lastAutoUpdateCheck = useRef<string | null>(null);
   const automaticallyOpenedUpdate = useRef<string | null>(null);
+  const startupRequestId = useRef(0);
   const activeInstance = config?.instances.find((instance) => instance.id === activeInstanceId) ?? null;
   const frontendPartition = activeInstanceId ? `persist:openfic-${activeInstanceId}` : "persist:openfic";
   const canCheckForUpdates = shellState === "frontend" && activeInstance !== null && updateState.status !== "unsupported";
@@ -93,19 +94,20 @@ export function App() {
     });
 
     const initialize = async () => {
+      const requestId = ++startupRequestId.current;
       try {
         const currentProgress = await window.openficDesktop.getStartupProgress();
-        if (!cancelled) setStartupProgress(currentProgress);
+        if (!cancelled && requestId === startupRequestId.current) setStartupProgress(currentProgress);
         const result = await window.openficDesktop.initializeApp();
         const nextConfig = await window.openficDesktop.getConfig();
-        if (cancelled) return;
+        if (cancelled || requestId !== startupRequestId.current) return;
         setConfig(nextConfig);
         setActiveInstanceId(result.activeInstanceId ?? nextConfig?.activeInstanceId ?? null);
         setError(result.message ?? null);
         setCompatibilityWarning(result.compatibilityWarning ?? null);
         setShellState(result.status === "ready" ? "frontend" : "setup");
       } catch (err) {
-        if (cancelled) return;
+        if (cancelled || requestId !== startupRequestId.current) return;
         setError(err instanceof Error ? err.message : "初始化失败");
         setShellState("setup");
       }
@@ -176,8 +178,9 @@ export function App() {
     return nextConfig;
   };
 
-  const showFrontend = async (result?: { compatibilityWarning?: string }) => {
+  const showFrontend = async (result?: { compatibilityWarning?: string }, requestId?: number) => {
     const nextConfig = await refreshConfig();
+    if (requestId !== undefined && requestId !== startupRequestId.current) return;
     setError(null);
     setCompatibilityWarning(result?.compatibilityWarning ?? null);
     setWebviewKey((key) => key + 1);
@@ -199,6 +202,7 @@ export function App() {
   };
 
   const handleSwitchInstance = async (instanceId: string) => {
+    const requestId = ++startupRequestId.current;
     setError(null);
     setCompatibilityWarning(null);
     setUpdateDialogOpen(false);
@@ -207,17 +211,32 @@ export function App() {
     try {
       const result = await window.openficDesktop.switchInstance(instanceId);
       const nextConfig = await refreshConfig();
+      if (requestId !== startupRequestId.current) return;
       setActiveInstanceId(result.activeInstanceId ?? nextConfig?.activeInstanceId ?? instanceId);
       setCompatibilityWarning(result.compatibilityWarning ?? null);
       setWebviewKey((key) => key + 1);
       setShellState(result.status === "ready" ? "frontend" : "setup");
     } catch (err) {
+      if (requestId !== startupRequestId.current) return;
       setError(err instanceof Error ? err.message : "切换实例失败");
       setShellState("setup");
     }
   };
 
+  const handleCancelStartup = async () => {
+    startupRequestId.current += 1;
+    await window.openficDesktop.cancelStartup();
+    const nextConfig = await window.openficDesktop.getConfig();
+    setError(null);
+    setConfig(nextConfig);
+    setActiveInstanceId(nextConfig?.activeInstanceId ?? null);
+    setStartupProgress(null);
+    setSetupInitialStep("mode");
+    setShellState("setup");
+  };
+
   const handleConnectRemote = async (url: string) => {
+    const requestId = ++startupRequestId.current;
     const normalizedUrl = normalizeRemoteUrl(url);
     setError(null);
     setCompatibilityWarning(null);
@@ -227,6 +246,7 @@ export function App() {
     setShellState("booting");
     try {
       const previousConfig = await window.openficDesktop.getConfig();
+      if (requestId !== startupRequestId.current) return;
       const existingInstance = previousConfig?.instances.find(
         (instance) => instance.mode === "remote" && instance.remoteUrl && normalizeRemoteUrl(instance.remoteUrl) === normalizedUrl,
       );
@@ -239,15 +259,18 @@ export function App() {
         installDir: null,
       };
       const nextConfig: DesktopConfig = {
-        activeInstanceId: instance.id,
+        activeInstanceId: previousConfig?.activeInstanceId ?? null,
         instances: existingInstance
           ? previousConfig?.instances ?? [instance]
           : [...(previousConfig?.instances ?? []), instance],
       };
       await window.openficDesktop.saveConfig(nextConfig);
+      if (requestId !== startupRequestId.current) return;
       const result = await window.openficDesktop.switchInstance(instance.id);
-      await showFrontend(result);
+      if (requestId !== startupRequestId.current) return;
+      await showFrontend(result, requestId);
     } catch (err) {
+      if (requestId !== startupRequestId.current) return;
       setError(err instanceof Error ? err.message : "无法连接到该地址");
       setSetupInitialStep("remote");
       setShellState("setup");
@@ -255,6 +278,7 @@ export function App() {
   };
 
   const handleStartLocal = async (installDir: string) => {
+    const requestId = ++startupRequestId.current;
     setError(null);
     setCompatibilityWarning(null);
     setUpdateDialogOpen(false);
@@ -263,8 +287,10 @@ export function App() {
     setShellState("booting");
     try {
       await window.openficDesktop.startLocalBackend(installDir);
-      await showFrontend();
+      if (requestId !== startupRequestId.current) return;
+      await showFrontend(undefined, requestId);
     } catch (err) {
+      if (requestId !== startupRequestId.current) return;
       setError(err instanceof Error ? err.message : "启动后端失败");
       setSetupInitialStep("local-directory");
       setShellState("setup");
@@ -334,7 +360,7 @@ export function App() {
       <DesktopHeader
         activeInstanceId={activeInstanceId}
         config={config}
-        disabled={shellState !== "frontend"}
+        disabled={shellState === "booting"}
         onAddInstance={handleAddInstance}
         onSaveConfig={handleSaveConfig}
         onSwitchInstance={handleSwitchInstance}
@@ -354,15 +380,20 @@ export function App() {
         }}
       />
       <section className="desktop-content">
-        {shellState === "booting" ? <BootPage error={error} progress={startupProgress} /> : null}
+        {shellState === "booting" ? (
+          <BootPage error={error} progress={startupProgress} onCancel={() => void handleCancelStartup()} />
+        ) : null}
         {shellState === "setup" ? (
           <SetupPage
             initialError={error}
             initialInstallDir={setupInitialInstallDir}
             initialStep={setupInitialStep}
             initialRemoteUrl={setupInitialRemoteUrl}
+            instances={config?.instances ?? []}
+            activeInstanceId={activeInstanceId}
             onClearError={() => setError(null)}
             onConnectRemote={(url) => void handleConnectRemote(url)}
+            onConnectInstance={(instanceId) => void handleSwitchInstance(instanceId)}
             onStartLocal={(installDir) => void handleStartLocal(installDir)}
           />
         ) : null}

--- a/desktop/src/ui/global.d.ts
+++ b/desktop/src/ui/global.d.ts
@@ -15,17 +15,15 @@ declare global {
       getConfig: () => Promise<DesktopConfig | null>;
       saveConfig: (config: DesktopConfig) => Promise<void>;
       initializeApp: () => Promise<InitializeAppResult>;
+      cancelStartup: () => Promise<void>;
       ensureInstanceSession: (partition: string) => Promise<void>;
       getDefaultInstallDir: () => Promise<string>;
       installRuntime: (installDir: string) => Promise<void>;
       startLocalBackend: (installDir: string) => Promise<void>;
-      checkRemote: (url: string) => Promise<void>;
       switchInstance: (instanceId: string) => Promise<InitializeAppResult>;
       pingInstance: (instance: DesktopInstance) => Promise<PingInstanceResult>;
       selectDirectory: () => Promise<string | null>;
       inspectLocalRuntime: (installDir: string) => Promise<InspectLocalRuntimeResult>;
-      closeSetup: () => Promise<void>;
-      showSetup: () => Promise<void>;
       frontendHostPreloadPath: string;
       minimizeWindow: () => Promise<void>;
       toggleMaximizeWindow: () => Promise<void>;

--- a/desktop/src/ui/pages/boot/page.tsx
+++ b/desktop/src/ui/pages/boot/page.tsx
@@ -4,14 +4,20 @@ import type { StartupProgressEvent } from "../../../shared/ipc";
 interface BootPageProps {
   error: string | null;
   progress: StartupProgressEvent | null;
+  onCancel: () => void;
 }
 
-export function BootPage({ error, progress }: BootPageProps) {
+export function BootPage({ error, progress, onCancel }: BootPageProps) {
   return (
     <section className="content-page content-page-centered startup-page">
       <div className="boot-state">
         <StartupProgress bare progress={progress} />
         {error ? <p className="error">{error}</p> : null}
+        <div className="boot-actions">
+          <button className="boot-cancel-button" type="button" onClick={onCancel}>
+            取消连接
+          </button>
+        </div>
       </div>
     </section>
   );

--- a/desktop/src/ui/pages/setup/page.tsx
+++ b/desktop/src/ui/pages/setup/page.tsx
@@ -7,11 +7,13 @@ import {
   CircleCheck,
   FolderOpen,
   HardDriveDownload,
+  Link2,
   RefreshCw,
   Server,
   X,
 } from "lucide-react";
 import type { InspectLocalRuntimeResult, SetupProgressEvent, SetupStep } from "../../../shared/ipc";
+import type { DesktopInstance } from "../../../shared/config";
 import "./setup.css";
 
 type WizardStep = "mode" | "remote" | "local-directory" | "local-installing" | "local-success";
@@ -61,9 +63,17 @@ interface SetupPageProps {
   initialError?: string | null;
   initialInstallDir?: string | null;
   initialRemoteUrl?: string | null;
+  instances: DesktopInstance[];
+  activeInstanceId: string | null;
   onClearError: () => void;
   onConnectRemote: (url: string) => void;
+  onConnectInstance: (instanceId: string) => void;
   onStartLocal: (installDir: string) => void;
+}
+
+function getInstanceDetail(instance: DesktopInstance): string {
+  if (instance.mode === "remote") return instance.remoteUrl ?? "未设置服务地址";
+  return instance.installDir ? getRuntimeDisplayPath(instance.installDir) : "未设置运行环境目录";
 }
 
 function applyProgress(prev: StepState, event: SetupProgressEvent): StepState {
@@ -90,8 +100,11 @@ export function SetupPage({
   initialError,
   initialInstallDir,
   initialRemoteUrl,
+  instances,
+  activeInstanceId,
   onClearError,
   onConnectRemote,
+  onConnectInstance,
   onStartLocal,
 }: SetupPageProps) {
   const [step, setStep] = useState<WizardStep>(initialStep);
@@ -222,33 +235,69 @@ export function SetupPage({
             </div>
           ) : null}
           {step === "mode" ? (
-            <div className="setup-choices">
-              <button className="setup-choice" type="button" onClick={() => selectMode("remote")}>
-                <span className="setup-choice-icon">
-                  <Server size={20} strokeWidth={2} />
-                </span>
-                <span className="setup-choice-body">
-                  <strong>连接到已有服务</strong>
-                  <span>连接到已有运行中的 OpenFic 后端服务</span>
-                </span>
-                <span className="setup-choice-arrow">
-                  前往连接
-                  <ArrowRight size={15} strokeWidth={2} />
-                </span>
-              </button>
-              <button className="setup-choice" type="button" onClick={() => selectMode("local-directory")}>
-                <span className="setup-choice-icon">
-                  <HardDriveDownload size={20} strokeWidth={2} />
-                </span>
-                <span className="setup-choice-body">
-                  <strong>设置本地运行环境</strong>
-                  <span>在本地下载、安装并启动 OpenFic 服务</span>
-                </span>
-                <span className="setup-choice-arrow">
-                  前往设置
-                  <ArrowRight size={15} strokeWidth={2} />
-                </span>
-              </button>
+            <div className="setup-mode-content">
+              <div className="setup-choices">
+                <button className="setup-choice" type="button" onClick={() => selectMode("remote")}>
+                  <span className="setup-choice-icon">
+                    <Server size={20} strokeWidth={2} />
+                  </span>
+                  <span className="setup-choice-body">
+                    <strong>连接到已有服务</strong>
+                    <span>连接到已有运行中的 OpenFic 后端服务</span>
+                  </span>
+                  <span className="setup-choice-arrow">
+                    前往连接
+                    <ArrowRight size={15} strokeWidth={2} />
+                  </span>
+                </button>
+                <button className="setup-choice" type="button" onClick={() => selectMode("local-directory")}>
+                  <span className="setup-choice-icon">
+                    <HardDriveDownload size={20} strokeWidth={2} />
+                  </span>
+                  <span className="setup-choice-body">
+                    <strong>设置本地运行环境</strong>
+                    <span>在本地下载、安装并启动 OpenFic 服务</span>
+                  </span>
+                  <span className="setup-choice-arrow">
+                    前往设置
+                    <ArrowRight size={15} strokeWidth={2} />
+                  </span>
+                </button>
+              </div>
+              {instances.length ? (
+                <section className="setup-configured-instances" aria-label="已配置的实例">
+                  <div className="setup-configured-instances-heading">
+                    <h2>已配置的实例</h2>
+                    <span>{instances.length}</span>
+                  </div>
+                  <div className="setup-configured-instance-list">
+                    {instances.map((instance) => {
+                      const isActive = instance.id === activeInstanceId;
+                      return (
+                        <button
+                          className="setup-configured-instance"
+                          type="button"
+                          key={instance.id}
+                          data-active={isActive}
+                          onClick={() => onConnectInstance(instance.id)}
+                        >
+                          <span className="setup-configured-instance-icon">
+                            <Link2 size={16} strokeWidth={2} />
+                          </span>
+                          <span className="setup-configured-instance-copy">
+                            <strong>{instance.name}</strong>
+                            <span title={getInstanceDetail(instance)}>{getInstanceDetail(instance)}</span>
+                          </span>
+                          <span className="setup-configured-instance-action">
+                            {isActive ? "重新连接" : "连接"}
+                            <ArrowRight size={15} strokeWidth={2} />
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                </section>
+              ) : null}
             </div>
           ) : null}
 
@@ -332,6 +381,10 @@ export function SetupPage({
                   disabled={!installDir || runtimeChecking || !runtimeInspection}
                   onClick={() => {
                     if (runtimeIsReady) {
+                      if (configuredInstance) {
+                        onConnectInstance(configuredInstance.id);
+                        return;
+                      }
                       onStartLocal(installDir);
                       return;
                     }

--- a/desktop/src/ui/pages/setup/setup.css
+++ b/desktop/src/ui/pages/setup/setup.css
@@ -63,10 +63,129 @@
 }
 
 /* mode selection */
+.setup-mode-content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
 .setup-choices {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 14px;
+}
+
+.setup-configured-instances {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-top: 20px;
+  border-top: 1px solid var(--gray-a5);
+}
+
+.setup-configured-instances-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.setup-configured-instances-heading h2 {
+  margin: 0;
+  color: var(--gray-12);
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.setup-configured-instances-heading span {
+  color: var(--gray-10);
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+
+.setup-configured-instance-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: 190px;
+  overflow-y: auto;
+  padding: 2px;
+}
+
+.setup-configured-instance {
+  display: grid;
+  grid-template-columns: 32px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 10px;
+  border: 1px solid transparent;
+  border-radius: 10px;
+  background: transparent;
+  color: var(--gray-12);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+.setup-configured-instance:hover,
+.setup-configured-instance[data-active="true"] {
+  border-color: var(--gray-a5);
+  background: var(--gray-a3);
+}
+
+.setup-configured-instance:focus-visible {
+  outline: 2px solid var(--gray-a8);
+  outline-offset: 2px;
+}
+
+.setup-configured-instance-icon {
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: var(--gray-a4);
+  color: var(--gray-11);
+}
+
+.setup-configured-instance-copy {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.setup-configured-instance-copy strong,
+.setup-configured-instance-copy span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.setup-configured-instance-copy strong {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.setup-configured-instance-copy span {
+  color: var(--gray-10);
+  font-family: var(--code-font-family, monospace);
+  font-size: 11px;
+}
+
+.setup-configured-instance-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--gray-10);
+  font-size: 12px;
+}
+
+.setup-configured-instance:hover .setup-configured-instance-action,
+.setup-configured-instance[data-active="true"] .setup-configured-instance-action {
+  color: var(--gray-12);
 }
 
 .setup-choice {

--- a/desktop/src/ui/styles.css
+++ b/desktop/src/ui/styles.css
@@ -888,6 +888,30 @@ h1 {
   gap: 14px;
 }
 
+.boot-actions {
+  display: flex;
+  justify-content: center;
+}
+
+.boot-cancel-button {
+  border: 0;
+  background: transparent;
+  color: var(--gray-11);
+  font: inherit;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.boot-cancel-button:hover {
+  color: var(--gray-12);
+}
+
+.boot-cancel-button:focus-visible {
+  outline: 2px solid var(--gray-a8);
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+
 .startup-page {
   padding: 32px;
 }


### PR DESCRIPTION
## PR 标题

fix(desktop): 优化运行时连接流程

## 变更说明

- 问题: 启动时自动连接已配置实例无法取消，Setup 页面无法直接复用已配置的本地或远程实例。
- 重要性: 用户误入 Setup 或连接卡住时，需要等待超时或重新选择本地运行时目录。
- 变化: 为启动连接增加可取消信号及竞态保护；取消本地后端启动时会终止尚未就绪的后端进程。
- 变化: Setup 页面展示可滚动的已配置实例列表，并允许通过标题栏实例面板重新连接。
- 变化: 细化本地后端日志驱动的启动说明，保持进度单调递增且标题稳定。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

启动流程缺少取消信号与界面竞态保护；Setup 页面未提供已配置实例的直接连接入口；后端启动进度在健康检查回退后会丢失后续日志里程碑。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证记录：

- `pnpm type-check`
- `pnpm lint`
- `pnpm build`
- `git diff --check`
