### PR TITLE
fix(agent): 修复重启后会话设置持续锁定的问题

### DIFF
--- a/backend/app/agent_runtime/persistence/child_runs.py
+++ b/backend/app/agent_runtime/persistence/child_runs.py
@@ -736,6 +736,38 @@ async def cancel_child_run(
     return row
 
 
+async def cancel_interrupted_child_runs(session: AsyncSession) -> int:
+    """Finalize non-resumable child runs left behind by a server restart."""
+    result = await session.execute(
+        select(AgentChildRun).where(
+            col(AgentChildRun.is_active).is_(True),
+            col(AgentChildRun.status).in_(("queued", "running", "waiting_user")),
+        )
+    )
+    rows = list(result.scalars().all())
+    if not rows:
+        return 0
+
+    now = datetime.now(UTC)
+    for row in rows:
+        await _cancel_open_child_run_requests(
+            session,
+            child_run_id=row.id,
+            now=now,
+            error="server restarted",
+        )
+        row.status = "cancelled"
+        row.pending_approval_id = None
+        row.pending_approval_json = None
+        row.completed_at = now
+        row.last_completed_at = now
+        row.error = "server restarted"
+        row.updated_at = now
+
+    await session.flush()
+    return len(rows)
+
+
 async def recycle_child_run(
     session: AsyncSession,
     child_run_id: str,

--- a/backend/app/api/routers/health.py
+++ b/backend/app/api/routers/health.py
@@ -1,8 +1,9 @@
-"""
-Health check router.
-"""
+"""Health check and local server lifecycle routes."""
 
-from fastapi import APIRouter
+from hmac import compare_digest
+from os import getenv
+
+from fastapi import APIRouter, Header, HTTPException, Request, status
 
 from app.api.schemas.health import HealthResponse
 from app.settings import settings
@@ -21,3 +22,23 @@ async def health_check() -> HealthResponse:
         status="healthy",
         version=settings.app_version,
     )
+
+
+@router.post("/shutdown", status_code=status.HTTP_202_ACCEPTED)
+async def request_shutdown(
+    request: Request,
+    shutdown_token: str | None = Header(default=None, alias="X-OpenFic-Shutdown-Token"),
+) -> None:
+    """Request a graceful shutdown from the desktop process that owns this server."""
+    expected_token = getenv("OPENFIC_SHUTDOWN_TOKEN")
+    if (
+        not expected_token
+        or shutdown_token is None
+        or not compare_digest(shutdown_token, expected_token)
+    ):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+
+    server = getattr(request.app.state, "uvicorn_server", None)
+    if server is None:
+        raise HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE)
+    server.should_exit = True

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -58,9 +58,10 @@ def handle_serve(args: argparse.Namespace) -> None:
     os.environ["OPENFIC_SERVER_PORT"] = str(args.port)
 
     import uvicorn
+    from app.main import app as asgi_app, fastapi_app
 
