### PR TITLE
fix(editor): 修复移动端滑动后无法呼出键盘的问题

### DIFF
--- a/frontend/src/components/context-menu.tsx
+++ b/frontend/src/components/context-menu.tsx
@@ -87,7 +87,7 @@ export function ContextMenu({
   } | null>(null);
   const mobileLongPressTimerRef = useRef<number | null>(null);
   const suppressNextEditorContextMenuRef = useRef(false);
-  const editorInputModeRestoreRef = useRef<string | null>(null);
+  const editorInputModeRestoreRef = useRef<string | null | undefined>(undefined);
 
   // 判断使用哪种模式
   const isEditorMode = !!editor && !!containerRef;
@@ -171,6 +171,7 @@ export function ContextMenu({
     const editorElement = editor?.view.dom;
     if (!editorElement) return;
 
+    if (editorInputModeRestoreRef.current !== undefined) return;
     editorInputModeRestoreRef.current = editorElement.getAttribute("inputmode");
     editorElement.setAttribute("inputmode", "none");
   }, [editor]);
@@ -180,12 +181,13 @@ export function ContextMenu({
     if (!editorElement) return;
 
     const previousInputMode = editorInputModeRestoreRef.current;
+    if (previousInputMode === undefined) return;
     if (previousInputMode === null) {
       editorElement.removeAttribute("inputmode");
     } else {
       editorElement.setAttribute("inputmode", previousInputMode);
     }
-    editorInputModeRestoreRef.current = null;
+    editorInputModeRestoreRef.current = undefined;
   }, [editor]);
 
   useEffect(
@@ -208,7 +210,6 @@ export function ContextMenu({
 
       clearMobilePointer();
       setInternalPosition(null);
-      suppressEditorKeyboard();
       mobilePointerRef.current = {
         pointerId: event.pointerId,
         x: event.clientX,
@@ -221,6 +222,7 @@ export function ContextMenu({
       mobileLongPressTimerRef.current = window.setTimeout(() => {
         if (!mobilePointerRef.current) return;
         mobilePointerRef.current.isLongPress = true;
+        suppressEditorKeyboard();
         editor?.view.dom.blur();
       }, MOBILE_POINTER_LONG_PRESS_MS);
     };


### PR DESCRIPTION
## PR 标题

fix(editor): 修复移动端滑动后无法呼出键盘的问题

## 变更说明

- 问题: 移动端正文编辑器在每次触摸按下时都会切换 `inputmode`，键盘已打开后点击正文其他位置会被重复呼出。
- 重要性: 影响手机端章节和笔记编辑时的光标移动与连续输入体验。
- 变化: 仅在确认长按时抑制编辑器键盘；普通点击和滑动不再修改 `inputmode`。
- 变化: 使用显式状态区分未抑制与原始属性为空，确保长按结束后准确恢复原有键盘设置。

## 关联 Issue / PR (如有)

Closes #220

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

移动端长按菜单逻辑在 `pointerdown` 阶段立即设置编辑器 `inputmode="none"`，普通点击也会经历该状态切换。移动浏览器因此在后续恢复属性时重新处理输入法。此前滑动取消长按时还可能遗留该属性，导致键盘无法呼出。

## 自查清单

- [ ] 已添加/更新必要的测试（前端当前未配置测试脚本）
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过（前端当前未配置测试脚本）
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理（不涉及数据库变更）
- [x] 提交信息符合规范

## 补充信息

验证命令：

- `pnpm format:check`
- `pnpm type-check`
- `pnpm lint`
- `git diff --check`
