### PR TITLE
chore(editor): 优化编辑器体验

### DIFF
--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -18,6 +18,7 @@ export type { AutocompleteItem, AutocompletePopoverProps } from "./autocomplete-
 export { GlobalLoading } from "./global-loading";
 export { Spinner } from "./spinner";
 export type { SpinnerProps } from "./spinner";
+export { PanelLayoutLoading } from "./panel-layout-loading";
 export { ModelIdSelect } from "./model-id-select";
 export type { ModelIdSelectOption } from "./model-id-select";
 export { getModelValue } from "./model-id-select";

--- a/frontend/src/components/markdown-editor.tsx
+++ b/frontend/src/components/markdown-editor.tsx
@@ -108,8 +108,17 @@ export function MarkdownEditor({
     if (!currentEditor) return;
     if (content === contentSyncedRef.current) return;
 
+    const { from, to } = currentEditor.state.selection;
+    const wasFocused = currentEditor.isFocused;
     contentSyncedRef.current = content;
     currentEditor.commands.setContent(content, { contentType: "markdown", emitUpdate: false });
+    if (!wasFocused) return;
+
+    const maxPosition = Math.max(1, currentEditor.state.doc.content.size);
+    currentEditor.commands.setTextSelection({
+      from: Math.min(from, maxPosition),
+      to: Math.min(to, maxPosition),
+    });
   }, [content]);
 
   useHotkeys(

--- a/frontend/src/components/markdown-editor.tsx
+++ b/frontend/src/components/markdown-editor.tsx
@@ -30,6 +30,8 @@ export interface MarkdownEditorProps {
   lockedBanner?: React.ReactNode;
   maxWidth?: number;
   editorRef?: React.MutableRefObject<Editor | null>;
+  scrollTop?: number;
+  onScrollPositionChange?: (scrollTop: number) => void;
 }
 
 export function MarkdownEditor({
@@ -52,10 +54,16 @@ export function MarkdownEditor({
   lockedBanner,
   maxWidth = 800,
   editorRef: externalEditorRef,
+  scrollTop = 0,
+  onScrollPositionChange,
 }: MarkdownEditorProps) {
   const { t } = useTranslation();
   const contentSyncedRef = useRef(content);
   const editorContentRef = useRef<HTMLDivElement>(null);
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const initialScrollTopRef = useRef(scrollTop);
+  const latestScrollTopRef = useRef(scrollTop);
+  const scrollPositionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const editor = useEditor({
     extensions: createMarkdownEditorExtensions({
@@ -121,6 +129,62 @@ export function MarkdownEditor({
     });
   }, [content]);
 
+  const flushScrollPosition = useCallback(() => {
+    if (scrollPositionTimerRef.current) {
+      clearTimeout(scrollPositionTimerRef.current);
+      scrollPositionTimerRef.current = null;
+    }
+    const scrollPosition = scrollContainerRef.current?.scrollTop ?? latestScrollTopRef.current;
+    latestScrollTopRef.current = scrollPosition;
+    onScrollPositionChange?.(scrollPosition);
+  }, [onScrollPositionChange]);
+
+  const handleEditorScroll = useCallback(() => {
+    if (!onScrollPositionChange) return;
+
+    const scrollPosition = scrollContainerRef.current?.scrollTop;
+    if (scrollPosition === undefined) return;
+
+    latestScrollTopRef.current = scrollPosition;
+    if (scrollPositionTimerRef.current) return;
+
+    scrollPositionTimerRef.current = setTimeout(() => {
+      scrollPositionTimerRef.current = null;
+      onScrollPositionChange?.(latestScrollTopRef.current);
+    }, 250);
+  }, [onScrollPositionChange]);
+
+  useEffect(() => {
+    if (!onScrollPositionChange) return;
+
+    return flushScrollPosition;
+  }, [flushScrollPosition, onScrollPositionChange]);
+
+  useEffect(() => {
+    if (!editor || !onScrollPositionChange) return;
+
+    let restoreFrameId: number | null = null;
+    const frameId = window.requestAnimationFrame(() => {
+      restoreFrameId = window.requestAnimationFrame(() => {
+        const container = scrollContainerRef.current;
+        if (!container) return;
+
+        const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight);
+        const restoredScrollTop = Math.min(initialScrollTopRef.current, maxScrollTop);
+        container.scrollTop = restoredScrollTop;
+        latestScrollTopRef.current = restoredScrollTop;
+        if (restoredScrollTop !== initialScrollTopRef.current) {
+          onScrollPositionChange?.(restoredScrollTop);
+        }
+      });
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      if (restoreFrameId !== null) window.cancelAnimationFrame(restoreFrameId);
+    };
+  }, [editor, onScrollPositionChange]);
+
   useHotkeys(
     "mod+s",
     (event) => {
@@ -166,8 +230,10 @@ export function MarkdownEditor({
       />
 
       <Box
+        ref={scrollContainerRef}
         style={{ flex: 1, minHeight: 0, overflow: "auto" }}
         className="tiptap-editor-wrapper"
+        onScroll={handleEditorScroll}
       >
         <Box
           style={{

--- a/frontend/src/components/panel-layout-loading.tsx
+++ b/frontend/src/components/panel-layout-loading.tsx
@@ -1,0 +1,16 @@
+import { Flex } from "@radix-ui/themes";
+
+import { Spinner } from "./spinner";
+
+export function PanelLayoutLoading() {
+  return (
+    <Flex
+      align="center"
+      justify="center"
+      height="100%"
+      className="panel-layout-loading"
+    >
+      <Spinner size={18} />
+    </Flex>
+  );
+}

--- a/frontend/src/features/characters/components/character-editor.tsx
+++ b/frontend/src/features/characters/components/character-editor.tsx
@@ -128,6 +128,14 @@ export function CharacterEditor({
 
   useEffect(() => {
     if (!character) return;
+
+    if (hasChangesRef.current) return;
+
+    const hasSameContent =
+      latestValueRef.current.name === character.name &&
+      latestValueRef.current.description === character.description;
+    if (hasSameContent) return;
+
     if (saveTimerRef.current) {
       clearTimeout(saveTimerRef.current);
       saveTimerRef.current = null;

--- a/frontend/src/features/characters/pages/characters-page.tsx
+++ b/frontend/src/features/characters/pages/characters-page.tsx
@@ -7,9 +7,11 @@ import { useTranslation } from "react-i18next";
 import { Group, Panel, Separator } from "react-resizable-panels";
 import { useSearchParams } from "react-router";
 
+import { PanelLayoutLoading } from "@/components";
 import { toast } from "@/components/toast";
 import { AssistantSidebarHost, MobileAppSidebarTrigger, useAppShell } from "@/features/app-shell";
 import type { AssistantSidebarState } from "@/features/assistant";
+import { usePersistedPanelLayout } from "@/hooks/use-persisted-panel-layout";
 import {
   batchDeleteCharacters,
   batchFavoriteCharacters,
@@ -34,6 +36,8 @@ import "./characters-page.css";
 
 const LAST_PROJECT_KEY = "characters.lastProjectId";
 const LAST_CHARACTER_KEY = "characters.lastCharacterId";
+const PANEL_LAYOUT_KEY = "panel-layout.characters";
+const PANEL_IDS = ["characters-list", "characters-editor", "characters-right"];
 const MotionBox = motion.create(Box);
 const MOBILE_SIDEBAR_WIDTH = 320;
 
@@ -80,6 +84,7 @@ export function CharactersPage() {
     isAgentRunning: false,
   });
   const [selectedCharacterLoadVersion, setSelectedCharacterLoadVersion] = useState(0);
+  const panelLayout = usePersistedPanelLayout(PANEL_LAYOUT_KEY, PANEL_IDS, !isMobile);
   const isCreatingCharacterRef = useRef(false);
   const skipCharacterRestoreProjectIdRef = useRef<string | null>(null);
 
@@ -403,10 +408,12 @@ export function CharactersPage() {
       className="characters-page"
       direction="column"
     >
-      {currentProjectId && !isMobile ? (
+      {currentProjectId && !isMobile && panelLayout.isLoaded ? (
         <Group
           orientation="horizontal"
           className="characters-page-body"
+          defaultLayout={panelLayout.defaultLayout}
+          onLayoutChanged={panelLayout.onLayoutChanged}
         >
           <Panel
             id="characters-list"
@@ -445,7 +452,7 @@ export function CharactersPage() {
             </Box>
           </Panel>
         </Group>
-      ) : currentProjectId ? (
+      ) : currentProjectId && isMobile ? (
         <Box className="characters-page-body characters-page-body--mobile">
           <Box className="characters-panel characters-editor-shell characters-editor-shell--mobile">
             <Flex
@@ -510,6 +517,8 @@ export function CharactersPage() {
             </MotionBox>
           </Box>
         </Box>
+      ) : currentProjectId ? (
+        <PanelLayoutLoading />
       ) : (
         <Flex
           className="characters-project-empty"

--- a/frontend/src/features/prompt-chains/pages/prompt-chains-page.tsx
+++ b/frontend/src/features/prompt-chains/pages/prompt-chains-page.tsx
@@ -15,8 +15,9 @@ import "./prompt-chains-page.css";
 import { useSearchParams } from "react-router";
 import { v4 as uuidv4 } from "uuid";
 
-import { ConfirmDialog, PromptChainDialog } from "@/components";
-import { MobileAppSidebarTrigger } from "@/features/app-shell";
+import { ConfirmDialog, PanelLayoutLoading, PromptChainDialog } from "@/components";
+import { MobileAppSidebarTrigger, useAppShell } from "@/features/app-shell";
+import { usePersistedPanelLayout } from "@/hooks/use-persisted-panel-layout";
 import { fetchPromptChainsMetadata, compilePromptChain, resetPromptChain } from "@/lib/api-client";
 import type { PromptEntryData, CompileResponse } from "@/lib/prompt-chain.types";
 import type { PromptChainsMetadata } from "@/lib/prompt-chain.types";
@@ -31,6 +32,8 @@ const MotionBox = motion.create(Box);
 const DEFAULT_PROMPT_ID = "builtin-agent--explore";
 const VERSION_HISTORY_COLLAPSED_SIZE = 36;
 const VERSION_HISTORY_MIN_SIZE = 72;
+const PANEL_LAYOUT_KEY = "panel-layout.prompt-chains";
+const PANEL_IDS = ["left-sidebar", "editor"];
 
 function getInitialPromptSelection(searchParams: URLSearchParams): string {
   return searchParams.get("prompt") || DEFAULT_PROMPT_ID;
@@ -81,21 +84,11 @@ export function PromptChainsPage() {
   // 重置相关状态
   const [isResetting, setIsResetting] = useState(false);
 
-  // 响应式检测
-  const [isMobile, setIsMobile] = useState(false);
+  const { isMobile } = useAppShell();
   const [mobileEntriesOpen, setMobileEntriesOpen] = useState(false);
   const [isVersionHistoryCollapsed, setIsVersionHistoryCollapsed] = useState(false);
   const versionHistoryPanelRef = useRef<PanelImperativeHandle | null>(null);
-
-  useEffect(() => {
-    const checkMobile = () => {
-      setIsMobile(window.innerWidth < 768);
-    };
-
-    checkMobile();
-    window.addEventListener("resize", checkMobile);
-    return () => window.removeEventListener("resize", checkMobile);
-  }, []);
+  const panelLayout = usePersistedPanelLayout(PANEL_LAYOUT_KEY, PANEL_IDS, !isMobile);
 
   // 加载元数据
   useEffect(() => {
@@ -349,10 +342,12 @@ export function PromptChainsPage() {
     <Box className="prompt-chains-page-root">
       {/* 主内容区 - resizable panels */}
       <Box className="prompt-chains-page-main">
-        {!isMobile ? (
+        {!isMobile && panelLayout.isLoaded ? (
           <Group
             orientation="horizontal"
             className="prompt-chains-page-group"
+            defaultLayout={panelLayout.defaultLayout}
+            onLayoutChanged={panelLayout.onLayoutChanged}
           >
             {/* 左侧边栏：条目列表 */}
             <Panel
@@ -402,7 +397,7 @@ export function PromptChainsPage() {
               </div>
             </Panel>
           </Group>
-        ) : (
+        ) : isMobile ? (
           <Flex className="prompt-chains-page-mobile-layout">
             <Flex
               align="center"
@@ -458,6 +453,8 @@ export function PromptChainsPage() {
               )}
             </div>
           </Flex>
+        ) : (
+          <PanelLayoutLoading />
         )}
 
         {isMobile && (

--- a/frontend/src/features/world-info/pages/world-info-page.tsx
+++ b/frontend/src/features/world-info/pages/world-info-page.tsx
@@ -15,9 +15,11 @@ import { useSearchParams } from "react-router";
 
 import "./world-info-page.css";
 
+import { PanelLayoutLoading } from "@/components";
 import { toast } from "@/components/toast";
 import { AssistantSidebarHost, MobileAppSidebarTrigger, useAppShell } from "@/features/app-shell";
 import type { AssistantSidebarState } from "@/features/assistant";
+import { usePersistedPanelLayout } from "@/hooks/use-persisted-panel-layout";
 import {
   fetchWorldInfoByProject,
   fetchProjects,
@@ -49,6 +51,8 @@ import {
 
 const LAST_PROJECT_KEY = "worldInfo.lastProjectId";
 const LAST_ENTRY_KEY = "worldInfo.lastEntryId";
+const PANEL_LAYOUT_KEY = "panel-layout.world-info";
+const PANEL_IDS = ["left-sidebar", "editor", "right-sidebar"];
 const MotionBox = motion.create(Box);
 const MOBILE_SIDEBAR_WIDTH = 320;
 
@@ -85,6 +89,7 @@ export function WorldInfoPage() {
   // 删除确认对话框状态
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [entryToDelete, setEntryToDelete] = useState<WorldInfoEntryBrief | null>(null);
+  const panelLayout = usePersistedPanelLayout(PANEL_LAYOUT_KEY, PANEL_IDS, !isMobile);
 
   // 排序状态
   type SortField = "order" | "uid" | "tokenCount" | "name";
@@ -767,10 +772,12 @@ export function WorldInfoPage() {
           direction="column"
           style={{ height: "100%", minHeight: 0 }}
         >
-          {!isMobile && currentProjectId ? (
+          {!isMobile && currentProjectId && panelLayout.isLoaded ? (
             <Group
               orientation="horizontal"
               className="world-info-page-group"
+              defaultLayout={panelLayout.defaultLayout}
+              onLayoutChanged={panelLayout.onLayoutChanged}
             >
               <Panel
                 id="left-sidebar"
@@ -812,7 +819,7 @@ export function WorldInfoPage() {
                 </Box>
               </Panel>
             </Group>
-          ) : currentProjectId ? (
+          ) : currentProjectId && isMobile ? (
             <Flex className="world-info-page-mobile-layout">
               <Box className="world-info-page-editor-shell world-info-page-editor-shell--mobile">
                 <Flex
@@ -882,6 +889,8 @@ export function WorldInfoPage() {
                 </MotionBox>
               </Box>
             </Flex>
+          ) : currentProjectId ? (
+            <PanelLayoutLoading />
           ) : (
             <Flex
               align="center"

--- a/frontend/src/features/writing/components/chapter-editor.tsx
+++ b/frontend/src/features/writing/components/chapter-editor.tsx
@@ -56,7 +56,9 @@ const wordsCount = (wordsCountModule as unknown as WordsCountModule).wordsCount;
 
 interface ChapterEditorProps {
   chapterId: string | null;
+  scrollTop?: number;
   onChapterUpdate?: (chapter: Chapter) => void;
+  onScrollPositionChange?: (chapterId: string, scrollTop: number) => void;
   onAddToConversation?: (markup: string) => void;
   projectId?: string;
   isAgentLocked?: boolean;
@@ -65,10 +67,12 @@ interface ChapterEditorProps {
 
 interface ChapterEditorContentProps {
   chapter: Chapter;
+  scrollTop: number;
   initialDraft: WritingDraft;
   initialDraftUpdatedAt: Date;
   workingCopy: WritingWorkingCopyController;
   onChapterUpdate?: (chapter: Chapter) => void;
+  onScrollPositionChange?: (chapterId: string, scrollTop: number) => void;
   onAddToConversation?: (markup: string) => void;
   projectId?: string;
   isAgentLocked?: boolean;
@@ -77,10 +81,12 @@ interface ChapterEditorContentProps {
 
 function ChapterEditorContent({
   chapter,
+  scrollTop,
   initialDraft,
   initialDraftUpdatedAt,
   workingCopy,
   onChapterUpdate,
+  onScrollPositionChange,
   onAddToConversation,
   projectId,
   isAgentLocked = false,
@@ -90,6 +96,9 @@ function ChapterEditorContent({
   const updateMutation = useUpdateChapter();
   const { containerRef, scrollbarProps } = useScrollbarAutoHide();
   const editorContentRef = useRef<HTMLDivElement>(null);
+  const initialScrollTopRef = useRef(scrollTop);
+  const latestScrollTopRef = useRef(scrollTop);
+  const scrollPositionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const { updateTabTitle } = useTabsStore();
   const navigate = useNavigate();
   const { clearWorkingCopy, persistWorkingCopy } = workingCopy;
@@ -192,6 +201,33 @@ function ChapterEditorContent({
     setFindReplaceMode("replace");
   }, [isAgentLocked, showLockedToast]);
 
+  const flushScrollPosition = useCallback(() => {
+    if (scrollPositionTimerRef.current) {
+      clearTimeout(scrollPositionTimerRef.current);
+      scrollPositionTimerRef.current = null;
+    }
+    const scrollPosition = containerRef.current?.scrollTop ?? latestScrollTopRef.current;
+    latestScrollTopRef.current = scrollPosition;
+    onScrollPositionChange?.(chapter.id, scrollPosition);
+  }, [chapter.id, containerRef, onScrollPositionChange]);
+
+  const handleEditorScroll = useCallback(() => {
+    const scrollPosition = containerRef.current?.scrollTop;
+    if (scrollPosition === undefined) return;
+
+    latestScrollTopRef.current = scrollPosition;
+    if (scrollPositionTimerRef.current) return;
+
+    scrollPositionTimerRef.current = setTimeout(() => {
+      scrollPositionTimerRef.current = null;
+      onScrollPositionChange?.(chapter.id, latestScrollTopRef.current);
+    }, 250);
+  }, [chapter.id, containerRef, onScrollPositionChange]);
+
+  useEffect(() => {
+    return flushScrollPosition;
+  }, [flushScrollPosition]);
+
   const persistDraft = useCallback(
     (draft: WritingDraft) => {
       latestDraftUpdatedAtRef.current = getNextWritingWorkingCopyTimestamp(
@@ -253,6 +289,31 @@ function ChapterEditorContent({
       setWordCount(wordsCount(editor.getText()));
     },
   });
+
+  useEffect(() => {
+    if (!editor) return;
+
+    let restoreFrameId: number | null = null;
+    const frameId = window.requestAnimationFrame(() => {
+      restoreFrameId = window.requestAnimationFrame(() => {
+        const container = containerRef.current;
+        if (!container) return;
+
+        const maxScrollTop = Math.max(0, container.scrollHeight - container.clientHeight);
+        const restoredScrollTop = Math.min(initialScrollTopRef.current, maxScrollTop);
+        container.scrollTop = restoredScrollTop;
+        latestScrollTopRef.current = restoredScrollTop;
+        if (restoredScrollTop !== initialScrollTopRef.current) {
+          onScrollPositionChange?.(chapter.id, restoredScrollTop);
+        }
+      });
+    });
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      if (restoreFrameId !== null) window.cancelAnimationFrame(restoreFrameId);
+    };
+  }, [chapter.id, containerRef, editor, onScrollPositionChange]);
 
   const handleSave = useCallback(
     async (isManualSave = false) => {
@@ -549,6 +610,7 @@ function ChapterEditorContent({
         onWheel={scrollbarProps.onWheel}
         onMouseMove={scrollbarProps.onMouseMove}
         onMouseLeave={scrollbarProps.onMouseLeave}
+        onScroll={handleEditorScroll}
         onClick={isAgentLocked ? showLockedToast : undefined}
       >
         <Box
@@ -621,7 +683,9 @@ function ChapterEditorContent({
 
 export function ChapterEditor({
   chapterId,
+  scrollTop = 0,
   onChapterUpdate,
+  onScrollPositionChange,
   onAddToConversation,
   projectId,
   isAgentLocked = false,
@@ -667,9 +731,11 @@ export function ChapterEditor({
     <ChapterEditorWorkingCopy
       key={`${data.entity.id}:${data.draftUpdatedAt.getTime()}`}
       chapter={data.entity}
+      scrollTop={scrollTop}
       initialDraft={data.draft}
       initialDraftUpdatedAt={data.draftUpdatedAt}
       onChapterUpdate={onChapterUpdate}
+      onScrollPositionChange={onScrollPositionChange}
       onAddToConversation={onAddToConversation}
       projectId={projectId}
       isAgentLocked={isAgentLocked}
@@ -680,9 +746,11 @@ export function ChapterEditor({
 
 function ChapterEditorWorkingCopy({
   chapter,
+  scrollTop,
   initialDraft,
   initialDraftUpdatedAt,
   onChapterUpdate,
+  onScrollPositionChange,
   onAddToConversation,
   projectId,
   isAgentLocked,
@@ -697,10 +765,12 @@ function ChapterEditorWorkingCopy({
     <ChapterEditorContent
       key={`${chapter.id}:${initialDraftUpdatedAt.getTime()}`}
       chapter={chapter}
+      scrollTop={scrollTop}
       initialDraft={initialDraft}
       initialDraftUpdatedAt={initialDraftUpdatedAt}
       workingCopy={workingCopy}
       onChapterUpdate={onChapterUpdate}
+      onScrollPositionChange={onScrollPositionChange}
       onAddToConversation={onAddToConversation}
       projectId={projectId}
       isAgentLocked={isAgentLocked}

--- a/frontend/src/features/writing/components/note-editor.tsx
+++ b/frontend/src/features/writing/components/note-editor.tsx
@@ -34,25 +34,31 @@ import { useTabsStore } from "../store/use-tabs-store";
 
 interface NoteEditorProps {
   noteId: string | null;
+  scrollTop?: number;
   projectId?: string;
   isAgentLocked?: boolean;
+  onScrollPositionChange?: (noteId: string, scrollTop: number) => void;
   onAddToConversation?: (markup: string) => void;
 }
 
 interface NoteEditorContentProps {
   note: Note;
+  scrollTop: number;
   initialDraft: WritingDraft;
   initialDraftUpdatedAt: Date;
   workingCopy: WritingWorkingCopyController;
   isAgentLocked?: boolean;
+  onScrollPositionChange?: (noteId: string, scrollTop: number) => void;
 }
 
 function NoteEditorContent({
   note,
+  scrollTop,
   initialDraft,
   initialDraftUpdatedAt,
   workingCopy,
   isAgentLocked = false,
+  onScrollPositionChange,
 }: NoteEditorContentProps) {
   const { t } = useTranslation();
   const updateMutation = useUpdateNote(note.projectId);
@@ -244,6 +250,13 @@ function NoteEditorContent({
     [persistDraft, title],
   );
 
+  const handleScrollPositionChange = useCallback(
+    (nextScrollTop: number) => {
+      onScrollPositionChange?.(note.id, nextScrollTop);
+    },
+    [note.id, onScrollPositionChange],
+  );
+
   const lockedBanner = note.isLocked ? (
     <Flex
       px="4"
@@ -281,6 +294,8 @@ function NoteEditorContent({
       onLockedAction={showLockedToast}
       placeholder={t("writing.noteContentPlaceholder")}
       lockedBanner={lockedBanner}
+      scrollTop={scrollTop}
+      onScrollPositionChange={handleScrollPositionChange}
     />
   );
 }
@@ -326,18 +341,22 @@ export function NoteEditor(props: NoteEditorProps) {
     <NoteEditorWorkingCopy
       key={`${data.entity.id}:${data.draftUpdatedAt.getTime()}`}
       note={data.entity}
+      scrollTop={props.scrollTop ?? 0}
       initialDraft={data.draft}
       initialDraftUpdatedAt={data.draftUpdatedAt}
       isAgentLocked={props.isAgentLocked ?? false}
+      onScrollPositionChange={props.onScrollPositionChange}
     />
   );
 }
 
 function NoteEditorWorkingCopy({
   note,
+  scrollTop,
   initialDraft,
   initialDraftUpdatedAt,
   isAgentLocked,
+  onScrollPositionChange,
 }: Omit<NoteEditorContentProps, "workingCopy">) {
   const workingCopy = useWritingWorkingCopy({
     type: "note",
@@ -348,10 +367,12 @@ function NoteEditorWorkingCopy({
     <NoteEditorContent
       key={`${note.id}:${initialDraftUpdatedAt.getTime()}`}
       note={note}
+      scrollTop={scrollTop}
       initialDraft={initialDraft}
       initialDraftUpdatedAt={initialDraftUpdatedAt}
       workingCopy={workingCopy}
       isAgentLocked={isAgentLocked}
+      onScrollPositionChange={onScrollPositionChange}
     />
   );
 }

--- a/frontend/src/features/writing/lib/tab.types.ts
+++ b/frontend/src/features/writing/lib/tab.types.ts
@@ -4,6 +4,7 @@ export interface EditorTab {
   refId: string | null;
   title: string;
   isLocked: boolean;
+  scrollTop: number;
 }
 
 export const MAX_TABS = 10;

--- a/frontend/src/features/writing/pages/writing-page.tsx
+++ b/frontend/src/features/writing/pages/writing-page.tsx
@@ -8,8 +8,10 @@ import { useParams } from "react-router";
 
 import "./writing-page.css";
 
+import { PanelLayoutLoading } from "@/components";
 import { AssistantSidebarHost, MobileAppSidebarTrigger, useAppShell } from "@/features/app-shell";
 import type { AssistantSidebarState } from "@/features/assistant";
+import { usePersistedPanelLayout } from "@/hooks/use-persisted-panel-layout";
 import { getLastChapterId, setLastChapterId } from "@/lib/local-db";
 
 import { ChapterEditor } from "../components/chapter-editor";
@@ -26,6 +28,8 @@ import { useWritingStore } from "../store/use-writing-store";
 
 const MotionBox = motion.create(Box);
 const MOBILE_SIDEBAR_WIDTH = 320;
+const PANEL_LAYOUT_KEY = "panel-layout.writing";
+const PANEL_IDS = ["left-sidebar", "editor", "right-sidebar"];
 const SummaryPanel = lazy(() =>
   import("../components/summary-panel").then((module) => ({ default: module.SummaryPanel })),
 );
@@ -45,10 +49,12 @@ export function WritingPage() {
     closeAllTabs,
     showEmptyTab,
     setCurrentProject,
+    updateTabScrollPosition,
   } = useTabsStore();
   const activeTabId = useActiveTabId();
   const tabs = useTabs();
   const isTabsLoaded = useTabsLoaded();
+  const panelLayout = usePersistedPanelLayout(PANEL_LAYOUT_KEY, PANEL_IDS, !isMobile);
 
   const activeTab = useMemo(() => tabs.find((t) => t.id === activeTabId), [tabs, activeTabId]);
   const activeRefId = useMemo(() => activeTab?.refId ?? null, [activeTab]);
@@ -58,6 +64,7 @@ export function WritingPage() {
     () => (activeTab?.type === "chapter" ? activeTab.refId : null),
     [activeTab],
   );
+  const activeChapterScrollTop = activeTab?.type === "chapter" ? activeTab.scrollTop : 0;
 
   const createMutation = useCreateChapter(projectId ?? "");
   const createVolumeMutation = useCreateVolume(projectId ?? "");
@@ -254,6 +261,13 @@ export function WritingPage() {
     [handleSelectItem],
   );
 
+  const handleChapterScrollPositionChange = useCallback(
+    (chapterId: string, scrollTop: number) => {
+      updateTabScrollPosition(`chapter:${chapterId}`, scrollTop);
+    },
+    [updateTabScrollPosition],
+  );
+
   const handleNoteSelect = useCallback(
     (noteId: string, noteTitle: string) => {
       handleSelectItem(noteId, noteTitle, "note");
@@ -348,10 +362,12 @@ export function WritingPage() {
       <PageLoadingOverlay isLoading={isPageLoading} />
 
       <Box className="writing-page-shell">
-        {!isMobile ? (
+        {!isMobile && panelLayout.isLoaded ? (
           <Group
             orientation="horizontal"
             className="writing-page-group"
+            defaultLayout={panelLayout.defaultLayout}
+            onLayoutChanged={panelLayout.onLayoutChanged}
           >
             <Panel
               id="left-sidebar"
@@ -388,8 +404,10 @@ export function WritingPage() {
                     ) : (
                       <ChapterEditor
                         chapterId={activeRefId}
+                        scrollTop={activeChapterScrollTop}
                         projectId={projectId}
                         isAgentLocked={isAgentLocked}
+                        onScrollPositionChange={handleChapterScrollPositionChange}
                         onAddToConversation={
                           isViewingSubagent ? undefined : handleAddToConversation
                         }
@@ -425,7 +443,7 @@ export function WritingPage() {
               </Box>
             </Panel>
           </Group>
-        ) : (
+        ) : isMobile ? (
           <Flex className="writing-page-mobile-layout">
             <div className="writing-page-editor-shell writing-page-editor-shell--mobile">
               <Flex
@@ -475,8 +493,10 @@ export function WritingPage() {
                   ) : (
                     <ChapterEditor
                       chapterId={activeRefId}
+                      scrollTop={activeChapterScrollTop}
                       projectId={projectId}
                       isAgentLocked={isAgentLocked}
+                      onScrollPositionChange={handleChapterScrollPositionChange}
                       onOpenSummary={handleOpenSummary}
                     />
                   )
@@ -523,6 +543,8 @@ export function WritingPage() {
               </MotionBox>
             </div>
           </Flex>
+        ) : (
+          <PanelLayoutLoading />
         )}
       </Box>
 

--- a/frontend/src/features/writing/pages/writing-page.tsx
+++ b/frontend/src/features/writing/pages/writing-page.tsx
@@ -64,7 +64,7 @@ export function WritingPage() {
     () => (activeTab?.type === "chapter" ? activeTab.refId : null),
     [activeTab],
   );
-  const activeChapterScrollTop = activeTab?.type === "chapter" ? activeTab.scrollTop : 0;
+  const activeEditorScrollTop = activeTab?.scrollTop ?? 0;
 
   const createMutation = useCreateChapter(projectId ?? "");
   const createVolumeMutation = useCreateVolume(projectId ?? "");
@@ -261,11 +261,25 @@ export function WritingPage() {
     [handleSelectItem],
   );
 
-  const handleChapterScrollPositionChange = useCallback(
-    (chapterId: string, scrollTop: number) => {
-      updateTabScrollPosition(`chapter:${chapterId}`, scrollTop);
+  const handleEditorScrollPositionChange = useCallback(
+    (type: "chapter" | "note", entityId: string, scrollTop: number) => {
+      updateTabScrollPosition(`${type}:${entityId}`, scrollTop);
     },
     [updateTabScrollPosition],
+  );
+
+  const handleChapterScrollPositionChange = useCallback(
+    (chapterId: string, scrollTop: number) => {
+      handleEditorScrollPositionChange("chapter", chapterId, scrollTop);
+    },
+    [handleEditorScrollPositionChange],
+  );
+
+  const handleNoteScrollPositionChange = useCallback(
+    (noteId: string, scrollTop: number) => {
+      handleEditorScrollPositionChange("note", noteId, scrollTop);
+    },
+    [handleEditorScrollPositionChange],
   );
 
   const handleNoteSelect = useCallback(
@@ -398,13 +412,15 @@ export function WritingPage() {
                     activeType === "note" ? (
                       <NoteEditor
                         noteId={activeRefId}
+                        scrollTop={activeEditorScrollTop}
                         projectId={projectId}
                         isAgentLocked={isAgentLocked}
+                        onScrollPositionChange={handleNoteScrollPositionChange}
                       />
                     ) : (
                       <ChapterEditor
                         chapterId={activeRefId}
-                        scrollTop={activeChapterScrollTop}
+                        scrollTop={activeEditorScrollTop}
                         projectId={projectId}
                         isAgentLocked={isAgentLocked}
                         onScrollPositionChange={handleChapterScrollPositionChange}
@@ -487,13 +503,15 @@ export function WritingPage() {
                   activeType === "note" ? (
                     <NoteEditor
                       noteId={activeRefId}
+                      scrollTop={activeEditorScrollTop}
                       projectId={projectId}
                       isAgentLocked={isAgentLocked}
+                      onScrollPositionChange={handleNoteScrollPositionChange}
                     />
                   ) : (
                     <ChapterEditor
                       chapterId={activeRefId}
-                      scrollTop={activeChapterScrollTop}
+                      scrollTop={activeEditorScrollTop}
                       projectId={projectId}
                       isAgentLocked={isAgentLocked}
                       onScrollPositionChange={handleChapterScrollPositionChange}

--- a/frontend/src/features/writing/store/use-tabs-store.ts
+++ b/frontend/src/features/writing/store/use-tabs-store.ts
@@ -29,6 +29,7 @@ interface TabsActions {
   setActiveTab: (tabId: string | null) => void;
   toggleLock: (tabId: string) => void;
   updateTabTitle: (tabId: string, title: string) => void;
+  updateTabScrollPosition: (tabId: string, scrollTop: number) => void;
   syncTabsWithChapters: (chapters: { id: string; title: string }[]) => void;
   syncTabs: (items: { id: string; title: string }[], type: "chapter" | "note") => void;
   removeTabsByReference: (type: "chapter" | "note", refId: string) => void;
@@ -59,18 +60,21 @@ function toRecord(tab: EditorTab): EditorTabRecord {
     type: tab.type,
     title: tab.title,
     isLocked: tab.isLocked,
+    scrollTop: tab.scrollTop,
   };
 }
 
 function fromRecord(record: EditorTabRecord): EditorTab {
   const type = (record.type as "chapter" | "note") || "chapter";
   const refId = record.refId ?? record.chapterId ?? null;
+  const scrollTop = Number.isFinite(record.scrollTop) ? Math.max(0, record.scrollTop!) : 0;
   return {
     id: record.id,
     type,
     refId,
     title: record.title,
     isLocked: record.isLocked,
+    scrollTop,
   };
 }
 
@@ -149,6 +153,7 @@ export const useTabsStore = create<TabsStore>()((set, get) => ({
       refId,
       title,
       isLocked: false,
+      scrollTop: 0,
     };
     newTabs.push(newTab);
 
@@ -167,6 +172,7 @@ export const useTabsStore = create<TabsStore>()((set, get) => ({
       refId,
       title,
       isLocked: false,
+      scrollTop: 0,
     };
 
     set({
@@ -195,6 +201,7 @@ export const useTabsStore = create<TabsStore>()((set, get) => ({
         refId: null,
         title: "",
         isLocked: false,
+        scrollTop: 0,
       };
       set({
         tabs: [emptyTab],
@@ -242,6 +249,7 @@ export const useTabsStore = create<TabsStore>()((set, get) => ({
         refId: null,
         title: "",
         isLocked: false,
+        scrollTop: 0,
       };
       set({
         tabs: [emptyTab],
@@ -273,6 +281,7 @@ export const useTabsStore = create<TabsStore>()((set, get) => ({
       refId: null,
       title: "",
       isLocked: false,
+      scrollTop: 0,
     };
 
     const newTabs = [...tabs, emptyTab];
@@ -293,6 +302,21 @@ export const useTabsStore = create<TabsStore>()((set, get) => ({
   updateTabTitle: (tabId, title) => {
     const { tabs, activeTabId, currentProjectId } = get();
     const newTabs = tabs.map((t) => (t.id === tabId ? { ...t, title } : t));
+    set({ tabs: newTabs });
+    persistTabs(currentProjectId, newTabs, activeTabId);
+  },
+
+  updateTabScrollPosition: (tabId, scrollTop) => {
+    if (!Number.isFinite(scrollTop)) return;
+
+    const { tabs, activeTabId, currentProjectId } = get();
+    const nextScrollTop = Math.max(0, scrollTop);
+    const tab = tabs.find((item) => item.id === tabId);
+    if (!tab || tab.type !== "chapter" || tab.scrollTop === nextScrollTop) return;
+
+    const newTabs = tabs.map((item) =>
+      item.id === tabId ? { ...item, scrollTop: nextScrollTop } : item,
+    );
     set({ tabs: newTabs });
     persistTabs(currentProjectId, newTabs, activeTabId);
   },

--- a/frontend/src/features/writing/store/use-tabs-store.ts
+++ b/frontend/src/features/writing/store/use-tabs-store.ts
@@ -312,7 +312,7 @@ export const useTabsStore = create<TabsStore>()((set, get) => ({
     const { tabs, activeTabId, currentProjectId } = get();
     const nextScrollTop = Math.max(0, scrollTop);
     const tab = tabs.find((item) => item.id === tabId);
-    if (!tab || tab.type !== "chapter" || tab.scrollTop === nextScrollTop) return;
+    if (!tab || tab.scrollTop === nextScrollTop) return;
 
     const newTabs = tabs.map((item) =>
       item.id === tabId ? { ...item, scrollTop: nextScrollTop } : item,

--- a/frontend/src/hooks/use-persisted-panel-layout.ts
+++ b/frontend/src/hooks/use-persisted-panel-layout.ts
@@ -1,0 +1,100 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Layout } from "react-resizable-panels";
+
+import { getPreference, setPreference } from "@/lib/local-db";
+
+const SAVE_DELAY = 250;
+
+function parseLayout(value: string | null, panelIds: readonly string[]): Layout | null {
+  if (!value) return null;
+
+  try {
+    const layout: unknown = JSON.parse(value);
+    if (typeof layout !== "object" || layout === null || Array.isArray(layout)) return null;
+
+    const layoutEntries = Object.entries(layout);
+    const totalSize = layoutEntries.reduce(
+      (total, [, size]) => (typeof size === "number" ? total + size : total),
+      0,
+    );
+    if (
+      layoutEntries.length !== panelIds.length ||
+      !panelIds.every((panelId) => Object.hasOwn(layout, panelId)) ||
+      !layoutEntries.every(
+        ([, size]) => typeof size === "number" && Number.isFinite(size) && size >= 0 && size <= 100,
+      ) ||
+      Math.abs(totalSize - 100) > 0.01
+    ) {
+      return null;
+    }
+
+    return layout as Layout;
+  } catch {
+    return null;
+  }
+}
+
+export function usePersistedPanelLayout(
+  key: string,
+  panelIds: readonly string[],
+  isEnabled: boolean,
+) {
+  const [defaultLayout, setDefaultLayout] = useState<Layout | undefined>(undefined);
+  const [isLoaded, setIsLoaded] = useState(false);
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestLayoutRef = useRef<{ key: string; layout: Layout } | null>(null);
+
+  useEffect(() => {
+    let isDiscarded = false;
+    setDefaultLayout(undefined);
+    if (!isEnabled) {
+      setIsLoaded(true);
+      return;
+    }
+    setIsLoaded(false);
+
+    void getPreference(key).then((value) => {
+      if (isDiscarded) return;
+
+      setDefaultLayout(parseLayout(value, panelIds) ?? undefined);
+      setIsLoaded(true);
+    });
+
+    return () => {
+      isDiscarded = true;
+    };
+  }, [isEnabled, key, panelIds]);
+
+  const onLayoutChanged = useCallback(
+    (layout: Layout) => {
+      if (!isEnabled) return;
+      latestLayoutRef.current = { key, layout };
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+
+      saveTimerRef.current = setTimeout(() => {
+        saveTimerRef.current = null;
+        const latestLayout = latestLayoutRef.current;
+        if (latestLayout?.key === key) {
+          void setPreference(key, JSON.stringify(latestLayout.layout));
+        }
+      }, SAVE_DELAY);
+    },
+    [isEnabled, key],
+  );
+
+  useEffect(() => {
+    return () => {
+      if (saveTimerRef.current) {
+        clearTimeout(saveTimerRef.current);
+        saveTimerRef.current = null;
+      }
+
+      const latestLayout = latestLayoutRef.current;
+      if (latestLayout?.key === key) {
+        void setPreference(key, JSON.stringify(latestLayout.layout));
+      }
+    };
+  }, [isEnabled, key]);
+
+  return { defaultLayout, isLoaded, onLayoutChanged };
+}

--- a/frontend/src/lib/local-db.ts
+++ b/frontend/src/lib/local-db.ts
@@ -32,6 +32,7 @@ interface EditorTabRecord {
   type?: string;
   title: string;
   isLocked: boolean;
+  scrollTop?: number;
 }
 
 interface ProjectTabs {

--- a/frontend/src/styles/index.css
+++ b/frontend/src/styles/index.css
@@ -8,3 +8,8 @@
 @import "./overrides/sonner.css";
 
 @layer tokens, base, utilities;
+@layer base {
+  .panel-layout-loading {
+    min-height: 0;
+  }
+}


### PR DESCRIPTION
## PR 标题

chore(editor): 优化编辑器体验

## 变更说明

- 问题: 角色编辑器自动保存后可能重置光标；章节与笔记页签切换后会丢失阅读位置；编辑工作区侧栏尺寸不会被复用。
- 重要性: 上述问题会打断编辑与阅读流程，频繁切换页签或页面时尤为明显。
- 变化: 自动保存同步时保留编辑器选区；章节和笔记页签持久化各自的滚动位置；角色、世界书、提示词和写作页的桌面分栏尺寸保存至 IndexedDB 并在下次进入时恢复。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因(如有)

编辑器外部内容同步会重设 Tiptap 选区；页签记录未保存滚动位置；可调整面板布局未接入本地持久化。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

已执行 `pnpm format:check`、`pnpm type-check`、`pnpm lint` 和 `git diff --check`。前端项目未配置测试运行脚本，本次未新增测试文件。
