### PR TITLE
fix(agent): 修复编辑工具转义空白匹配失败的问题

### DIFF
--- a/backend/app/agent_runtime/tools/text_match.py
+++ b/backend/app/agent_runtime/tools/text_match.py
@@ -163,6 +163,48 @@ def _match_end_is_whitespace_or_end(content: str, pos: int, length: int) -> bool
     return pos >= length or content[pos].isspace()
 
 
+def _decode_escaped_whitespace(text: str) -> str | None:
+    """Decode an escaped whitespace-only value produced by tool-calling models."""
+    decoded: list[str] = []
+    found_escape = False
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if char.isspace():
+            decoded.append(char)
+            index += 1
+            continue
+        if char != "\\" or index + 1 >= len(text):
+            return None
+        escaped = text[index + 1]
+        replacement = {"n": "\n", "r": "\r", "t": "\t"}.get(escaped)
+        if replacement is None:
+            return None
+        decoded.append(replacement)
+        found_escape = True
+        index += 2
+    return "".join(decoded) if found_escape else None
+
+
+def _replace_escaped_whitespace(
+    content: str,
+    old_text: str,
+    new_text: str,
+    *,
+    replace_all: bool,
+) -> FuzzyReplaceResult | None:
+    decoded_old_text = _decode_escaped_whitespace(old_text)
+    if decoded_old_text is None:
+        return None
+    decoded_new_text = _decode_escaped_whitespace(new_text) or new_text
+    return fuzzy_replace(
+        content,
+        decoded_old_text,
+        decoded_new_text,
+        replace_all=replace_all,
+    )
+
+
 def fuzzy_replace(
     content: str,
     old_text: str,
@@ -207,7 +249,9 @@ def fuzzy_replace(
     # position -- corrupting content with ``replace_all=False`` and looping
     # forever with ``replace_all=True``. Treat it as "not found".
     if not fuzzy_old_text:
-        return None
+        return _replace_escaped_whitespace(
+            content, old_text, new_text, replace_all=replace_all
+        )
 
     # When the query's trailing whitespace was stripped by normalization,
     # ``fuzzy_old_text`` may be a *prefix* of a longer run in the content --
@@ -240,7 +284,9 @@ def fuzzy_replace(
         start = match_end
 
     if not replacements:
-        return None
+        return _replace_escaped_whitespace(
+            content, old_text, new_text, replace_all=replace_all
+        )
 
     new_content = _apply_replacements_preserving_unchanged(
         content, fuzzy_content, replacements

--- a/backend/tests/agent_runtime/tools/test_text_match.py
+++ b/backend/tests/agent_runtime/tools/test_text_match.py
@@ -242,6 +242,71 @@ def test_whitespace_old_text_exact_match_replace_all() -> None:
 
 
 # ---------------------------------------------------------------------------
+# fuzzy_replace - escaped whitespace fallback
+# ---------------------------------------------------------------------------
+
+
+def test_escaped_newlines_replace_blank_lines() -> None:
+    result = fuzzy_replace("11\n\n11\n\n111", r"\n\n", r"\n", replace_all=True)
+    assert result == FuzzyReplaceResult("11\n11\n111", used_fuzzy_match=False)
+
+
+@pytest.mark.parametrize(
+    ("old_text", "actual_old_text", "new_text", "expected_new_text"),
+    [
+        (r"\n", "\n", r"\t", "\t"),
+        (r"\t", "\t", r"\r", "\n"),
+        (r"\r", "\r", r"\n", "\n"),
+    ],
+)
+def test_escaped_whitespace_sequences_are_decoded_for_search_and_replacement(
+    old_text: str,
+    actual_old_text: str,
+    new_text: str,
+    expected_new_text: str,
+) -> None:
+    result = fuzzy_replace(f"before{actual_old_text}after", old_text, new_text)
+    assert result == FuzzyReplaceResult(
+        f"before{expected_new_text}after", used_fuzzy_match=False
+    )
+
+
+@pytest.mark.parametrize(
+    ("content", "old_text"),
+    [
+        ("start\n end", r"\n "),
+        ("start \nend", r" \n"),
+    ],
+)
+def test_escaped_newline_with_surrounding_space_replaces_as_whitespace(
+    content: str,
+    old_text: str,
+) -> None:
+    result = fuzzy_replace(content, old_text, "0")
+    assert result == FuzzyReplaceResult("start0end", used_fuzzy_match=False)
+
+
+@pytest.mark.parametrize(
+    ("old_text", "new_text"),
+    [
+        (r"\n", r"\t"),
+        (r"\t", r"\r"),
+        (r"\r", r"\n"),
+    ],
+)
+def test_literal_escaped_whitespace_takes_precedence_over_fallback(
+    old_text: str,
+    new_text: str,
+) -> None:
+    result = fuzzy_replace(old_text, old_text, new_text)
+    assert result == FuzzyReplaceResult(new_text, used_fuzzy_match=False)
+
+
+def test_mixed_text_and_escaped_newline_is_not_decoded() -> None:
+    assert fuzzy_replace("start\nend", r"start\nend", "X") is None
+
+
+# ---------------------------------------------------------------------------
 # fuzzy_replace - replace_all fuzzy path must be linear (regression)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## PR 标题

fix(agent): 修复编辑工具转义空白匹配失败

## 变更说明

- 问题: Agent 调用编辑工具时，模型可能将仅由空白组成的匹配片段以 `\\n`、`\\t`、`\\r` 字面量传入，导致无法匹配实际控制字符。
- 重要性: 删除空行、制表符或回车等编辑操作会失败，并要求 Agent 重试或改用包含上下文的替换片段。
- 变化: 在原始精确匹配和模糊匹配均失败后，仅对由空白和 `\\n`、`\\t`、`\\r` 组成的参数解码后重试；原始字面量匹配保持优先。
- 测试: 增加换行、制表符、回车、带空格空白片段及字面量优先级的回归覆盖。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [x] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

部分模型在仅编辑控制字符或空白片段时，会将 JSON 转义再次转义为字面量 `\\n`、`\\t`、`\\r`。现有匹配器将其视为普通字符，无法与正文中的实际换行、制表符或回车匹配。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令：

```text
uv run pytest tests/agent_runtime/tools/test_text_match.py tests/agent_runtime/tools/test_chapter_tools.py tests/agent_runtime/tools/test_context_tools.py tests/agent_runtime/tools/test_note_tools.py -q
# 118 passed in 2.69s

uv run ruff check app/agent_runtime/tools/text_match.py tests/agent_runtime/tools/test_text_match.py
# All checks passed!
```
