### PR TITLE
fix(desktop): 修复 macOS 运行时与安装包校验异常

### DIFF
--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -143,13 +143,14 @@ jobs:
       - name: Build desktop application
         working-directory: desktop
         run: pnpm build
+      - name: Smoke test macOS runtime
+        if: runner.os == 'macOS'
+        working-directory: desktop
+        timeout-minutes: 20
+        run: pnpm exec electron tests/main/runtime-smoke.mjs
       - name: Build desktop package
         working-directory: desktop
         run: pnpm exec electron-builder --config electron-builder.yml ${{ matrix.target }} --${{ matrix.arch }} --publish never
-      - name: Run macOS runtime tests
-        if: runner.os == 'macOS'
-        working-directory: desktop
-        run: node --test tests/main/*.test.mjs
       - name: Verify macOS disk images
         if: runner.os == 'macOS'
         working-directory: desktop

--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -146,6 +146,20 @@ jobs:
       - name: Build desktop package
         working-directory: desktop
         run: pnpm exec electron-builder --config electron-builder.yml ${{ matrix.target }} --${{ matrix.arch }} --publish never
+      - name: Run macOS runtime tests
+        if: runner.os == 'macOS'
+        working-directory: desktop
+        run: node --test tests/main/*.test.mjs
+      - name: Verify macOS disk images
+        if: runner.os == 'macOS'
+        working-directory: desktop
+        run: |
+          shopt -s nullglob
+          dmg_files=(dist-electron/*.dmg)
+          ((${#dmg_files[@]}))
+          for dmg_file in "${dmg_files[@]}"; do
+            hdiutil verify "$dmg_file"
+          done
 
   summary:
     name: Summary

--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -161,6 +161,54 @@ jobs:
           for dmg_file in "${dmg_files[@]}"; do
             hdiutil verify "$dmg_file"
           done
+      - name: Install and launch macOS application
+        if: runner.os == 'macOS'
+        working-directory: desktop
+        timeout-minutes: 5
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          dmg_files=(dist-electron/OpenFic-*-mac-${{ matrix.arch }}.dmg)
+          ((${#dmg_files[@]} == 1))
+
+          mount_dir=$(mktemp -d)
+          install_dir=$(mktemp -d)
+          user_data_dir=$(mktemp -d)
+          app_log=$(mktemp)
+          app_pid=""
+          is_mounted=false
+
+          cleanup() {
+            if [[ "$is_mounted" == true ]]; then hdiutil detach "$mount_dir" -quiet || true; fi
+            if [[ -n "$app_pid" ]] && kill -0 "$app_pid" 2>/dev/null; then
+              kill "$app_pid" || true
+              sleep 2
+              if kill -0 "$app_pid" 2>/dev/null; then kill -9 "$app_pid" || true; fi
+              wait "$app_pid" || true
+            fi
+            rm -rf "$mount_dir" "$install_dir" "$user_data_dir" "$app_log"
+          }
+          trap cleanup EXIT
+
+          hdiutil attach -readonly -nobrowse -mountpoint "$mount_dir" "${dmg_files[0]}"
+          is_mounted=true
+          app_sources=("$mount_dir"/*.app)
+          ((${#app_sources[@]} == 1))
+          ditto "${app_sources[0]}" "$install_dir/OpenFic.app"
+          hdiutil detach "$mount_dir" -quiet
+          is_mounted=false
+
+          "$install_dir/OpenFic.app/Contents/MacOS/OpenFic" --user-data-dir="$user_data_dir" > "$app_log" 2>&1 &
+          app_pid=$!
+          for _ in {1..10}; do
+            if ! kill -0 "$app_pid" 2>/dev/null; then
+              cat "$app_log"
+              wait "$app_pid"
+              exit 1
+            fi
+            sleep 1
+          done
 
   summary:
     name: Summary

--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -67,6 +67,10 @@ jobs:
       - name: Build Python package
         working-directory: backend
         run: uv build
+      - uses: actions/upload-artifact@v7
+        with:
+          name: backend-dist
+          path: backend/dist/*.whl
 
   docker:
     name: Docker (${{ matrix.platform }})
@@ -93,7 +97,7 @@ jobs:
 
   desktop:
     name: Desktop (${{ matrix.os }} ${{ matrix.arch }})
-    needs: frontend
+    needs: [frontend, python]
     if: "!startsWith(github.event.pull_request.head.ref, 'release-please--')"
     strategy:
       fail-fast: false
@@ -124,6 +128,11 @@ jobs:
         with:
           name: frontend-dist
           path: frontend/dist
+      - uses: actions/download-artifact@v8
+        if: matrix.os == 'macos-15'
+        with:
+          name: backend-dist
+          path: backend-dist
       - uses: pnpm/action-setup@v6
         with:
           version: ${{ env.PNPM_VERSION }}
@@ -144,10 +153,10 @@ jobs:
         working-directory: desktop
         run: pnpm build
       - name: Smoke test macOS runtime
-        if: runner.os == 'macOS'
+        if: matrix.os == 'macos-15'
         working-directory: desktop
         timeout-minutes: 20
-        run: pnpm exec electron tests/main/runtime-smoke.mjs
+        run: pnpm exec electron tests/main/runtime-smoke.mjs ../backend-dist/openfic-*.whl
       - name: Build desktop package
         working-directory: desktop
         run: pnpm exec electron-builder --config electron-builder.yml ${{ matrix.target }} --${{ matrix.arch }} --publish never

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "charset-normalizer>=3.4.7",
     "cryptography>=46.0.3",
     "fastapi>=0.127.0",
+    "greenlet>=3.0.0",
     "gunicorn>=23.0.0",
     "itsdangerous>=2.2.0",
     "json-repair>=0.60.1",

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -835,7 +835,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/6e/4c37d51a2b7f82d2ff11bb6b5f7d766d9a011726624af255e843727627a3/greenlet-3.5.3-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:719757059f5a53fd0dde23f78cffeafcdd97b21c850ddb7ca684a3c1a1f122e2", size = 288685, upload-time = "2026-06-26T18:22:08.977Z" },
     { url = "https://files.pythonhosted.org/packages/7a/73/815dd90131c1b71ebdf53dbc7c276cafec2a1173b97559f97aba72724a87/greenlet-3.5.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa9f765dd09f9d0cdac651ffdf631ee59ec5dc6ee7a73e0c012ba9c52fbdf5b", size = 604761, upload-time = "2026-06-26T19:07:10.114Z" },
     { url = "https://files.pythonhosted.org/packages/9f/57/079cfe76bcef36b153b25607ee91c6fcb58f17f8b23c86bbbeabe0c88d72/greenlet-3.5.3-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7faba15ac005376e02a0384504e0243be3370ce010296a44a820feb342b505ab", size = 617044, upload-time = "2026-06-26T19:10:07.25Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/fb/d97dc261209c80744b7c8132693a30d70ec6e7315e632cb0a10b3fec94dd/greenlet-3.5.3-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5795cd1101371140551c645f2d408b8d3c01a5a29cf8a9bce6e759c983682d23", size = 622351, upload-time = "2026-06-26T19:24:16.32Z" },
     { url = "https://files.pythonhosted.org/packages/37/87/b4d095775a3fb1bcafbb483fc206b27ebb785724c83051447737085dc54e/greenlet-3.5.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:87142215824be6ac05e2e8e2786eec307ccbc27c36723c3881959df654af6861", size = 614244, upload-time = "2026-06-26T18:32:17.594Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/e5fee13cbbd0e8de312d9a146584b8a51891c68847330ef9dc8b5109d23f/greenlet-3.5.3-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:af4923b3096e26a36d7e9cf24ab88083a20f97d191e3b97f253731ce9b41b28c", size = 425395, upload-time = "2026-06-26T19:25:37.144Z" },
     { url = "https://files.pythonhosted.org/packages/8a/70/7559b609683650fa2b95b8ab84b4ab0b26556a635d19675e12aa832d826d/greenlet-3.5.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:215275b1b49320987352e6c1b054acca0064f965a2c66992bed9a6f7d913f149", size = 1574210, upload-time = "2026-06-26T19:09:03.077Z" },
     { url = "https://files.pythonhosted.org/packages/ae/73/be55392074c60fc37655ca40fa6022457bfbf6718e9e342a7b0b41f96dd2/greenlet-3.5.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6b1b0eed82364b0e32c4ea0f221452d33e6bb17ae094d9f72aed9851812747ea", size = 1638627, upload-time = "2026-06-26T18:31:44.748Z" },
     { url = "https://files.pythonhosted.org/packages/14/40/c57489acf8e37d74e2913d4eff63aa0dba17acccc4bdeef874dde2dbbec9/greenlet-3.5.3-cp312-cp312-win_amd64.whl", hash = "sha256:cde8adafa2365676f74a979744629589999093bc86e2484214f58e61df08902c", size = 239882, upload-time = "2026-06-26T18:23:27.518Z" },
@@ -843,7 +845,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/ff/a620267401db30a50cc8450ee90730e2d4a85658c055c0e760d4ed47fb13/greenlet-3.5.3-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:c8d87c2134d871df96ecdea9cec7cbaab286dadab0f56476e57aaf9e8ac11550", size = 287609, upload-time = "2026-06-26T18:21:14.724Z" },
     { url = "https://files.pythonhosted.org/packages/d6/fa/5401ac78021c826a25b6dde0c705e0a8f29b617509f9185a31dac15fbe1b/greenlet-3.5.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a2d185dd1621757e70c3861cceffd5317ab4e7ed7eb09c82994828468527ade5", size = 607435, upload-time = "2026-06-26T19:07:11.412Z" },
     { url = "https://files.pythonhosted.org/packages/e9/76/1dc144a2e56e65d36405078ed774224375ea520a1870a6e46e08bb4ac7bf/greenlet-3.5.3-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1c514a468149bf8fbbab874188a3535cd8a48a3e353eb53a3d424296f8dbacd3", size = 619787, upload-time = "2026-06-26T19:10:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/57/61/2f5b1adf256d039f5dab8005de8d3d7ad2b0070a3219c0e036b3fbfeb440/greenlet-3.5.3-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:9ad04dd75458c6300b047c61b8639092433d205a25a14e310d6582a480efcca1", size = 625580, upload-time = "2026-06-26T19:24:18.344Z" },
     { url = "https://files.pythonhosted.org/packages/bf/87/c298cee62df1de4ad7fec32abda73526cff347fd143a6ed4ac369246668a/greenlet-3.5.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:915f887cf2682b66419b879423a2e072634aa7b7dce6f3ada4957cfced3f1e9a", size = 616786, upload-time = "2026-06-26T18:32:19.128Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d9/ab7fc9e543e44d6879b0a6ef9a4b2188940fd180cc65d6f646883ddf7201/greenlet-3.5.3-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:afaabdd554cd7ae9bbb3ca070b0d7fdfd207dbf1d16865f7233837709d354bda", size = 427933, upload-time = "2026-06-26T19:25:38.219Z" },
     { url = "https://files.pythonhosted.org/packages/9e/2e/e6f009885ed0705ccf33fe0583c117cfd03cde77e31a596dd5785a30762b/greenlet-3.5.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:766cfd421c13e450feb340cd472a3ed9957d438727b7b4593ad7c76c5d2b0deb", size = 1574316, upload-time = "2026-06-26T19:09:04.273Z" },
     { url = "https://files.pythonhosted.org/packages/ef/fe/43fd110b01e40da0adb7c90ac7ea744bef2d43dca00de5095fd2351c2a68/greenlet-3.5.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2ecda9ec22edf38fa389369eaed8c3d37c05f3c54e69f69438dbb2cc1de1458b", size = 1638614, upload-time = "2026-06-26T18:31:46.297Z" },
     { url = "https://files.pythonhosted.org/packages/0f/7c/062447147a61f8b4337b156fe70d32a165fcf2f89d7ca6255e572806705c/greenlet-3.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:c82304750f057167ff60d188df1d0cc1764ce9567eadf03e6a7443bcedd0b30b", size = 239850, upload-time = "2026-06-26T18:21:54.613Z" },
@@ -1580,7 +1584,7 @@ name = "macholib"
 version = "1.16.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "altgraph" },
+    { name = "altgraph", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
 wheels = [
@@ -1894,6 +1898,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "fastembed" },
+    { name = "greenlet" },
     { name = "gunicorn" },
     { name = "itsdangerous" },
     { name = "json-repair" },
@@ -1956,6 +1961,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=46.0.3" },
     { name = "fastapi", specifier = ">=0.127.0" },
     { name = "fastembed", specifier = ">=0.8.0" },
+    { name = "greenlet", specifier = ">=3.0.0" },
     { name = "gunicorn", specifier = ">=23.0.0" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "json-repair", specifier = ">=0.60.1" },

--- a/desktop/src/main/runtime/python.ts
+++ b/desktop/src/main/runtime/python.ts
@@ -38,7 +38,7 @@ export function getPortablePythonRoot(runtimeDir: string): string {
 
 export function getPortablePythonPath(rootDir: string): string {
   if (process.platform === "win32") return path.join(rootDir, "python", "python.exe");
-  return path.join(rootDir, "python", "install", "bin", "python3");
+  return path.join(rootDir, "python", "bin", "python3");
 }
 
 async function pathExists(filePath: string): Promise<boolean> {

--- a/desktop/tests/main/runtime-smoke.mjs
+++ b/desktop/tests/main/runtime-smoke.mjs
@@ -1,12 +1,34 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { app } from "electron";
 import { stopBackendProcess } from "../../dist/main/process.js";
-import { ensureOpenFicRuntime, startLocalOpenFicBackend } from "../../dist/main/runtime/openfic.js";
+import { startLocalOpenFicBackend } from "../../dist/main/runtime/openfic.js";
 import { ensurePortablePython } from "../../dist/main/runtime/python.js";
 
 const BACKEND_STOP_TIMEOUT_MS = 15_000;
+
+function run(command, args, cwd) {
+  return new Promise((resolve, reject) => {
+    const process = spawn(command, args, { cwd, stdio: "inherit" });
+    process.on("error", reject);
+    process.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`${command} ${args.join(" ")} exited with code ${code}`));
+    });
+  });
+}
+
+async function getWheelPath() {
+  const wheelPath = process.argv[2];
+  if (!wheelPath?.endsWith(".whl")) throw new Error("OpenFic wheel path is required");
+  await access(wheelPath);
+  return path.resolve(wheelPath);
+}
 
 async function waitForBackendProcessToStop(backend, timeoutMs) {
   if (backend.process.exitCode !== null || backend.process.signalCode !== null) return;
@@ -43,6 +65,9 @@ async function readDesktopVersion() {
 async function smokeTestRuntime() {
   const userDataDir = await mkdtemp(path.join(os.tmpdir(), "openfic-runtime-smoke-"));
   const runtimeDir = path.join(userDataDir, "runtime");
+  const venvDir = path.join(runtimeDir, "venv");
+  const venvPythonPath = path.join(venvDir, "bin", "python");
+  const uvPath = path.join(venvDir, "bin", "uv");
   let backend = null;
 
   app.setPath("userData", userDataDir);
@@ -51,10 +76,11 @@ async function smokeTestRuntime() {
     await app.whenReady();
     const python = await ensurePortablePython(runtimeDir, (phase, message) => console.log(`${phase}: ${message}`), () => {});
     const expectedVersion = await readDesktopVersion();
-    console.log(`Installing OpenFic runtime ${expectedVersion}`);
-    const { venvPythonPath } = await ensureOpenFicRuntime(python, runtimeDir, expectedVersion, (step, message) => {
-      console.log(`${step}: ${message}`);
-    });
+    const wheelPath = await getWheelPath();
+    console.log(`Installing OpenFic runtime ${expectedVersion} from ${wheelPath}`);
+    await run(python.pythonPath, ["-m", "venv", venvDir], runtimeDir);
+    await run(venvPythonPath, ["-m", "pip", "install", "uv"], runtimeDir);
+    await run(uvPath, ["pip", "install", "--python", venvPythonPath, wheelPath], runtimeDir);
 
     backend = await startLocalOpenFicBackend(venvPythonPath, expectedVersion);
     console.log(`OpenFic runtime smoke test passed: ${backend.baseUrl}`);

--- a/desktop/tests/main/runtime-smoke.mjs
+++ b/desktop/tests/main/runtime-smoke.mjs
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { app } from "electron";
@@ -34,6 +34,12 @@ async function stopBackend(backend) {
   }
 }
 
+async function readDesktopVersion() {
+  const packageJson = JSON.parse(await readFile(new URL("../../package.json", import.meta.url), "utf8"));
+  if (typeof packageJson.version !== "string") throw new Error("desktop package version is missing");
+  return packageJson.version;
+}
+
 async function smokeTestRuntime() {
   const userDataDir = await mkdtemp(path.join(os.tmpdir(), "openfic-runtime-smoke-"));
   const runtimeDir = path.join(userDataDir, "runtime");
@@ -44,7 +50,7 @@ async function smokeTestRuntime() {
   try {
     await app.whenReady();
     const python = await ensurePortablePython(runtimeDir, (phase, message) => console.log(`${phase}: ${message}`), () => {});
-    const expectedVersion = app.getVersion();
+    const expectedVersion = await readDesktopVersion();
     console.log(`Installing OpenFic runtime ${expectedVersion}`);
     const { venvPythonPath } = await ensureOpenFicRuntime(python, runtimeDir, expectedVersion, (step, message) => {
       console.log(`${step}: ${message}`);

--- a/desktop/tests/main/runtime-smoke.mjs
+++ b/desktop/tests/main/runtime-smoke.mjs
@@ -58,6 +58,14 @@ async function smokeTestRuntime() {
 
     backend = await startLocalOpenFicBackend(venvPythonPath, expectedVersion);
     console.log(`OpenFic runtime smoke test passed: ${backend.baseUrl}`);
+  } catch (error) {
+    const backendLogPath = path.join(userDataDir, "logs", "backend.log");
+    try {
+      console.error(`Backend log:\n${await readFile(backendLogPath, "utf8")}`);
+    } catch {
+      // The backend may fail before its logger has written a file.
+    }
+    throw error;
   } finally {
     if (backend) {
       await stopBackend(backend);

--- a/desktop/tests/main/runtime-smoke.mjs
+++ b/desktop/tests/main/runtime-smoke.mjs
@@ -1,0 +1,69 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { app } from "electron";
+import { stopBackendProcess } from "../../dist/main/process.js";
+import { ensureOpenFicRuntime, startLocalOpenFicBackend } from "../../dist/main/runtime/openfic.js";
+import { ensurePortablePython } from "../../dist/main/runtime/python.js";
+
+const BACKEND_STOP_TIMEOUT_MS = 15_000;
+
+async function waitForBackendProcessToStop(backend, timeoutMs) {
+  if (backend.process.exitCode !== null || backend.process.signalCode !== null) return;
+
+  await new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("backend process did not stop within timeout")), timeoutMs);
+    backend.process.once("close", () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+    if (backend.process.exitCode !== null || backend.process.signalCode !== null) {
+      clearTimeout(timeout);
+      resolve();
+    }
+  });
+}
+
+async function stopBackend(backend) {
+  stopBackendProcess(backend);
+  try {
+    await waitForBackendProcessToStop(backend, BACKEND_STOP_TIMEOUT_MS);
+  } catch {
+    backend.process.kill("SIGKILL");
+    await waitForBackendProcessToStop(backend, BACKEND_STOP_TIMEOUT_MS);
+  }
+}
+
+async function smokeTestRuntime() {
+  const userDataDir = await mkdtemp(path.join(os.tmpdir(), "openfic-runtime-smoke-"));
+  const runtimeDir = path.join(userDataDir, "runtime");
+  let backend = null;
+
+  app.setPath("userData", userDataDir);
+
+  try {
+    await app.whenReady();
+    const python = await ensurePortablePython(runtimeDir, (phase, message) => console.log(`${phase}: ${message}`), () => {});
+    const expectedVersion = app.getVersion();
+    console.log(`Installing OpenFic runtime ${expectedVersion}`);
+    const { venvPythonPath } = await ensureOpenFicRuntime(python, runtimeDir, expectedVersion, (step, message) => {
+      console.log(`${step}: ${message}`);
+    });
+
+    backend = await startLocalOpenFicBackend(venvPythonPath, expectedVersion);
+    console.log(`OpenFic runtime smoke test passed: ${backend.baseUrl}`);
+  } finally {
+    if (backend) {
+      await stopBackend(backend);
+    }
+    await rm(userDataDir, { recursive: true, force: true });
+  }
+}
+
+void smokeTestRuntime().then(
+  () => app.quit(),
+  (error) => {
+    console.error(error);
+    app.exit(1);
+  },
+);


### PR DESCRIPTION
## PR 标题

fix(desktop): 修复 macOS 运行时与安装包校验

## 变更说明

- 问题: macOS/Linux 解压便携 Python 后，程序按不存在的 `python/install/bin/python3` 路径查找可执行文件，导致初始化失败。
- 重要性: macOS 用户无法完成运行时安装，且损坏的 DMG 未在 PR 阶段被拦截。
- 变化: 将非 Windows 平台的 Python 路径改为归档实际结构 `python/bin/python3`。
- 变化: macOS 打包检查新增主进程测试和 `hdiutil verify`，验证所有生成的 DMG。

## 关联 Issue / PR (如有)

Closes #213

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

`python-build-standalone` 的 macOS/Linux `install_only` 归档中，可执行文件位于 `python/bin/python3`，但运行时路径额外拼接了不存在的 `install` 目录。DMG 构建流程此前未执行 `hdiutil verify`，无法在发布前发现损坏产物。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

未配置 macOS 代码签名或公证。
