### PR TITLE
chore(skills): 优化技能配置体验

### DIFF
--- a/backend/app/api/routers/skills.py
+++ b/backend/app/api/routers/skills.py
@@ -166,6 +166,26 @@ async def toggle_skill(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
 
 
+@router.post(
+    "/skills/{skill_db_id}/fork",
+    response_model=SkillResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def fork_skill(
+    skill_db_id: str,
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> SkillResponse:
+    try:
+        await require_agent_settings_unlocked(session)
+        logger.info(f"复制 Skill: skill_db_id={skill_db_id}")
+        skill = await skill_service.fork_skill(session, skill_db_id)
+        return _to_response(skill)
+    except NotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))
+    except skill_service.SkillValidationError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc))
+
+
 @router.delete("/skills/{skill_db_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_skill(
     skill_db_id: str,

--- a/backend/app/storage/services/skill_service.py
+++ b/backend/app/storage/services/skill_service.py
@@ -16,6 +16,7 @@ from app.skills import (
     load_builtin_skills,
 )
 from app.storage.models.skill import Skill
+from app.storage.models.skill_reference_doc import SkillReferenceDoc
 from app.storage.repos import skill_reference_doc_repo, skill_repo
 
 
@@ -146,6 +147,28 @@ async def create_skill(
     if skill.is_enabled and not is_skill_complete(skill):
         raise SkillValidationError("Skill 信息未完整填写，无法启用。")
     return await skill_repo.create(session, skill)
+
+
+async def fork_skill(session: AsyncSession, skill_db_id: str) -> Skill:
+    source = await get_skill(session, skill_db_id)
+    fork = await create_skill(
+        session,
+        name=f"{source.name}- Fork",
+        summary=source.summary,
+        content=source.content,
+    )
+    reference_docs = await list_reference_docs(session, skill_db_id)
+    for reference_doc in reference_docs:
+        await skill_reference_doc_repo.create(
+            session,
+            SkillReferenceDoc(
+                skill_db_id=fork.id,
+                title=reference_doc.title,
+                content=reference_doc.content,
+                tokens=reference_doc.tokens,
+            ),
+        )
+    return fork
 
 
 async def get_skill(session: AsyncSession, skill_db_id: str) -> SkillData:

--- a/backend/tests/api/test_skills.py
+++ b/backend/tests/api/test_skills.py
@@ -150,6 +150,82 @@ async def test_create_skill_dedupes_duplicate_name(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_fork_skill_copies_custom_skill_and_reference_docs(client: AsyncClient) -> None:
+    create_response = await client.post(
+        "/api/v1/skills",
+        json={
+            "name": "原技能",
+            "summary": "原简述",
+            "content": "原技能内容",
+            "is_enabled": True,
+        },
+    )
+    source = create_response.json()
+    await client.post(
+        f"/api/v1/skills/{source['id']}/reference-docs",
+        json={"title": "参考文档一", "content": "参考内容一"},
+    )
+    await client.post(
+        f"/api/v1/skills/{source['id']}/reference-docs",
+        json={"title": "参考文档二", "content": "参考内容二"},
+    )
+
+    fork_response = await client.post(f"/api/v1/skills/{source['id']}/fork")
+
+    assert fork_response.status_code == 201
+    fork = fork_response.json()
+    assert fork["id"] != source["id"]
+    assert fork["name"] == "原技能- Fork"
+    assert fork["summary"] == source["summary"]
+    assert fork["content"] == source["content"]
+    assert fork["source"] == "custom"
+    assert fork["is_enabled"] is False
+
+    fork_docs_response = await client.get(f"/api/v1/skills/{fork['id']}/reference-docs")
+    assert fork_docs_response.status_code == 200
+    assert [
+        (doc["title"], doc["content"]) for doc in fork_docs_response.json()
+    ] == [
+        ("参考文档一", "参考内容一"),
+        ("参考文档二", "参考内容二"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_fork_skill_copies_builtin_skill_and_reference_docs(client: AsyncClient) -> None:
+    list_response = await client.get("/api/v1/skills")
+    builtin_skills = [
+        item for item in list_response.json()["items"] if item["source"] == "builtin"
+    ]
+    source = None
+    source_docs = []
+    for skill in builtin_skills:
+        docs_response = await client.get(f"/api/v1/skills/{skill['id']}/reference-docs")
+        if docs_response.json():
+            source = skill
+            source_docs = docs_response.json()
+            break
+
+    assert source is not None
+
+    fork_response = await client.post(f"/api/v1/skills/{source['id']}/fork")
+
+    assert fork_response.status_code == 201
+    fork = fork_response.json()
+    assert fork["name"] == f"{source['name']}- Fork"
+    assert fork["summary"] == source["summary"]
+    assert fork["content"] == source["content"]
+    assert fork["source"] == "custom"
+    assert fork["is_enabled"] is False
+
+    fork_docs_response = await client.get(f"/api/v1/skills/{fork['id']}/reference-docs")
+    assert fork_docs_response.status_code == 200
+    assert [
+        (doc["title"], doc["content"]) for doc in fork_docs_response.json()
+    ] == [(doc["title"], doc["content"]) for doc in source_docs]
+
+
+@pytest.mark.asyncio
 async def test_update_skill_name_conflict(client: AsyncClient) -> None:
     await client.post(
         "/api/v1/skills",

--- a/docs/develop/commit-conventions.md
+++ b/docs/develop/commit-conventions.md
@@ -12,8 +12,8 @@
 [optional footer(s)]
 ```
 
-- `type` 与 `:` 及其后空格为必须；`scope`、`!`、`body`、`footer` 均为可选。
-- 除 `BREAKING CHANGE` 必须大写外，各元素大小写不敏感。
+- `type` 与 `:` 及其后空格为必须；`scope`、`!`、`body`、`footer` 均为可选
+- 除 `BREAKING CHANGE` 必须大写外，各元素大小写不敏感
 
 ## type
 
@@ -35,18 +35,19 @@
 
 ## scope
 
-- 可选，置于 type 之后、`:` 之前，用括号包裹。
-- 必须是一个描述代码库某部分的名词，如 `fix(parser):`。
+- 可选，置于 type 之后、`:` 之前，用括号包裹
+- 必须是一个描述代码库某部分的名词，如 `fix(parser):`
 
 ## description
 
-- 必须，紧跟冒号与空格之后。
-- 是对代码变更的简短概括。
+- 必须，紧跟冒号与空格之后
+- 是对代码变更的简短概括
+- 对于bug修复类型，应遵循的格式：`<动作><问题><结果>`，如“修复xxx导致的xx的问题”，对于
 
 ## body
 
-- 可选，在 description 之后空一行开始。
-- 自由格式，可包含任意多段（以空行分隔）。
+- 可选，在 description 之后空一行开始
+- 自由格式，可包含任意多段（以空行分隔）
 
 ## footer
 
@@ -54,4 +55,4 @@
 - 每个 footer 由一个 token + 分隔符 + 值组成：
   - 分隔符为 `:<space>` 或 `<space>#`
   - token 中的空格用 `-` 替代，如 `Acked-by`（以此区分 footer 与多段 body）
-- `BREAKING CHANGE` 是例外，可原样作为 token（保持大写）；`BREAKING-CHANGE` 与 `BREAKING CHANGE` 同义。
+- `BREAKING CHANGE` 是例外，可原样作为 token（保持大写）；`BREAKING-CHANGE` 与 `BREAKING CHANGE` 同义

--- a/frontend/src/features/settings/components/agent-definitions-settings.tsx
+++ b/frontend/src/features/settings/components/agent-definitions-settings.tsx
@@ -284,7 +284,10 @@ function AgentForm({
     );
   }, []);
 
-  const selectableSkills = useMemo(() => skills.filter((skill) => skill.name.trim()), [skills]);
+  const selectableSkills = useMemo(
+    () => skills.filter((skill) => skill.name.trim() && skill.isEnabled),
+    [skills],
+  );
 
   return (
     <Flex
@@ -473,7 +476,7 @@ function AgentForm({
             gap="2"
           >
             {selectableSkills.map((skill) => {
-              const disabled = isAgentSettingsLocked || !skill.isEnabled || !skill.isComplete;
+              const disabled = isAgentSettingsLocked || !skill.isComplete;
               return (
                 <label
                   key={skill.id}

--- a/frontend/src/features/settings/components/skills-settings.css
+++ b/frontend/src/features/settings/components/skills-settings.css
@@ -56,6 +56,45 @@
   overflow-y: auto;
 }
 
+.skills-settings-list,
+.skills-settings-editor-scroll,
+.rt-TextAreaRoot.skills-settings-skill-content .rt-TextAreaInput,
+.rt-TextAreaRoot.skills-settings-refdoc-editor-content .rt-TextAreaInput {
+  scrollbar-width: thin;
+  scrollbar-color: var(--gray-a5) transparent;
+}
+
+.skills-settings-list::-webkit-scrollbar,
+.skills-settings-editor-scroll::-webkit-scrollbar,
+.rt-TextAreaRoot.skills-settings-skill-content .rt-TextAreaInput::-webkit-scrollbar,
+.rt-TextAreaRoot.skills-settings-refdoc-editor-content .rt-TextAreaInput::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.skills-settings-list::-webkit-scrollbar-track,
+.skills-settings-editor-scroll::-webkit-scrollbar-track,
+.rt-TextAreaRoot.skills-settings-skill-content .rt-TextAreaInput::-webkit-scrollbar-track,
+.rt-TextAreaRoot.skills-settings-refdoc-editor-content .rt-TextAreaInput::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.skills-settings-list::-webkit-scrollbar-thumb,
+.skills-settings-editor-scroll::-webkit-scrollbar-thumb,
+.rt-TextAreaRoot.skills-settings-skill-content .rt-TextAreaInput::-webkit-scrollbar-thumb,
+.rt-TextAreaRoot.skills-settings-refdoc-editor-content .rt-TextAreaInput::-webkit-scrollbar-thumb {
+  background: var(--gray-a5);
+  border-radius: 4px;
+}
+
+.skills-settings-list::-webkit-scrollbar-thumb:hover,
+.skills-settings-editor-scroll::-webkit-scrollbar-thumb:hover,
+.rt-TextAreaRoot.skills-settings-skill-content .rt-TextAreaInput::-webkit-scrollbar-thumb:hover,
+.rt-TextAreaRoot.skills-settings-refdoc-editor-content
+  .rt-TextAreaInput::-webkit-scrollbar-thumb:hover {
+  background: var(--gray-a7);
+}
+
 .skills-settings-list-body {
   width: 100%;
   min-width: 0;
@@ -335,6 +374,40 @@
 
 .skills-settings-refdocs-empty {
   padding: 6px 8px;
+}
+
+.rt-DialogContent.skills-settings-refdoc-dialog {
+  display: flex;
+  width: min(900px, calc(100vw - 32px));
+  max-width: calc(100vw - 32px);
+  height: min(70vh, calc(100vh - 64px));
+  max-height: calc(100vh - 64px);
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.rt-Box.skills-settings-refdoc-dialog-content {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.rt-Flex.skills-settings-refdoc-editor {
+  flex: 1;
+  min-height: 0;
+}
+
+.rt-TextAreaRoot.skills-settings-refdoc-editor-content {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+}
+
+.rt-TextAreaRoot.skills-settings-refdoc-editor-content .rt-TextAreaInput {
+  height: 100%;
+  min-height: 0;
+  resize: none;
 }
 
 .rt-Box.skills-settings-mobile-page {

--- a/frontend/src/features/settings/components/skills-settings.tsx
+++ b/frontend/src/features/settings/components/skills-settings.tsx
@@ -13,7 +13,18 @@ import {
 } from "@radix-ui/themes";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import Fuse from "fuse.js";
-import { FilePen, MoreHorizontal, PenLine, Plus, Search, Trash2, Import, X } from "lucide-react";
+import {
+  Copy,
+  Eye,
+  FilePen,
+  MoreHorizontal,
+  PenLine,
+  Plus,
+  Search,
+  Trash2,
+  Import,
+  X,
+} from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -32,6 +43,7 @@ import {
   deleteSkillReferenceDoc,
   fetchSkills,
   fetchSkillReferenceDocs,
+  forkSkill,
   toggleSkill,
   updateSkill,
   updateSkillReferenceDoc,
@@ -108,6 +120,7 @@ export function SkillsSettings({
   const { t } = useTranslation();
   const queryClient = useQueryClient();
   const [selectedSkillId, setSelectedSkillId] = useState<string | null>(null);
+  const [pendingForkSkillId, setPendingForkSkillId] = useState<string | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [contextMenuPos, setContextMenuPos] = useState<ContextMenuPosition | null>(null);
@@ -125,6 +138,7 @@ export function SkillsSettings({
   const [editingRefDoc, setEditingRefDoc] = useState<SkillReferenceDoc | null>(null);
   const [renamingRefDocId, setRenamingRefDocId] = useState<string | null>(null);
   const [deletingRefDoc, setDeletingRefDoc] = useState<SkillReferenceDoc | null>(null);
+  const skillListItemRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
   useEffect(() => {
     const checkMobile = () => setIsMobile(window.innerWidth < 768);
@@ -222,6 +236,34 @@ export function SkillsSettings({
     },
     [controlledMobileDirection, mobilePage, onMobilePageChange],
   );
+
+  useEffect(() => {
+    if (!pendingForkSkillId) return;
+    if (isMobile && (currentMobilePage !== "list" || currentMobileRefDocEdit)) {
+      setInternalMobileRefDocEdit(false);
+      onMobileRefDocEditChange?.(false);
+      handleMobilePageChange("list");
+      return;
+    }
+    if (!filteredSkills.some((skill) => skill.id === pendingForkSkillId)) {
+      return;
+    }
+    const skillElement = skillListItemRefs.current.get(pendingForkSkillId);
+    if (!skillElement) return;
+
+    skillElement.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    setSelectedSkillId(pendingForkSkillId);
+    if (isMobile) handleMobilePageChange("detail");
+    setPendingForkSkillId(null);
+  }, [
+    currentMobilePage,
+    currentMobileRefDocEdit,
+    filteredSkills,
+    handleMobilePageChange,
+    isMobile,
+    onMobileRefDocEditChange,
+    pendingForkSkillId,
+  ]);
 
   useEffect(() => {
     onMobileDetailTitleChange?.(selectedSkill?.name || null);
@@ -325,6 +367,19 @@ export function SkillsSettings({
       queryClient.invalidateQueries({ queryKey: ["skills"] });
       setDeleteDialogOpen(false);
       toast.success(t("common.delete"));
+    },
+    onError: () => {
+      toast.error(t("common.error"));
+    },
+  });
+
+  const forkMutation = useMutation({
+    mutationFn: (skillDbId: string) => forkSkill(skillDbId),
+    onSuccess: async (forkedSkill) => {
+      setSearchQuery("");
+      await queryClient.invalidateQueries({ queryKey: ["skills"] });
+      setPendingForkSkillId(forkedSkill.id);
+      toast.success(t("settingsExtra.skills.forkedSkill"));
     },
     onError: () => {
       toast.error(t("common.error"));
@@ -457,22 +512,34 @@ export function SkillsSettings({
   const contextMenuItems = useMemo<ContextMenuItem[]>(() => {
     if (!contextMenuSkillId || isAgentSettingsLocked) return [];
     const skill = skills.find((s) => s.id === contextMenuSkillId);
-    if (!skill || skill.source === "builtin") return [];
+    if (!skill) return [];
 
-    return [
+    const items: ContextMenuItem[] = [
       {
-        id: "delete",
-        label: t("common.delete"),
-        icon: Trash2,
-        danger: true,
+        id: "fork",
+        label: t("common.copy"),
+        icon: Copy,
         onClick: () => {
-          setSelectedSkillId(contextMenuSkillId);
-          setDeleteDialogOpen(true);
+          forkMutation.mutate(skill.id);
           handleCloseContextMenu();
         },
       },
     ];
-  }, [contextMenuSkillId, skills, handleCloseContextMenu, isAgentSettingsLocked, t]);
+    if (skill.source === "builtin") return items;
+
+    items.push({
+      id: "delete",
+      label: t("common.delete"),
+      icon: Trash2,
+      danger: true,
+      onClick: () => {
+        setSelectedSkillId(contextMenuSkillId);
+        setDeleteDialogOpen(true);
+        handleCloseContextMenu();
+      },
+    });
+    return items;
+  }, [contextMenuSkillId, forkMutation, skills, handleCloseContextMenu, isAgentSettingsLocked, t]);
 
   const handleCreateRefDoc = useCallback(() => {
     if (isAgentSettingsLocked) return;
@@ -533,6 +600,18 @@ export function SkillsSettings({
       selectedSkill,
       t,
     ],
+  );
+
+  const handlePreviewRefDoc = useCallback(
+    (doc: SkillReferenceDoc) => {
+      setEditingRefDoc(doc);
+      if (isMobile) {
+        setInternalMobileRefDocEdit(true);
+        onMobileRefDocEditChange?.(true);
+        onMobileDetailTitleChange?.(doc.title || t("settingsExtra.skills.untitledReferenceDoc"));
+      }
+    },
+    [isMobile, onMobileRefDocEditChange, onMobileDetailTitleChange, t],
   );
 
   const handleDeleteRefDoc = useCallback(
@@ -673,6 +752,13 @@ export function SkillsSettings({
               <SkillListItem
                 key={skill.id}
                 skill={skill}
+                itemRef={(element) => {
+                  if (element) {
+                    skillListItemRefs.current.set(skill.id, element);
+                    return;
+                  }
+                  skillListItemRefs.current.delete(skill.id);
+                }}
                 agentCount={agentCountBySkillId.get(skill.id) ?? 0}
                 isSelected={skill.id === effectiveSelectedSkillId}
                 isMenuOpen={skill.id === contextMenuSkillId}
@@ -741,6 +827,7 @@ export function SkillsSettings({
       onConfirmRenameRefDoc={handleConfirmRenameRefDoc}
       onCancelRenameRefDoc={handleCancelRenameRefDoc}
       onEditRefDoc={handleEditRefDoc}
+      onPreviewRefDoc={handlePreviewRefDoc}
       onDeleteRefDoc={handleDeleteRefDoc}
       isCreatingRefDoc={createRefDocMutation.isPending}
       isRenamingRefDoc={renameRefDocMutation.isPending}
@@ -1002,6 +1089,7 @@ export function SkillsSettings({
 
 interface SkillListItemProps {
   skill: Skill;
+  itemRef: (element: HTMLDivElement | null) => void;
   agentCount: number;
   isSelected: boolean;
   isMenuOpen: boolean;
@@ -1013,6 +1101,7 @@ interface SkillListItemProps {
 
 function SkillListItem({
   skill,
+  itemRef,
   agentCount,
   isSelected,
   isMenuOpen,
@@ -1033,6 +1122,7 @@ function SkillListItem({
 
   return (
     <div
+      ref={itemRef}
       role="button"
       tabIndex={0}
       className={`skills-settings-list-item${isSelected ? " skills-settings-list-item--selected" : ""}${isMenuOpen ? " skills-settings-list-item--menu-open" : ""}${!skill.isComplete ? " skills-settings-list-item--incomplete" : ""}`}
@@ -1129,7 +1219,7 @@ function SkillListItem({
                 const rect = event.currentTarget.getBoundingClientRect();
                 onContextMenu({ x: rect.right, y: rect.bottom + 4 });
               }}
-              disabled={isAgentSettingsLocked || skill.source === "builtin"}
+              disabled={isAgentSettingsLocked}
             >
               <MoreHorizontal size={14} />
             </IconButton>
@@ -1157,6 +1247,7 @@ interface SkillEditorProps {
   onConfirmRenameRefDoc: (newTitle: string) => void;
   onCancelRenameRefDoc: () => void;
   onEditRefDoc: (doc: SkillReferenceDoc) => void;
+  onPreviewRefDoc: (doc: SkillReferenceDoc) => void;
   onDeleteRefDoc: (doc: SkillReferenceDoc) => void;
   isCreatingRefDoc: boolean;
   isRenamingRefDoc: boolean;
@@ -1174,6 +1265,7 @@ function SkillEditor({
   onConfirmRenameRefDoc,
   onCancelRenameRefDoc,
   onEditRefDoc,
+  onPreviewRefDoc,
   onDeleteRefDoc,
   isCreatingRefDoc,
   isRenamingRefDoc,
@@ -1269,6 +1361,7 @@ function SkillEditor({
               onChange={(e) => setForm((prev) => ({ ...prev, content: e.target.value }))}
               placeholder={t("settingsExtra.skills.contentPlaceholder")}
               rows={12}
+              className="skills-settings-skill-content"
               disabled={isAgentSettingsLocked || isReadonly}
             />
           </Box>
@@ -1281,6 +1374,7 @@ function SkillEditor({
             onConfirmRename={onConfirmRenameRefDoc}
             onCancelRename={onCancelRenameRefDoc}
             onEdit={onEditRefDoc}
+            onPreview={onPreviewRefDoc}
             onDelete={onDeleteRefDoc}
             isCreating={isCreatingRefDoc}
             isRenaming={isRenamingRefDoc}
@@ -1310,6 +1404,7 @@ interface SkillReferenceDocsSectionProps {
   onConfirmRename: (newTitle: string) => void;
   onCancelRename: () => void;
   onEdit: (doc: SkillReferenceDoc) => void;
+  onPreview: (doc: SkillReferenceDoc) => void;
   onDelete: (doc: SkillReferenceDoc) => void;
   isCreating: boolean;
   isRenaming: boolean;
@@ -1325,6 +1420,7 @@ function SkillReferenceDocsSection({
   onConfirmRename,
   onCancelRename,
   onEdit,
+  onPreview,
   onDelete,
   isCreating,
   isRenaming,
@@ -1415,42 +1511,58 @@ function SkillReferenceDocsSection({
                   gap="1"
                   className="skills-settings-refdocs-item-actions"
                 >
-                  <Tooltip content={t("common.rename")}>
-                    <IconButton
-                      size="1"
-                      variant="ghost"
-                      color="gray"
-                      aria-label={t("common.rename")}
-                      disabled={isAgentSettingsLocked || isReadonly || isRenaming}
-                      onClick={() => onStartRename(doc)}
-                    >
-                      <PenLine size={14} />
-                    </IconButton>
-                  </Tooltip>
-                  <Tooltip content={t("common.edit")}>
-                    <IconButton
-                      size="1"
-                      variant="ghost"
-                      color="gray"
-                      aria-label={t("common.edit")}
-                      onClick={() => onEdit(doc)}
-                      disabled={isAgentSettingsLocked || isReadonly}
-                    >
-                      <FilePen size={14} />
-                    </IconButton>
-                  </Tooltip>
-                  <Tooltip content={t("common.delete")}>
-                    <IconButton
-                      size="1"
-                      variant="ghost"
-                      color="red"
-                      aria-label={t("common.delete")}
-                      onClick={() => onDelete(doc)}
-                      disabled={isAgentSettingsLocked || isReadonly}
-                    >
-                      <Trash2 size={14} />
-                    </IconButton>
-                  </Tooltip>
+                  {isReadonly ? (
+                    <Tooltip content={t("settingsExtra.skills.previewReferenceDoc")}>
+                      <IconButton
+                        size="1"
+                        variant="ghost"
+                        color="gray"
+                        aria-label={t("settingsExtra.skills.previewReferenceDoc")}
+                        onClick={() => onPreview(doc)}
+                      >
+                        <Eye size={14} />
+                      </IconButton>
+                    </Tooltip>
+                  ) : (
+                    <>
+                      <Tooltip content={t("common.rename")}>
+                        <IconButton
+                          size="1"
+                          variant="ghost"
+                          color="gray"
+                          aria-label={t("common.rename")}
+                          disabled={isAgentSettingsLocked || isRenaming}
+                          onClick={() => onStartRename(doc)}
+                        >
+                          <PenLine size={14} />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip content={t("common.edit")}>
+                        <IconButton
+                          size="1"
+                          variant="ghost"
+                          color="gray"
+                          aria-label={t("common.edit")}
+                          onClick={() => onEdit(doc)}
+                          disabled={isAgentSettingsLocked}
+                        >
+                          <FilePen size={14} />
+                        </IconButton>
+                      </Tooltip>
+                      <Tooltip content={t("common.delete")}>
+                        <IconButton
+                          size="1"
+                          variant="ghost"
+                          color="red"
+                          aria-label={t("common.delete")}
+                          onClick={() => onDelete(doc)}
+                          disabled={isAgentSettingsLocked}
+                        >
+                          <Trash2 size={14} />
+                        </IconButton>
+                      </Tooltip>
+                    </>
+                  )}
                 </Flex>
               </Box>
             </Flex>
@@ -1555,12 +1667,14 @@ function ReferenceDocEditor({
     <Flex
       direction="column"
       gap="3"
+      className="skills-settings-refdoc-editor"
     >
       <TextArea
         value={content}
         onChange={(e) => setContent(e.target.value)}
         placeholder={t("settingsExtra.skills.referenceDocContentPlaceholder")}
         rows={12}
+        className="skills-settings-refdoc-editor-content"
         disabled={isAgentSettingsLocked || isReadonly}
       />
       <Flex
@@ -1573,15 +1687,17 @@ function ReferenceDocEditor({
           onClick={onDone}
           disabled={isSaving}
         >
-          {t("common.cancel")}
+          {isReadonly ? t("common.close") : t("common.cancel")}
         </Button>
-        <Button
-          onClick={() => void handleSave()}
-          disabled={isAgentSettingsLocked || isReadonly || isSaving || !hasChanges}
-        >
-          {isSaving ? <Spinner size={18} /> : null}
-          {t("common.save")}
-        </Button>
+        {!isReadonly ? (
+          <Button
+            onClick={() => void handleSave()}
+            disabled={isAgentSettingsLocked || isSaving || !hasChanges}
+          >
+            {isSaving ? <Spinner size={18} /> : null}
+            {t("common.save")}
+          </Button>
+        ) : null}
       </Flex>
     </Flex>
   );
@@ -1613,10 +1729,13 @@ function SkillReferenceDocEditDialog({
       open={open}
       onOpenChange={onOpenChange}
     >
-      <Dialog.Content style={{ maxWidth: 640 }}>
+      <Dialog.Content className="skills-settings-refdoc-dialog">
         <Dialog.Title>{doc?.title || t("settingsExtra.skills.untitledReferenceDoc")}</Dialog.Title>
         {doc ? (
-          <Box mt="4">
+          <Box
+            mt="1"
+            className="skills-settings-refdoc-dialog-content"
+          >
             <ReferenceDocEditor
               doc={doc}
               onSave={onSave}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1828,6 +1828,7 @@
       "referenceDocsEmpty": "No reference docs",
       "renameReferenceDoc": "Rename Reference Doc",
       "editReferenceDoc": "Edit Reference Doc",
+      "previewReferenceDoc": "Preview Reference Doc",
       "deleteReferenceDoc": "Delete Reference Doc",
       "deleteReferenceDocDescription": "This cannot be undone.",
       "referenceDocTitle": "Title",
@@ -1836,6 +1837,7 @@
       "referenceDocCreated": "Reference doc created",
       "referenceDocRenamed": "Renamed",
       "referenceDocRenameFailed": "Rename failed",
+      "forkedSkill": "Skill fork created",
       "tokens": "tokens",
       "importDialog": {
         "invalidFileType": "Only .md / .zip files and folders are supported",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1891,6 +1891,7 @@
       "referenceDocsEmpty": "暂无参考文档",
       "renameReferenceDoc": "重命名参考文档",
       "editReferenceDoc": "编辑参考文档",
+      "previewReferenceDoc": "预览参考文档",
       "deleteReferenceDoc": "删除参考文档",
       "deleteReferenceDocDescription": "删除后无法恢复。",
       "referenceDocTitle": "标题",
@@ -1899,6 +1900,7 @@
       "referenceDocCreated": "已创建参考文档",
       "referenceDocRenamed": "已重命名",
       "referenceDocRenameFailed": "重命名失败",
+      "forkedSkill": "已创建技能副本",
       "tokens": "tokens",
       "importDialog": {
         "invalidFileType": "仅支持 .md / .zip 文件与文件夹",

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -433,6 +433,11 @@ export async function toggleSkill(skillDbId: string): Promise<Skill> {
   return transformSkill(response.data);
 }
 
+export async function forkSkill(skillDbId: string): Promise<Skill> {
+  const response = await apiClient.post(`/skills/${skillDbId}/fork`);
+  return transformSkill(response.data);
+}
+
 export async function deleteSkill(skillDbId: string): Promise<void> {
   await apiClient.delete(`/skills/${skillDbId}`);
 }


### PR DESCRIPTION
## PR 标题

chore(skills): 优化技能配置体验

## 变更说明

- 问题: 内置技能的参考文档无法查看，技能复制后无法快速定位到新副本，配置页面交互与滚动体验不一致。
- 重要性: 内置技能需要可复用和可编辑的副本，参考文档需要可读访问，避免用户在长列表中手动寻找新副本。
- 变化: 新增技能 Fork 接口和右键复制入口，完整复制正文与参考文档，并自动定位打开新副本。
- 变化: 内置技能参考文档支持只读预览，扩大并自适应参考文档面板，统一技能页滚动条样式。
- 变化: 更新 Agent 技能选择逻辑与提交说明约定。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因(如有)

技能配置页缺少内置技能参考文档的查看入口和完整复制路径；复制完成后未协调列表刷新、定位与详情打开；参考文档面板尺寸调整后内部内容未填充可用高度。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- `uv run pytest tests/api/test_skills.py -v`：17 项通过。
- `just check`：Ruff、类型检查与后端全量 pytest（1304 项）通过。
- `pnpm type-check`、`pnpm lint`、`pnpm format:check`、`pnpm build` 通过。
