### PR TITLE
fix(desktop): 修复本地后端 Socket 代理连接失败的问题

### DIFF
--- a/desktop/src/main/proxy.ts
+++ b/desktop/src/main/proxy.ts
@@ -3,13 +3,17 @@ import { appendLog } from "./logging.js";
 
 const configuredSessions = new WeakMap<Session, Promise<void>>();
 const LOCAL_BYPASS_HOSTS = ["localhost", "127.0.0.1"];
+const SYSTEM_PROXY_BYPASS_RULES = "<local>,127.0.0.1/8";
 const INVALID_NO_PROXY_HOSTS = new Set(["::1", "[::1]"]);
 
 export function configureSystemProxy(targetSession: Session): Promise<void> {
   const configured = configuredSessions.get(targetSession);
   if (configured) return configured;
 
-  const configuration = targetSession.setProxy({ mode: "system" }).catch((error: unknown) => {
+  const configuration = targetSession.setProxy({
+    mode: "system",
+    proxyBypassRules: SYSTEM_PROXY_BYPASS_RULES,
+  }).catch((error: unknown) => {
     appendLog("startup", `配置系统代理失败：${error instanceof Error ? error.message : String(error)}`);
   });
   configuredSessions.set(targetSession, configuration);


### PR DESCRIPTION
## PR 标题

fix(desktop): 修复本地后端 Socket 代理连接失败的问题

## 变更说明

- 问题: 桌面端 Webview 使用系统代理时，本地后端 HTTP 请求可用，但 Socket.IO 连接可能被代理接管而失败
- 重要性: 本地运行模式无法接收实时事件，影响 Agent、后台任务等依赖 Socket.IO 的功能
- 变化: 为 Electron 会话配置本地地址绕过规则，使环回地址直连本地后端，外部请求仍使用系统代理

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

Electron Webview 会话仅配置了系统代理，未通过 `proxyBypassRules` 绕过本地环回地址。HTTP 健康检查由 Node 直接访问本地后端，因此不会暴露该问题；Socket.IO 请求使用 Chromium 网络栈，可能被系统代理处理并导致连接失败。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

未新增自动化测试：桌面端当前未配置测试运行器，本次为 Electron `setProxy` 配置项变更。已执行 `pnpm type-check`、`pnpm lint` 和 `git diff --check`。
