### PR TITLE
fix(summary): 修复跨卷删除章节导致区间摘要丢失的问题

### DIFF
--- a/backend/app/storage/services/chapter_service.py
+++ b/backend/app/storage/services/chapter_service.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.editor_content_limits import validate_editor_content
 from app.core.errors import NotFoundError
+from app.memory.chapter.sequence import global_order_index
 from app.storage.models.chapter import Chapter
 from app.storage.models.volume import Volume
 from app.storage.repos import (
@@ -529,7 +530,10 @@ async def delete_chapter(
     chapter = await get_chapter(session, chapter_id)
     project_id = chapter.project_id
     volume_id = chapter.volume_id
-    deleted_order = chapter.order
+    deleted_volume_order = chapter.order
+    chapters = await chapter_repo.list_by_project(session, project_id)
+    volumes = await volume_repo.list_by_project(session, project_id)
+    deleted_global_order = global_order_index(chapters, volumes)[chapter_id]
     old_title = chapter.title
     old_word_count = chapter.word_count
 
@@ -553,7 +557,7 @@ async def delete_chapter(
             for summary in long_term_summaries
             if summary.start_order is not None
             and summary.end_order is not None
-            and summary.end_order >= deleted_order
+            and summary.end_order >= deleted_global_order
         }
     )
     if affected_ranges:
@@ -581,10 +585,10 @@ async def delete_chapter(
 
     # 调整后续章节的顺序
     max_order = await chapter_repo.get_max_order(session, volume_id)
-    if deleted_order <= max_order:
-        # 将所有 order > deleted_order 的章节 order 减 1
+    if deleted_volume_order <= max_order:
+        # 将所有 order > deleted_volume_order 的章节 order 减 1
         await chapter_repo.shift_orders(
-            session, volume_id, deleted_order + 1, max_order, -1
+            session, volume_id, deleted_volume_order + 1, max_order, -1
         )
 
     # 更新项目统计

--- a/backend/tests/api/test_chapters.py
+++ b/backend/tests/api/test_chapters.py
@@ -432,6 +432,67 @@ async def test_delete_chapter_removes_summary_and_affected_long_term_summaries(
 
 
 @pytest.mark.asyncio
+async def test_delete_chapter_in_later_volume_keeps_prior_long_term_summaries(
+    client: AsyncClient, session
+) -> None:
+    project_id, first_volume_id = await _create_project(client)
+    second_volume_response = await client.post(
+        f"/api/v1/projects/{project_id}/volumes",
+        json={"title": "第二卷"},
+    )
+    assert second_volume_response.status_code == 201
+    second_volume_id = second_volume_response.json()["id"]
+
+    for order in range(10):
+        await _create_chapter(
+            client,
+            project_id,
+            first_volume_id,
+            title=f"第{order + 1}章",
+            content="内容",
+            word_count=800,
+        )
+    second_volume_chapters = [
+        await _create_chapter(
+            client,
+            project_id,
+            second_volume_id,
+            title=f"第{order + 1}章",
+            content="内容",
+            word_count=800,
+        )
+        for order in range(10)
+    ]
+
+    for start_order, end_order in ((1, 10), (11, 20)):
+        session.add(
+            ChapterSummary(
+                project_id=project_id,
+                summary_type=SUMMARY_TYPE_LONG_TERM,
+                status=SUMMARY_STATUS_READY,
+                start_order=start_order,
+                end_order=end_order,
+                summary=f"区间摘要{start_order}-{end_order}",
+            )
+        )
+    await session.commit()
+
+    response = await client.delete(
+        f"/api/v1/chapters/{second_volume_chapters[0]['id']}"
+    )
+
+    assert response.status_code == 204
+    long_term_list = await client.get(
+        f"/api/v1/projects/{project_id}/chapter-context/summaries/long-term"
+    )
+    assert long_term_list.status_code == 200
+    assert [
+        (item["start_order"], item["end_order"])
+        for item in long_term_list.json()["items"]
+    ] == [(1, 10)]
+
+
+@pytest.mark.asyncio
 async def test_delete_project_cascades_chapters_and_volumes(
     client: AsyncClient,
 ) -> None:


### PR DESCRIPTION
## PR 标题

fix(summary): 修复跨卷删除章节导致区间摘要丢失的问题

## 变更说明

- 问题: 删除后续卷的章节时，卷内章节序号被用于匹配项目级区间摘要序位，导致前序卷的区间摘要被误删。
- 重要性: 多卷项目中删除章节可能清空全部区间摘要，影响已生成的上下文内容。
- 变化: 删除章节前计算项目级全局阅读序位，仅使被删除章节及其后的区间摘要失效；卷内章节重排继续使用卷内序号。
- 变化: 新增跨卷回归测试，验证删除第二卷章节后保留第一卷的区间摘要。
- 验证: `just lint`、`just type-check` 通过；`just test` 为 1305 passed, 1 warning。

## 关联 Issue / PR (如有)

Closes #224

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [x] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

章节的 `order` 仅在卷内连续，而区间摘要的 `start_order` 和 `end_order` 为按卷和章节排序后的项目级全局序位。删除逻辑直接比较了两种不同语义的序位，导致跨卷删除时误判受影响范围。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

未涉及数据库结构变更。
