### PR TITLE
chore(list): 优化角色和世界书列表体验

### DIFF
--- a/backend/app/agent_runtime/tools/impls/context/character.py
+++ b/backend/app/agent_runtime/tools/impls/context/character.py
@@ -135,10 +135,7 @@ def _build_character_diff(
 
 
 async def _list_project_characters(session, project_id: str) -> list[Character]:
-    characters, _ = await character_repo.list_by_project(
-        session, project_id, page=1, page_size=10000
-    )
-    return characters
+    return await character_repo.list_all_by_project(session, project_id)
 
 
 async def _resolve_character_by_name(session, project_id: str, name: str) -> Character:

--- a/backend/app/agent_runtime/tools/impls/context/world_entry.py
+++ b/backend/app/agent_runtime/tools/impls/context/world_entry.py
@@ -153,9 +153,7 @@ async def _resolve_entry_by_title(session, world_info_id: str, title: str) -> Wo
     normalized_title = title.strip()
     if not normalized_title:
         raise ToolExecutionError("世界书条目标题不能为空")
-    entries = await world_info_entry_repo.list_by_world_info(
-        session, world_info_id, offset=0, limit=10000
-    )
+    entries = await world_info_entry_repo.list_all_by_world_info(session, world_info_id)
     matches = [entry for entry in entries if entry.name == normalized_title]
     if not matches:
         raise ToolExecutionError(f"世界书条目不存在: {normalized_title}")
@@ -173,9 +171,7 @@ async def _ensure_title_available(
     normalized_title = title.strip()
     if not normalized_title:
         raise ToolExecutionError("世界书条目标题不能为空")
-    entries = await world_info_entry_repo.list_by_world_info(
-        session, world_info_id, offset=0, limit=10000
-    )
+    entries = await world_info_entry_repo.list_all_by_world_info(session, world_info_id)
     if any(
         entry.name == normalized_title and entry.id != exclude_entry_id for entry in entries
     ):

--- a/backend/app/api/routers/characters.py
+++ b/backend/app/api/routers/characters.py
@@ -64,19 +64,13 @@ def to_list_item_response(character: Character) -> CharacterListItemResponse:
 async def list_project_characters(
     project_id: str,
     session: Annotated[AsyncSession, Depends(get_session)],
-    page: Annotated[int, Query(ge=1, description="页码")] = 1,
-    page_size: Annotated[int, Query(ge=1, le=100, description="每页数量")] = 50,
 ) -> CharacterListResponse:
     """获取项目角色列表。"""
     try:
-        result = await character_service.list_characters_by_project(
-            session, project_id, page=page, page_size=page_size
-        )
+        characters = await character_service.list_characters_by_project(session, project_id)
         return CharacterListResponse(
-            items=[to_list_item_response(character) for character in result.items],
-            total=result.total,
-            page=result.page,
-            page_size=result.page_size,
+            items=[to_list_item_response(character) for character in characters],
+            total=len(characters),
         )
     except NotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/backend/app/api/routers/world_info_entries.py
+++ b/backend/app/api/routers/world_info_entries.py
@@ -253,8 +253,6 @@ async def create_entry(
 async def list_entries(
     world_info_id: str,
     session: Annotated[AsyncSession, Depends(get_session)],
-    page: Annotated[int, Query(ge=1, description="页码")] = 1,
-    page_size: Annotated[int, Query(ge=1, le=500, description="每页数量")] = 100,
 ) -> WorldInfoEntryBriefListResponse:
     """
     获取世界书的条目列表（轻量，不含 content）。
@@ -262,9 +260,6 @@ async def list_entries(
     Args:
         world_info_id: 世界书 ID。
         session: 数据库 session。
-        page: 页码。
-        page_size: 每页数量。
-
     Returns:
         条目轻量列表。
 
@@ -272,14 +267,10 @@ async def list_entries(
         HTTPException: 世界书不存在。
     """
     try:
-        result = await world_info_entry_service.list_entries(
-            session, world_info_id, page=page, page_size=page_size
-        )
+        entries = await world_info_entry_service.list_entries(session, world_info_id)
         return WorldInfoEntryBriefListResponse(
-            items=[_entry_to_brief_response(e) for e in result.items],
-            total=result.total,
-            page=result.page,
-            page_size=result.page_size,
+            items=[_entry_to_brief_response(entry) for entry in entries],
+            total=len(entries),
         )
     except NotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/backend/app/api/schemas/character.py
+++ b/backend/app/api/schemas/character.py
@@ -37,8 +37,6 @@ class CharacterListResponse(BaseModel):
 
     items: list[CharacterListItemResponse] = Field(description="角色列表")
     total: int = Field(description="总数")
-    page: int = Field(description="当前页码")
-    page_size: int = Field(description="每页数量")
 
 
 class CharacterSearchMatch(BaseModel):

--- a/backend/app/api/schemas/world_info.py
+++ b/backend/app/api/schemas/world_info.py
@@ -126,8 +126,6 @@ class WorldInfoEntryBriefListResponse(BaseModel):
 
     items: list[WorldInfoEntryBriefResponse] = Field(description="条目列表")
     total: int = Field(description="总数")
-    page: int = Field(description="当前页码")
-    page_size: int = Field(description="每页数量")
 
 
 class WorldInfoImportPreviewEntry(BaseModel):

--- a/backend/app/storage/repos/character_repo.py
+++ b/backend/app/storage/repos/character_repo.py
@@ -78,6 +78,16 @@ async def list_by_project(
     return list(result.scalars().all()), total
 
 
+async def list_all_by_project(session: AsyncSession, project_id: str) -> list[Character]:
+    """按项目获取全部角色列表。"""
+    result = await session.execute(
+        select(Character)
+        .where(col(Character.project_id) == project_id)
+        .order_by(col(Character.is_favorited).desc(), col(Character.updated_at).desc())
+    )
+    return list(result.scalars().all())
+
+
 async def update(session: AsyncSession, character: Character) -> Character:
     """更新角色。"""
     session.add(character)

--- a/backend/app/storage/repos/world_info_entry_repo.py
+++ b/backend/app/storage/repos/world_info_entry_repo.py
@@ -76,6 +76,19 @@ async def list_by_world_info(
     return list(result.scalars().all())
 
 
+async def list_all_by_world_info(
+    session: AsyncSession,
+    world_info_id: str,
+) -> list[WorldInfoEntry]:
+    """获取世界书的全部条目列表。"""
+    result = await session.execute(
+        select(WorldInfoEntry)
+        .where(col(WorldInfoEntry.world_info_id) == world_info_id)
+        .order_by(col(WorldInfoEntry.order))
+    )
+    return list(result.scalars().all())
+
+
 async def list_enabled_by_world_info(
     session: AsyncSession,
     world_info_id: str,

--- a/backend/app/storage/services/character_service.py
+++ b/backend/app/storage/services/character_service.py
@@ -16,16 +16,6 @@ from app.storage.repos import character_repo, project_repo
 
 
 @dataclass
-class CharacterListResult:
-    """角色列表结果。"""
-
-    items: list[Character]
-    total: int
-    page: int
-    page_size: int
-
-
-@dataclass
 class CharacterSearchMatch:
     """角色搜索匹配项。"""
 
@@ -108,16 +98,13 @@ async def get_character(session: AsyncSession, character_id: str) -> Character:
 async def list_characters_by_project(
     session: AsyncSession,
     project_id: str,
-    page: int = 1,
-    page_size: int = 50,
-) -> CharacterListResult:
+) -> list[Character]:
     """按项目获取角色列表。"""
     project = await project_repo.get_by_id(session, project_id)
     if project is None:
         raise NotFoundError(f"项目不存在: {project_id}")
 
-    items, total = await character_repo.list_by_project(session, project_id, page, page_size)
-    return CharacterListResult(items=items, total=total, page=page, page_size=page_size)
+    return await character_repo.list_all_by_project(session, project_id)
 
 
 async def search_characters(

--- a/backend/app/storage/services/world_info_entry_service.py
+++ b/backend/app/storage/services/world_info_entry_service.py
@@ -22,16 +22,6 @@ class WorldInfoEntryNameConflictError(ValueError):
 
 
 @dataclass
-class WorldInfoEntryListResult:
-    """世界书条目列表结果。"""
-
-    items: list[WorldInfoEntry]
-    total: int
-    page: int
-    page_size: int
-
-
-@dataclass
 class WorldInfoImportEntry:
     """归一化后的世界书导入条目。"""
 
@@ -106,9 +96,7 @@ async def _get_existing_entry_names(
     world_info_id: str,
     exclude_entry_id: str | None = None,
 ) -> set[str]:
-    entries = await world_info_entry_repo.list_by_world_info(
-        session, world_info_id, offset=0, limit=10000
-    )
+    entries = await world_info_entry_repo.list_all_by_world_info(session, world_info_id)
     return {entry.name for entry in entries if entry.id != exclude_entry_id}
 
 
@@ -213,9 +201,7 @@ async def import_entries(
         await world_info_entry_repo.delete_by_world_info(session, world_info_id)
         existing_entries: list[WorldInfoEntry] = []
     else:
-        existing_entries = await world_info_entry_repo.list_by_world_info(
-            session, world_info_id, offset=0, limit=10000
-        )
+        existing_entries = await world_info_entry_repo.list_all_by_world_info(session, world_info_id)
 
     existing_by_name = {entry.name: entry for entry in existing_entries}
     max_uid = await world_info_entry_repo.get_max_uid(session, world_info_id)
@@ -332,20 +318,15 @@ async def get_entry(session: AsyncSession, entry_id: str) -> WorldInfoEntry:
 async def list_entries(
     session: AsyncSession,
     world_info_id: str,
-    page: int = 1,
-    page_size: int = 100,
-) -> WorldInfoEntryListResult:
+) -> list[WorldInfoEntry]:
     """
     获取世界书条目列表。
 
     Args:
         session: 数据库 session。
         world_info_id: 世界书 ID。
-        page: 页码（从 1 开始）。
-        page_size: 每页数量。
-
     Returns:
-        条目列表结果。
+        条目列表。
 
     Raises:
         NotFoundError: 世界书不存在。
@@ -353,14 +334,7 @@ async def list_entries(
     # 检查世界书是否存在
     await get_world_info(session, world_info_id)
 
-    offset = (page - 1) * page_size
-    items = await world_info_entry_repo.list_by_world_info(
-        session, world_info_id, offset=offset, limit=page_size
-    )
-    total = await world_info_entry_repo.count_by_world_info(session, world_info_id)
-    return WorldInfoEntryListResult(
-        items=items, total=total, page=page, page_size=page_size
-    )
+    return await world_info_entry_repo.list_all_by_world_info(session, world_info_id)
 
 
 async def update_entry(
@@ -421,7 +395,7 @@ async def delete_all_entries(session: AsyncSession, world_info_id: str) -> int:
         删除的条目数量。
     """
     await get_world_info(session, world_info_id)
-    entries = await world_info_entry_repo.list_by_world_info(session, world_info_id)
+    entries = await world_info_entry_repo.list_all_by_world_info(session, world_info_id)
     count = len(entries)
     await world_info_entry_repo.delete_by_world_info(session, world_info_id)
     return count
@@ -526,15 +500,11 @@ async def reorder_entries(
     """
     if not orders:
         # 如果没有需要更新的条目，返回所有条目
-        return await world_info_entry_repo.list_by_world_info(
-            session, world_info_id, offset=0, limit=10000
-        )
+        return await world_info_entry_repo.list_all_by_world_info(session, world_info_id)
 
     # 验证所有条目ID是否存在且属于该世界书
     entry_ids = list(orders.keys())
-    entries = await world_info_entry_repo.list_by_world_info(
-        session, world_info_id, offset=0, limit=10000
-    )
+    entries = await world_info_entry_repo.list_all_by_world_info(session, world_info_id)
     entry_map = {entry.id: entry for entry in entries}
 
     for entry_id in entry_ids:
@@ -572,9 +542,7 @@ async def reorder_entries(
         await session.refresh(entry)
 
     # 返回所有条目，按新顺序排序
-    all_entries = await world_info_entry_repo.list_by_world_info(
-        session, world_info_id, offset=0, limit=10000
-    )
+    all_entries = await world_info_entry_repo.list_all_by_world_info(session, world_info_id)
     return sorted(all_entries, key=lambda e: e.order)
 
 

--- a/backend/tests/agent_runtime/tools/test_context_tool_approval_previews.py
+++ b/backend/tests/agent_runtime/tools/test_context_tool_approval_previews.py
@@ -59,7 +59,7 @@ async def test_create_world_entry_builds_approval_diff_preview() -> None:
             AsyncMock(return_value=_make_world_info()),
         ),
         patch(
-            "app.agent_runtime.tools.impls.context.world_entry.world_info_entry_repo.list_by_world_info",
+            "app.agent_runtime.tools.impls.context.world_entry.world_info_entry_repo.list_all_by_world_info",
             AsyncMock(return_value=[]),
         ),
     ):
@@ -102,7 +102,7 @@ async def test_edit_world_entry_builds_approval_diff_preview() -> None:
             AsyncMock(return_value=_make_world_info()),
         ),
         patch(
-            "app.agent_runtime.tools.impls.context.world_entry.world_info_entry_repo.list_by_world_info",
+            "app.agent_runtime.tools.impls.context.world_entry.world_info_entry_repo.list_all_by_world_info",
             AsyncMock(return_value=[entry]),
         ),
     ):
@@ -148,8 +148,8 @@ async def test_create_character_builds_approval_diff_preview() -> None:
     object.__setattr__(tool, "_config", {"configurable": {"db_session": runtime_session}})
 
     with patch(
-        "app.agent_runtime.tools.impls.context.character.character_repo.list_by_project",
-        AsyncMock(return_value=([], 0)),
+        "app.agent_runtime.tools.impls.context.character.character_repo.list_all_by_project",
+        AsyncMock(return_value=[]),
     ):
         preview = await tool.build_interrupt_preview({"name": "新角色", "description": "角色描述"})
 
@@ -185,8 +185,8 @@ async def test_edit_character_builds_approval_diff_preview() -> None:
     object.__setattr__(tool, "_config", {"configurable": {"db_session": runtime_session}})
 
     with patch(
-        "app.agent_runtime.tools.impls.context.character.character_repo.list_by_project",
-        AsyncMock(return_value=([character], 1)),
+        "app.agent_runtime.tools.impls.context.character.character_repo.list_all_by_project",
+        AsyncMock(return_value=[character]),
     ):
         preview = await tool.build_interrupt_preview(
             {"name": "旧角色", "old_description": "旧描述", "new_description": "新描述"}

--- a/backend/tests/agent_runtime/tools/test_context_tools.py
+++ b/backend/tests/agent_runtime/tools/test_context_tools.py
@@ -185,7 +185,7 @@ async def test_list_characters_returns_project_character_names() -> None:
     ) as mock_character_repo:
         mock_session = AsyncMock()
         mock_cs.return_value = mock_session
-        mock_character_repo.list_by_project = AsyncMock(return_value=(characters, 2))
+        mock_character_repo.list_all_by_project = AsyncMock(return_value=characters)
 
         result = await tool.ainvoke({})
 
@@ -218,7 +218,7 @@ async def test_read_character_reads_description_by_name() -> None:
     ) as mock_character_repo:
         mock_session = AsyncMock()
         mock_cs.return_value = mock_session
-        mock_character_repo.list_by_project = AsyncMock(return_value=(characters, 1))
+        mock_character_repo.list_all_by_project = AsyncMock(return_value=characters)
 
         result = await tool.ainvoke({"name": "林舟"})
 
@@ -253,7 +253,7 @@ async def test_create_character_returns_diff() -> None:
     ) as mock_record_diffs:
         mock_session = AsyncMock()
         mock_cs.return_value = mock_session
-        mock_character_repo.list_by_project = AsyncMock(return_value=([], 0))
+        mock_character_repo.list_all_by_project = AsyncMock(return_value=[])
         mock_character_service.create_character = AsyncMock(return_value=created)
         mock_record_diffs.return_value = ["char-1"]
 
@@ -345,7 +345,7 @@ async def test_edit_character_replaces_description_text() -> None:
     ) as mock_record_diffs:
         mock_session = AsyncMock()
         mock_cs.return_value = mock_session
-        mock_character_repo.list_by_project = AsyncMock(return_value=([character], 1))
+        mock_character_repo.list_all_by_project = AsyncMock(return_value=[character])
         mock_character_service.update_character = AsyncMock(return_value=updated_character)
         mock_record_diffs.return_value = ["char-1"]
 
@@ -398,7 +398,7 @@ async def test_edit_character_rejects_over_limit_replacement_without_updating() 
         "app.agent_runtime.tools.impls.context.character.character_service"
     ) as mock_character_service:
         mock_cs.return_value = AsyncMock()
-        mock_character_repo.list_by_project = AsyncMock(return_value=([character], 1))
+        mock_character_repo.list_all_by_project = AsyncMock(return_value=[character])
         mock_character_service.update_character = AsyncMock()
 
         result = await tool.ainvoke(
@@ -437,7 +437,7 @@ async def test_delete_character_removes_name() -> None:
     ) as mock_record_diffs:
         mock_session = AsyncMock()
         mock_cs.return_value = mock_session
-        mock_character_repo.list_by_project = AsyncMock(return_value=([character], 1))
+        mock_character_repo.list_all_by_project = AsyncMock(return_value=[character])
         mock_character_service.delete_character = AsyncMock(return_value=None)
         mock_record_diffs.return_value = ["char-1"]
 
@@ -502,7 +502,7 @@ async def test_read_world_entry_reads_content_by_title() -> None:
         mock_session = AsyncMock()
         mock_cs.return_value = mock_session
         mock_world_repo.get_by_project_id = AsyncMock(return_value=SimpleNamespace(id="world-1"))
-        mock_entry_repo.list_by_world_info = AsyncMock(return_value=entries)
+        mock_entry_repo.list_all_by_world_info = AsyncMock(return_value=entries)
 
         result = await tool.ainvoke({"title": "主角"})
 
@@ -534,7 +534,7 @@ async def test_read_world_entry_rejects_duplicate_titles() -> None:
         mock_session = AsyncMock()
         mock_cs.return_value = mock_session
         mock_world_repo.get_by_project_id = AsyncMock(return_value=SimpleNamespace(id="world-1"))
-        mock_entry_repo.list_by_world_info = AsyncMock(return_value=entries)
+        mock_entry_repo.list_all_by_world_info = AsyncMock(return_value=entries)
 
         result = await tool.ainvoke({"title": "主角"})
 
@@ -571,7 +571,7 @@ async def test_create_world_entry_returns_diff() -> None:
         mock_session = AsyncMock()
         mock_cs.return_value = mock_session
         mock_world_repo.get_by_project_id = AsyncMock(return_value=SimpleNamespace(id="world-1"))
-        mock_entry_repo.list_by_world_info = AsyncMock(return_value=[])
+        mock_entry_repo.list_all_by_world_info = AsyncMock(return_value=[])
         mock_entry_service.create_entry = AsyncMock(return_value=created)
         mock_record_diffs.return_value = ["e1"]
 
@@ -617,7 +617,7 @@ async def test_create_world_entry_rejects_duplicate_title() -> None:
         mock_session = AsyncMock()
         mock_cs.return_value = mock_session
         mock_world_repo.get_by_project_id = AsyncMock(return_value=SimpleNamespace(id="world-1"))
-        mock_entry_repo.list_by_world_info = AsyncMock(
+        mock_entry_repo.list_all_by_world_info = AsyncMock(
             return_value=[SimpleNamespace(id="e1", name="主角", uid=1, order=1, content="")]
         )
 
@@ -698,7 +698,7 @@ async def test_edit_world_entry_returns_diff() -> None:
         mock_session = AsyncMock()
         mock_cs.return_value = mock_session
         mock_world_repo.get_by_project_id = AsyncMock(return_value=SimpleNamespace(id="world-1"))
-        mock_entry_repo.list_by_world_info = AsyncMock(return_value=[entry])
+        mock_entry_repo.list_all_by_world_info = AsyncMock(return_value=[entry])
         mock_entry_service.update_entry = AsyncMock(return_value=updated_entry)
         mock_record_diffs.return_value = ["e1"]
 
@@ -758,7 +758,7 @@ async def test_edit_world_entry_rejects_over_limit_replacement_without_updating(
     ) as mock_entry_service:
         mock_cs.return_value = AsyncMock()
         mock_world_repo.get_by_project_id = AsyncMock(return_value=SimpleNamespace(id="world-1"))
-        mock_entry_repo.list_by_world_info = AsyncMock(return_value=[entry])
+        mock_entry_repo.list_all_by_world_info = AsyncMock(return_value=[entry])
         mock_entry_service.update_entry = AsyncMock()
 
         result = await tool.ainvoke(
@@ -793,7 +793,7 @@ async def test_edit_world_entry_rejects_duplicate_new_title() -> None:
         mock_session = AsyncMock()
         mock_cs.return_value = mock_session
         mock_world_repo.get_by_project_id = AsyncMock(return_value=SimpleNamespace(id="world-1"))
-        mock_entry_repo.list_by_world_info = AsyncMock(return_value=entries)
+        mock_entry_repo.list_all_by_world_info = AsyncMock(return_value=entries)
 
         result = await tool.ainvoke({"title": "主角", "new_title": "反派"})
 
@@ -830,7 +830,7 @@ async def test_delete_world_entry_removes_title() -> None:
         mock_session = AsyncMock()
         mock_cs.return_value = mock_session
         mock_world_repo.get_by_project_id = AsyncMock(return_value=SimpleNamespace(id="world-1"))
-        mock_entry_repo.list_by_world_info = AsyncMock(return_value=[entry])
+        mock_entry_repo.list_all_by_world_info = AsyncMock(return_value=[entry])
         mock_entry_service.delete_entry = AsyncMock(return_value=None)
         mock_record_diffs.return_value = ["e1"]
 

--- a/backend/tests/api/test_characters.py
+++ b/backend/tests/api/test_characters.py
@@ -7,6 +7,9 @@ from pathlib import Path
 import pytest
 from httpx import AsyncClient
 from PIL import Image
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.storage.models.character import Character
 
 
 def make_image_file(color: str = "red") -> bytes:
@@ -156,6 +159,28 @@ async def test_list_characters_orders_by_updated_at_desc(client: AsyncClient) ->
     assert response.status_code == 200
     names = [item["name"] for item in response.json()["items"]]
     assert names == ["最近编辑", second["name"]]
+
+
+@pytest.mark.asyncio
+async def test_list_characters_returns_all_project_characters(
+    client: AsyncClient,
+    session: AsyncSession,
+) -> None:
+    project_id = await create_project(client, "完整角色列表项目")
+    session.add_all(
+        [
+            Character(project_id=project_id, name=f"角色 {index}")
+            for index in range(101)
+        ]
+    )
+    await session.flush()
+
+    response = await client.get(f"/api/v1/projects/{project_id}/characters")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 101
+    assert len(data["items"]) == 101
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_world_info_entries.py
+++ b/backend/tests/api/test_world_info_entries.py
@@ -7,6 +7,9 @@ import json
 
 import pytest
 from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.storage.models.world_info_entry import WorldInfoEntry
 
 
 @pytest.fixture
@@ -133,6 +136,33 @@ async def test_list_entries(client: AsyncClient, world_info_id: str) -> None:
     data = response.json()
     assert len(data["items"]) == 3
     assert data["total"] == 3
+
+
+@pytest.mark.asyncio
+async def test_list_entries_returns_all_world_info_entries(
+    client: AsyncClient,
+    session: AsyncSession,
+    world_info_id: str,
+) -> None:
+    session.add_all(
+        [
+            WorldInfoEntry(
+                world_info_id=world_info_id,
+                uid=index + 1,
+                name=f"条目 {index + 1}",
+                order=index + 1,
+            )
+            for index in range(101)
+        ]
+    )
+    await session.flush()
+
+    response = await client.get(f"/api/v1/world-info/{world_info_id}/entries")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["total"] == 101
+    assert len(data["items"]) == 101
 
 
 @pytest.mark.asyncio

--- a/frontend/src/features/characters/components/character-list.tsx
+++ b/frontend/src/features/characters/components/character-list.tsx
@@ -45,6 +45,7 @@ interface CharacterListProps {
   currentProjectId: string;
   selectedCharacterId: string | null;
   isLoading?: boolean;
+  isCreating?: boolean;
   onSelectProject: (projectId: string) => void;
   onCreateCharacter: () => void;
   onSelectCharacter: (characterId: string) => void;
@@ -129,6 +130,7 @@ export function CharacterList({
   currentProjectId,
   selectedCharacterId,
   isLoading = false,
+  isCreating = false,
   onSelectProject,
   onCreateCharacter,
   onSelectCharacter,
@@ -586,6 +588,7 @@ export function CharacterList({
                 <IconButton
                   size="2"
                   variant="soft"
+                  disabled={isCreating}
                   onClick={onCreateCharacter}
                   style={{ width: "100%" }}
                 >
@@ -666,6 +669,7 @@ export function CharacterList({
               <Button
                 size="2"
                 variant="soft"
+                disabled={isCreating}
                 onClick={onCreateCharacter}
               >
                 {t("characters.newCharacter")}

--- a/frontend/src/features/characters/pages/characters-page.tsx
+++ b/frontend/src/features/characters/pages/characters-page.tsx
@@ -2,7 +2,7 @@ import { AlertDialog, Box, Button, Flex, IconButton, Tooltip, Text } from "@radi
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Bot, List } from "lucide-react";
 import { motion } from "motion/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Group, Panel, Separator } from "react-resizable-panels";
 import { useSearchParams } from "react-router";
@@ -80,6 +80,8 @@ export function CharactersPage() {
     isAgentRunning: false,
   });
   const [selectedCharacterLoadVersion, setSelectedCharacterLoadVersion] = useState(0);
+  const isCreatingCharacterRef = useRef(false);
+  const skipCharacterRestoreProjectIdRef = useRef<string | null>(null);
 
   const { data: projectsData } = useQuery({
     queryKey: ["projects", "characters-page"],
@@ -112,9 +114,15 @@ export function CharactersPage() {
     if (currentProjectId) void setPreference(LAST_PROJECT_KEY, currentProjectId);
   }, [currentProjectId]);
 
+  useEffect(() => {
+    if (skipCharacterRestoreProjectIdRef.current !== currentProjectId) {
+      skipCharacterRestoreProjectIdRef.current = null;
+    }
+  }, [currentProjectId]);
+
   const { data: charactersData, isLoading: isCharactersLoading } = useQuery({
     queryKey: ["characters", currentProjectId],
-    queryFn: () => fetchCharactersByProject(currentProjectId!, { page: 1, pageSize: 100 }),
+    queryFn: () => fetchCharactersByProject(currentProjectId!),
     enabled: !!currentProjectId,
     staleTime: 0,
   });
@@ -123,7 +131,13 @@ export function CharactersPage() {
 
   useEffect(() => {
     const restoreCharacter = async () => {
-      if (!currentProjectId || currentCharacterId || characters.length === 0) return;
+      if (
+        !currentProjectId ||
+        currentCharacterId ||
+        characters.length === 0 ||
+        skipCharacterRestoreProjectIdRef.current === currentProjectId
+      )
+        return;
       const cachedCharacterId = await getPreference(LAST_CHARACTER_KEY);
       const nextCharacterId =
         (cachedCharacterId && characters.some((character) => character.id === cachedCharacterId)
@@ -166,11 +180,40 @@ export function CharactersPage() {
             : [updated, ...old.items];
           return {
             ...old,
-            items: sortCharacters(items).slice(0, old.pageSize),
+            items: sortCharacters(items),
             total: exists ? old.total : old.total + 1,
           };
         },
       );
+    },
+    [queryClient],
+  );
+
+  const removeCharacterCaches = useCallback(
+    async (projectId: string, characterIds: string[]) => {
+      const deletedCharacterIds = new Set(characterIds);
+      await queryClient.cancelQueries({ queryKey: ["characters", projectId], exact: true });
+      await Promise.all(
+        characterIds.map((characterId) =>
+          queryClient.cancelQueries({ queryKey: ["character", characterId] }),
+        ),
+      );
+      queryClient.setQueryData(
+        ["characters", projectId],
+        (old: CharacterListResponse | undefined) => {
+          if (!old) return old;
+          const items = old.items.filter((character) => !deletedCharacterIds.has(character.id));
+          if (items.length === old.items.length) return old;
+          return {
+            ...old,
+            items,
+            total: old.total - (old.items.length - items.length),
+          };
+        },
+      );
+      characterIds.forEach((characterId) => {
+        queryClient.removeQueries({ queryKey: ["character", characterId] });
+      });
     },
     [queryClient],
   );
@@ -190,7 +233,16 @@ export function CharactersPage() {
       setCurrentCharacter(character.id);
       toast.success(t("characters.created"));
     },
+    onSettled: () => {
+      isCreatingCharacterRef.current = false;
+    },
   });
+
+  const handleCreateCharacter = () => {
+    if (isCreatingCharacterRef.current) return;
+    isCreatingCharacterRef.current = true;
+    createMutation.mutate();
+  };
 
   const updateMutation = useMutation({
     mutationFn: ({
@@ -245,9 +297,14 @@ export function CharactersPage() {
 
   const deleteMutation = useMutation({
     mutationFn: (characterId: string) => deleteCharacter(characterId),
-    onSuccess: () => {
+    onSuccess: async (_data, characterId) => {
+      if (!currentProjectId) return;
+      if (useCharactersStore.getState().currentCharacterId === characterId) {
+        skipCharacterRestoreProjectIdRef.current = currentProjectId;
+        setCurrentCharacter(null);
+      }
+      await removeCharacterCaches(currentProjectId, [characterId]);
       queryClient.invalidateQueries({ queryKey: ["characters", currentProjectId] });
-      setCurrentCharacter(null);
       setDeleteCharacterTarget(null);
       toast.success(t("characters.deleted"));
     },
@@ -255,10 +312,15 @@ export function CharactersPage() {
 
   const batchDeleteMutation = useMutation({
     mutationFn: (characterIds: string[]) => batchDeleteCharacters(currentProjectId!, characterIds),
-    onSuccess: (_deletedCount, characterIds) => {
-      queryClient.invalidateQueries({ queryKey: ["characters", currentProjectId] });
-      if (currentCharacterId && characterIds.includes(currentCharacterId))
+    onSuccess: async (_deletedCount, characterIds) => {
+      if (!currentProjectId) return;
+      const currentCharacterId = useCharactersStore.getState().currentCharacterId;
+      if (currentCharacterId && characterIds.includes(currentCharacterId)) {
+        skipCharacterRestoreProjectIdRef.current = currentProjectId;
         setCurrentCharacter(null);
+      }
+      await removeCharacterCaches(currentProjectId, characterIds);
+      queryClient.invalidateQueries({ queryKey: ["characters", currentProjectId] });
       toast.success(t("characters.deleted"));
     },
   });
@@ -304,10 +366,11 @@ export function CharactersPage() {
       projectId={currentProjectId ?? ""}
       selectedCharacterId={currentCharacterId}
       isLoading={isCharactersLoading}
+      isCreating={createMutation.isPending}
       projects={projects}
       currentProjectId={currentProjectId ?? ""}
       onSelectProject={handleSelectProject}
-      onCreateCharacter={() => createMutation.mutate()}
+      onCreateCharacter={handleCreateCharacter}
       onSelectCharacter={handleSelectCharacter}
       onEditProfile={setProfileCharacter}
       onDeleteCharacter={setDeleteCharacterTarget}

--- a/frontend/src/features/world-info/pages/world-info-page.tsx
+++ b/frontend/src/features/world-info/pages/world-info-page.tsx
@@ -8,7 +8,7 @@ import { Box, Flex, Text, Dialog, Button, Skeleton, IconButton, Tooltip } from "
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Bot, List } from "lucide-react";
 import { motion } from "motion/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Panel, Group, Separator } from "react-resizable-panels";
 import { useSearchParams } from "react-router";
@@ -93,6 +93,7 @@ export function WorldInfoPage() {
   const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
   const [isCreatingEntry, setIsCreatingEntry] = useState(false);
   const [scrollToLine, setScrollToLine] = useState<number | null>(null);
+  const skipEntryRestoreWorldInfoIdRef = useRef<string | null>(null);
   const [importDialogOpen, setImportDialogOpen] = useState(false);
   const [assistantState, setAssistantState] = useState<AssistantSidebarState>({
     agentStatus: "idle",
@@ -158,13 +159,19 @@ export function WorldInfoPage() {
   }, [currentProjectId, setCurrentEntry, setCurrentWorldInfo]);
 
   useEffect(() => {
+    if (skipEntryRestoreWorldInfoIdRef.current !== currentWorldInfoId) {
+      skipEntryRestoreWorldInfoIdRef.current = null;
+    }
+  }, [currentWorldInfoId]);
+
+  useEffect(() => {
     if (currentEntryId) void setPreference(LAST_ENTRY_KEY, currentEntryId);
   }, [currentEntryId]);
 
   // 获取条目列表（轻量，不含 content）
   const { data: entriesData, isLoading: entriesLoading } = useQuery({
     queryKey: ["world-info-entries", currentWorldInfoId],
-    queryFn: () => fetchWorldInfoEntries(currentWorldInfoId!, { page: 1, pageSize: 500 }),
+    queryFn: () => fetchWorldInfoEntries(currentWorldInfoId!),
     enabled: !!currentWorldInfoId,
     staleTime: 0,
   });
@@ -181,7 +188,13 @@ export function WorldInfoPage() {
 
   useEffect(() => {
     const restoreEntry = async () => {
-      if (!currentWorldInfoId || currentEntryId || entries.length === 0) return;
+      if (
+        !currentWorldInfoId ||
+        currentEntryId ||
+        entries.length === 0 ||
+        skipEntryRestoreWorldInfoIdRef.current === currentWorldInfoId
+      )
+        return;
       const cachedEntryId = await getPreference(LAST_ENTRY_KEY);
       if (cachedEntryId && entries.some((entry) => entry.id === cachedEntryId)) {
         setCurrentEntry(cachedEntryId);
@@ -214,6 +227,44 @@ export function WorldInfoPage() {
     [],
   );
 
+  const removeEntryCaches = useCallback(
+    async (worldInfoId: string, entryIds: string[]) => {
+      const deletedEntryIds = new Set(entryIds);
+      await queryClient.cancelQueries({
+        queryKey: ["world-info-entries", worldInfoId],
+        exact: true,
+      });
+      await Promise.all(
+        entryIds.map((entryId) =>
+          queryClient.cancelQueries({
+            queryKey: ["world-info-entry-detail", entryId],
+            exact: true,
+          }),
+        ),
+      );
+      queryClient.setQueryData(
+        ["world-info-entries", worldInfoId],
+        (oldData: WorldInfoEntryBriefListResponse | undefined) => {
+          if (!oldData) return oldData;
+          const items = oldData.items.filter((entry) => !deletedEntryIds.has(entry.id));
+          if (items.length === oldData.items.length) return oldData;
+          return {
+            ...oldData,
+            items,
+            total: oldData.total - (oldData.items.length - items.length),
+          };
+        },
+      );
+      entryIds.forEach((entryId) => {
+        queryClient.removeQueries({
+          queryKey: ["world-info-entry-detail", entryId],
+          exact: true,
+        });
+      });
+    },
+    [queryClient],
+  );
+
   // 创建条目
   const createEntryMutation = useMutation({
     mutationFn: (name: string) =>
@@ -229,8 +280,6 @@ export function WorldInfoPage() {
             return {
               items: [brief],
               total: 1,
-              page: 1,
-              pageSize: 500,
             };
           }
 
@@ -295,14 +344,17 @@ export function WorldInfoPage() {
   // 删除条目
   const deleteEntryMutation = useMutation({
     mutationFn: (entryId: string) => deleteWorldInfoEntry(entryId),
-    onSuccess: () => {
-      toast.success(t("worldInfo.entryDeleted"));
+    onSuccess: async (_data, entryId) => {
+      if (!currentWorldInfoId) return;
+      if (useWorldInfoStore.getState().currentEntryId === entryId) {
+        skipEntryRestoreWorldInfoIdRef.current = currentWorldInfoId;
+        setCurrentEntry(null);
+      }
+      await removeEntryCaches(currentWorldInfoId, [entryId]);
       queryClient.invalidateQueries({
         queryKey: ["world-info-entries", currentWorldInfoId],
       });
-      if (entryToDelete && currentEntryId === entryToDelete.id) {
-        setCurrentEntry(null);
-      }
+      toast.success(t("worldInfo.entryDeleted"));
       setEntryToDelete(null);
       setDeleteDialogOpen(false);
     },
@@ -372,8 +424,6 @@ export function WorldInfoPage() {
             return {
               items: reorderedEntries,
               total: reorderedEntries.length,
-              page: 1,
-              pageSize: 500,
             };
           }
           return {
@@ -458,21 +508,25 @@ export function WorldInfoPage() {
 
   /** 批量删除条目 */
   const handleBatchDelete = useCallback(
-    (entryIds: string[]) => {
+    async (entryIds: string[]) => {
       if (!currentWorldInfoId) return;
-      batchDeleteWorldInfoEntries(currentWorldInfoId, entryIds)
-        .then((count) => {
-          toast.success(t("worldInfo.batchDeleted", { count }));
+      try {
+        const count = await batchDeleteWorldInfoEntries(currentWorldInfoId, entryIds);
+        const currentEntryId = useWorldInfoStore.getState().currentEntryId;
+        if (currentEntryId && entryIds.includes(currentEntryId)) {
+          skipEntryRestoreWorldInfoIdRef.current = currentWorldInfoId;
           setCurrentEntry(null);
-          queryClient.invalidateQueries({
-            queryKey: ["world-info-entries", currentWorldInfoId],
-          });
-        })
-        .catch(() => {
-          toast.error(t("worldInfo.deleteFailed"));
+        }
+        await removeEntryCaches(currentWorldInfoId, entryIds);
+        queryClient.invalidateQueries({
+          queryKey: ["world-info-entries", currentWorldInfoId],
         });
+        toast.success(t("worldInfo.batchDeleted", { count }));
+      } catch {
+        toast.error(t("worldInfo.deleteFailed"));
+      }
     },
-    [currentWorldInfoId, queryClient, setCurrentEntry, t],
+    [currentWorldInfoId, queryClient, removeEntryCaches, setCurrentEntry, t],
   );
 
   const batchToggleMutation = useMutation({
@@ -630,7 +684,7 @@ export function WorldInfoPage() {
         />
       </Flex>
     </Box>
-  ) : selectedEntry ? (
+  ) : currentEntryId && selectedEntry ? (
     <EntryEditor
       key={selectedEntry.id}
       entry={selectedEntry}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -77,9 +77,8 @@ import type {
   Character,
   CharacterCreate,
   CharacterListItem,
-  CharacterListParams,
-  CharacterListResponse,
   CharacterSearchResponse,
+  CharacterListResponse,
   CharacterUpdate,
 } from "./character.types";
 import type { AssistantMentionCandidate } from "./mention.types";
@@ -262,22 +261,12 @@ function transformCharacterListItem(raw: Record<string, unknown>): CharacterList
   };
 }
 
-export async function fetchCharactersByProject(
-  projectId: string,
-  params?: CharacterListParams,
-): Promise<CharacterListResponse> {
-  const response = await apiClient.get(`/projects/${projectId}/characters`, {
-    params: {
-      page: params?.page ?? 1,
-      page_size: params?.pageSize ?? 100,
-    },
-  });
+export async function fetchCharactersByProject(projectId: string): Promise<CharacterListResponse> {
+  const response = await apiClient.get(`/projects/${projectId}/characters`);
   const data = response.data;
   return {
     items: (data.items as Record<string, unknown>[]).map(transformCharacterListItem),
     total: data.total,
-    page: data.page,
-    pageSize: data.page_size,
   };
 }
 
@@ -1341,7 +1330,6 @@ import type {
   WorldInfoEntryCreate,
   WorldInfoEntryUpdate,
   WorldInfoEntryBriefListResponse,
-  WorldInfoEntryListParams,
   WorldInfoEntrySearchResponse,
 } from "./world-info.types";
 
@@ -1432,20 +1420,12 @@ export async function deleteWorldInfo(worldInfoId: string): Promise<void> {
  */
 export async function fetchWorldInfoEntries(
   worldInfoId: string,
-  params?: WorldInfoEntryListParams,
 ): Promise<WorldInfoEntryBriefListResponse> {
-  const response = await apiClient.get(`/world-info/${worldInfoId}/entries`, {
-    params: {
-      page: params?.page ?? 1,
-      page_size: params?.pageSize ?? 100,
-    },
-  });
+  const response = await apiClient.get(`/world-info/${worldInfoId}/entries`);
   const data = response.data;
   return {
     items: (data.items as Record<string, unknown>[]).map(transformWorldInfoEntryBrief),
     total: data.total,
-    page: data.page,
-    pageSize: data.page_size,
   };
 }
 

--- a/frontend/src/lib/character.types.ts
+++ b/frontend/src/lib/character.types.ts
@@ -38,13 +38,6 @@ export interface CharacterUpdate {
 export interface CharacterListResponse {
   items: CharacterListItem[];
   total: number;
-  page: number;
-  pageSize: number;
-}
-
-export interface CharacterListParams {
-  page?: number;
-  pageSize?: number;
 }
 
 export interface CharacterSearchMatch {

--- a/frontend/src/lib/world-info.types.ts
+++ b/frontend/src/lib/world-info.types.ts
@@ -67,14 +67,6 @@ export interface WorldInfoEntryUpdate {
 export interface WorldInfoEntryBriefListResponse {
   items: WorldInfoEntryBrief[];
   total: number;
-  page: number;
-  pageSize: number;
-}
-
-/** 条目列表请求参数 */
-export interface WorldInfoEntryListParams {
-  page?: number;
-  pageSize?: number;
 }
 
 export interface WorldInfoImportPreviewEntry {


### PR DESCRIPTION
## PR 标题

chore(list): 优化角色和世界书列表体验

## 变更说明

- 问题: 角色和世界书条目列表受分页上限影响，删除当前项后可能重新请求已删除详情并保留编辑器内容。
- 重要性: 大型项目中的角色和世界书条目无法完整显示，删除操作会产生 404 请求和错误的编辑状态。
- 变化: 两类列表改为完整加载，统一前后端、Agent 工具和缓存契约；删除后立即清理列表与详情缓存，并清空当前编辑状态。
- 变化: 新建角色期间禁用新建入口，避免连续点击产生重复角色。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因(如有)

列表接口和前端缓存仍保留分页约束；删除成功后旧列表和详情缓存未在选中状态变更前清理。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证记录：`backend/just check`（1289 项测试通过）；`frontend/pnpm format:check`、`pnpm type-check`、`pnpm lint` 均通过。
