### PR TITLE
chore(provider): 新增 Anthropic Compatible 提供商

### DIFF
--- a/backend/app/agent_runtime/content_blocks.py
+++ b/backend/app/agent_runtime/content_blocks.py
@@ -1,0 +1,41 @@
+"""Normalize structured LangChain content blocks for text-only application surfaces."""
+
+from typing import Any
+
+
+def extract_text_content(content: Any) -> str:
+    """Return text from plain content or standard LangChain content blocks."""
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return ""
+
+    parts: list[str] = []
+    for block in content:
+        if isinstance(block, str):
+            parts.append(block)
+        elif isinstance(block, dict) and block.get("type") == "text":
+            text = block.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+    return "".join(parts)
+
+
+def extract_reasoning_content(content: Any) -> str:
+    """Return reasoning from Anthropic-style content blocks."""
+    if not isinstance(content, list):
+        return ""
+
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "reasoning":
+            reasoning = block.get("reasoning")
+            if isinstance(reasoning, str):
+                parts.append(reasoning)
+        elif block.get("type") == "thinking":
+            thinking = block.get("thinking")
+            if isinstance(thinking, str):
+                parts.append(thinking)
+    return "".join(parts)

--- a/backend/app/agent_runtime/graph/react_agent.py
+++ b/backend/app/agent_runtime/graph/react_agent.py
@@ -31,6 +31,7 @@ from langgraph.runtime import Runtime
 from langgraph.types import RetryPolicy
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.agent_runtime.content_blocks import extract_text_content
 from app.agent_runtime.types import ReactAgentConfig
 from app.agent_runtime.context import build_context, build_context_parts
 from app.agent_runtime.context.processors.filter import (
@@ -98,7 +99,7 @@ async def _invoke_model(model: Any, messages: list[BaseMessage]) -> AIMessage:
         raise ValueError("LLM流式调用未返回响应")
 
     normalized = AIMessage(
-        content=response.content,
+        content=extract_text_content(response.content),
         additional_kwargs=dict(response.additional_kwargs or {}),
         response_metadata=dict(response.response_metadata or {}),
         tool_calls=recover_message_tool_calls(response),

--- a/backend/app/agent_runtime/persistence/persister.py
+++ b/backend/app/agent_runtime/persistence/persister.py
@@ -9,6 +9,7 @@ from typing import Literal
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.agent_runtime.content_blocks import extract_reasoning_content, extract_text_content
 from app.agent_runtime.persistence import repo
 from app.agent_runtime.persistence.child_runs import (
     get_child_run_agent_number,
@@ -120,13 +121,13 @@ class MessagePersister:
         if chunk is None:
             return
 
-        content = getattr(chunk, "content", "") or ""
-        if isinstance(content, str) and content:
+        content = extract_text_content(getattr(chunk, "content", ""))
+        if content:
             buf.content_parts.append(content)
 
-        reasoning = (getattr(chunk, "additional_kwargs", {}) or {}).get(
-            "reasoning_content"
-        )
+        reasoning = (getattr(chunk, "additional_kwargs", {}) or {}).get("reasoning_content")
+        if not isinstance(reasoning, str) or not reasoning:
+            reasoning = extract_reasoning_content(getattr(chunk, "content", None))
         if reasoning:
             chunk_received_at = datetime.now(UTC)
             if buf.reasoning_started_at is None:
@@ -302,8 +303,7 @@ class MessagePersister:
 
     @staticmethod
     def _extract_output_content(output: object | None) -> str:
-        content = getattr(output, "content", "")
-        return content if isinstance(content, str) else ""
+        return extract_text_content(getattr(output, "content", ""))
 
     @staticmethod
     def _extract_output_reasoning(output: object | None) -> str | None:
@@ -325,7 +325,7 @@ class MessagePersister:
                 if isinstance(value, str) and value:
                     return value
 
-        return None
+        return extract_reasoning_content(getattr(output, "content", None))
 
     @staticmethod
     def _extract_output_tool_calls(

--- a/backend/app/agent_runtime/runner/event_translator.py
+++ b/backend/app/agent_runtime/runner/event_translator.py
@@ -1,5 +1,6 @@
 from langchain_core.messages import ToolMessage
 
+from app.agent_runtime.content_blocks import extract_reasoning_content, extract_text_content
 from app.agent_runtime.runner.event_scope import is_subagent_child_event
 from app.agent_runtime.tool_call_recovery import (
     build_malformed_tool_call_error,
@@ -46,7 +47,7 @@ class EventTranslator:
                     }
                 )
             events.extend(self._extract_streaming_tool_call_events(event, chunk))
-            content = getattr(chunk, "content", "") if chunk else ""
+            content = extract_text_content(getattr(chunk, "content", "") if chunk else "")
             if content:
                 events.append(
                     {
@@ -252,7 +253,7 @@ class EventTranslator:
                 if isinstance(value, str) and value:
                     return value
 
-        return ""
+        return extract_reasoning_content(getattr(chunk, "content", None))
 
     @staticmethod
     def _extract_usage(output: object | None) -> dict | None:

--- a/backend/app/models/adapters/__init__.py
+++ b/backend/app/models/adapters/__init__.py
@@ -7,6 +7,7 @@ Adapters Module - Provider适配器模块。
 
 from app.models.adapters.base import BaseAdapter
 from app.models.adapters.anthropic import AnthropicAdapter
+from app.models.adapters.anthropic_compatible import AnthropicCompatibleAdapter
 from app.models.adapters.deepseek import DeepSeekAdapter
 from app.models.adapters.google_genai import GoogleGenAIAdapter
 from app.models.adapters.mistral import MistralAdapter
@@ -25,6 +26,7 @@ __all__ = [
     "BaseAdapter",
     "AmazonNovaAdapter",
     "AnthropicAdapter",
+    "AnthropicCompatibleAdapter",
     "CohereAdapter",
     "DeepSeekAdapter",
     "GoogleGenAIAdapter",

--- a/backend/app/models/adapters/anthropic_compatible.py
+++ b/backend/app/models/adapters/anthropic_compatible.py
@@ -1,0 +1,26 @@
+"""Anthropic-compatible adapter without a model discovery endpoint."""
+
+import httpx
+
+from app.models.adapters.base import BaseAdapter
+
+
+class AnthropicCompatibleAdapter(BaseAdapter):
+    """Anthropic-compatible provider adapter supporting LLM calls only."""
+
+    @property
+    def provider_type(self) -> str:
+        return "anthropic-compatible"
+
+    def supports_embedding(self) -> bool:
+        return False
+
+    async def get_llm_models(
+        self, client: httpx.AsyncClient, base_url: str, api_key: str
+    ) -> list[dict[str, str]]:
+        return []
+
+    async def get_embedding_models(
+        self, client: httpx.AsyncClient, base_url: str, api_key: str
+    ) -> list[dict[str, str]]:
+        return []

--- a/backend/app/models/clients/model_factory.py
+++ b/backend/app/models/clients/model_factory.py
@@ -113,7 +113,7 @@ def create_chat_model(config: ModelConfig) -> Runnable[LanguageModelInput, BaseM
     provider = config.provider_type
     reasoning_effort = _enabled_reasoning_effort(config)
 
-    if provider == "anthropic":
+    if provider in {"anthropic", "anthropic-compatible"}:
         from langchain_anthropic import ChatAnthropic
 
         return ChatAnthropic(**_compact_kwargs(

--- a/backend/app/models/registry.py
+++ b/backend/app/models/registry.py
@@ -9,6 +9,7 @@ from typing import Type
 
 from app.models.adapters.base import BaseAdapter
 from app.models.adapters.anthropic import AnthropicAdapter
+from app.models.adapters.anthropic_compatible import AnthropicCompatibleAdapter
 from app.models.adapters.deepseek import DeepSeekAdapter
 from app.models.adapters.google_genai import GoogleGenAIAdapter
 from app.models.adapters.mistral import MistralAdapter
@@ -31,6 +32,7 @@ class AdapterRegistry:
     _registry: dict[str, Type[BaseAdapter]] = {
         "openai": OpenAIAdapter,
         "anthropic": AnthropicAdapter,
+        "anthropic-compatible": AnthropicCompatibleAdapter,
         "google-genai": GoogleGenAIAdapter,
         "ollama": OpenAICompatibleAdapter,
         "groq": GroqAdapter,

--- a/backend/app/models/services/model_provider_service.py
+++ b/backend/app/models/services/model_provider_service.py
@@ -128,7 +128,7 @@ class ModelProviderService:
         return provider
 
     async def _resolve_provider_url(self, provider_type: str, url: str) -> str:
-        if provider_type == "openai-compatible":
+        if provider_type in {"openai-compatible", "anthropic-compatible"}:
             return url
 
         try:
@@ -259,7 +259,12 @@ class ModelProviderService:
         url = await self._resolve_provider_url(provider_type, url)
 
         # 使用统一的Adapter获取模型
-        adapter = AdapterRegistry.get_adapter("openai-compatible")
+        runtime_provider_type = (
+            "anthropic-compatible"
+            if provider_type == "anthropic-compatible"
+            else "openai-compatible"
+        )
+        adapter = AdapterRegistry.get_adapter(runtime_provider_type)
 
         try:
             async with httpx.AsyncClient(timeout=30.0) as client:
@@ -294,7 +299,11 @@ class ModelProviderService:
         )
 
         # 检查是否支持
-        runtime_provider_type = "openai-compatible"
+        runtime_provider_type = (
+            "anthropic-compatible"
+            if provider.provider_type == "anthropic-compatible"
+            else "openai-compatible"
+        )
         if not AdapterRegistry.is_supported(runtime_provider_type, task_type):
             raise ValueError(
                 f"Provider '{provider.provider_type}' does not support task_type '{task_type}'"

--- a/backend/tests/agent_runtime/persistence/test_persister.py
+++ b/backend/tests/agent_runtime/persistence/test_persister.py
@@ -59,6 +59,41 @@ async def test_persister_normal_chat_model_stream(
 
 
 @pytest.mark.asyncio
+async def test_persister_extracts_anthropic_text_content_blocks(
+    db_session: AsyncSession, db_session_factory, sample_task
+):
+    sid = "session_anthropic_content_blocks"
+    p = MessagePersister(
+        session_id=sid,
+        task_id=sample_task.id,
+        project_id=sample_task.project_id,
+        db_session_factory=db_session_factory,
+    )
+
+    await p.handle({"event": "on_chat_model_start", "data": {}})
+    await p.handle({
+        "event": "on_chat_model_stream",
+        "data": {
+            "chunk": AIMessageChunk(
+                content=[
+                    {"type": "thinking", "thinking": "分析中"},
+                    {"type": "text", "text": "可见回复"},
+                ]
+            )
+        },
+    })
+    await p.handle({
+        "event": "on_chat_model_end",
+        "data": {"output": AIMessage(content=[{"type": "text", "text": "可见回复"}])},
+    })
+
+    items = await repo.list_by_session(db_session, sid)
+    assert len(items) == 1
+    assert items[0].content == "可见回复"
+    assert items[0].reasoning == "分析中"
+
+
+@pytest.mark.asyncio
 async def test_persister_persists_non_streaming_chat_model_end_output(
     db_session: AsyncSession, db_session_factory, sample_task
 ):

--- a/backend/tests/agent_runtime/test_event_translator.py
+++ b/backend/tests/agent_runtime/test_event_translator.py
@@ -24,6 +24,34 @@ def test_translate_chat_model_stream():
     assert result["data"]["session_id"] == "sess_001"
 
 
+def test_translate_chat_model_stream_extracts_anthropic_text_content_blocks():
+    translator = EventTranslator(session_id="sess_001")
+    event = {
+        "event": "on_chat_model_stream",
+        "data": {
+            "chunk": type(
+                "Chunk",
+                (),
+                {
+                    "content": [
+                        {"type": "thinking", "thinking": "分析中"},
+                        {"type": "text", "text": "可见回复"},
+                    ]
+                },
+            )()
+        },
+        "name": "ChatAnthropic",
+        "tags": [],
+    }
+
+    result = translator.translate(event)
+
+    assert isinstance(result, list)
+    assert [item["name"] for item in result] == ["agent:reasoning", "agent:token"]
+    assert result[0]["data"]["content"] == "分析中"
+    assert result[1]["data"]["content"] == "可见回复"
+
+
 def test_translate_ignores_subagent_child_events():
     translator = EventTranslator(session_id="sess_001")
     event = {

--- a/backend/tests/agent_runtime/test_model_factory.py
+++ b/backend/tests/agent_runtime/test_model_factory.py
@@ -51,6 +51,25 @@ def test_create_chat_model_anthropic_uses_native_client():
     assert isinstance(model, ChatAnthropic)
 
 
+def test_create_chat_model_anthropic_compatible_uses_anthropic_client_with_custom_url():
+    config = ModelConfig(
+        provider_type="anthropic-compatible",
+        base_url="https://gateway.example/v1",
+        api_key="test-key",
+        model_id="custom-claude",
+        reasoning_effort="high",
+    )
+
+    model = create_chat_model(config)
+
+    from langchain_anthropic import ChatAnthropic
+
+    assert isinstance(model, ChatAnthropic)
+    assert model.anthropic_api_url == "https://gateway.example/v1"
+    assert model.effort == "high"
+    assert model.max_retries == 0
+
+
 def test_create_chat_model_with_temperature():
     config = ModelConfig(
         provider_type="openai",

--- a/backend/tests/agent_runtime/test_react_agent.py
+++ b/backend/tests/agent_runtime/test_react_agent.py
@@ -125,6 +125,22 @@ async def test_invoke_model_normalizes_recoverable_invalid_tool_calls_to_ai_mess
     assert response.invalid_tool_calls == []
 
 
+@pytest.mark.asyncio
+async def test_invoke_model_extracts_anthropic_text_content_blocks() -> None:
+    class StreamingModel:
+        async def astream(self, _messages):
+            yield AIMessageChunk(
+                content=[
+                    {"type": "thinking", "thinking": "分析中"},
+                    {"type": "text", "text": "可见回复"},
+                ]
+            )
+
+    response = await _invoke_model(StreamingModel(), [HumanMessage(content="Hello")])
+
+    assert response.content == "可见回复"
+
+
 def test_create_react_agent_returns_compiled_graph(dummy_tool):
     config = ReactAgentConfig(
         name="test",

--- a/backend/tests/api/test_model_providers.py
+++ b/backend/tests/api/test_model_providers.py
@@ -248,6 +248,55 @@ async def test_validate_provider_invalid_credentials(
 
 
 @pytest.mark.asyncio
+async def test_validate_anthropic_compatible_provider_succeeds_without_model_discovery(
+    client: AsyncClient,
+):
+    response = await client.post(
+        "/api/v1/model-providers/validate",
+        json={
+            "provider_type": "anthropic-compatible",
+            "url": "https://gateway.example/v1",
+            "api_key": "test-key",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "success": True,
+        "message": "连接验证成功，但该提供商可能不支持模型列表 API",
+        "models": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_anthropic_compatible_provider_models_returns_empty_success(
+    client: AsyncClient,
+    session: AsyncSession,
+):
+    from app.core.encryption import EncryptionService
+    from app.settings import settings
+
+    encrypted_key = EncryptionService(settings.encryption_key).encrypt("test-key")
+    provider = await model_provider_repo.create(
+        session=session,
+        name="Anthropic Compatible",
+        url="https://gateway.example/v1",
+        api_key_encrypted=encrypted_key,
+        provider_type="anthropic-compatible",
+    )
+    await session.commit()
+
+    response = await client.get(f"/api/v1/model-providers/{provider.id}/models")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "success": True,
+        "message": "该提供商可能不支持模型列表 API",
+        "models": [],
+    }
+
+
+@pytest.mark.asyncio
 async def test_create_openrouter_provider(client: AsyncClient, session: AsyncSession):
     """测试创建 OpenRouter 提供商。"""
     # 使用 FormData 格式（与 API 定义一致）

--- a/backend/tests/models/test_anthropic_compatible_adapter.py
+++ b/backend/tests/models/test_anthropic_compatible_adapter.py
@@ -1,0 +1,36 @@
+import httpx
+import pytest
+
+from app.models.registry import AdapterRegistry
+
+
+class _RecordingClient:
+    def __init__(self) -> None:
+        self.urls: list[str] = []
+
+    async def get(self, url: str, **kwargs: object) -> httpx.Response:
+        self.urls.append(url)
+        return httpx.Response(
+            200,
+            json={"data": [{"id": "unexpected-model"}]},
+            request=httpx.Request("GET", url),
+        )
+
+
+@pytest.mark.asyncio
+async def test_anthropic_compatible_adapter_only_supports_llm_without_model_discovery() -> None:
+    adapter = AdapterRegistry.get_adapter("anthropic-compatible")
+    client = _RecordingClient()
+
+    models = await adapter.get_llm_models(
+        client,  # type: ignore[arg-type]
+        "https://gateway.example/v1",
+        "test-key",
+    )
+
+    assert adapter.provider_type == "anthropic-compatible"
+    assert adapter.supports_llm()
+    assert not adapter.supports_embedding()
+    assert not adapter.supports_rerank()
+    assert models == []
+    assert client.urls == []

--- a/backend/tests/models/test_model_provider_service.py
+++ b/backend/tests/models/test_model_provider_service.py
@@ -89,6 +89,80 @@ async def test_get_available_models_uses_openai_compatible_adapter_for_catalog_p
 
 
 @pytest.mark.asyncio
+async def test_validate_anthropic_compatible_connection_uses_its_adapter(monkeypatch):
+    encryption_service = EncryptionService("id-hEPdEELwlgep9FQhcYQtX7ow188l7WHwy65qOZGQ=")
+    service = ModelProviderService(encryption_service)
+    requested_provider_types: list[str] = []
+
+    def get_adapter(cls, provider_type: str):
+        requested_provider_types.append(provider_type)
+        return _FakeAdapter()
+
+    monkeypatch.setattr(AdapterRegistry, "get_adapter", classmethod(get_adapter))
+
+    models = await service.validate_and_get_models(
+        "anthropic-compatible",
+        "https://gateway.example/v1",
+        "test-key",
+    )
+
+    assert models == [{"id": "llm-1", "name": "LLM 1"}]
+    assert requested_provider_types == ["anthropic-compatible"]
+
+
+@pytest.mark.asyncio
+async def test_validate_native_anthropic_connection_keeps_openai_compatible_discovery(
+    monkeypatch,
+):
+    encryption_service = EncryptionService("id-hEPdEELwlgep9FQhcYQtX7ow188l7WHwy65qOZGQ=")
+    service = ModelProviderService(encryption_service)
+    requested_provider_types: list[str] = []
+
+    def get_adapter(cls, provider_type: str):
+        requested_provider_types.append(provider_type)
+        return _FakeAdapter()
+
+    monkeypatch.setattr(AdapterRegistry, "get_adapter", classmethod(get_adapter))
+
+    await service.validate_and_get_models(
+        "anthropic",
+        "https://api.anthropic.com",
+        "test-key",
+    )
+
+    assert requested_provider_types == ["anthropic", "openai-compatible"]
+
+
+@pytest.mark.asyncio
+async def test_get_available_models_uses_anthropic_compatible_adapter(monkeypatch):
+    encryption_service = EncryptionService("id-hEPdEELwlgep9FQhcYQtX7ow188l7WHwy65qOZGQ=")
+    service = ModelProviderService(encryption_service)
+    provider = ModelProvider(
+        name="Anthropic Compatible",
+        url="https://gateway.example/v1",
+        api_key_encrypted=encryption_service.encrypt("test-key"),
+        provider_type="anthropic-compatible",
+    )
+    requested_provider_types: list[str] = []
+
+    def get_adapter(cls, provider_type: str):
+        requested_provider_types.append(provider_type)
+        return _FakeAdapter()
+
+    def is_supported(cls, provider_type: str, task_type: str) -> bool:
+        requested_provider_types.append(provider_type)
+        return task_type == "llm"
+
+    monkeypatch.setattr(AdapterRegistry, "get_adapter", classmethod(get_adapter))
+    monkeypatch.setattr(AdapterRegistry, "is_supported", classmethod(is_supported))
+
+    models = await service.get_available_models(provider, "llm")
+
+    assert models == [{"id": "llm-1", "name": "LLM 1"}]
+    assert requested_provider_types == ["anthropic-compatible", "anthropic-compatible"]
+
+
+@pytest.mark.asyncio
 async def test_create_provider_uses_catalog_api_for_directory_provider(monkeypatch):
     encryption_service = EncryptionService("id-hEPdEELwlgep9FQhcYQtX7ow188l7WHwy65qOZGQ=")
     service = ModelProviderService(encryption_service)

--- a/backend/tests/models/test_model_registry.py
+++ b/backend/tests/models/test_model_registry.py
@@ -21,5 +21,6 @@ def test_registry_lists_only_current_first_class_provider_types() -> None:
         "amazon-nova",
         "deepseek",
         "openai-compatible",
+        "anthropic-compatible",
     }
     assert "google-vertex" not in AdapterRegistry.list_providers()

--- a/frontend/src/components/model-id-select.tsx
+++ b/frontend/src/components/model-id-select.tsx
@@ -61,6 +61,14 @@ export function getModelValue(model: ModelIdSelectOption): string {
   return model.value ?? model.id;
 }
 
+export function shouldShowCustomModelOption(
+  allowCustomValue: boolean,
+  searchQuery: string,
+  filteredModelCount: number,
+): boolean {
+  return allowCustomValue && Boolean(searchQuery.trim()) && filteredModelCount === 0;
+}
+
 const PRICE_FORMATTER = new Intl.NumberFormat("en-US", {
   minimumFractionDigits: 0,
   maximumFractionDigits: 4,
@@ -197,8 +205,11 @@ export function ModelIdSelect({
     };
   }, [isListReady, isLoading, open]);
 
-  const showCustomOption =
-    allowCustomValue && searchQuery.trim() && filteredModels.length === 0 && models.length > 0;
+  const showCustomOption = shouldShowCustomModelOption(
+    allowCustomValue,
+    searchQuery,
+    filteredModels.length,
+  );
 
   const handleSelectModel = (model: ModelIdSelectOption) => {
     const nextValue = getModelValue(model);
@@ -451,30 +462,38 @@ export function ModelIdSelect({
                     </Text>
                   </MotionBox>
                 ) : null}
-                <Flex
-                  align="center"
-                  justify="center"
-                  direction="column"
-                  gap="2"
-                  style={{ height: placeholderHeight, padding: 20 }}
-                >
-                  <Text
-                    size={labelSize}
-                    color="gray"
+                {showCustomOption ? (
+                  <CustomModelOption
+                    modelId={searchQuery}
+                    onSelect={handleUseCustom}
+                    itemPadding={itemPadding}
+                  />
+                ) : (
+                  <Flex
                     align="center"
+                    justify="center"
+                    direction="column"
+                    gap="2"
+                    style={{ height: placeholderHeight, padding: 20 }}
                   >
-                    {t("models.noModelsAvailable")}
-                  </Text>
-                  {allowCustomValue ? (
                     <Text
-                      size="1"
+                      size={labelSize}
                       color="gray"
                       align="center"
                     >
-                      {t("models.manualInputHint")}
+                      {t("models.noModelsAvailable")}
                     </Text>
-                  ) : null}
-                </Flex>
+                    {allowCustomValue ? (
+                      <Text
+                        size="1"
+                        color="gray"
+                        align="center"
+                      >
+                        {t("models.manualInputHint")}
+                      </Text>
+                    ) : null}
+                  </Flex>
+                )}
               </Flex>
             ) : (
               <Flex direction="column">
@@ -503,40 +522,11 @@ export function ModelIdSelect({
                 ) : null}
 
                 {showCustomOption ? (
-                  <MotionBox
-                    onClick={handleUseCustom}
-                    style={{
-                      padding: itemPadding,
-                      cursor: "pointer",
-                      borderBottom:
-                        filteredModels.length > 0 ? "1px solid var(--gray-a3)" : undefined,
-                      backgroundColor: "var(--blue-a2)",
-                    }}
-                    whileHover={{ backgroundColor: "var(--blue-a3)" }}
-                    whileTap={{ scale: 0.98 }}
-                    transition={{ duration: 0.15 }}
-                  >
-                    <Flex
-                      direction="column"
-                      gap="1"
-                    >
-                      <Text
-                        size="2"
-                        weight="medium"
-                        color="blue"
-                      >
-                        {t("models.useCustomModelId", {
-                          modelId: searchQuery,
-                        })}
-                      </Text>
-                      <Text
-                        size="1"
-                        color="gray"
-                      >
-                        {t("models.customModelIdHint")}
-                      </Text>
-                    </Flex>
-                  </MotionBox>
+                  <CustomModelOption
+                    modelId={searchQuery}
+                    onSelect={handleUseCustom}
+                    itemPadding={itemPadding}
+                  />
                 ) : null}
 
                 {filteredModels.map((model, index) => {
@@ -677,5 +667,48 @@ export function ModelIdSelect({
         </Box>
       </Popover.Content>
     </Popover.Root>
+  );
+}
+
+interface CustomModelOptionProps {
+  modelId: string;
+  onSelect: () => void;
+  itemPadding: string;
+}
+
+function CustomModelOption({ modelId, onSelect, itemPadding }: CustomModelOptionProps) {
+  const { t } = useTranslation();
+
+  return (
+    <MotionBox
+      onClick={onSelect}
+      style={{
+        padding: itemPadding,
+        cursor: "pointer",
+        backgroundColor: "var(--blue-a2)",
+      }}
+      whileHover={{ backgroundColor: "var(--blue-a3)" }}
+      whileTap={{ scale: 0.98 }}
+      transition={{ duration: 0.15 }}
+    >
+      <Flex
+        direction="column"
+        gap="1"
+      >
+        <Text
+          size="2"
+          weight="medium"
+          color="blue"
+        >
+          {t("models.useCustomModelId", { modelId })}
+        </Text>
+        <Text
+          size="1"
+          color="gray"
+        >
+          {t("models.customModelIdHint")}
+        </Text>
+      </Flex>
+    </MotionBox>
   );
 }

--- a/frontend/src/components/provider-id-select.tsx
+++ b/frontend/src/components/provider-id-select.tsx
@@ -30,6 +30,12 @@ const OPENAI_COMPATIBLE_OPTION: ProviderIdSelectOption = {
   iconPath: null,
 };
 
+const ANTHROPIC_COMPATIBLE_OPTION: ProviderIdSelectOption = {
+  value: "anthropic-compatible",
+  label: "Anthropic Compatible",
+  iconPath: null,
+};
+
 export function ProviderIdSelect({
   value,
   onChange,
@@ -49,8 +55,10 @@ export function ProviderIdSelect({
       iconPath: provider.iconPath,
     }));
 
-    if (!catalogOptions.some((option) => option.value === OPENAI_COMPATIBLE_OPTION.value)) {
-      catalogOptions.push(OPENAI_COMPATIBLE_OPTION);
+    for (const compatibleOption of [OPENAI_COMPATIBLE_OPTION, ANTHROPIC_COMPATIBLE_OPTION]) {
+      if (!catalogOptions.some((option) => option.value === compatibleOption.value)) {
+        catalogOptions.push(compatibleOption);
+      }
     }
 
     return catalogOptions.sort((left, right) => left.label.localeCompare(right.label));

--- a/frontend/src/features/settings/components/connection-form-dialog.tsx
+++ b/frontend/src/features/settings/components/connection-form-dialog.tsx
@@ -13,6 +13,10 @@ import { validateProvider } from "../lib/model-api";
 import { ProviderIcon } from "../lib/provider-icons";
 import { getProviderUrl } from "../lib/provider-utils";
 
+function isCustomUrlProvider(providerType: string): boolean {
+  return providerType === "openai-compatible" || providerType === "anthropic-compatible";
+}
+
 const connectionSchema = z
   .object({
     name: z.string().optional(),
@@ -22,8 +26,7 @@ const connectionSchema = z
   })
   .refine(
     (data) => {
-      // 如果是 OpenAI 兼容模式，URL 是必需的
-      if (data.providerType === "openai-compatible") {
+      if (isCustomUrlProvider(data.providerType)) {
         return data.url && data.url.trim().length > 0;
       }
       // 其他模式，URL 会自动填充，不需要验证
@@ -101,9 +104,8 @@ export function ConnectionFormDialog({
   useEffect(() => {
     if (!providerType) return;
 
-    if (providerType === "openai-compatible") {
-      // 切换到 OpenAI 兼容模式时，清空 URL（除非是编辑模式且原本就是 OpenAI 兼容）
-      if (!isEditing || connection?.providerType !== "openai-compatible") {
+    if (isCustomUrlProvider(providerType)) {
+      if (!isEditing || connection?.providerType !== providerType) {
         setValue("url", "");
       }
     }
@@ -111,7 +113,7 @@ export function ConnectionFormDialog({
 
   // 当提供商类型改变时，自动设置固定 URL
   useEffect(() => {
-    if (!providerType || providerType === "openai-compatible") {
+    if (!providerType || isCustomUrlProvider(providerType)) {
       return;
     }
 
@@ -234,7 +236,7 @@ export function ConnectionFormDialog({
 
   const canValidate = useMemo(() => {
     if (!providerType) return false;
-    if (providerType === "openai-compatible" && (!url || !url.trim())) return false;
+    if (isCustomUrlProvider(providerType) && (!url || !url.trim())) return false;
     if (!isEditing && !apiKey) return false;
     return true;
   }, [providerType, url, isEditing, apiKey]);
@@ -359,8 +361,7 @@ export function ConnectionFormDialog({
               </Flex>
             </Flex>
 
-            {/* 服务 URL - 仅 OpenAI 兼容模式显示 */}
-            {providerType === "openai-compatible" && (
+            {isCustomUrlProvider(providerType) && (
               <Flex
                 direction="column"
                 gap="2"

--- a/frontend/src/features/settings/components/connections-settings.tsx
+++ b/frontend/src/features/settings/components/connections-settings.tsx
@@ -244,7 +244,8 @@ export function ConnectionsSettings({
                           weight="medium"
                         >
                           {connection.name ||
-                            (connection.providerType === "openai-compatible"
+                            (connection.providerType === "openai-compatible" ||
+                            connection.providerType === "anthropic-compatible"
                               ? connection.url
                               : null) ||
                             resolveProviderDisplayName(connection)}
@@ -261,8 +262,8 @@ export function ConnectionsSettings({
                           {connection.catalogMatch?.displayName ||
                             getProviderDisplayName(connection.providerType)}
                         </Text>
-                        {/* 仅未匹配目录的 OpenAI Compatible 连接显示自定义 URL。 */}
-                        {connection.providerType === "openai-compatible" &&
+                        {(connection.providerType === "openai-compatible" ||
+                          connection.providerType === "anthropic-compatible") &&
                           !connection.catalogMatch && (
                             <>
                               <Text

--- a/frontend/src/features/settings/components/model-form-dialog.tsx
+++ b/frontend/src/features/settings/components/model-form-dialog.tsx
@@ -613,7 +613,8 @@ export function ModelFormDialog({
                     {t(`models.${errors.modelId.message}`)}
                   </Text>
                 )}
-                {selectedProvider?.providerType === "openai-compatible" &&
+                {(selectedProvider?.providerType === "openai-compatible" ||
+                  selectedProvider?.providerType === "anthropic-compatible") &&
                   !selectedCatalogProviderType &&
                   !loadingModels && (
                     <Text

--- a/frontend/src/features/settings/lib/provider-utils.ts
+++ b/frontend/src/features/settings/lib/provider-utils.ts
@@ -46,6 +46,7 @@ export function getProviderDisplayName(providerType: string): string {
     "amazon-nova": "Amazon Nova",
     deepseek: "DeepSeek",
     "openai-compatible": "OpenAI Compatible",
+    "anthropic-compatible": "Anthropic Compatible",
     builtin: "Builtin",
   };
 
@@ -59,7 +60,7 @@ export function getProviderUrl(
   providerType: string,
   catalogProviders?: ModelProviderCatalogProvider[],
 ): string | null {
-  if (providerType === "openai-compatible") {
+  if (providerType === "openai-compatible" || providerType === "anthropic-compatible") {
     return null;
   }
 
@@ -70,7 +71,10 @@ export function getProviderUrl(
 }
 
 export function resolveProviderCatalogType(provider: ModelProvider): string | null {
-  if (provider.providerType === "openai-compatible") {
+  if (
+    provider.providerType === "openai-compatible" ||
+    provider.providerType === "anthropic-compatible"
+  ) {
     return provider.catalogMatch?.catalogProviderType ?? null;
   }
 


### PR DESCRIPTION
## PR 标题

chore(provider): 新增 Anthropic Compatible 提供商

## 变更说明

- 问题: 现有提供商仅支持 OpenAI Compatible 自定义网关，无法接入 Anthropic Messages 协议的兼容服务。
- 重要性: 支持使用 Anthropic 兼容网关的模型，并避免无模型发现接口时的配置、选择和响应展示问题。
- 变化: 新增 `anthropic-compatible` 类型，支持自定义 URL 和 API Key，仅支持 LLM，模型 ID 可手动填写且不请求模型目录或远端模型列表。
- 变化: 运行时使用 `ChatAnthropic` 发送 Anthropic 格式请求，并将内容块中的文本和推理分别转换为现有的显示与持久化格式。
- 变化: 空模型列表时可使用手动模型 ID，且不再请求 `anthropic-compatible` 的目录模型接口。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因(如有)

不适用。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 已运行 `just check`，后端全量 1287 项测试通过，存在 1 条已有 NVIDIA 模型弃用警告。
- 已运行 `pnpm type-check`、`pnpm lint`、`pnpm format:check` 与 `pnpm build`；构建仅输出已有的 bundle 体积警告。
- 前端测试文件未保留，遵循项目规则。
