### PR TITLE
fix(dashboard): 修复调用记录时间未转换时区的问题

### DIFF
--- a/backend/app/api/routers/dashboard.py
+++ b/backend/app/api/routers/dashboard.py
@@ -3,7 +3,7 @@
 Dashboard Router - LLM API 统计仪表盘 API。
 """
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Literal
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -38,10 +38,15 @@ from app.storage.services import writing_activity_service
 router = APIRouter(prefix="/dashboard", tags=["Dashboard"])
 
 
+def _as_utc(value: datetime) -> datetime:
+    """将 SQLite 返回的无时区 UTC 时间恢复为带时区时间。"""
+    return value.replace(tzinfo=UTC) if value.tzinfo is None else value.astimezone(UTC)
+
+
 def _serialize_record(record: DashboardRecordRow) -> DashboardAuditRecord:
     return DashboardAuditRecord(
         id=record.id,
-        created_at=record.created_at,
+        created_at=_as_utc(record.created_at),
         task_id=record.task_id,
         session_id=record.session_id,
         project_id=record.project_id,

--- a/backend/tests/api/test_dashboard_llm.py
+++ b/backend/tests/api/test_dashboard_llm.py
@@ -52,6 +52,7 @@ async def test_llm_dashboard_records_include_output_details(
     assert response.status_code == 200
     record = response.json()["records"]["items"][0]
     assert record["project_title"] == "测试小说"
+    assert record["created_at"] == "2026-05-09T07:30:00Z"
     assert record["token_cache"] == 20
     assert "request_messages" not in record
     assert record["has_request_messages"] is True


### PR DESCRIPTION
## PR 标题

fix(dashboard): 修复调用记录时间未转换时区的问题

## 变更说明

- 问题: 调用记录接口返回的时间缺少 UTC 时区标识，前端会按浏览器本地时区解析，导致显示时间存在时差。
- 重要性: 用户无法准确判断实际调用时间。
- 变化: 在仪表盘调用记录序列化时，将 SQLite 读取的无时区时间恢复为 UTC 时间，并补充接口回归测试。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [x] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

SQLite 读取 `created_at` 后会丢失 UTC 时区信息，接口将无时区时间直接序列化，浏览器按本地时区解析。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令：

- `uv run pytest tests/api/test_dashboard_llm.py -q`（7 passed）
- `uv run ruff check app/api/routers/dashboard.py tests/api/test_dashboard_llm.py`
- `uv run ty check app/api/routers/dashboard.py`