-    uvicorn.run(
-        "app.main:app",
+    config = uvicorn.Config(
+        asgi_app,
         host=args.host,
         port=args.port,
         loop=_get_uvicorn_loop_factory(),
@@ -68,6 +69,9 @@ def handle_serve(args: argparse.Namespace) -> None:
         log_config=None,
         access_log=False,
     )
+    server = uvicorn.Server(config)
+    fastapi_app.state.uvicorn_server = server
+    server.run()
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -52,6 +52,7 @@ from app.api.routers import (
     world_info_entries,
 )
 from app.audit import start_audit_queue, stop_audit_queue
+from app.agent_runtime.persistence.child_runs import cancel_interrupted_child_runs
 from app.audit.queue import load_audit_details_persistence
 from app.agent_runtime.runner.checkpointer import (
     cleanup_unreachable_checkpoints,
@@ -117,6 +118,16 @@ async def _reset_task_running_state() -> int:
         cleared = await task_service.clear_running_tasks(session)
         await session.commit()
         return cleared
+    finally:
+        await session.close()
+
+
+async def _reset_interrupted_child_run_state() -> int:
+    session = await create_session()
+    try:
+        cancelled = await cancel_interrupted_child_runs(session)
+        await session.commit()
+        return cancelled
     finally:
         await session.close()
 
@@ -304,6 +315,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     cleared_tasks = await _reset_task_running_state()
     if cleared_tasks:
         logger.warning(f"已重置 {cleared_tasks} 个遗留的运行中任务状态")
+    cancelled_child_runs = await _reset_interrupted_child_run_state()
+    if cancelled_child_runs:
+        logger.warning(f"已取消 {cancelled_child_runs} 个因服务重启中断的子 Agent 任务")
     await _seed_builtin_models()
     await init_checkpointer()
     await _cleanup_unreachable_checkpoints()
@@ -327,6 +341,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         cancelled_runs = await get_agent_run_registry().cancel_all()
         if cancelled_runs:
             logger.info(f"已取消 {cancelled_runs} 个运行中的 Agent 任务")
+        cancelled_child_runs = await _reset_interrupted_child_run_state()
+        if cancelled_child_runs:
+            logger.info(f"已取消 {cancelled_child_runs} 个中断的子 Agent 任务")
         cleared_tasks = await _reset_task_running_state()
         if cleared_tasks:
             logger.info(f"已清理 {cleared_tasks} 个任务的运行状态")

--- a/backend/tests/agent_runtime/persistence/test_child_runs.py
+++ b/backend/tests/agent_runtime/persistence/test_child_runs.py
@@ -4,6 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
 from app.agent_runtime.persistence.child_runs import (
+    cancel_interrupted_child_runs,
     complete_child_run_request,
     create_child_run,
     enqueue_child_run_request,
@@ -163,6 +164,72 @@ async def test_list_child_runs_for_parent_orders_by_creation(
     rows = await list_child_runs_for_parent(db_session, "parent-session")
 
     assert [row.child_thread_id for row in rows] == ["child-1", "child-2"]
+
+
+@pytest.mark.asyncio
+async def test_cancel_interrupted_child_runs_finalizes_all_active_runs(
+    db_session: AsyncSession,
+    sample_task,
+):
+    queued = await create_child_run(
+        db_session,
+        parent_session_id="parent-session",
+        parent_task_id=sample_task.id,
+        parent_thread_id="parent-thread",
+        child_thread_id="queued-child",
+        agent_key="writer",
+        dispatch_id="dispatch-queued",
+        tool_call_id="tool-call-queued",
+        request={},
+        status="queued",
+    )
+    running = await create_child_run(
+        db_session,
+        parent_session_id="parent-session",
+        parent_task_id=sample_task.id,
+        parent_thread_id="parent-thread",
+        child_thread_id="running-child",
+        agent_key="reviewer",
+        dispatch_id="dispatch-running",
+        tool_call_id="tool-call-running",
+        request={},
+        status="running",
+    )
+    waiting = await create_child_run(
+        db_session,
+        parent_session_id="parent-session",
+        parent_task_id=sample_task.id,
+        parent_thread_id="parent-thread",
+        child_thread_id="waiting-child",
+        agent_key="composer",
+        dispatch_id="dispatch-waiting",
+        tool_call_id="tool-call-waiting",
+        request={},
+        status="waiting_user",
+    )
+
+    cancelled = await cancel_interrupted_child_runs(db_session)
+
+    assert cancelled == 3
+    for child_run_id in (queued.id, running.id, waiting.id):
+        row = await db_session.get(AgentChildRun, child_run_id)
+        assert row is not None
+        assert row.status == "cancelled"
+        assert row.completed_at is not None
+        assert row.last_completed_at is not None
+        assert row.error == "server restarted"
+
+        result = await db_session.execute(
+            select(AgentChildRunRequest).where(
+                col(AgentChildRunRequest.child_run_id) == child_run_id
+            )
+        )
+        requests = list(result.scalars().all())
+        assert requests
+        assert all(request.status == "cancelled" for request in requests)
+        assert all(request.error == "server restarted" for request in requests)
+        assert all(request.completed_at is not None for request in requests)
+
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_health.py
+++ b/backend/tests/api/test_health.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_shutdown_endpoint_requests_graceful_server_exit(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = client._transport.app  # type: ignore[attr-defined]
+    server = SimpleNamespace(should_exit=False)
+    app.state.uvicorn_server = server
+    monkeypatch.setenv("OPENFIC_SHUTDOWN_TOKEN", "desktop-shutdown-token")
+
+    response = await client.post(
+        "/api/v1/health/shutdown",
+        headers={"X-OpenFic-Shutdown-Token": "desktop-shutdown-token"},
+    )
+
+    assert response.status_code == 202
+    assert server.should_exit is True
+
+
+@pytest.mark.asyncio
+async def test_shutdown_endpoint_rejects_invalid_token(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = client._transport.app  # type: ignore[attr-defined]
+    server = SimpleNamespace(should_exit=False)
+    app.state.uvicorn_server = server
+    monkeypatch.setenv("OPENFIC_SHUTDOWN_TOKEN", "desktop-shutdown-token")
+
+    response = await client.post(
+        "/api/v1/health/shutdown",
+        headers={"X-OpenFic-Shutdown-Token": "invalid-token"},
+    )
+
+    assert response.status_code == 404
+    assert server.should_exit is False

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -47,7 +47,9 @@ def test_dev_command_loads_windows_selector_loop_factory() -> None:
 
 
 def test_handle_serve_passes_loop_factory_to_uvicorn(monkeypatch) -> None:
-    uvicorn_run = Mock()
+    uvicorn_config = Mock()
+    uvicorn_server = Mock()
+    fastapi_app = SimpleNamespace(state=SimpleNamespace())
     monkeypatch.setattr(cli, "_ensure_data_dir", Mock())
     monkeypatch.setattr(cli, "configure_standard_logging", Mock())
     monkeypatch.setattr(
@@ -55,8 +57,22 @@ def test_handle_serve_passes_loop_factory_to_uvicorn(monkeypatch) -> None:
         "_get_uvicorn_loop_factory",
         Mock(return_value="app.cli:_windows_selector_loop_factory"),
     )
-    monkeypatch.setitem(sys.modules, "uvicorn", SimpleNamespace(run=uvicorn_run))
+    monkeypatch.setitem(
+        sys.modules,
+        "uvicorn",
+        SimpleNamespace(
+            Config=Mock(return_value=uvicorn_config),
+            Server=Mock(return_value=uvicorn_server),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "app.main",
+        SimpleNamespace(app=object(), fastapi_app=fastapi_app),
+    )
 
     cli.handle_serve(type("Args", (), {"host": "127.0.0.1", "port": 8000})())
 
-    assert uvicorn_run.call_args.kwargs["loop"] == "app.cli:_windows_selector_loop_factory"
+    assert sys.modules["uvicorn"].Config.call_args.kwargs["loop"] == "app.cli:_windows_selector_loop_factory"
+    assert fastapi_app.state.uvicorn_server is uvicorn_server
+    uvicorn_server.run.assert_called_once_with()

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -56,6 +56,7 @@ async def test_lifespan_refreshes_catalog_in_background_and_cancels_on_shutdown(
     monkeypatch.setattr(main, "ModelProviderCatalogService", FakeCatalogService, raising=False)
     monkeypatch.setattr(main, "init_db", do_nothing)
     monkeypatch.setattr(main, "_reset_task_running_state", reset_task_state)
+    monkeypatch.setattr(main, "_reset_interrupted_child_run_state", reset_task_state)
     monkeypatch.setattr(main, "_seed_builtin_models", do_nothing)
     monkeypatch.setattr(main, "init_checkpointer", do_nothing)
     monkeypatch.setattr(main, "_cleanup_unreachable_checkpoints", do_nothing)

--- a/desktop/src/main/backend-stop.ts
+++ b/desktop/src/main/backend-stop.ts
@@ -1,0 +1,52 @@
+import type { EventEmitter } from "node:events";
+
+export const BACKEND_GRACEFUL_STOP_TIMEOUT_MS = 10_000;
+
+export interface BackendStopHandle {
+  baseUrl: string;
+  process: EventEmitter & { killed: boolean };
+  shutdownToken: string;
+}
+
+export interface BackendStopDependencies {
+  requestGracefulShutdown: (handle: BackendStopHandle) => Promise<void>;
+  forceStop: (handle: BackendStopHandle) => void;
+  scheduleFallback: (callback: () => void, delayMs: number) => unknown;
+  cancelFallback: (timeout: unknown) => void;
+}
+
+export function abortBackendStartup(
+  handle: BackendStopHandle | null,
+  forceStop: (handle: BackendStopHandle) => void,
+): void {
+  if (!handle || handle.process.killed) return;
+  forceStop(handle);
+}
+
+export function requestBackendStop(
+  handle: BackendStopHandle | null,
+  dependencies: BackendStopDependencies,
+): Promise<void> {
+  if (!handle || handle.process.killed) return Promise.resolve();
+
+  return new Promise((resolve) => {
+    let isStopped = false;
+    const fallback = { timeout: undefined as unknown };
+
+    const finish = () => {
+      if (isStopped) return;
+      isStopped = true;
+      dependencies.cancelFallback(fallback.timeout);
+      handle.process.off("exit", finish);
+      resolve();
+    };
+    const forceStop = () => {
+      dependencies.forceStop(handle);
+      finish();
+    };
+
+    handle.process.once("exit", finish);
+    fallback.timeout = dependencies.scheduleFallback(forceStop, BACKEND_GRACEFUL_STOP_TIMEOUT_MS);
+    void dependencies.requestGracefulShutdown(handle).catch(() => undefined);
+  });
+}

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -6,7 +6,7 @@ import { registerIpc } from "./ipc.js";
 import { throwIfAborted, waitForBackend } from "./health.js";
 import { ensurePortablePython, resolveRuntimeDir } from "./runtime/python.js";
 import { ensureOpenFicRuntime, startLocalOpenFicBackend } from "./runtime/openfic.js";
-import { stopBackendProcess, type BackendProcessHandle } from "./process.js";
+import { forceStopBackendProcess, stopBackendProcess, type BackendProcessHandle } from "./process.js";
 import { initializeUpdater } from "./updater.js";
 import { configureDefaultSystemProxy } from "./proxy.js";
 import { createStartupProgressTracker, type StartupProgressTracker } from "./startup-progress.js";
@@ -40,13 +40,13 @@ function setBackend(handle: BackendProcessHandle): void {
       app.quit();
     }
   });
-  if (previousHandle && previousHandle !== handle) stopBackendProcess(previousHandle);
+  if (previousHandle && previousHandle !== handle) void stopBackendProcess(previousHandle);
 }
 
 function clearBackend(): void {
   const previousHandle = backendHandle;
   backendHandle = null;
-  if (previousHandle) stopBackendProcess(previousHandle);
+  if (previousHandle) void stopBackendProcess(previousHandle);
 }
 
 function setBackendBaseUrl(url: string): void {
@@ -370,18 +370,26 @@ if (!gotLock) {
     app.quit();
   });
 
-  app.on("before-quit", () => {
+  app.on("before-quit", (event) => {
+    if (isQuitting) return;
+    const handle = backendHandle;
+    if (!handle) {
+      isQuitting = true;
+      return;
+    }
+
+    event.preventDefault();
     isQuitting = true;
-    stopBackendProcess(backendHandle);
+    void stopBackendProcess(handle).finally(() => app.quit());
   });
 
-  process.on("exit", () => stopBackendProcess(backendHandle));
+  process.on("exit", () => forceStopBackendProcess(backendHandle));
   process.on("SIGINT", () => {
-    stopBackendProcess(backendHandle);
+    forceStopBackendProcess(backendHandle);
     process.exit(0);
   });
   process.on("SIGTERM", () => {
-    stopBackendProcess(backendHandle);
+    forceStopBackendProcess(backendHandle);
     process.exit(0);
   });
 

--- a/desktop/src/main/process.ts
+++ b/desktop/src/main/process.ts
@@ -1,11 +1,19 @@
 import { app } from "electron";
 import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import {
+  abortBackendStartup,
+  requestBackendStop,
+  type BackendStopHandle,
+} from "./backend-stop.js";
 import { appendLog, createLogStream, getLogPath } from "./logging.js";
 
-export interface BackendProcessHandle {
+export interface BackendProcessHandle extends BackendStopHandle {
   process: ChildProcessWithoutNullStreams;
   baseUrl: string;
   logPath: string;
+  shutdownToken: string;
+  stopPromise?: Promise<void>;
 }
 
 export interface StartBackendOptions {
@@ -44,6 +52,7 @@ export function startBackendProcess(options: StartBackendOptions): BackendProces
   const stdoutLog = createLogStream("backend");
   const stderrLog = createLogStream("backend");
   let logsClosed = false;
+  const shutdownToken = randomUUID();
 
   const closeLogs = () => {
     if (logsClosed) return;
@@ -61,6 +70,7 @@ export function startBackendProcess(options: StartBackendOptions): BackendProces
       OPENFIC_SERVER_HOST: "127.0.0.1",
       OPENFIC_SERVER_PORT: String(options.port),
       OPENFIC_DATA_DIR: dataDir,
+      OPENFIC_SHUTDOWN_TOKEN: shutdownToken,
       PYTHONIOENCODING: "utf-8",
       PYTHONUTF8: "1",
       ...options.environment,
@@ -87,10 +97,11 @@ export function startBackendProcess(options: StartBackendOptions): BackendProces
     process: child,
     baseUrl: `http://127.0.0.1:${options.port}`,
     logPath,
+    shutdownToken,
   };
 }
 
-export function stopBackendProcess(handle: BackendProcessHandle | null): void {
+export function forceStopBackendProcess(handle: BackendProcessHandle | null): void {
   if (!handle || handle.process.killed) return;
 
   appendLog("backend", `请求停止后端进程：pid=${handle.process.pid ?? "unknown"}`);
@@ -104,4 +115,32 @@ export function stopBackendProcess(handle: BackendProcessHandle | null): void {
   }
 
   handle.process.kill("SIGTERM");
+}
+
+export function abortStartingBackendProcess(handle: BackendProcessHandle | null): void {
+  abortBackendStartup(handle, (startingHandle) =>
+    forceStopBackendProcess(startingHandle as BackendProcessHandle),
+  );
+}
+
+async function requestGracefulBackendShutdown(handle: BackendStopHandle): Promise<void> {
+  const response = await fetch(`${handle.baseUrl}/api/v1/health/shutdown`, {
+    method: "POST",
+    headers: { "X-OpenFic-Shutdown-Token": handle.shutdownToken },
+  });
+  if (!response.ok) throw new Error(`graceful backend shutdown rejected: ${response.status}`);
+}
+
+export function stopBackendProcess(handle: BackendProcessHandle | null): Promise<void> {
+  if (!handle) return Promise.resolve();
+  if (handle.stopPromise) return handle.stopPromise;
+
+  appendLog("backend", `请求优雅停止后端进程：pid=${handle.process.pid ?? "unknown"}`);
+  handle.stopPromise = requestBackendStop(handle, {
+    requestGracefulShutdown: requestGracefulBackendShutdown,
+    forceStop: (stopHandle) => forceStopBackendProcess(stopHandle as BackendProcessHandle),
+    scheduleFallback: (callback, delayMs) => setTimeout(callback, delayMs),
+    cancelFallback: (timeout) => clearTimeout(timeout as NodeJS.Timeout),
+  });
+  return handle.stopPromise;
 }

--- a/desktop/src/main/runtime/openfic.ts
+++ b/desktop/src/main/runtime/openfic.ts
@@ -3,7 +3,11 @@ import { spawn } from "node:child_process";
 import { access, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { findFreePort } from "../ports.js";
-import { startBackendProcess, stopBackendProcess, type BackendProcessHandle } from "../process.js";
+import {
+  abortStartingBackendProcess,
+  startBackendProcess,
+  type BackendProcessHandle,
+} from "../process.js";
 import { configureDefaultSystemProxy, getSystemProxyEnvironment } from "../proxy.js";
 import { throwIfAborted, waitForBackend } from "../health.js";
 import type { PortablePython, RuntimeIntegrityCheck } from "./python.js";
@@ -463,13 +467,13 @@ export async function startLocalOpenFicBackend(
       progress: 0.98,
     });
     if (health.version !== expectedVersion) {
-      stopBackendProcess(handle);
+      abortStartingBackendProcess(handle);
       throw new Error(`本地后端版本不匹配：期望 ${expectedVersion}，实际 ${health.version ?? "未知"}`);
     }
     return handle;
   } catch (error) {
     if (healthFallbackTimer) clearTimeout(healthFallbackTimer);
-    stopBackendProcess(handle);
+    abortStartingBackendProcess(handle);
     const message = error instanceof Error ? error.message : String(error);
     throw new Error(`${message}。日志路径：${handle.logPath}`);
   }


### PR DESCRIPTION
## PR 标题

fix(agent): 修复重启后会话设置持续锁定的问题

## 变更说明

- 问题: Windows 桌面端强制结束本地后端后，子 Agent 的运行或待审批状态会遗留在数据库中，重启后持续锁定 Agent 相关设置。
- 重要性: 用户在界面中看不到运行中的会话时，仍无法修改模型、提供商、规则和技能配置。
- 变化: 后端启动和关闭时取消全部遗留的活跃子 Agent 状态，包括待审批状态，并清理未完成请求和审批载荷。
- 变化: Windows 桌面端在已连接的本地后端退出时优先请求 Uvicorn 优雅关闭，10 秒未退出才强制终止；启动或连接失败时立即强制终止。

## 关联 Issue / PR (如有)

Closes #206

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

设置锁定同时检查父任务和子 Agent 的持久化状态。应用启动时此前只重置 `tasks.is_running`，未结束的 `agent_child_runs` 会继续匹配锁定条件。Windows 桌面端使用 `taskkill /F /T` 结束后端，无法运行 FastAPI 关闭钩子，增加了该状态遗留的概率。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 后端验证: `uv run pytest -q`，结果为 `1302 passed, 1 warning`；`uv run ruff check app tests`、`uv run ty check app` 通过。
- 桌面端验证: `pnpm lint`、`pnpm type-check`、`pnpm build:main` 通过；既有 `node --test tests/main/archive.test.mjs` 结果为 `5 passed`。
- 未新增或保留桌面端 `.mjs` 测试文件。
