### PR TITLE
fix(agent): 修复旧会话配置无法恢复的问题

### DIFF
--- a/backend/app/api/routers/agent_runtime.py
+++ b/backend/app/api/routers/agent_runtime.py
@@ -35,6 +35,7 @@ from app.agent_runtime.model_config import without_api_key
 from app.agent_runtime.runner.checkpointer import (
     delete_checkpoints_after_for_thread,
     delete_checkpoints_for_thread,
+    get_checkpointer,
 )
 from app.agent_runtime.runner.session_runner import SessionRunner
 from app.agent_runtime.runner.subagent_runner import SubagentRunner
@@ -249,7 +250,11 @@ async def _cancel_subagent_session_tree(
             await status_publisher.publish_parent_subagent_status(row.id)
 
 
-async def _get_runner(session_id: str, session: AsyncSession | None = None) -> SessionRunner:
+async def _get_runner(
+    session_id: str,
+    session: AsyncSession | None = None,
+    model_config: dict | None = None,
+) -> SessionRunner:
     runner = _SESSION_RUNNERS.get(session_id)
     if runner is not None:
         return runner
@@ -270,7 +275,9 @@ async def _get_runner(session_id: str, session: AsyncSession | None = None) -> S
     if not _is_valid_model_config(restored_model_config):
         raise NotFoundError(f"会话不存在: {session_id}")
     model_record_id = restored_model_config.get("model_record_id")
-    if isinstance(model_record_id, str) and model_record_id:
+    if model_config is not None:
+        runner.model_config = model_config
+    elif isinstance(model_record_id, str) and model_record_id:
         restored_reasoning_effort = restored_model_config.get("reasoning_effort")
         runner.model_config = await _resolve_model_config(
             session,
@@ -291,7 +298,16 @@ async def _get_runner(session_id: str, session: AsyncSession | None = None) -> S
         )
     restored_agent_key = values.get("agent_key")
     if isinstance(restored_agent_key, str) and restored_agent_key:
-        runner.agent_key = restored_agent_key
+        try:
+            await _validate_primary_agent(session, restored_agent_key)
+        except HTTPException:
+            await graph.aupdate_state(
+                {"configurable": {"thread_id": session_id}},
+                {"agent_key": "build"},
+                as_node="primary",
+            )
+        else:
+            runner.agent_key = restored_agent_key
     _SESSION_RUNNERS[session_id] = runner
     return runner
 
@@ -319,6 +335,26 @@ async def _build_model_config(
     if reasoning_effort and reasoning_effort != "off":
         model_config["reasoning_effort"] = reasoning_effort
     return model_config
+
+
+async def _validate_primary_agent(session: AsyncSession, agent_key: str) -> None:
+    try:
+        definition = await load_agent_definition(session, agent_key)
+    except KeyError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"主智能体不存在: {agent_key}",
+        ) from exc
+    if not definition.enabled:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"主智能体 '{agent_key}' 已被禁用",
+        )
+    if definition.kind != "primary":
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"智能体 '{agent_key}' 不是主智能体 (kind != primary)",
+        )
 
 
 async def _resolve_model_config(
@@ -660,7 +696,21 @@ async def send_agent_message(
     body: AgentSendMessageRequest,
     session: AsyncSession = Depends(get_session),
 ) -> AgentSendMessageResponse:
-    runner = await _get_runner(session_id, session)
+    requested_model_config: dict | None = None
+    if body.model_id and session_id not in _SESSION_RUNNERS:
+        try:
+            requested_model_config = await _resolve_model_config(
+                session, body.model_id, body.reasoning_effort
+            )
+        except NotFoundError as exc:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=str(exc),
+            ) from exc
+
+    runner = await _get_runner(session_id, session, requested_model_config)
     registry = get_agent_run_registry()
     task = await task_service.get_task(session, runner.task_id)
     status_session_factory = _make_status_session_factory(session)
@@ -680,10 +730,12 @@ async def send_agent_message(
     model_updated = False
     if body.model_id:
         try:
-            runner.update_model_config(
-                await _resolve_model_config(
+            if requested_model_config is None:
+                requested_model_config = await _resolve_model_config(
                     session, body.model_id, body.reasoning_effort
                 )
+            runner.update_model_config(
+                requested_model_config
             )
             model_updated = True
         except NotFoundError as exc:
@@ -701,6 +753,9 @@ async def send_agent_message(
                     session, model_record_id, body.reasoning_effort
                 )
             )
+    if body.agent_key:
+        await _validate_primary_agent(session, body.agent_key)
+        runner.agent_key = body.agent_key
     coro = runner.run(user_request=body.message)
     await _launch_task(
         db_session_factory=status_session_factory,
@@ -944,17 +999,19 @@ async def submit_agent_tool_approval(
 @router.get("/sessions/{session_id}", response_model=AgentSessionStateResponse)
 async def get_agent_session_state(
     session_id: str,
-    session: AsyncSession = Depends(get_session),
 ) -> AgentSessionStateResponse:
-    runner = await _get_runner(session_id, session)
-    graph = await runner._get_graph()
-    state = await graph.aget_state({"configurable": {"thread_id": session_id}})
+    checkpointer = await get_checkpointer()
+    checkpoint = await checkpointer.aget_tuple(
+        {"configurable": {"thread_id": session_id}}
+    )
+    checkpoint_values = checkpoint.checkpoint.get("channel_values") if checkpoint else None
+    state_values = dict(checkpoint_values) if isinstance(checkpoint_values, dict) else {}
     is_running = await get_agent_run_registry().is_running(session_id)
-    if not state.values and not is_running:
+    if not state_values and not is_running:
         raise NotFoundError(f"会话不存在: {session_id}")
     return AgentSessionStateResponse(
         session_id=session_id,
-        state=dict(state.values or {}),
+        state=state_values,
         is_running=is_running,
     )
 

--- a/backend/app/api/schemas/agent.py
+++ b/backend/app/api/schemas/agent.py
@@ -52,6 +52,7 @@ class AgentSendMessageRequest(BaseModel):
 
     message: str = Field(..., description="用户消息内容")
     model_id: str | None = Field(default=None, description="下一轮执行使用的模型ID")
+    agent_key: str | None = Field(default=None, description="下一轮执行使用的主智能体标识")
     reasoning_effort: ReasoningEffort | None = Field(
         default=None,
         description="当前轮推理强度，仅 reasoning 模型可用",

--- a/backend/tests/api/test_agent.py
+++ b/backend/tests/api/test_agent.py
@@ -100,6 +100,7 @@ async def _seed_agent_target(client: AsyncClient) -> dict[str, str]:
     return {
         "project_id": project_id,
         "chapter_id": chapter_id,
+        "provider_id": provider_id,
         "model_id": model_id,
     }
 
@@ -392,6 +393,183 @@ class TestAgentAPI:
         resolve_model_config.assert_awaited_once_with(session, "next-model-record", None)
         assert runner.model_config == next_model_config
         runner.run.assert_called_once_with(user_request="使用新模型继续")
+
+    async def test_send_agent_message_uses_requested_primary_agent_for_next_run(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        definition_response = await client.post(
+            "/api/v1/agent-definitions",
+            json={
+                "key": "custom-primary",
+                "display_name": "Custom Primary",
+                "kind": "primary",
+                "prompt_agent_name": "custom-primary",
+                "enabled_tool_categories": ["orchestration", "interaction", "chapter_read"],
+                "enabled_skills": [],
+                "metadata": {},
+            },
+        )
+        assert definition_response.status_code == status.HTTP_201_CREATED
+        session.add(
+            Task(
+                id="task-agent-switch",
+                project_id=target["project_id"],
+                title="主智能体切换",
+                mode="agent",
+                agent_session_id="session-agent-switch",
+            )
+        )
+        await session.commit()
+
+        runner = SessionRunner(
+            session_id="session-agent-switch",
+            task_id="task-agent-switch",
+            model_config={"max_context_tokens": 8000, "model_id": "test-model"},
+            project_id=target["project_id"],
+            agent_key="build",
+        )
+        runner.run = MagicMock(return_value=object())
+        _SESSION_RUNNERS["session-agent-switch"] = runner
+
+        with patch(
+            "app.api.routers.agent_runtime._launch_task",
+            AsyncMock(),
+        ):
+            response = await client.post(
+                "/api/v1/agent/sessions/session-agent-switch/message",
+                json={"message": "切换主智能体继续", "agent_key": "custom-primary"},
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert runner.agent_key == "custom-primary"
+        runner.run.assert_called_once_with(user_request="切换主智能体继续")
+
+    async def test_send_agent_message_falls_back_after_persisted_primary_agent_deleted(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        definition_response = await client.post(
+            "/api/v1/agent-definitions",
+            json={
+                "key": "custom-primary",
+                "display_name": "Custom Primary",
+                "kind": "primary",
+                "prompt_agent_name": "custom-primary",
+                "enabled_tool_categories": ["orchestration", "interaction", "chapter_read"],
+                "enabled_skills": [],
+                "metadata": {},
+            },
+        )
+        assert definition_response.status_code == status.HTTP_201_CREATED
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={
+                "project_id": target["project_id"],
+                "model_id": target["model_id"],
+                "agent_key": "custom-primary",
+                "max_iterations": 5,
+            },
+        )
+        session_id = session_response.json()["session_id"]
+
+        delete_response = await client.delete("/api/v1/agent-definitions/custom-primary")
+        assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+        _SESSION_RUNNERS.clear()
+
+        with patch(
+            "app.api.routers.agent_runtime._launch_task",
+            AsyncMock(side_effect=lambda **kwargs: kwargs["coro"].close()),
+        ):
+            response = await client.post(
+                f"/api/v1/agent/sessions/{session_id}/message",
+                json={"message": "继续旧会话"},
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert _SESSION_RUNNERS[session_id].agent_key == "build"
+
+    async def test_send_agent_message_rejects_deleted_primary_agent(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session.add(
+            Task(
+                id="task-deleted-agent",
+                project_id=target["project_id"],
+                title="已删除主智能体",
+                mode="agent",
+                agent_session_id="session-deleted-agent",
+            )
+        )
+        await session.commit()
+        runner = SessionRunner(
+            session_id="session-deleted-agent",
+            task_id="task-deleted-agent",
+            model_config={"max_context_tokens": 8000, "model_id": "test-model"},
+            project_id=target["project_id"],
+        )
+        _SESSION_RUNNERS["session-deleted-agent"] = runner
+
+        response = await client.post(
+            "/api/v1/agent/sessions/session-deleted-agent/message",
+            json={"message": "使用已删除主智能体", "agent_key": "deleted-primary"},
+        )
+
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json()["detail"] == "主智能体不存在: deleted-primary"
+
+    async def test_send_agent_message_uses_new_model_after_deleted_model_session_rehydration(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={
+                "project_id": target["project_id"],
+                "model_id": target["model_id"],
+                "max_iterations": 5,
+            },
+        )
+        assert session_response.status_code == status.HTTP_200_OK
+        session_id = session_response.json()["session_id"]
+
+        new_model_response = await client.post(
+            "/api/v1/models",
+            json={
+                "name": "新测试模型",
+                "provider_id": target["provider_id"],
+                "model_id": "gpt-4.1-mini",
+                "temperature": 0.7,
+                "max_tokens": 2000,
+                "context_length": 32000,
+            },
+        )
+        assert new_model_response.status_code == status.HTTP_201_CREATED
+        new_model_id = new_model_response.json()["id"]
+
+        delete_response = await client.delete(f"/api/v1/models/{target['model_id']}")
+        assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+        _SESSION_RUNNERS.clear()
+
+        with patch(
+            "app.api.routers.agent_runtime._launch_task",
+            AsyncMock(side_effect=lambda **kwargs: kwargs["coro"].close()),
+        ):
+            response = await client.post(
+                f"/api/v1/agent/sessions/{session_id}/message",
+                json={"message": "使用新模型继续", "model_id": new_model_id},
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["model_updated"] is True
+        assert _SESSION_RUNNERS[session_id].model_config["model_record_id"] == new_model_id
 
     async def test_send_agent_message_updates_reasoning_effort_for_current_model(
         self,
@@ -956,17 +1134,9 @@ class TestAgentAPI:
         )
         session_id = session_response.json()["session_id"]
 
-        class FakeGraph:
-            async def aget_state(self, config):
-                return SimpleNamespace(values={"session_id": session_id})
-
         fake_registry = SimpleNamespace(is_running=AsyncMock(return_value=True))
 
-        with patch.object(
-            _SESSION_RUNNERS[session_id],
-            "_get_graph",
-            AsyncMock(return_value=FakeGraph()),
-        ), patch(
+        with patch(
             "app.api.routers.agent_runtime.get_agent_run_registry",
             return_value=fake_registry,
         ):
@@ -975,7 +1145,7 @@ class TestAgentAPI:
         assert response.status_code == status.HTTP_200_OK
         data = response.json()
         assert data["session_id"] == session_id
-        assert data["state"] == {"session_id": session_id}
+        assert data["state"]["session_id"] == session_id
         assert data["is_running"] is True
         fake_registry.is_running.assert_awaited_once_with(session_id)
 
@@ -1417,7 +1587,7 @@ class TestAgentAPI:
         await asyncio.sleep(0.05)
         mock_run.assert_awaited_once_with(user_request="取消上一轮后重新开始")
 
-    async def test_get_session_state_rehydrates_persisted_session_without_runner(
+    async def test_get_session_state_reads_persisted_session_without_runner(
         self,
         client: AsyncClient,
     ) -> None:
@@ -1441,10 +1611,34 @@ class TestAgentAPI:
         assert data["session_id"] == session_id
         assert data["is_running"] is False
         assert data["state"]["model_config"]["model_id"] == "gpt-3.5-turbo"
-        assert session_id in _SESSION_RUNNERS
-        assert _SESSION_RUNNERS[session_id].model_config["api_key"] == "test_api_key"
+        assert session_id not in _SESSION_RUNNERS
 
-    async def test_get_session_state_rehydrates_legacy_model_config_without_record_id(
+    async def test_get_session_state_allows_deleted_model_without_runner(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={
+                "project_id": target["project_id"],
+                "model_id": target["model_id"],
+                "max_iterations": 5,
+            },
+        )
+        session_id = session_response.json()["session_id"]
+
+        delete_response = await client.delete(f"/api/v1/models/{target['model_id']}")
+        assert delete_response.status_code == status.HTTP_204_NO_CONTENT
+        _SESSION_RUNNERS.clear()
+
+        response = await client.get(f"/api/v1/agent/sessions/{session_id}")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["state"]["model_config"]["model_record_id"] == target["model_id"]
+        assert session_id not in _SESSION_RUNNERS
+
+    async def test_get_session_state_reads_legacy_model_config_without_record_id(
         self,
         client: AsyncClient,
     ) -> None:
@@ -1473,7 +1667,8 @@ class TestAgentAPI:
         response = await client.get(f"/api/v1/agent/sessions/{session_id}")
 
         assert response.status_code == status.HTTP_200_OK
-        assert response.json()["state"]["model_config"]["model_record_id"] == target["model_id"]
+        assert "model_record_id" not in response.json()["state"]["model_config"]
+        assert session_id not in _SESSION_RUNNERS
 
     async def test_agent_checkpoint_and_session_state_do_not_contain_api_key(
         self,

--- a/frontend/src/features/assistant/hooks/use-agent-session.ts
+++ b/frontend/src/features/assistant/hooks/use-agent-session.ts
@@ -761,6 +761,7 @@ export function useAgentSession({
           message,
           nextModelId,
           reasoningEffort,
+          agentKey,
         );
         if (response.model_updated && nextModelId) activeModelIdRef.current = nextModelId;
         if (response.queued && response.pending_message) {

--- a/frontend/src/lib/agent.types.ts
+++ b/frontend/src/lib/agent.types.ts
@@ -259,6 +259,7 @@ export interface AgentSessionStateResponse {
 export interface AgentSendMessageRequest {
   message: string;
   model_id?: string;
+  agent_key?: string;
   reasoning_effort?: ReasoningEffort;
 }
 

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -2300,11 +2300,13 @@ export async function sendAgentMessage(
   message: string,
   modelId?: string,
   reasoningEffort?: ReasoningEffort,
+  agentKey?: string,
 ): Promise<AgentSendMessageResponse> {
   const request: AgentSendMessageRequest = {
     message,
     ...(modelId ? { model_id: modelId } : {}),
     ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
+    ...(agentKey ? { agent_key: agentKey } : {}),
   };
   const response = await apiClient.post(`/agent/sessions/${sessionId}/message`, request);
   const data = response.data as Record<string, unknown>;


### PR DESCRIPTION
## PR 标题

fix(agent): 修复旧会话配置恢复

## 变更说明

- 问题: 删除模型或自定义主智能体后，重启并加载旧会话时可能因已删除配置返回 404 或无法继续执行；已有会话切换主智能体也未生效。
- 重要性: 用户无法保留历史记录继续旧会话，且会话配置在重启后的行为不一致。
- 变化: 会话状态查询直接读取检查点；继续旧会话时优先使用当前选择的模型和主智能体；已删除主智能体自动回退到 build。
- 变化: 为已删除模型、已删除主智能体、主智能体切换及旧检查点场景补充回归测试。

## 关联 Issue / PR (如有)

Closes #200

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [x] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

会话恢复和状态查询依赖持久化的旧模型、主智能体配置。模型或自定义主智能体被删除后，恢复路径在应用当前选择前解析旧配置；同时，继续会话请求未传递主智能体选择。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令：

- `uv run pytest tests/api/test_agent.py`（50 passed）
- `uv run ruff check app/api/routers/agent_runtime.py app/api/schemas/agent.py tests/api/test_agent.py`
- `pnpm type-check`
- `pnpm lint`
- `pnpm format:check`
