### PR TITLE
feat(agent): 支持用户消息图片附件输入

### DIFF
--- a/backend/app/agent_runtime/attachments.py
+++ b/backend/app/agent_runtime/attachments.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-import io
 import base64
+import io
 from pathlib import Path
+import shutil
 from typing import Any
 
 import aiofiles
@@ -177,6 +178,90 @@ async def delete_attachments_for_message_ids(
     for attachment in attachments:
         (root / attachment.storage_name).unlink(missing_ok=True)
     await session.execute(delete(AgentAttachment).where(col(AgentAttachment.id).in_(attachment_ids)))
+
+
+async def delete_attachments_for_task(
+    session: AsyncSession,
+    *,
+    task_id: str,
+) -> int:
+    """删除任务所有 Agent 附件的文件与记录。"""
+    from app.agent_runtime.persistence.model import AgentAttachment
+
+    result = await session.execute(
+        select(AgentAttachment).where(col(AgentAttachment.task_id) == task_id)
+    )
+    attachments = list(result.scalars())
+    root = ensure_agent_attachments_dir()
+    directories: set[Path] = set()
+    for attachment in attachments:
+        path = root / attachment.storage_name
+        path.unlink(missing_ok=True)
+        directories.update(path.parents)
+    await session.execute(delete(AgentAttachment).where(col(AgentAttachment.task_id) == task_id))
+    _remove_empty_attachment_directories(root, directories)
+    return len(attachments)
+
+
+async def cleanup_orphaned_agent_attachment_files(session: AsyncSession) -> int:
+    """先删除失效会话目录，再清理现存会话的孤儿文件。"""
+    from app.agent_runtime.persistence.model import (
+        AgentAttachment,
+        AgentChildRun,
+        AgentRunMessage,
+    )
+    from app.storage.models.task import Task
+
+    root = settings.agent_attachments_dir
+    root.mkdir(parents=True, exist_ok=True)
+    result = await session.execute(select(AgentAttachment))
+    attachments = list(result.scalars())
+    storage_names = {attachment.storage_name for attachment in attachments}
+    message_result = await session.execute(select(AgentRunMessage))
+    active_session_ids = {
+        message.session_id for message in message_result.scalars()
+    }
+    task_result = await session.execute(select(Task))
+    active_session_ids.update(
+        task.agent_session_id
+        for task in task_result.scalars()
+        if task.agent_session_id is not None
+    )
+    child_run_result = await session.execute(select(AgentChildRun))
+    active_session_ids.update(
+        child_run.child_thread_id for child_run in child_run_result.scalars()
+    )
+    deleted_files = 0
+    directories: set[Path] = set()
+
+    for session_dir in root.iterdir():
+        if not session_dir.is_dir() or session_dir.name in active_session_ids:
+            continue
+        deleted_files += sum(1 for path in session_dir.rglob("*") if path.is_file())
+        shutil.rmtree(session_dir)
+
+    file_paths = [path for path in root.rglob("*") if path.is_file()]
+    for path in file_paths:
+        storage_name = path.relative_to(root).as_posix()
+        if storage_name in storage_names:
+            continue
+        path.unlink(missing_ok=True)
+        deleted_files += 1
+        directories.update(path.parents)
+
+    _remove_empty_attachment_directories(root, directories)
+
+    return deleted_files
+
+
+def _remove_empty_attachment_directories(root: Path, directories: set[Path]) -> None:
+    for directory in sorted(directories, key=lambda item: len(item.parts), reverse=True):
+        if directory == root:
+            continue
+        try:
+            directory.rmdir()
+        except OSError:
+            continue
 
 
 def _image_metadata(content: bytes) -> tuple[str, str, int, int]:

--- a/backend/app/agent_runtime/attachments.py
+++ b/backend/app/agent_runtime/attachments.py
@@ -1,0 +1,245 @@
+"""Storage and validation for Agent image attachments."""
+
+from __future__ import annotations
+
+import io
+import base64
+from pathlib import Path
+from typing import Any
+
+import aiofiles
+from fastapi import UploadFile
+from PIL import Image, UnidentifiedImageError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import delete, select
+from sqlmodel import col
+
+from app.core.ids import generate_id
+from app.settings import settings
+
+MAX_AGENT_IMAGE_ATTACHMENTS = 20
+MAX_AGENT_IMAGE_BYTES = 10 * 1024 * 1024
+SUPPORTED_IMAGE_MIME_TYPES = frozenset({"image/jpeg", "image/png", "image/webp"})
+
+_IMAGE_FORMATS = {
+    "JPEG": ("image/jpeg", "jpg"),
+    "PNG": ("image/png", "png"),
+    "WEBP": ("image/webp", "webp"),
+}
+
+
+def ensure_agent_attachments_dir() -> Path:
+    """确保 Agent 附件目录存在。"""
+    settings.agent_attachments_dir.mkdir(parents=True, exist_ok=True)
+    return settings.agent_attachments_dir
+
+
+def get_agent_attachment_url(storage_name: str) -> str:
+    """返回供应用展示的附件静态地址。"""
+    return f"/agent-attachments/{storage_name}"
+
+
+def serialize_agent_attachment(attachment: Any) -> dict[str, Any]:
+    """返回可写入消息元数据的最小附件描述。"""
+    return {
+        "id": attachment.id,
+        "storage_name": attachment.storage_name,
+        "file_name": attachment.file_name,
+        "mime_type": attachment.mime_type,
+        "size_bytes": attachment.size_bytes,
+        "width": attachment.width,
+        "height": attachment.height,
+        "url": get_agent_attachment_url(attachment.storage_name),
+    }
+
+
+async def load_session_attachments(
+    session: AsyncSession,
+    *,
+    session_id: str,
+    attachment_ids: list[str],
+) -> list[Any]:
+    """加载并验证一组属于指定会话的图片附件。"""
+    unique_ids = list(dict.fromkeys(attachment_ids))
+    if len(unique_ids) != len(attachment_ids):
+        raise ValueError("图片附件不能重复")
+    if len(unique_ids) > MAX_AGENT_IMAGE_ATTACHMENTS:
+        raise ValueError("单条消息最多附带 20 张图片")
+    if not unique_ids:
+        return []
+
+    from app.agent_runtime.persistence.model import AgentAttachment
+
+    result = await session.execute(
+        select(AgentAttachment).where(
+            col(AgentAttachment.session_id) == session_id,
+            col(AgentAttachment.id).in_(unique_ids),
+        )
+    )
+    attachments_by_id = {attachment.id: attachment for attachment in result.scalars()}
+    missing_ids = [attachment_id for attachment_id in unique_ids if attachment_id not in attachments_by_id]
+    if missing_ids:
+        raise ValueError("图片附件不存在或不属于当前会话")
+    return [attachments_by_id[attachment_id] for attachment_id in unique_ids]
+
+
+async def build_image_content_blocks(
+    attachments: list[dict[str, Any]],
+) -> list[dict[str, str]]:
+    """从服务端文件构建供 LangChain 发送的标准图片内容块。"""
+    blocks: list[dict[str, str]] = []
+    root = ensure_agent_attachments_dir().resolve()
+    for attachment in attachments:
+        storage_name = attachment.get("storage_name")
+        mime_type = attachment.get("mime_type")
+        if not isinstance(storage_name, str) or not isinstance(mime_type, str):
+            continue
+        if mime_type not in SUPPORTED_IMAGE_MIME_TYPES:
+            continue
+        path = (root / storage_name).resolve()
+        if root not in path.parents or not path.is_file():
+            continue
+        async with aiofiles.open(path, "rb") as image_file:
+            content = await image_file.read()
+        blocks.append(
+            {
+                "type": "image",
+                "base64": base64.b64encode(content).decode("ascii"),
+                "mime_type": mime_type,
+            }
+        )
+    return blocks
+
+
+async def copy_attachments_for_fork(
+    session: AsyncSession,
+    *,
+    source_session_id: str,
+    target_session_id: str,
+    target_task_id: str,
+    project_id: str,
+    attachment_ids: set[str],
+) -> dict[str, dict[str, Any]]:
+    """复制源会话附件，返回旧附件 ID 到新元数据的映射。"""
+    from app.agent_runtime.persistence.model import AgentAttachment
+
+    if not attachment_ids:
+        return {}
+    result = await session.execute(
+        select(AgentAttachment).where(
+            col(AgentAttachment.session_id) == source_session_id,
+            col(AgentAttachment.id).in_(attachment_ids),
+        )
+    )
+    root = ensure_agent_attachments_dir()
+    copied: dict[str, dict[str, Any]] = {}
+    for source in result.scalars():
+        source_path = root / source.storage_name
+        if not source_path.is_file():
+            continue
+        attachment_id = generate_id()
+        storage_name = f"{target_session_id}/{attachment_id}{source_path.suffix}"
+        target_path = root / storage_name
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_bytes(source_path.read_bytes())
+        target = AgentAttachment(
+            id=attachment_id,
+            session_id=target_session_id,
+            task_id=target_task_id,
+            project_id=project_id,
+            storage_name=storage_name,
+            file_name=source.file_name,
+            mime_type=source.mime_type,
+            size_bytes=source.size_bytes,
+            width=source.width,
+            height=source.height,
+        )
+        session.add(target)
+        copied[source.id] = serialize_agent_attachment(target)
+    return copied
+
+
+async def delete_attachments_for_message_ids(
+    session: AsyncSession,
+    *,
+    attachment_ids: set[str],
+) -> None:
+    """删除已不再被保留消息引用的附件记录与文件。"""
+    if not attachment_ids:
+        return
+    from app.agent_runtime.persistence.model import AgentAttachment
+
+    result = await session.execute(
+        select(AgentAttachment).where(col(AgentAttachment.id).in_(attachment_ids))
+    )
+    attachments = list(result.scalars())
+    root = ensure_agent_attachments_dir()
+    for attachment in attachments:
+        (root / attachment.storage_name).unlink(missing_ok=True)
+    await session.execute(delete(AgentAttachment).where(col(AgentAttachment.id).in_(attachment_ids)))
+
+
+def _image_metadata(content: bytes) -> tuple[str, str, int, int]:
+    try:
+        with Image.open(io.BytesIO(content)) as image:
+            image.verify()
+        with Image.open(io.BytesIO(content)) as image:
+            format_info = _IMAGE_FORMATS.get(image.format or "")
+            if format_info is None:
+                raise ValueError("仅支持 PNG、JPEG 或 WebP 图片")
+            mime_type, extension = format_info
+            width, height = image.size
+    except (UnidentifiedImageError, OSError, ValueError) as exc:
+        if isinstance(exc, ValueError) and str(exc) == "仅支持 PNG、JPEG 或 WebP 图片":
+            raise
+        raise ValueError("上传文件不是有效图片") from exc
+
+    if width < 1 or height < 1:
+        raise ValueError("图片尺寸无效")
+    return mime_type, extension, width, height
+
+
+async def save_agent_image_attachment(
+    session: AsyncSession,
+    *,
+    session_id: str,
+    task_id: str,
+    project_id: str,
+    image_file: UploadFile,
+) -> Any:
+    """校验并保存一张会话归属图片。"""
+    from app.agent_runtime.persistence.model import AgentAttachment
+
+    content = await image_file.read()
+    if not content:
+        raise ValueError("图片不能为空")
+    if len(content) > MAX_AGENT_IMAGE_BYTES:
+        raise ValueError("单张图片不能超过 10 MB")
+
+    mime_type, extension, width, height = _image_metadata(content)
+    attachment_id = generate_id()
+    storage_name = f"{session_id}/{attachment_id}.{extension}"
+    storage_path = ensure_agent_attachments_dir() / storage_name
+    storage_path.parent.mkdir(parents=True, exist_ok=True)
+    storage_path.write_bytes(content)
+
+    attachment = AgentAttachment(
+        id=attachment_id,
+        session_id=session_id,
+        task_id=task_id,
+        project_id=project_id,
+        storage_name=storage_name,
+        file_name=image_file.filename or f"image.{extension}",
+        mime_type=mime_type,
+        size_bytes=len(content),
+        width=width,
+        height=height,
+    )
+    try:
+        session.add(attachment)
+        await session.commit()
+        await session.refresh(attachment)
+    except Exception:
+        storage_path.unlink(missing_ok=True)
+        raise
+    return attachment

--- a/backend/app/agent_runtime/context/compaction/tokens.py
+++ b/backend/app/agent_runtime/context/compaction/tokens.py
@@ -11,6 +11,8 @@ def count_text_tokens(text: str) -> int:
 
 def _message_token_text(message: ContextMessage) -> str:
     parts = [message.content or ""]
+    if message.attachments:
+        parts.append(f"[图片附件 {len(message.attachments)} 张]")
     if message.role == "assistant" and message.tool_calls:
         parts.append(
             json.dumps(

--- a/backend/app/agent_runtime/context/compaction/transcript.py
+++ b/backend/app/agent_runtime/context/compaction/transcript.py
@@ -81,6 +81,8 @@ def to_transcript(messages: list[ContextMessage]) -> str:
     for message in messages:
         content = _escape_xml_like(message.content or "")
         if message.role == "user":
+            if message.attachments:
+                content = f"{content}\n[图片附件 {len(message.attachments)} 张]".strip()
             parts.append(f"<user>{content}</user>")
         elif message.role == "assistant":
             parts.append(f"<assistant>{_assistant_body(message)}</assistant>")

--- a/backend/app/agent_runtime/context/parts/history.py
+++ b/backend/app/agent_runtime/context/parts/history.py
@@ -3,6 +3,7 @@ from typing import Any
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.context.helpers import compile_canonical_mentions
+from app.agent_runtime.attachments import build_image_content_blocks
 from app.agent_runtime.context.types import ContextMessage
 
 def _is_context_history_message(raw: dict) -> bool:
@@ -62,15 +63,25 @@ async def build_history(
         content = raw.get("content", "")
         if role == "user" and db_session is not None and isinstance(content, str) and "<of-mention" in content:
             content = await compile_canonical_mentions(content, db_session)
+        additional_kwargs = (
+            raw.get("additional_kwargs") if isinstance(raw.get("additional_kwargs"), dict) else None
+        )
+        attachment_metadata = (
+            additional_kwargs.get("openfic_attachments") if additional_kwargs is not None else None
+        )
+        attachments = (
+            await build_image_content_blocks(attachment_metadata)
+            if role == "user" and isinstance(attachment_metadata, list)
+            else None
+        )
         result.append(ContextMessage(
             role=role,
             content=content,
             name=name,
             tool_call_id=raw.get("tool_call_id"),
             tool_calls=raw.get("tool_calls"),
-            additional_kwargs=raw.get("additional_kwargs")
-            if isinstance(raw.get("additional_kwargs"), dict)
-            else None,
+            additional_kwargs=additional_kwargs,
             metadata=metadata,
+            attachments=attachments,
         ))
     return result

--- a/backend/app/agent_runtime/context/processors/filter.py
+++ b/backend/app/agent_runtime/context/processors/filter.py
@@ -22,7 +22,7 @@ def filter_invalid(parts: list[ContextMessage]) -> list[ContextMessage]:
         if not _is_history(m):
             keep.append(True)
             continue
-        if (not m.content or not m.content.strip()) and not (
+        if (not m.content or not m.content.strip()) and not m.attachments and not (
             m.role == "assistant" and m.tool_calls
         ):
             keep.append(False)

--- a/backend/app/agent_runtime/context/processors/to_langchain.py
+++ b/backend/app/agent_runtime/context/processors/to_langchain.py
@@ -17,7 +17,14 @@ def to_langchain_messages(parts: list[ContextMessage]) -> list[BaseMessage]:
         if p.role == "system":
             out.append(SystemMessage(content=p.content))
         elif p.role == "user":
-            out.append(HumanMessage(content=p.content))
+            if p.attachments:
+                content: list[dict] = []
+                if p.content:
+                    content.append({"type": "text", "text": p.content})
+                content.extend(p.attachments)
+                out.append(HumanMessage(content=content))
+            else:
+                out.append(HumanMessage(content=p.content))
         elif p.role == "assistant":
             out.append(
                 AIMessage(

--- a/backend/app/agent_runtime/context/processors/to_langchain.py
+++ b/backend/app/agent_runtime/context/processors/to_langchain.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from langchain_core.messages import (
     AIMessage,
     BaseMessage,
@@ -18,7 +20,7 @@ def to_langchain_messages(parts: list[ContextMessage]) -> list[BaseMessage]:
             out.append(SystemMessage(content=p.content))
         elif p.role == "user":
             if p.attachments:
-                content: list[dict] = []
+                content: list[str | dict[Any, Any]] = []
                 if p.content:
                     content.append({"type": "text", "text": p.content})
                 content.extend(p.attachments)

--- a/backend/app/agent_runtime/context/types.py
+++ b/backend/app/agent_runtime/context/types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 
 @dataclass
@@ -11,3 +11,4 @@ class ContextMessage:
     tool_calls: list[dict] | None = None
     additional_kwargs: dict | None = None
     metadata: dict | None = None
+    attachments: list[dict[str, Any]] | None = None

--- a/backend/app/agent_runtime/fork.py
+++ b/backend/app/agent_runtime/fork.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
 from app.agent_runtime.persistence import compaction_repo, repo as message_repo
+from app.agent_runtime.attachments import copy_attachments_for_fork
 from app.agent_runtime.persistence.model import AgentRunMessage
 from app.agent_runtime.model_config import without_api_key
 from app.core.errors import NotFoundError
@@ -72,6 +73,7 @@ def _build_fork_state(
         "error": None,
         "retry_count": 0,
         "user_request": "",
+        "user_attachments": [],
         "current_revision_id": None,
     }
     return state
@@ -83,9 +85,16 @@ def _clone_message_row(
     session_id: str,
     task_id: str,
     seq: int,
+    attachments_by_source_id: dict[str, dict[str, Any]],
 ) -> AgentRunMessage:
     metadata = dict(row.metadata or {})
     metadata.pop("revision_id", None)
+    attachments = metadata.get("attachments")
+    if isinstance(attachments, list):
+        metadata["attachments"] = [
+            attachments_by_source_id.get(item.get("id"), item) if isinstance(item, dict) else item
+            for item in attachments
+        ]
     return AgentRunMessage(
         id=generate_id(),
         session_id=session_id,
@@ -154,6 +163,22 @@ async def fork_agent_session_at_revision(
         mode=cast(Literal["agent"], source_task.mode),
         agent_session_id=fork_session_id,
     )
+    source_attachment_ids = {
+        attachment.get("id")
+        for row in rows_to_clone
+        for attachments in [row.metadata.get("attachments")]
+        if isinstance(attachments, list)
+        for attachment in attachments
+        if isinstance(attachment, dict) and isinstance(attachment.get("id"), str)
+    }
+    attachments_by_source_id = await copy_attachments_for_fork(
+        session,
+        source_session_id=source_session_id,
+        target_session_id=fork_session_id,
+        target_task_id=fork_task.id,
+        project_id=source_task.project_id,
+        attachment_ids=source_attachment_ids,
+    )
 
     for index, row in enumerate(rows_to_clone):
         session.add(
@@ -162,6 +187,7 @@ async def fork_agent_session_at_revision(
                 session_id=fork_session_id,
                 task_id=fork_task.id,
                 seq=index,
+                attachments_by_source_id=attachments_by_source_id,
             )
         )
 

--- a/backend/app/agent_runtime/graph/orchestrator/graph.py
+++ b/backend/app/agent_runtime/graph/orchestrator/graph.py
@@ -72,11 +72,17 @@ async def _primary_build_hooks(
     ]
 
 
-def _primary_messages(state: OrchestratorState) -> list[BaseMessage]:
+async def _primary_messages(state: OrchestratorState) -> list[BaseMessage]:
     messages = list(state.get("messages") or [])
     user_request = state.get("user_request") or ""
-    if user_request:
-        messages.append(HumanMessage(content=user_request))
+    attachments = state.get("user_attachments") or []
+    if user_request or attachments:
+        messages.append(
+            HumanMessage(
+                content=user_request,
+                additional_kwargs={"openfic_attachments": attachments} if attachments else {},
+            )
+        )
     return messages
 
 
@@ -128,7 +134,7 @@ async def primary_node(
     effective_state["active_agent"] = agent_key
     await react_graph.ainvoke(
         {
-            "messages": _primary_messages(state),
+            "messages": await _primary_messages(state),
             "iteration_count": 0,
             "is_done": False,
             "final_output": None,

--- a/backend/app/agent_runtime/graph/react_agent.py
+++ b/backend/app/agent_runtime/graph/react_agent.py
@@ -32,6 +32,7 @@ from langgraph.types import RetryPolicy
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.content_blocks import extract_text_content
+from app.agent_runtime.attachments import build_image_content_blocks
 from app.agent_runtime.types import ReactAgentConfig
 from app.agent_runtime.context import build_context, build_context_parts
 from app.agent_runtime.context.processors.filter import (
@@ -336,10 +337,8 @@ async def maybe_auto_compact(
             compactions,
             max_context_tokens,
         )
-    except CompactionNoWindowError as exc:
-        error = CompactionError("no_compactable_window", "没有可压缩的上下文窗口")
-        await emit_error_once(error)
-        raise error from exc
+    except CompactionNoWindowError:
+        return False
     except Exception as exc:
         error = CompactionError(
             "compaction_window_failed", "压缩窗口选择失败，当前请求已中止"
@@ -481,9 +480,18 @@ def _to_history_dict(m: BaseMessage) -> dict:
         metadata["tool_name"] = tool_name
     out: dict = {
         "role": role,
-        "content": m.content if isinstance(m.content, str) else str(m.content),
+        "content": extract_text_content(m.content),
         "metadata": metadata,
     }
+    if isinstance(m, HumanMessage):
+        additional_kwargs = getattr(m, "additional_kwargs", None)
+        attachments = (
+            additional_kwargs.get("openfic_attachments")
+            if isinstance(additional_kwargs, dict)
+            else None
+        )
+        if isinstance(attachments, list):
+            out["additional_kwargs"] = {"openfic_attachments": attachments}
     if isinstance(m, AIMessage) and m.tool_calls:
         out["tool_calls"] = list(m.tool_calls)
     if isinstance(m, AIMessage):
@@ -601,6 +609,9 @@ def create_react_agent(
         inject_message_consumed_sink = configurable.get("inject_message_consumed_sink")
         if not callable(inject_message_consumed_sink):
             inject_message_consumed_sink = None
+        inject_message_attachments = configurable.get("inject_message_attachments")
+        if not callable(inject_message_attachments):
+            inject_message_attachments = None
         agent_event_sink = configurable.get("agent_event_sink")
         if not callable(agent_event_sink):
             agent_event_sink = None
@@ -704,15 +715,30 @@ def create_react_agent(
                                 content, db_session
                             )
                         drained_injected_user_message = True
+                        attachment_metadata = (
+                            inject_message_attachments(message_id)
+                            if isinstance(message_id, str) and inject_message_attachments is not None
+                            else []
+                        )
+                        attachments = await build_image_content_blocks(attachment_metadata)
                         transient_parts.append(
                             ContextMessage(
                                 role="user",
                                 content=compiled_content,
                                 metadata={"part": "runtime"},
+                                attachments=attachments,
                             )
                         )
-                        transient_messages.append(
-                            HumanMessage(content=compiled_content)
+                        transient_messages.extend(
+                            to_langchain_messages(
+                                [
+                                    ContextMessage(
+                                        role="user",
+                                        content=compiled_content,
+                                        attachments=attachments,
+                                    )
+                                ]
+                            )
                         )
 
         if (

--- a/backend/app/agent_runtime/graph/state.py
+++ b/backend/app/agent_runtime/graph/state.py
@@ -1,4 +1,4 @@
-from typing import TypedDict
+from typing import Any, TypedDict
 
 
 class AgentRuntimeState(TypedDict):
@@ -12,4 +12,5 @@ class AgentRuntimeState(TypedDict):
     error: str | None
     retry_count: int
     user_request: str
+    user_attachments: list[dict[str, Any]]
     current_revision_id: str | None

--- a/backend/app/agent_runtime/persistence/loader.py
+++ b/backend/app/agent_runtime/persistence/loader.py
@@ -37,6 +37,15 @@ def _response_metadata(row: AgentRunMessage) -> dict:
     return metadata
 
 
+def _user_additional_kwargs(row: AgentRunMessage) -> dict:
+    try:
+        metadata = json.loads(row.message_metadata or "{}")
+    except (TypeError, ValueError):
+        return {}
+    attachments = metadata.get("attachments") if isinstance(metadata, dict) else None
+    return {"openfic_attachments": attachments} if isinstance(attachments, list) else {}
+
+
 def _order_tool_results_by_call_order(
     rows: list[AgentRunMessage],
 ) -> list[AgentRunMessage]:
@@ -181,6 +190,7 @@ async def load_history(db_session: AsyncSession, session_id: str) -> list[BaseMe
             messages.append(
                 HumanMessage(
                     content=part.content,
+                    additional_kwargs=_user_additional_kwargs(row),
                     response_metadata=_response_metadata(row),
                 )
             )

--- a/backend/app/agent_runtime/persistence/model.py
+++ b/backend/app/agent_runtime/persistence/model.py
@@ -39,6 +39,24 @@ class AgentRunMessage(SQLModel, table=True):
     updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 
 
+class AgentAttachment(SQLModel, table=True):
+    """Agent 用户消息的图片附件。"""
+
+    __tablename__ = "agent_attachments"
+
+    id: str = Field(default_factory=generate_id, primary_key=True)
+    session_id: str = Field(index=True, max_length=64)
+    task_id: str = Field(index=True, foreign_key="tasks.id", max_length=64)
+    project_id: str = Field(index=True, default="", max_length=64)
+    storage_name: str = Field(max_length=500, unique=True)
+    file_name: str = Field(max_length=255)
+    mime_type: str = Field(max_length=50)
+    size_bytes: int = Field(ge=0)
+    width: int = Field(ge=1)
+    height: int = Field(ge=1)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC), index=True)
+
+
 class AgentContextCompaction(SQLModel, table=True):
     """Agent context compaction range persisted per session."""
 

--- a/backend/app/agent_runtime/persistence/task_projection.py
+++ b/backend/app/agent_runtime/persistence/task_projection.py
@@ -302,6 +302,9 @@ def _project_rows(
             payload = {"kind": "user_request"}
             if isinstance(revision_id, str) and revision_id:
                 payload["revision_id"] = revision_id
+            attachments = row.metadata.get("attachments")
+            if isinstance(attachments, list):
+                payload["attachments"] = attachments
             projected.append(
                 _base_message(
                     row,

--- a/backend/app/agent_runtime/revisions.py
+++ b/backend/app/agent_runtime/revisions.py
@@ -10,6 +10,7 @@ from typing import Literal
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.persistence import compaction_repo, repo as message_repo
+from app.agent_runtime.attachments import delete_attachments_for_message_ids
 from app.agent_runtime.persistence.child_runs import rollback_child_runs_for_parent_revisions
 from app.agent_runtime.persistence.model import AgentRunMessage
 from app.core.editor_content_limits import validate_editor_content
@@ -110,6 +111,7 @@ class AgentRollbackResult:
     affected_world_entries: list[str]
     affected_characters: list[str]
     restored_message_content: str
+    restored_attachments: list[dict]
     restored_checkpoint_id: str | None
     child_checkpoint_boundaries: list[tuple[str, str | None]]
     affected_child_run_ids: list[str]
@@ -868,10 +870,20 @@ async def rollback_revision_for_session(
             )
 
     restored_message_content = ""
+    restored_attachments: list[dict] = []
     if target.user_message_id:
         user_message = await session.get(AgentRunMessage, target.user_message_id)
         if user_message is not None:
             restored_message_content = user_message.content
+            try:
+                metadata = json.loads(user_message.message_metadata or "{}")
+            except (TypeError, ValueError):
+                metadata = {}
+            attachments = metadata.get("attachments") if isinstance(metadata, dict) else None
+            if isinstance(attachments, list):
+                restored_attachments = [
+                    attachment for attachment in attachments if isinstance(attachment, dict)
+                ]
     if not restored_message_content and target.message.startswith("用户消息:"):
         restored_message_content = target.message.removeprefix("用户消息:").strip()
 
@@ -1118,7 +1130,37 @@ async def rollback_revision_for_session(
         agent_session_id,
         target.user_message_seq,
     )
+    removed_messages = [
+        row for row in await message_repo.list_by_session(session, agent_session_id)
+        if row.seq >= target.user_message_seq
+    ]
+    removed_attachment_ids = {
+        attachment.get("id")
+        for row in removed_messages
+        for attachment in [row.metadata.get("attachments")]
+        if isinstance(attachment, list)
+        for attachment in attachment
+        if isinstance(attachment, dict) and isinstance(attachment.get("id"), str)
+    }
+    restored_attachment_ids = {
+        attachment.get("id")
+        for attachment in restored_attachments
+        if isinstance(attachment.get("id"), str)
+    }
+    retained_attachment_ids = {
+        attachment.get("id")
+        for row in await message_repo.list_by_session(session, agent_session_id)
+        if row.seq < target.user_message_seq
+        for attachments in [row.metadata.get("attachments")]
+        if isinstance(attachments, list)
+        for attachment in attachments
+        if isinstance(attachment, dict) and isinstance(attachment.get("id"), str)
+    }
     await message_repo.delete_from_seq(session, agent_session_id, target.user_message_seq)
+    await delete_attachments_for_message_ids(
+        session,
+        attachment_ids=removed_attachment_ids - retained_attachment_ids - restored_attachment_ids,
+    )
     child_rollback_result = await rollback_child_runs_for_parent_revisions(
         session,
         parent_revision_ids=[revision.id for revision in revisions],
@@ -1148,6 +1190,7 @@ async def rollback_revision_for_session(
         affected_world_entries=list(dict.fromkeys(affected_world_entries)),
         affected_characters=list(dict.fromkeys(affected_characters)),
         restored_message_content=restored_message_content,
+        restored_attachments=restored_attachments,
         restored_checkpoint_id=target.pre_run_checkpoint_id,
         child_checkpoint_boundaries=child_rollback_result.checkpoint_boundaries,
         affected_child_run_ids=child_rollback_result.child_run_ids,

--- a/backend/app/agent_runtime/runner/session_runner.py
+++ b/backend/app/agent_runtime/runner/session_runner.py
@@ -102,6 +102,8 @@ class SessionRunner:
         self._graph: CompiledStateGraph | None = None
         self._inject_queue: asyncio.Queue[tuple[str | None, str, str]] = asyncio.Queue()
         self._queued_user_messages: dict[str, tuple[str, datetime]] = {}
+        self._queued_user_message_attachments: dict[str, list[dict[str, Any]]] = {}
+        self._injected_user_message_attachments: dict[str, list[dict[str, Any]]] = {}
         self._cancelled_user_message_ids: set[str] = set()
         self._cancel_event = asyncio.Event()
         self._translator = EventTranslator(session_id)
@@ -134,6 +136,7 @@ class SessionRunner:
         self,
         content: str,
         *,
+        attachments: list[dict[str, Any]] | None = None,
         message_id: str | None = None,
         created_at: datetime | None = None,
     ):
@@ -147,6 +150,7 @@ class SessionRunner:
                 role="user",
                 status="sent",
                 content=content,
+                metadata={"attachments": attachments} if attachments else None,
                 message_id=message_id,
                 created_at=created_at,
             )
@@ -159,6 +163,7 @@ class SessionRunner:
         content: str,
         revision_id: str,
         *,
+        attachments: list[dict[str, Any]] | None = None,
         created_at: str | None = None,
     ) -> None:
         data = {
@@ -169,7 +174,11 @@ class SessionRunner:
             "status": "completed",
             "display": "list",
             "content": content,
-            "payload": {"kind": "user_request", "revision_id": revision_id},
+            "payload": {
+                "kind": "user_request",
+                "revision_id": revision_id,
+                **({"attachments": attachments} if attachments else {}),
+            },
             "revision_id": revision_id,
             "is_checkpoint": True,
         }
@@ -181,6 +190,7 @@ class SessionRunner:
         *,
         message_id: str,
         action: Literal["queued", "consumed", "cancelled"],
+        attachments: list[dict[str, Any]] | None = None,
         created_at: str | None = None,
     ) -> None:
         data = {
@@ -195,6 +205,7 @@ class SessionRunner:
                 "content": content,
                 "action": action,
                 "created_at": created_at or datetime.now(UTC).isoformat(),
+                **({"attachments": attachments} if attachments else {}),
             },
         }
         await self._emit_agent_event("agent:pending_message", data)
@@ -498,6 +509,7 @@ class SessionRunner:
                 "compaction_usage_sink": self._emit_persisted_task_usage_events,
                 "inject_queue": self._inject_queue,
                 "inject_message_consumed_sink": self._mark_injected_user_message_sent,
+                "inject_message_attachments": self._get_injected_user_message_attachments,
                 "model_config": self.model_config,
             }
         }
@@ -511,9 +523,11 @@ class SessionRunner:
         queued = self._queued_user_messages.pop(message_id, None)
         if queued is not None:
             content, created_at = queued
+            attachments = self._queued_user_message_attachments.pop(message_id, [])
             created_at_iso = _format_utc_iso_datetime(created_at)
             await self._emit_pending_user_message(
                 content,
+                attachments=attachments,
                 message_id=message_id,
                 action="consumed",
                 created_at=created_at_iso,
@@ -521,11 +535,13 @@ class SessionRunner:
             await self._persist_user_message(
                 content,
                 message_id=message_id,
+                attachments=attachments,
                 created_at=created_at,
             )
             await self._emit_runtime_user_message(
                 content,
                 message_id=message_id,
+                attachments=attachments,
                 created_at=created_at_iso,
             )
             return True
@@ -539,6 +555,7 @@ class SessionRunner:
         content: str,
         *,
         message_id: str,
+        attachments: list[dict[str, Any]] | None = None,
         created_at: str | None = None,
     ) -> None:
         data = {
@@ -550,7 +567,10 @@ class SessionRunner:
             "status": "completed",
             "display": "list",
             "content": content,
-            "payload": {"kind": "user_request"},
+            "payload": {
+                "kind": "user_request",
+                **({"attachments": attachments} if attachments else {}),
+            },
             "is_checkpoint": False,
         }
         await self._emit_agent_event("agent:text", data)
@@ -576,9 +596,11 @@ class SessionRunner:
         *,
         graph: CompiledStateGraph,
         user_request: str,
+        attachments: list[dict[str, Any]] | None = None,
     ) -> tuple[Any, Any]:
         pre_run_checkpoint_id = await self._current_root_checkpoint_id(graph)
-        user_message = await self._persist_user_message(user_request)
+        persistence_kwargs = {"attachments": attachments} if attachments else {}
+        user_message = await self._persist_user_message(user_request, **persistence_kwargs)
 
         revision_session = await create_session()
         try:
@@ -603,6 +625,7 @@ class SessionRunner:
         await self._emit_user_message(
             user_request,
             revision.id,
+            attachments=attachments,
             created_at=emitted_created_at,
         )
         return user_message, revision
@@ -666,6 +689,7 @@ class SessionRunner:
                 "error": None,
                 "retry_count": 0,
                 "user_request": "",
+                "user_attachments": [],
                 "current_revision_id": None,
             })
             agent_name = state.get("active_agent") or state.get("agent_key") or "build"
@@ -718,6 +742,7 @@ class SessionRunner:
     async def run(
         self,
         user_request: str,
+        attachments: list[dict[str, Any]] | None = None,
         user_message_id: str | None = None,
     ) -> None:
         runtime_session = await create_session()
@@ -747,6 +772,7 @@ class SessionRunner:
                 _user_message, revision = await self._begin_user_turn(
                     graph=graph,
                     user_request=user_request,
+                    attachments=attachments,
                 )
                 state_user_request = compiled_user_request
             else:
@@ -770,6 +796,7 @@ class SessionRunner:
                 "error": None,
                 "retry_count": 0,
                 "user_request": state_user_request,
+                "user_attachments": attachments or [],
                 "current_revision_id": revision.id,
                 "messages": history_messages,
             }
@@ -870,21 +897,37 @@ class SessionRunner:
             )
             await self._clear_replay_session()
 
-    async def inject_message(self, content: str, message_id: str) -> None:
+    async def inject_message(
+        self,
+        content: str,
+        message_id: str,
+        attachments: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self._injected_user_message_attachments[message_id] = attachments or []
         await self._inject_queue.put((message_id, "user", content))
 
-    async def queue_pending_user_message(self, content: str) -> dict[str, str]:
+    def _get_injected_user_message_attachments(self, message_id: str) -> list[dict[str, Any]]:
+        return list(self._injected_user_message_attachments.get(message_id, []))
+
+    async def queue_pending_user_message(
+        self,
+        content: str,
+        *,
+        attachments: list[dict[str, Any]] | None = None,
+    ) -> dict[str, str]:
         message_id = generate_id()
         created_at = datetime.now(UTC)
         self._queued_user_messages[message_id] = (content, created_at)
+        self._queued_user_message_attachments[message_id] = attachments or []
         created_at_iso = _format_utc_iso_datetime(created_at)
         await self._emit_pending_user_message(
             content,
             message_id=message_id,
             action="queued",
+            attachments=attachments,
             created_at=created_at_iso,
         )
-        await self.inject_message(content, message_id)
+        await self.inject_message(content, message_id, attachments)
         return {
             "message_id": message_id,
             "content": content,
@@ -897,11 +940,13 @@ class SessionRunner:
             return None
         self._cancelled_user_message_ids.add(message_id)
         content, created_at = queued
+        attachments = self._queued_user_message_attachments.pop(message_id, [])
         created_at_iso = _format_utc_iso_datetime(created_at)
         await self._emit_pending_user_message(
             content,
             message_id=message_id,
             action="cancelled",
+            attachments=attachments,
             created_at=created_at_iso,
         )
         return {
@@ -930,12 +975,21 @@ class SessionRunner:
             return None
 
         message_id, content, created_at = pending
+        attachments = self._queued_user_message_attachments.get(message_id, [])
         created_at_iso = _format_utc_iso_datetime(created_at)
-        await self._persist_user_message(
-            content,
-            message_id=message_id,
-            created_at=created_at,
-        )
+        if attachments:
+            await self._persist_user_message(
+                content,
+                attachments=attachments,
+                message_id=message_id,
+                created_at=created_at,
+            )
+        else:
+            await self._persist_user_message(
+                content,
+                message_id=message_id,
+                created_at=created_at,
+            )
 
         self._queued_user_messages.pop(message_id, None)
         next_queue: asyncio.Queue[tuple[str | None, str, str]] = asyncio.Queue()
@@ -946,16 +1000,20 @@ class SessionRunner:
             await next_queue.put((queued_message_id, role, queued_content))
         self._inject_queue = next_queue
 
+        pending_event_kwargs = {"attachments": attachments} if attachments else {}
         await self._emit_pending_user_message(
             content,
             message_id=message_id,
             action="consumed",
             created_at=created_at_iso,
+            **pending_event_kwargs,
         )
+        runtime_event_kwargs = {"attachments": attachments} if attachments else {}
         await self._emit_runtime_user_message(
             content,
             message_id=message_id,
             created_at=created_at_iso,
+            **runtime_event_kwargs,
         )
         return message_id, content
 
@@ -967,6 +1025,8 @@ class SessionRunner:
     def cancel(self) -> None:
         self._cancel_event.set()
         self._queued_user_messages.clear()
+        self._queued_user_message_attachments.clear()
+        self._injected_user_message_attachments.clear()
         self._cancelled_user_message_ids.clear()
         self._inject_queue = asyncio.Queue()
 

--- a/backend/app/api/routers/agent_runtime.py
+++ b/backend/app/api/routers/agent_runtime.py
@@ -10,11 +10,17 @@ from collections.abc import Callable
 from datetime import UTC, datetime
 from typing import TypeGuard, cast
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from app.agent_runtime.agents.definitions import load_agent_definition
+from app.agent_runtime.attachments import (
+    get_agent_attachment_url,
+    load_session_attachments,
+    save_agent_image_attachment,
+    serialize_agent_attachment,
+)
 from app.agent_runtime.context.compaction.service import CompactionError
 from app.agent_runtime.persistence.child_runs import get_child_run_by_pending_approval
 from app.agent_runtime.persistence.child_runs import (
@@ -47,6 +53,7 @@ from app.api.schemas.agent import (
     AgentCancelPendingMessageRequest,
     AgentCancelPendingMessageResponse,
     AgentCancelResponse,
+    AgentAttachmentResponse,
     AgentCompactionResponse,
     AgentForkRequest,
     AgentForkResponse,
@@ -162,6 +169,7 @@ def _build_seed_state(
         "error": None,
         "retry_count": 0,
         "user_request": "",
+        "user_attachments": [],
         "current_revision_id": current_revision_id,
         "messages": [],
     }
@@ -690,12 +698,49 @@ async def create_agent_session(
         )
 
 
+@router.post(
+    "/sessions/{session_id}/attachments",
+    response_model=AgentAttachmentResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def upload_agent_attachment(
+    session_id: str,
+    image: UploadFile = File(...),
+    session: AsyncSession = Depends(get_session),
+) -> AgentAttachmentResponse:
+    """上传一张仅供指定 Agent 会话使用的图片附件。"""
+    task = await task_service.get_task_by_agent_session_id(session, session_id)
+    try:
+        attachment = await save_agent_image_attachment(
+            session,
+            session_id=session_id,
+            task_id=task.id,
+            project_id=task.project_id,
+            image_file=image,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    return AgentAttachmentResponse(
+        id=attachment.id,
+        session_id=attachment.session_id,
+        storage_name=attachment.storage_name,
+        file_name=attachment.file_name,
+        mime_type=attachment.mime_type,
+        size_bytes=attachment.size_bytes,
+        width=attachment.width,
+        height=attachment.height,
+        url=get_agent_attachment_url(attachment.storage_name),
+    )
+
+
 @router.post("/sessions/{session_id}/message", response_model=AgentSendMessageResponse)
 async def send_agent_message(
     session_id: str,
     body: AgentSendMessageRequest,
     session: AsyncSession = Depends(get_session),
 ) -> AgentSendMessageResponse:
+    if not body.message.strip() and not body.attachments:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="消息或图片不能为空")
     requested_model_config: dict | None = None
     if body.model_id and session_id not in _SESSION_RUNNERS:
         try:
@@ -711,6 +756,15 @@ async def send_agent_message(
             ) from exc
 
     runner = await _get_runner(session_id, session, requested_model_config)
+    try:
+        attachments = await load_session_attachments(
+            session,
+            session_id=session_id,
+            attachment_ids=body.attachments,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)) from exc
+    attachment_metadata = [serialize_agent_attachment(attachment) for attachment in attachments]
     registry = get_agent_run_registry()
     task = await task_service.get_task(session, runner.task_id)
     status_session_factory = _make_status_session_factory(session)
@@ -718,7 +772,8 @@ async def send_agent_message(
         await enqueue_session_title_job(session, task, body.message)
         await background_service.commit_and_notify(session)
     if await registry.is_running(session_id):
-        pending_message = await runner.queue_pending_user_message(body.message)
+        queue_kwargs = {"attachments": attachment_metadata} if attachment_metadata else {}
+        pending_message = await runner.queue_pending_user_message(body.message, **queue_kwargs)
         return AgentSendMessageResponse(
             success=True,
             session_id=session_id,
@@ -756,7 +811,8 @@ async def send_agent_message(
     if body.agent_key:
         await _validate_primary_agent(session, body.agent_key)
         runner.agent_key = body.agent_key
-    coro = runner.run(user_request=body.message)
+    run_kwargs = {"attachments": attachment_metadata} if attachment_metadata else {}
+    coro = runner.run(user_request=body.message, **run_kwargs)
     await _launch_task(
         db_session_factory=status_session_factory,
         session_id=session_id,
@@ -1186,6 +1242,33 @@ async def rollback_agent_session(
         affected_note_categories=result.affected_note_categories,
         affected_world_entries=result.affected_world_entries,
         restored_message_content=result.restored_message_content,
+        restored_attachments=[
+            AgentAttachmentResponse(
+                id=attachment["id"],
+                session_id=session_id,
+                storage_name=attachment["storage_name"],
+                file_name=attachment["file_name"],
+                mime_type=attachment["mime_type"],
+                size_bytes=attachment["size_bytes"],
+                width=attachment["width"],
+                height=attachment["height"],
+                url=attachment["url"],
+            )
+            for attachment in result.restored_attachments
+            if all(
+                key in attachment
+                for key in (
+                    "id",
+                    "storage_name",
+                    "file_name",
+                    "mime_type",
+                    "size_bytes",
+                    "width",
+                    "height",
+                    "url",
+                )
+            )
+        ],
     )
 
 

--- a/backend/app/api/routers/tasks.py
+++ b/backend/app/api/routers/tasks.py
@@ -8,6 +8,7 @@ from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.modes import AgentMode
+from app.agent_runtime.attachments import delete_attachments_for_task
 from app.agent_runtime.persistence.child_runs import list_child_runs_for_parent
 from app.agent_runtime.persistence.task_projection import load_task_messages_for_agent_session
 from app.agent_runtime.runner.checkpointer import delete_checkpoints_for_thread
@@ -208,6 +209,7 @@ async def delete_task(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="任务运行中，不能删除",
             )
+        await delete_attachments_for_task(session, task_id=task.id)
         await task_service.delete_task(session, task_id)
         await session.commit()
         await _cleanup_task_checkpoints(session, task.agent_session_id)
@@ -235,6 +237,7 @@ async def delete_all_tasks(
         skipped_running_count = len(tasks) - len(deletable_tasks)
 
         for task in deletable_tasks:
+            await delete_attachments_for_task(session, task_id=task.id)
             await task_service.delete_task(session, task.id)
 
         await session.commit()

--- a/backend/app/api/schemas/agent.py
+++ b/backend/app/api/schemas/agent.py
@@ -47,10 +47,25 @@ class AgentSessionCreateResponse(BaseModel):
     agent_key: str = Field(..., description="当前会话使用的主智能体标识")
 
 
+class AgentAttachmentResponse(BaseModel):
+    """Agent 图片附件元数据。"""
+
+    id: str = Field(..., description="附件 ID")
+    session_id: str = Field(..., description="所属会话 ID")
+    storage_name: str = Field(..., description="服务端存储相对路径")
+    file_name: str = Field(..., description="原始文件名")
+    mime_type: str = Field(..., description="图片 MIME 类型")
+    size_bytes: int = Field(..., description="文件大小")
+    width: int = Field(..., description="图片宽度")
+    height: int = Field(..., description="图片高度")
+    url: str = Field(..., description="图片展示地址")
+
+
 class AgentSendMessageRequest(BaseModel):
     """发送用户消息请求。"""
 
-    message: str = Field(..., description="用户消息内容")
+    message: str = Field(default="", description="用户消息内容")
+    attachments: list[str] = Field(default_factory=list, description="图片附件 ID 列表")
     model_id: str | None = Field(default=None, description="下一轮执行使用的模型ID")
     agent_key: str | None = Field(default=None, description="下一轮执行使用的主智能体标识")
     reasoning_effort: ReasoningEffort | None = Field(
@@ -228,6 +243,10 @@ class AgentRollbackResponse(BaseModel):
         default_factory=list, description="受影响的世界书条目ID列表"
     )
     restored_message_content: str = Field(..., description="恢复的消息内容")
+    restored_attachments: list[AgentAttachmentResponse] = Field(
+        default_factory=list,
+        description="恢复到输入框的图片附件",
+    )
 
 
 class AgentForkRequest(BaseModel):

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -65,6 +65,7 @@ from app.background.runtime.supervisor import (
     start_background_runtime,
     stop_background_runtime,
 )
+from app.agent_runtime.attachments import ensure_agent_attachments_dir
 from app.core.storage import ensure_character_images_dir, ensure_covers_dir
 from app.chapter_export.service import cleanup_chapter_export_files
 from app.models.builtin import seed_builtin_models
@@ -415,6 +416,13 @@ def create_app() -> FastAPI:
         "/character-images",
         StaticFiles(directory=str(character_images_dir)),
         name="character_images",
+    )
+
+    agent_attachments_dir = ensure_agent_attachments_dir()
+    app.mount(
+        "/agent-attachments",
+        StaticFiles(directory=str(agent_attachments_dir)),
+        name="agent_attachments",
     )
 
     # 挂载前端构建产物；开发环境未构建时跳过，避免后端启动失败。

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -65,7 +65,10 @@ from app.background.runtime.supervisor import (
     start_background_runtime,
     stop_background_runtime,
 )
-from app.agent_runtime.attachments import ensure_agent_attachments_dir
+from app.agent_runtime.attachments import (
+    cleanup_orphaned_agent_attachment_files,
+    ensure_agent_attachments_dir,
+)
 from app.core.storage import ensure_character_images_dir, ensure_covers_dir
 from app.chapter_export.service import cleanup_chapter_export_files
 from app.models.builtin import seed_builtin_models
@@ -161,6 +164,16 @@ async def _cleanup_chapter_export_files() -> None:
         deleted_files = await cleanup_chapter_export_files(session)
         if deleted_files:
             logger.info(f"Deleted {deleted_files} expired or unreachable chapter export files")
+    finally:
+        await session.close()
+
+
+async def _cleanup_orphaned_agent_attachment_files() -> None:
+    session = await create_session()
+    try:
+        deleted_files = await cleanup_orphaned_agent_attachment_files(session)
+        if deleted_files:
+            logger.info(f"Deleted {deleted_files} orphaned agent attachment files at startup")
     finally:
         await session.close()
 
@@ -323,6 +336,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await init_checkpointer()
     await _cleanup_unreachable_checkpoints()
     await _cleanup_chapter_export_files()
+    await _cleanup_orphaned_agent_attachment_files()
     await load_audit_details_persistence()
     start_audit_queue()
     await start_background_runtime()

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -91,6 +91,7 @@ class Settings(BaseSettings):
     # Storage
     covers_dir: Path = BACKEND_DATA_DIR / "covers"
     character_images_dir: Path = BACKEND_DATA_DIR / "character-images"
+    agent_attachments_dir: Path = BACKEND_DATA_DIR / "agent-attachments"
     chapter_exports_dir: Path = BACKEND_DATA_DIR / "chapter-exports"
     static_dir: Path = BACKEND_DATA_DIR
 

--- a/backend/app/storage/migrations/versions/1015_add_agent_attachments.py
+++ b/backend/app/storage/migrations/versions/1015_add_agent_attachments.py
@@ -1,0 +1,51 @@
+"""add agent attachments
+
+Revision ID: 1015
+Revises: 1014
+Create Date: 2026-08-01 15:30:00.000000
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "1015"
+down_revision: Union[str, Sequence[str], None] = "1014"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_attachments",
+        sa.Column("id", sa.String(length=21), nullable=False),
+        sa.Column("session_id", sa.String(length=64), nullable=False),
+        sa.Column("task_id", sa.String(length=64), nullable=False),
+        sa.Column("project_id", sa.String(length=64), nullable=False),
+        sa.Column("storage_name", sa.String(length=500), nullable=False),
+        sa.Column("file_name", sa.String(length=255), nullable=False),
+        sa.Column("mime_type", sa.String(length=50), nullable=False),
+        sa.Column("size_bytes", sa.Integer(), nullable=False),
+        sa.Column("width", sa.Integer(), nullable=False),
+        sa.Column("height", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["task_id"], ["tasks.id"]),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("storage_name"),
+    )
+    op.create_index("ix_agent_attachments_session_id", "agent_attachments", ["session_id"])
+    op.create_index("ix_agent_attachments_task_id", "agent_attachments", ["task_id"])
+    op.create_index("ix_agent_attachments_project_id", "agent_attachments", ["project_id"])
+    op.create_index("ix_agent_attachments_created_at", "agent_attachments", ["created_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_agent_attachments_created_at", table_name="agent_attachments")
+    op.drop_index("ix_agent_attachments_project_id", table_name="agent_attachments")
+    op.drop_index("ix_agent_attachments_task_id", table_name="agent_attachments")
+    op.drop_index("ix_agent_attachments_session_id", table_name="agent_attachments")
+    op.drop_table("agent_attachments")

--- a/backend/app/storage/models/__init__.py
+++ b/backend/app/storage/models/__init__.py
@@ -13,7 +13,7 @@ from app.background.jobs.models import (
 from app.storage.models.llm_audit_log import LLMAuditLog
 from app.storage.models.agent_memory import AgentMemory
 from app.storage.models.agent_rule import AgentRule
-from app.agent_runtime.persistence.model import AgentContextCompaction, AgentRunMessage
+from app.agent_runtime.persistence.model import AgentAttachment, AgentContextCompaction, AgentRunMessage
 from app.storage.models.character import Character
 from app.storage.models.chapter import Chapter
 from app.storage.models.chapter_summary import ChapterSummary
@@ -46,6 +46,7 @@ __all__ = [
     "LLMAuditLog",
     "AgentMemory",
     "AgentRule",
+    "AgentAttachment",
     "AgentContextCompaction",
     "AgentRunMessage",
     "BackgroundJob",

--- a/backend/tests/agent_runtime/context/processors/test_to_langchain.py
+++ b/backend/tests/agent_runtime/context/processors/test_to_langchain.py
@@ -6,6 +6,10 @@ from app.agent_runtime.context.processors.to_langchain import to_langchain_messa
 from app.agent_runtime.context.types import ContextMessage
 
 
+def _accept_langchain_human_content(content: str | list[str | dict[object, object]]) -> None:
+    pass
+
+
 def test_system_message_mapped() -> None:
     parts = [ContextMessage(role="system", content="rules")]
     out = to_langchain_messages(parts)
@@ -43,6 +47,15 @@ def test_user_message_with_image_attachments_mapped_to_multimodal_content() -> N
         {"type": "text", "text": "描述这张图"},
         {"type": "image", "base64": "aW1hZ2U=", "mime_type": "image/png"},
     ]
+
+
+def test_multimodal_content_matches_langchain_human_message_contract() -> None:
+    content: list[str | dict[object, object]] = [
+        {"type": "text", "text": "描述这张图"},
+        {"type": "image", "base64": "aW1hZ2U=", "mime_type": "image/png"},
+    ]
+
+    _accept_langchain_human_content(content)
 
 
 def test_user_message_with_only_image_attachments_has_no_empty_text_block() -> None:

--- a/backend/tests/agent_runtime/context/processors/test_to_langchain.py
+++ b/backend/tests/agent_runtime/context/processors/test_to_langchain.py
@@ -21,6 +21,49 @@ def test_user_message_mapped_to_human() -> None:
     assert out[0].content == "hello"
 
 
+def test_user_message_with_image_attachments_mapped_to_multimodal_content() -> None:
+    parts = [
+        ContextMessage(
+            role="user",
+            content="描述这张图",
+            attachments=[
+                {
+                    "type": "image",
+                    "mime_type": "image/png",
+                    "base64": "aW1hZ2U=",
+                }
+            ],
+        )
+    ]
+
+    out = to_langchain_messages(parts)
+
+    assert isinstance(out[0], HumanMessage)
+    assert out[0].content == [
+        {"type": "text", "text": "描述这张图"},
+        {"type": "image", "base64": "aW1hZ2U=", "mime_type": "image/png"},
+    ]
+
+
+def test_user_message_with_only_image_attachments_has_no_empty_text_block() -> None:
+    out = to_langchain_messages(
+        [
+            ContextMessage(
+                role="user",
+                content="",
+                attachments=[
+                    {"type": "image", "base64": "aW1hZ2U=", "mime_type": "image/png"}
+                ],
+            )
+        ]
+    )
+
+    assert isinstance(out[0], HumanMessage)
+    assert out[0].content == [
+        {"type": "image", "base64": "aW1hZ2U=", "mime_type": "image/png"}
+    ]
+
+
 def test_assistant_message_mapped_to_ai_with_tool_calls() -> None:
     parts = [
         ContextMessage(

--- a/backend/tests/agent_runtime/graph/test_react_agent_context.py
+++ b/backend/tests/agent_runtime/graph/test_react_agent_context.py
@@ -8,8 +8,9 @@ from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, Tool
 from langchain_core.tools import BaseTool
 
 from app.agent_runtime.context.compaction.service import CompactionError
+from app.agent_runtime.context.compaction.window import CompactionNoWindowError
 from app.agent_runtime.context.types import ContextMessage
-from app.agent_runtime.graph.react_agent import create_react_agent, maybe_auto_compact
+from app.agent_runtime.graph.react_agent import _to_history_dict, create_react_agent, maybe_auto_compact
 from app.agent_runtime.persistence.errors import PersistenceLoadError
 from app.agent_runtime.types import ReactAgentConfig, TerminationCondition
 
@@ -232,6 +233,53 @@ async def test_auto_compaction_wraps_unhandled_compact_window_error() -> None:
             },
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_auto_compaction_skips_when_no_history_window_is_available() -> None:
+    events: list[tuple[str, dict]] = []
+
+    async def event_sink(name: str, payload: dict) -> None:
+        events.append((name, payload))
+
+    with (
+        patch(
+            "app.agent_runtime.graph.react_agent.count_context_tokens",
+            return_value=9,
+        ),
+        patch(
+            "app.agent_runtime.graph.react_agent.compaction_repo.list_by_session",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch(
+            "app.agent_runtime.graph.react_agent.select_compaction_window",
+            side_effect=CompactionNoWindowError(),
+        ),
+    ):
+        compacted = await maybe_auto_compact(
+            state=_auto_compaction_state(),
+            agent_name="writer",
+            parts=_compaction_parts(),
+            db_session=AsyncMock(),
+            event_sink=event_sink,
+            usage_sink=_noop_usage_sink,
+        )
+
+    assert compacted is False
+    assert events == []
+
+
+def test_history_conversion_does_not_serialize_image_base64() -> None:
+    history = _to_history_dict(
+        HumanMessage(
+            content=[
+                {"type": "text", "text": "请描述图片"},
+                {"type": "image", "base64": "x" * 10_000, "mime_type": "image/png"},
+            ]
+        )
+    )
+
+    assert history["content"] == "请描述图片"
 
 
 def test_auto_compaction_runs_before_main_model_and_rebuilds_context() -> None:
@@ -584,6 +632,22 @@ def test_to_history_dict_uses_openfic_response_metadata_for_internal_history_fie
         "tool_name": "read_chapter",
     }
     assert tool_out["name"] == "read_chapter"
+
+
+def test_to_history_dict_preserves_only_openfic_attachment_metadata() -> None:
+    from app.agent_runtime.graph.react_agent import _to_history_dict
+
+    message = HumanMessage(
+        content="图片请求",
+        additional_kwargs={
+            "openfic_attachments": [{"id": "image-1"}],
+            "unrelated": "must-not-persist",
+        },
+    )
+
+    assert _to_history_dict(message)["additional_kwargs"] == {
+        "openfic_attachments": [{"id": "image-1"}]
+    }
 
 
 def test_to_history_dict_normalizes_ai_message_chunk_role() -> None:

--- a/backend/tests/agent_runtime/persistence/conftest.py
+++ b/backend/tests/agent_runtime/persistence/conftest.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel
 
 from app.agent_runtime.persistence.model import (
+    AgentAttachment,
     AgentChildRun,
     AgentChildRunRequest,
     AgentContextCompaction,
@@ -44,6 +45,7 @@ _PERSISTENCE_TABLES = [
     _table(Chapter),
     _table(Task),
     _table(AgentRunMessage),
+    _table(AgentAttachment),
     _table(AgentContextCompaction),
     _table(AgentChildRun),
     _table(AgentChildRunRequest),

--- a/backend/tests/agent_runtime/persistence/test_loader.py
+++ b/backend/tests/agent_runtime/persistence/test_loader.py
@@ -13,8 +13,12 @@ from langchain_core.messages import (
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.persistence import repo
-from app.agent_runtime.attachments import build_image_content_blocks
-from app.agent_runtime.attachments import copy_attachments_for_fork
+from app.agent_runtime.attachments import (
+    build_image_content_blocks,
+    cleanup_orphaned_agent_attachment_files,
+    copy_attachments_for_fork,
+    delete_attachments_for_task,
+)
 from app.agent_runtime.persistence.model import AgentAttachment
 from app.agent_runtime.persistence.loader import load_history
 
@@ -168,6 +172,103 @@ async def test_copy_attachments_for_fork_creates_session_owned_copy(
     assert copied["source-image"]["id"] != "source-image"
     assert copied["source-image"]["storage_name"].startswith("fork/")
     assert (tmp_path / copied["source-image"]["storage_name"]).read_bytes() == b"source-image"
+
+
+@pytest.mark.asyncio
+async def test_delete_attachments_for_task_removes_files_and_records(
+    db_session: AsyncSession,
+    sample_task,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from app.settings import settings
+
+    monkeypatch.setattr(settings, "agent_attachments_dir", tmp_path)
+    storage_name = "session-1/image.png"
+    path = tmp_path / storage_name
+    path.parent.mkdir()
+    path.write_bytes(b"image-data")
+    db_session.add(
+        AgentAttachment(
+            id="attachment-1",
+            session_id="session-1",
+            task_id=sample_task.id,
+            project_id=sample_task.project_id,
+            storage_name=storage_name,
+            file_name="image.png",
+            mime_type="image/png",
+            size_bytes=10,
+            width=2,
+            height=3,
+        )
+    )
+    await db_session.commit()
+
+    deleted = await delete_attachments_for_task(db_session, task_id=sample_task.id)
+    await db_session.commit()
+
+    assert deleted >= 1
+    assert not path.exists()
+    assert not path.parent.exists()
+    assert await db_session.get(AgentAttachment, "attachment-1") is None
+
+
+@pytest.mark.asyncio
+async def test_cleanup_orphaned_agent_attachment_files_keeps_recorded_files(
+    db_session: AsyncSession,
+    sample_task,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from app.settings import settings
+
+    monkeypatch.setattr(settings, "agent_attachments_dir", tmp_path)
+    session_id = sample_task.agent_session_id or "session_test"
+    kept_path = tmp_path / session_id / "kept.png"
+    orphan_path = tmp_path / "orphan-session" / "orphan.png"
+    kept_path.parent.mkdir()
+    orphan_path.parent.mkdir()
+    kept_path.write_bytes(b"kept")
+    orphan_path.write_bytes(b"orphan")
+    db_session.add(
+        AgentAttachment(
+            id="attachment-kept",
+            session_id=session_id,
+            task_id=sample_task.id,
+            project_id=sample_task.project_id,
+            storage_name=f"{session_id}/kept.png",
+            file_name="kept.png",
+            mime_type="image/png",
+            size_bytes=4,
+            width=2,
+            height=3,
+        )
+    )
+    await db_session.commit()
+
+    deleted = await cleanup_orphaned_agent_attachment_files(db_session)
+
+    assert deleted >= 1
+    assert kept_path.exists()
+    assert not orphan_path.exists()
+    assert not orphan_path.parent.exists()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_orphaned_agent_attachment_files_removes_empty_deleted_session_directory(
+    db_session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from app.settings import settings
+
+    monkeypatch.setattr(settings, "agent_attachments_dir", tmp_path)
+    deleted_session_dir = tmp_path / "deleted-session"
+    deleted_session_dir.mkdir()
+
+    await cleanup_orphaned_agent_attachment_files(db_session)
+
+    assert not deleted_session_dir.exists()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/persistence/test_loader.py
+++ b/backend/tests/agent_runtime/persistence/test_loader.py
@@ -1,6 +1,7 @@
 """load_history 测试。"""
 
 import json
+from pathlib import Path
 
 import pytest
 from langchain_core.messages import (
@@ -12,6 +13,9 @@ from langchain_core.messages import (
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.persistence import repo
+from app.agent_runtime.attachments import build_image_content_blocks
+from app.agent_runtime.attachments import copy_attachments_for_fork
+from app.agent_runtime.persistence.model import AgentAttachment
 from app.agent_runtime.persistence.loader import load_history
 
 
@@ -59,6 +63,111 @@ async def test_load_history_basic_roles_in_seq_order(
     assert isinstance(msgs[0], SystemMessage) and msgs[0].content == "sys"
     assert isinstance(msgs[1], HumanMessage) and msgs[1].content == "hi"
     assert isinstance(msgs[2], AIMessage) and msgs[2].content == "hello back"
+
+
+@pytest.mark.asyncio
+async def test_load_history_preserves_user_attachment_metadata(
+    db_session: AsyncSession,
+    sample_task,
+) -> None:
+    await repo.insert_message(
+        db_session,
+        session_id="session-with-image",
+        task_id=sample_task.id,
+        project_id=sample_task.project_id,
+        role="user",
+        content="请看附件",
+        status="sent",
+        metadata={
+            "attachments": [
+                {
+                    "id": "attachment-1",
+                    "storage_name": "session-with-image/attachment-1.png",
+                    "mime_type": "image/png",
+                }
+            ]
+        },
+    )
+
+    messages = await load_history(db_session, "session-with-image")
+
+    assert isinstance(messages[0], HumanMessage)
+    assert messages[0].content == "请看附件"
+    assert messages[0].additional_kwargs["openfic_attachments"] == [
+        {
+            "id": "attachment-1",
+            "storage_name": "session-with-image/attachment-1.png",
+            "mime_type": "image/png",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_build_image_content_blocks_reads_server_attachment_file(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from app.settings import settings
+
+    monkeypatch.setattr(settings, "agent_attachments_dir", tmp_path)
+    attachment_path = tmp_path / "session-1" / "reference.png"
+    attachment_path.parent.mkdir()
+    attachment_path.write_bytes(b"image-data")
+
+    blocks = await build_image_content_blocks(
+        [
+            {
+                "storage_name": "session-1/reference.png",
+                "mime_type": "image/png",
+            }
+        ]
+    )
+
+    assert blocks == [
+        {"type": "image", "base64": "aW1hZ2UtZGF0YQ==", "mime_type": "image/png"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_copy_attachments_for_fork_creates_session_owned_copy(
+    db_session: AsyncSession,
+    sample_task,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from app.settings import settings
+
+    monkeypatch.setattr(settings, "agent_attachments_dir", tmp_path)
+    (tmp_path / "source" / "image.png").parent.mkdir()
+    (tmp_path / "source" / "image.png").write_bytes(b"source-image")
+    db_session.add(
+        AgentAttachment(
+            id="source-image",
+            session_id="source",
+            task_id=sample_task.id,
+            project_id=sample_task.project_id,
+            storage_name="source/image.png",
+            file_name="image.png",
+            mime_type="image/png",
+            size_bytes=12,
+            width=2,
+            height=3,
+        )
+    )
+    await db_session.commit()
+
+    copied = await copy_attachments_for_fork(
+        db_session,
+        source_session_id="source",
+        target_session_id="fork",
+        target_task_id=sample_task.id,
+        project_id=sample_task.project_id,
+        attachment_ids={"source-image"},
+    )
+
+    assert copied["source-image"]["id"] != "source-image"
+    assert copied["source-image"]["storage_name"].startswith("fork/")
+    assert (tmp_path / copied["source-image"]["storage_name"]).read_bytes() == b"source-image"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/test_agent_revision_rollback.py
+++ b/backend/tests/agent_runtime/test_agent_revision_rollback.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 from sqlmodel import SQLModel
 
+from app.agent_runtime.persistence.model import AgentAttachment
 from app.agent_runtime.persistence import repo as message_repo
 from app.storage.models.chapter import Chapter
 from app.storage.models.character import Character
@@ -447,6 +448,76 @@ async def test_rollback_revision_restores_chapters_and_messages(revision_db):
     assert rolled_back is not None
     assert rolled_back.status == "rolled_back"
     assert task is not None
+
+
+@pytest.mark.asyncio
+async def test_rollback_preserves_target_message_attachments_for_resending(revision_db):
+    from app.agent_runtime.revisions import (
+        begin_user_revision,
+        rollback_revision_for_session,
+    )
+
+    attachment_metadata = {
+        "id": "attachment-1",
+        "storage_name": "sess-1/attachment-1.png",
+        "file_name": "reference.png",
+        "mime_type": "image/png",
+        "size_bytes": 12,
+        "width": 2,
+        "height": 3,
+        "url": "/agent-attachments/sess-1/attachment-1.png",
+    }
+    async with revision_db() as session:
+        session.add(
+            AgentAttachment(
+                id="attachment-1",
+                session_id="sess-1",
+                task_id="task-1",
+                project_id="proj-1",
+                storage_name="sess-1/attachment-1.png",
+                file_name="reference.png",
+                mime_type="image/png",
+                size_bytes=12,
+                width=2,
+                height=3,
+            )
+        )
+        user_message = await message_repo.insert_message(
+            session,
+            session_id="sess-1",
+            task_id="task-1",
+            project_id="proj-1",
+            role="user",
+            status="sent",
+            content="请参考图片",
+            metadata={"attachments": [attachment_metadata]},
+        )
+        revision = await begin_user_revision(
+            session,
+            project_id="proj-1",
+            task_id="task-1",
+            agent_session_id="sess-1",
+            user_message_id=user_message.id,
+            user_message_seq=user_message.seq,
+            message="用户消息: 请参考图片",
+            pre_run_checkpoint_id="cp-before",
+            graph_thread_id="sess-1",
+        )
+        await session.commit()
+
+    async with revision_db() as session:
+        result = await rollback_revision_for_session(
+            session,
+            agent_session_id="sess-1",
+            revision_id=revision.id,
+        )
+        await session.commit()
+
+    assert result.restored_message_content == "请参考图片"
+    assert result.restored_attachments == [attachment_metadata]
+
+    async with revision_db() as session:
+        assert await session.get(AgentAttachment, "attachment-1") is not None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/test_orchestrator_graph.py
+++ b/backend/tests/agent_runtime/test_orchestrator_graph.py
@@ -2,7 +2,7 @@ import json
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessage, HumanMessage
 from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.types import Command
 from pydantic import BaseModel
@@ -38,6 +38,30 @@ def test_build_orchestrator_graph_has_only_primary_runtime_node():
     end_edges = [edge for edge in graph_data.edges if _edge_target(edge) == "__end__"]
     assert any(_edge_target(edge) == "primary" for edge in start_edges)
     assert any(_edge_source(edge) == "primary" for edge in end_edges)
+
+
+@pytest.mark.asyncio
+async def test_primary_messages_preserves_attachment_metadata_without_embedding_image_data() -> None:
+    from app.agent_runtime.graph.orchestrator.graph import _primary_messages
+
+    attachment = {
+        "id": "attachment-1",
+        "storage_name": "session-1/reference.png",
+        "mime_type": "image/png",
+    }
+
+    messages = await _primary_messages(
+        {
+            "messages": [],
+            "user_request": "请描述图片",
+            "user_attachments": [attachment],
+        }
+    )
+
+    assert len(messages) == 1
+    assert isinstance(messages[0], HumanMessage)
+    assert messages[0].content == "请描述图片"
+    assert messages[0].additional_kwargs == {"openfic_attachments": [attachment]}
 
 
 def test_session_runner_constructor_no_longer_accepts_mode():

--- a/backend/tests/api/test_agent.py
+++ b/backend/tests/api/test_agent.py
@@ -2,6 +2,7 @@
 """Agent API 测试。"""
 
 import asyncio
+import io
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
@@ -12,6 +13,7 @@ import pytest
 import pytest_asyncio
 from fastapi import status
 from httpx import AsyncClient
+from PIL import Image
 
 from app.agent_runtime.persistence import repo as message_repo
 from app.agent_runtime.persistence.child_runs import (
@@ -25,6 +27,7 @@ from app.agent_runtime.runner.run_registry import get_agent_run_registry
 from app.agent_runtime.runner.session_runner import SessionRunner
 from app.agent_runtime.streaming.replay_buffer import get_agent_event_replay_buffer
 from app.api.routers.agent_runtime import _SESSION_RUNNERS, _build_model_config
+from app.settings import settings
 from app.socket.handlers import agent_session_room, agent_subagents_room
 from app.storage.models.chapter import Chapter
 from app.storage.models.commit import Commit
@@ -105,8 +108,88 @@ async def _seed_agent_target(client: AsyncClient) -> dict[str, str]:
     }
 
 
+def _image_bytes() -> bytes:
+    buffer = io.BytesIO()
+    Image.new("RGB", (2, 3), color="white").save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
 @pytest.mark.asyncio
 class TestAgentAPI:
+    async def test_upload_agent_image_attachment_returns_session_owned_metadata(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={"project_id": target["project_id"], "model_id": target["model_id"]},
+        )
+        session_id = session_response.json()["session_id"]
+        monkeypatch.setattr(settings, "agent_attachments_dir", tmp_path / "agent-attachments", raising=False)
+
+        response = await client.post(
+            f"/api/v1/agent/sessions/{session_id}/attachments",
+            files={"image": ("reference.png", _image_bytes(), "image/png")},
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        attachment = response.json()
+        assert attachment["id"]
+        assert attachment["session_id"] == session_id
+        assert attachment["file_name"] == "reference.png"
+        assert attachment["mime_type"] == "image/png"
+        assert attachment["width"] == 2
+        assert attachment["height"] == 3
+        assert attachment["url"].startswith("/agent-attachments/")
+        assert settings.agent_attachments_dir.joinpath(attachment["storage_name"]).is_file()
+
+    async def test_send_agent_message_passes_session_attachment_metadata_to_runner(
+        self,
+        client: AsyncClient,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={"project_id": target["project_id"], "model_id": target["model_id"]},
+        )
+        session_id = session_response.json()["session_id"]
+        monkeypatch.setattr(settings, "agent_attachments_dir", tmp_path / "agent-attachments")
+        attachment_response = await client.post(
+            f"/api/v1/agent/sessions/{session_id}/attachments",
+            files={"image": ("reference.png", _image_bytes(), "image/png")},
+        )
+        attachment = attachment_response.json()
+        runner = _SESSION_RUNNERS[session_id]
+        runner.run = MagicMock(return_value=object())
+
+        with patch("app.api.routers.agent_runtime._launch_task", AsyncMock()):
+            response = await client.post(
+                f"/api/v1/agent/sessions/{session_id}/message",
+                json={"message": "请描述", "attachments": [attachment["id"]]},
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        runner.run.assert_called_once_with(
+            user_request="请描述",
+            attachments=[
+                {
+                    "id": attachment["id"],
+                    "storage_name": attachment["storage_name"],
+                    "file_name": "reference.png",
+                    "mime_type": "image/png",
+                    "size_bytes": attachment["size_bytes"],
+                    "width": 2,
+                    "height": 3,
+                    "url": attachment["url"],
+                }
+            ],
+        )
+
     async def test_build_model_config_allows_reasoning_effort_for_uncataloged_model(self) -> None:
         model = SimpleNamespace(
             id="uncataloged-model-record",

--- a/backend/tests/api/test_tasks.py
+++ b/backend/tests/api/test_tasks.py
@@ -262,10 +262,15 @@ class TestTaskAPI:
             "app.api.routers.tasks.delete_checkpoints_for_thread",
             new=AsyncMock(return_value=2),
         ) as delete_checkpoints:
-            response = await client.delete(f"/api/v1/tasks/{task.id}")
+            with patch(
+                "app.api.routers.tasks.delete_attachments_for_task",
+                new=AsyncMock(return_value=1),
+            ) as delete_attachments:
+                response = await client.delete(f"/api/v1/tasks/{task.id}")
 
         assert response.status_code == status.HTTP_204_NO_CONTENT
         delete_checkpoints.assert_awaited_once_with(task.agent_session_id)
+        delete_attachments.assert_awaited_once_with(session, task_id=task.id)
 
         get_response = await client.get(f"/api/v1/tasks/{task.id}")
         assert get_response.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/tests/model_registry.py
+++ b/backend/tests/model_registry.py
@@ -11,7 +11,7 @@ def register_sqlmodel_models() -> None:
     makes simple in-memory DB setup much slower and less predictable.
     """
 
-    from app.agent_runtime.persistence.model import AgentRunMessage
+    from app.agent_runtime.persistence.model import AgentAttachment, AgentRunMessage
     from app.background.jobs.models import (
         BackgroundJob,
         BackgroundJobEvent,
@@ -52,6 +52,7 @@ def register_sqlmodel_models() -> None:
         LLMAuditLog,
         AgentMemory,
         AgentRule,
+        AgentAttachment,
         AgentRunMessage,
         BackgroundJob,
         BackgroundJobEvent,

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -60,6 +60,8 @@ async def test_lifespan_refreshes_catalog_in_background_and_cancels_on_shutdown(
     monkeypatch.setattr(main, "_seed_builtin_models", do_nothing)
     monkeypatch.setattr(main, "init_checkpointer", do_nothing)
     monkeypatch.setattr(main, "_cleanup_unreachable_checkpoints", do_nothing)
+    monkeypatch.setattr(main, "_cleanup_chapter_export_files", do_nothing)
+    monkeypatch.setattr(main, "_cleanup_orphaned_agent_attachment_files", do_nothing)
     monkeypatch.setattr(main, "load_audit_details_persistence", do_nothing)
     monkeypatch.setattr(main, "start_audit_queue", lambda: None)
     monkeypatch.setattr(main, "start_background_runtime", do_nothing)

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -75,6 +75,7 @@
     "react-hook-form": "^7.75.0",
     "react-hotkeys-hook": "^5.3.2",
     "react-i18next": "^16.6.6",
+    "react-photo-view": "^1.2.7",
     "react-resizable-panels": "^4.11.0",
     "react-router": "^7.15.0",
     "react-svg": "^17.2.4",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -43,7 +43,7 @@ importers:
         version: 3.0.0
       '@radix-ui/themes':
         specifier: ^3.3.0
-        version: 3.3.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 3.3.0(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@streamdown/cjk':
         specifier: ^1.0.3
         version: 1.0.3(@types/mdast@4.0.4)(micromark-util-types@2.0.2)(micromark@4.0.2)(react@19.2.6)(unified@11.0.5)
@@ -112,7 +112,7 @@ importers:
         version: 3.27.1
       '@tiptap/react':
         specifier: ^3.27.1
-        version: 3.27.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 3.27.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@tiptap/starter-kit':
         specifier: ^3.27.1
         version: 3.27.1
@@ -169,7 +169,7 @@ importers:
         version: 12.38.0(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       radix-ui:
         specifier: ^1.4.3
-        version: 1.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 1.6.0(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
         specifier: ^19.2.6
         version: 19.2.6
@@ -194,6 +194,9 @@ importers:
       react-i18next:
         specifier: ^16.6.6
         version: 16.6.6(i18next@25.10.10(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+      react-photo-view:
+        specifier: ^1.2.7
+        version: 1.2.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-resizable-panels:
         specifier: ^4.11.0
         version: 4.11.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -248,7 +251,7 @@ importers:
         version: 19.2.14
       '@types/react-dom':
         specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.14)
+        version: 19.2.4(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^6.0.3
         version: 6.0.3(vite@8.1.4(@types/node@24.12.2)(jiti@2.7.0))
@@ -2095,8 +2098,8 @@ packages:
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
 
-  '@types/react-dom@19.2.3':
-    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+  '@types/react-dom@19.2.4':
+    resolution: {integrity: sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==}
     peerDependencies:
       '@types/react': ^19.2.0
 
@@ -3780,6 +3783,12 @@ packages:
   react-is@17.0.1:
     resolution: {integrity: sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==}
 
+  react-photo-view@1.2.7:
+    resolution: {integrity: sha512-MfOWVPxuibncRLaycZUNxqYU8D9IA+rbGDDaq6GM8RIoGJal592hEJoRAyRSI7ZxyyJNJTLMUWWL3UIXHJJOpw==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
@@ -4962,67 +4971,67 @@ snapshots:
 
   '@radix-ui/primitive@1.1.4': {}
 
-  '@radix-ui/react-accessible-icon@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-accessible-icon@1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-accordion@1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-accordion@1.2.14(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collapsible': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-collapsible': 1.1.14(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-alert-dialog@1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-alert-dialog@1.1.17(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-dialog': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-dialog': 1.1.17(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-arrow@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-arrow@1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-aspect-ratio@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-aspect-ratio@1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-avatar@1.2.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-avatar@1.2.0(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.6)
@@ -5030,15 +5039,15 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-checkbox@1.3.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-checkbox@1.3.5(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.14)(react@19.2.6)
@@ -5046,35 +5055,35 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-collapsible@1.1.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-collapsible@1.1.14(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-collection@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-collection@1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
   '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
@@ -5082,18 +5091,18 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-context-menu@2.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-context-menu@2.3.1(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-menu': 2.1.18(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-menu': 2.1.18(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
   '@radix-ui/react-context@1.1.4(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
@@ -5101,18 +5110,18 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-dialog@1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-dialog@1.1.17(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       aria-hidden: 1.2.6
@@ -5121,7 +5130,7 @@ snapshots:
       react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
   '@radix-ui/react-direction@1.1.2(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
@@ -5129,33 +5138,33 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-dismissable-layer@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-dismissable-layer@1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-escape-keydown': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-dropdown-menu@2.1.18(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-dropdown-menu@2.1.18(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-menu': 2.1.18(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-menu': 2.1.18(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
   '@radix-ui/react-focus-guards@1.1.4(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
@@ -5163,47 +5172,47 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-focus-scope@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-focus-scope@1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-form@0.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-form@0.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-label': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-label': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-hover-card@1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-hover-card@1.1.17(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-popper': 1.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-popper': 1.3.1(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
   '@radix-ui/react-id@1.1.2(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
@@ -5212,31 +5221,31 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-label@2.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-label@2.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-menu@2.1.18(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-menu@2.1.18(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-popper': 1.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-popper': 1.3.1(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       aria-hidden: 1.2.6
@@ -5245,58 +5254,58 @@ snapshots:
       react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-menubar@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-menubar@1.1.18(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-menu': 2.1.18(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-menu': 2.1.18(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-navigation-menu@1.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-navigation-menu@1.2.16(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-one-time-password-field@0.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-one-time-password-field@0.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/number': 1.1.2
       '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.14)(react@19.2.6)
@@ -5305,15 +5314,15 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-password-toggle-field@0.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-password-toggle-field@0.1.5(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.14)(react@19.2.6)
@@ -5321,21 +5330,21 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-popover@1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-popover@1.1.17(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-popper': 1.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-popper': 1.3.1(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       aria-hidden: 1.2.6
@@ -5344,15 +5353,15 @@ snapshots:
       react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-popper@1.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-popper@1.3.1(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@floating-ui/react-dom': 2.1.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-arrow': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-arrow': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-rect': 1.1.2(@types/react@19.2.14)(react@19.2.6)
@@ -5362,55 +5371,55 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-portal@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-portal@1.1.12(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-presence@1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-presence@1.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-primitive@2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-primitive@2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-progress@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-progress@1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-radio-group@1.4.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-radio-group@1.4.1(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.14)(react@19.2.6)
@@ -5418,90 +5427,90 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-roving-focus@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-roving-focus@1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-scroll-area@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-scroll-area@1.2.12(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/number': 1.1.2
       '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-select@2.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-select@2.3.1(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/number': 1.1.2
       '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-popper': 1.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-popper': 1.3.1(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       aria-hidden: 1.2.6
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-separator@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-separator@1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-slider@1.4.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-slider@1.4.1(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/number': 1.1.2
       '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.14)(react@19.2.6)
@@ -5510,7 +5519,7 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
   '@radix-ui/react-slot@1.3.0(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
@@ -5519,12 +5528,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-switch@1.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-switch@1.3.1(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.14)(react@19.2.6)
@@ -5532,104 +5541,104 @@ snapshots:
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-tabs@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-tabs@1.1.15(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-toast@1.2.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-toast@1.2.17(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-toggle-group@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-toggle-group@1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-toggle': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-toggle': 1.1.12(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-toggle@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-toggle@1.1.12(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-toolbar@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-toolbar@1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-separator': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-toggle-group': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-separator': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-toggle-group': 1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
-  '@radix-ui/react-tooltip@1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-tooltip@1.2.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-popper': 1.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-popper': 1.3.1(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
   '@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
@@ -5691,28 +5700,28 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-visually-hidden@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/react-visually-hidden@1.2.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
   '@radix-ui/rect@1.1.2': {}
 
-  '@radix-ui/themes@3.3.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@radix-ui/themes@3.3.0(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/colors': 3.0.0
       classnames: 2.5.1
-      radix-ui: 1.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      radix-ui: 1.6.0(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
   '@react-spring/animated@10.1.2(react@19.2.6)':
     dependencies:
@@ -6059,12 +6068,12 @@ snapshots:
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.41.8
 
-  '@tiptap/react@3.27.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@tiptap/react@3.27.1(@floating-ui/dom@1.7.6)(@tiptap/core@3.27.1(@tiptap/pm@3.27.1))(@tiptap/pm@3.27.1)(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@tiptap/core': 3.27.1(@tiptap/pm@3.27.1)
       '@tiptap/pm': 3.27.1
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
       '@types/use-sync-external-store': 0.0.6
       fast-equals: 5.4.0
       react: 19.2.6
@@ -6288,7 +6297,7 @@ snapshots:
 
   '@types/prop-types@15.7.15': {}
 
-  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+  '@types/react-dom@19.2.4(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
 
@@ -8230,55 +8239,55 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  radix-ui@1.6.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  radix-ui@1.6.0(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-accessible-icon': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-accordion': 1.2.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-alert-dialog': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-arrow': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-aspect-ratio': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-avatar': 1.2.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-checkbox': 1.3.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-collapsible': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-accessible-icon': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-accordion': 1.2.14(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-alert-dialog': 1.1.17(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-arrow': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-aspect-ratio': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-avatar': 1.2.0(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-checkbox': 1.3.5(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-collapsible': 1.1.14(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-context-menu': 2.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-dialog': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-context-menu': 2.3.1(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-dialog': 1.1.17(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-dropdown-menu': 2.1.18(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-dropdown-menu': 2.1.18(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-form': 0.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-hover-card': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-label': 2.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-menu': 2.1.18(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-menubar': 1.1.18(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-navigation-menu': 1.2.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-one-time-password-field': 0.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-password-toggle-field': 0.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-popover': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-popper': 1.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-progress': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-radio-group': 1.4.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-scroll-area': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-select': 2.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-separator': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-slider': 1.4.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-form': 0.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-hover-card': 1.1.17(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-label': 2.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-menu': 2.1.18(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-menubar': 1.1.18(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-navigation-menu': 1.2.16(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-one-time-password-field': 0.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-password-toggle-field': 0.1.5(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-popover': 1.1.17(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-popper': 1.3.1(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-progress': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-radio-group': 1.4.1(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-scroll-area': 1.2.12(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-select': 2.3.1(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-separator': 1.1.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-slider': 1.4.1(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-switch': 1.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-tabs': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-toast': 1.2.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-toggle': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-toggle-group': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-toolbar': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-tooltip': 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-switch': 1.3.1(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-tabs': 1.1.15(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-toast': 1.2.17(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-toggle': 1.1.12(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-toggle-group': 1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-toolbar': 1.1.13(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-tooltip': 1.2.10(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.14)(react@19.2.6)
@@ -8286,12 +8295,12 @@ snapshots:
       '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.6)
       '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.4(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@types/react-dom': 19.2.4(@types/react@19.2.14)
 
   react-day-picker@9.14.0(react@19.2.6):
     dependencies:
@@ -8340,6 +8349,11 @@ snapshots:
   react-is@16.13.1: {}
 
   react-is@17.0.1: {}
+
+  react-photo-view@1.2.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
   react-refresh@0.18.0: {}
 

--- a/frontend/src/components/model-id-select.tsx
+++ b/frontend/src/components/model-id-select.tsx
@@ -32,6 +32,7 @@ const MotionBox = motion.create(Box);
 export interface ModelIdSelectOption extends AvailableModel {
   value?: string;
   providerIconPath?: string | null;
+  isCatalogMatched?: boolean;
 }
 
 interface ModelIdSelectProps {

--- a/frontend/src/components/prompt-chain-dialog.css
+++ b/frontend/src/components/prompt-chain-dialog.css
@@ -80,3 +80,54 @@
   background: var(--yellow-a5);
   color: inherit;
 }
+
+.prompt-chain-dialog-attachments {
+  margin-top: 12px;
+  padding-top: 10px;
+  border-top: 1px solid var(--gray-a4);
+}
+
+.prompt-chain-dialog-attachments-title {
+  display: block;
+  margin-bottom: 8px;
+  color: var(--gray-11);
+}
+
+.prompt-chain-dialog-image-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.prompt-chain-dialog-image-trigger {
+  display: block;
+  width: 80px;
+  height: 80px;
+  padding: 0;
+  overflow: hidden;
+  appearance: none;
+  cursor: zoom-in;
+  background: var(--gray-a3);
+  border: 1px solid var(--gray-a5);
+  border-radius: var(--radius-2);
+}
+
+.prompt-chain-dialog-image-trigger:hover {
+  background: var(--gray-a4);
+}
+
+.prompt-chain-dialog-image-trigger:focus-visible {
+  outline: 2px solid var(--accent-8);
+  outline-offset: 2px;
+}
+
+.prompt-chain-dialog-image-trigger img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.PhotoView-Portal.prompt-chain-dialog-photo-viewer {
+  z-index: 10000;
+}

--- a/frontend/src/components/prompt-chain-dialog.tsx
+++ b/frontend/src/components/prompt-chain-dialog.tsx
@@ -3,15 +3,18 @@ import { Bot, ChevronDown, Search, Terminal, User } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { PhotoProvider, PhotoView } from "react-photo-view";
 
 import { Spinner } from "@/components";
 import { countTokens } from "@/lib/tiktoken-utils";
 
 import "./prompt-chain-dialog.css";
+import "react-photo-view/dist/react-photo-view.css";
 
 export interface PromptChainDialogEntry {
   role: string;
   content: string;
+  imageUrls?: string[];
   name?: string;
 }
 
@@ -79,6 +82,7 @@ export function PromptChainDialog({
   const [searchQuery, setSearchQuery] = useState("");
   const [expandedIndexes, setExpandedIndexes] = useState<Set<number>>(new Set());
   const [countedEntries, setCountedEntries] = useState<CountedPromptEntry[]>([]);
+  const [dialogContent, setDialogContent] = useState<HTMLDivElement | null>(null);
 
   useEffect(() => {
     if (!open || isLoading) return;
@@ -127,7 +131,10 @@ export function PromptChainDialog({
       open={open}
       onOpenChange={handleOpenChange}
     >
-      <Dialog.Content className="prompt-chain-dialog-content">
+      <Dialog.Content
+        ref={setDialogContent}
+        className="prompt-chain-dialog-content"
+      >
         <Flex
           justify="between"
           align="start"
@@ -249,11 +256,52 @@ export function PromptChainDialog({
                     </button>
                     {isExpanded ? (
                       <Box className="prompt-chain-dialog-entry-content">
-                        {entry.content ? (
-                          highlightContent(entry.content, searchQuery)
-                        ) : (
+                        {entry.content ? highlightContent(entry.content, searchQuery) : null}
+                        {entry.imageUrls?.length ? (
+                          <section
+                            className="prompt-chain-dialog-attachments"
+                            aria-label={t("promptChainDialog.imageAttachments")}
+                          >
+                            <Text
+                              className="prompt-chain-dialog-attachments-title"
+                              size="1"
+                              weight="medium"
+                            >
+                              {t("promptChainDialog.imageAttachments")}
+                            </Text>
+                            <PhotoProvider
+                              className="prompt-chain-dialog-photo-viewer"
+                              portalContainer={dialogContent ?? undefined}
+                            >
+                              <div className="prompt-chain-dialog-image-list">
+                                {entry.imageUrls.map((imageUrl, imageIndex) => (
+                                  <PhotoView
+                                    key={`${entry.role}-${index}-${imageIndex}`}
+                                    src={imageUrl}
+                                  >
+                                    <button
+                                      type="button"
+                                      className="prompt-chain-dialog-image-trigger"
+                                      aria-label={t("promptChainDialog.viewImage", {
+                                        index: imageIndex + 1,
+                                      })}
+                                    >
+                                      <img
+                                        src={imageUrl}
+                                        alt={t("promptChainDialog.imageAlt", {
+                                          index: imageIndex + 1,
+                                        })}
+                                      />
+                                    </button>
+                                  </PhotoView>
+                                ))}
+                              </div>
+                            </PhotoProvider>
+                          </section>
+                        ) : null}
+                        {!entry.content && !entry.imageUrls?.length ? (
                           <Text color="gray">{t("promptChainDialog.emptyContent")}</Text>
-                        )}
+                        ) : null}
                       </Box>
                     ) : null}
                   </Box>

--- a/frontend/src/features/assistant/components/agent/agent-composer-editor.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-composer-editor.tsx
@@ -5,7 +5,11 @@ import type { Editor } from "@tiptap/react";
 import { useEditor, EditorContent } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { KeyboardEvent as ReactKeyboardEvent } from "react";
+import type {
+  ClipboardEvent as ReactClipboardEvent,
+  DragEvent as ReactDragEvent,
+  KeyboardEvent as ReactKeyboardEvent,
+} from "react";
 
 import type { AssistantMentionCandidate } from "@/features/assistant/lib/mention-text";
 import {
@@ -44,6 +48,8 @@ interface AgentComposerEditorProps {
   disabled: boolean;
   onOpenMentionChapter?: (chapterId: string, chapterTitle: string) => void;
   onMentionSuggestionsChange?: (state: AgentComposerSuggestionState | null) => void;
+  onPasteFiles?: (dataTransfer: DataTransfer) => void;
+  onDropFiles?: (dataTransfer: DataTransfer) => void;
   onChange: (value: string) => void;
   onSubmit: () => void;
 }
@@ -60,6 +66,13 @@ function createClosedMentionQueryState(): MentionQueryState {
     replaceFrom: -1,
     visible: false,
   };
+}
+
+function hasFiles(dataTransfer: DataTransfer): boolean {
+  return (
+    dataTransfer.files.length > 0 ||
+    Array.from(dataTransfer.items).some((item) => item.kind === "file")
+  );
 }
 
 function docToCanonicalText(doc: ProseMirrorNode): string {
@@ -139,6 +152,8 @@ export function AgentComposerEditor({
   disabled,
   onOpenMentionChapter,
   onMentionSuggestionsChange,
+  onPasteFiles,
+  onDropFiles,
   onChange,
   onSubmit,
 }: AgentComposerEditorProps) {
@@ -338,6 +353,26 @@ export function AgentComposerEditor({
     [editor, onSubmit, suggestionItems.length, suggestionStatus],
   );
 
+  const handlePasteCapture = (event: ReactClipboardEvent<HTMLDivElement>) => {
+    if (!onPasteFiles || !hasFiles(event.clipboardData)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    onPasteFiles(event.clipboardData);
+  };
+
+  const handleDragOverCapture = (event: ReactDragEvent<HTMLDivElement>) => {
+    if (!hasFiles(event.dataTransfer)) return;
+    event.preventDefault();
+    event.stopPropagation();
+  };
+
+  const handleDropCapture = (event: ReactDragEvent<HTMLDivElement>) => {
+    if (!onDropFiles || !hasFiles(event.dataTransfer)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    onDropFiles(event.dataTransfer);
+  };
+
   useEffect(() => {
     if (!editor) return;
     updateMentionQuery(editor);
@@ -381,6 +416,9 @@ export function AgentComposerEditor({
       className="agent-composer-editor"
       data-disabled={disabled}
       onKeyDownCapture={handleEditorKeyDownCapture}
+      onPasteCapture={handlePasteCapture}
+      onDragOverCapture={handleDragOverCapture}
+      onDropCapture={handleDropCapture}
     >
       <EditorContent editor={editor} />
     </div>

--- a/frontend/src/features/assistant/components/agent/agent-input.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-input.tsx
@@ -2,8 +2,8 @@ import { Box, Flex, IconButton, Text, Tooltip } from "@radix-ui/themes";
 import {
   ArrowUp,
   CircleUserRound,
+  CloudUpload,
   ExternalLink,
-  ImagePlus,
   ShieldCheck,
   Square,
   X,
@@ -12,6 +12,9 @@ import { AnimatePresence, motion } from "motion/react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
+import { PhotoProvider, PhotoView } from "react-photo-view";
+
+import "react-photo-view/dist/react-photo-view.css";
 
 import { ModelIdSelect, Spinner, type ModelIdSelectOption } from "@/components";
 import { toast } from "@/components";
@@ -130,7 +133,6 @@ export function AgentInput({
     () => models.find((model) => model.value === modelId || model.id === modelId),
     [modelId, models],
   );
-  const fileInputRef = useRef<HTMLInputElement>(null);
   const [isDraggingImages, setIsDraggingImages] = useState(false);
   const canAttachImages = modelAllowsAgentImages(
     selectedModel?.inputModalities,
@@ -223,7 +225,7 @@ export function AgentInput({
     event.preventDefault();
     setIsDraggingImages(false);
     if (!canAttachImages) {
-      toast.error("当前模型不支持图片输入");
+      toast.error(t("writing.aiSidebar.modelImageInputUnsupported"));
       return;
     }
     void handleFiles(files);
@@ -233,7 +235,7 @@ export function AgentInput({
     const files = getAgentImageFiles(dataTransfer);
     if (files.length === 0) return;
     if (!canAttachImages) {
-      toast.error("当前模型不支持图片输入");
+      toast.error(t("writing.aiSidebar.modelImageInputUnsupported"));
       return;
     }
     void handleFiles(files);
@@ -303,6 +305,15 @@ export function AgentInput({
           }}
           onDrop={handleDrop}
         >
+          <div
+            className="agent-image-drop-overlay"
+            aria-hidden="true"
+          >
+            <span className="agent-image-drop-overlay-content">
+              <CloudUpload size={16} />
+              {t("writing.aiSidebar.dropImageAttachments")}
+            </span>
+          </div>
           <AnimatePresence
             initial={false}
             mode="wait"
@@ -353,30 +364,43 @@ export function AgentInput({
                 transition={{ duration: 0.18, ease: "easeOut" }}
               >
                 {attachments.length > 0 ? (
-                  <div className="agent-image-attachment-strip">
-                    {attachments.map((attachment) => (
-                      <div
-                        key={attachment.id}
-                        className="agent-image-attachment-preview"
-                      >
-                        <img
-                          src={attachment.previewUrl}
-                          alt={
-                            attachment.file?.name ??
-                            attachment.uploadedAttachment?.fileName ??
-                            "图片"
-                          }
-                        />
-                        <button
-                          type="button"
-                          aria-label={`移除图片 ${attachment.file?.name ?? attachment.uploadedAttachment?.fileName ?? ""}`}
-                          onClick={() => handleRemoveAttachment(attachment.id)}
-                        >
-                          <X size={12} />
-                        </button>
-                      </div>
-                    ))}
-                  </div>
+                  <PhotoProvider>
+                    <div className="agent-image-attachment-strip">
+                      {attachments.map((attachment) => {
+                        const fileName =
+                          attachment.file?.name ??
+                          attachment.uploadedAttachment?.fileName ??
+                          t("writing.aiSidebar.imageFallbackAlt");
+                        return (
+                          <div
+                            key={attachment.id}
+                            className="agent-image-attachment-preview"
+                          >
+                            <PhotoView src={attachment.previewUrl}>
+                              <button
+                                type="button"
+                                className="agent-image-preview-trigger"
+                                aria-label={t("writing.aiSidebar.viewImage", { fileName })}
+                              >
+                                <img
+                                  src={attachment.previewUrl}
+                                  alt={fileName}
+                                />
+                              </button>
+                            </PhotoView>
+                            <button
+                              type="button"
+                              className="agent-image-attachment-remove"
+                              aria-label={t("writing.aiSidebar.removeImage", { fileName })}
+                              onClick={() => handleRemoveAttachment(attachment.id)}
+                            >
+                              <X size={12} />
+                            </button>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </PhotoProvider>
                 ) : null}
                 <AgentComposerEditor
                   projectId={projectId}
@@ -538,29 +562,6 @@ export function AgentInput({
           >
             <AgentIndexStatusIndicator projectId={projectId} />
 
-            <input
-              ref={fileInputRef}
-              className="agent-image-attachment-input"
-              type="file"
-              accept="image/png,image/jpeg,image/webp"
-              multiple
-              onChange={(event) => {
-                void handleFiles(Array.from(event.target.files ?? []));
-                event.target.value = "";
-              }}
-            />
-            <Tooltip content={canAttachImages ? "添加图片" : "当前模型不支持图片输入"}>
-              <IconButton
-                type="button"
-                variant="ghost"
-                size="1"
-                onClick={() => fileInputRef.current?.click()}
-                disabled={!canAttachImages || isComposerLocked}
-                aria-label="添加图片"
-              >
-                <ImagePlus size={15} />
-              </IconButton>
-            </Tooltip>
             <Tooltip
               content={
                 toolApprovalBypassEnabled

--- a/frontend/src/features/assistant/components/agent/agent-input.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-input.tsx
@@ -1,15 +1,31 @@
 import { Box, Flex, IconButton, Text, Tooltip } from "@radix-ui/themes";
-import { ArrowUp, CircleUserRound, ExternalLink, ShieldCheck, Square } from "lucide-react";
+import {
+  ArrowUp,
+  CircleUserRound,
+  ExternalLink,
+  ImagePlus,
+  ShieldCheck,
+  Square,
+  X,
+} from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import { ModelIdSelect, Spinner, type ModelIdSelectOption } from "@/components";
+import { toast } from "@/components";
 import { SimpleSelect, type SelectOption } from "@/components/select";
 import { ProviderIcon } from "@/features/settings/lib/provider-icons";
 import type { AgentPendingMessage, AgentSessionStatus, ReasoningEffort } from "@/lib/agent.types";
 
+import {
+  getAgentImageFiles,
+  hasLeftAgentImageDropZone,
+  modelAllowsAgentImages,
+  type PendingAgentImageAttachment,
+  validateAgentImageFiles,
+} from "../../lib/agent-image-attachments";
 import { AgentComposerEditor, type AgentComposerSuggestionState } from "./agent-composer-editor";
 import { AgentIndexStatusIndicator } from "./agent-index-status-indicator";
 import { canSendAgentInput, getAgentInputBodyMode, isAgentInputLocked } from "./agent-input-state";
@@ -19,6 +35,7 @@ import { AgentPendingMessageCard } from "./pending-message-card";
 interface AgentInputProps {
   projectId: string;
   value: string;
+  attachments: PendingAgentImageAttachment[];
   modelId: string;
   models: ModelIdSelectOption[];
   reasoningEffort?: ReasoningEffort;
@@ -29,6 +46,7 @@ interface AgentInputProps {
   isModelsLoading: boolean;
   modelsError: boolean;
   onChange: (value: string) => void;
+  onAttachmentsChange: (attachments: PendingAgentImageAttachment[]) => void;
   onSend: () => void;
   onAbort: () => void;
   onModelChange: (modelId: string) => void;
@@ -46,12 +64,14 @@ interface AgentInputProps {
   forceSpecialPanels?: boolean;
   readOnly?: boolean;
   readOnlyMessage?: ReactNode;
+  onUploadAttachments: (files: File[]) => Promise<void>;
   [ignoredModeSelectorProp: string]: unknown;
 }
 
 export function AgentInput({
   projectId,
   value,
+  attachments,
   modelId,
   models,
   reasoningEffort,
@@ -62,6 +82,7 @@ export function AgentInput({
   isModelsLoading,
   modelsError,
   onChange,
+  onAttachmentsChange,
   onSend,
   onAbort,
   onModelChange,
@@ -79,10 +100,11 @@ export function AgentInput({
   forceSpecialPanels = false,
   readOnly = false,
   readOnlyMessage,
+  onUploadAttachments,
 }: AgentInputProps) {
   const { t } = useTranslation();
   const bodyMode = getAgentInputBodyMode(agentStatus, Boolean(specialPanels), forceSpecialPanels);
-  const hasContent = value.trim().length > 0;
+  const hasContent = value.trim().length > 0 || attachments.length > 0;
   const hasPendingMessage = pendingMessage !== null;
   const isComposerLocked = isAgentInputLocked({
     disabled,
@@ -107,6 +129,12 @@ export function AgentInput({
   const selectedModel = useMemo(
     () => models.find((model) => model.value === modelId || model.id === modelId),
     [modelId, models],
+  );
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [isDraggingImages, setIsDraggingImages] = useState(false);
+  const canAttachImages = modelAllowsAgentImages(
+    selectedModel?.inputModalities,
+    selectedModel?.isCatalogMatched === true,
   );
   const modelTriggerPrefix = selectedModel ? (
     <ProviderIcon
@@ -160,12 +188,66 @@ export function AgentInput({
     };
   }, [bodyMode, isComposerLocked, readOnly]);
 
+  useEffect(() => {
+    if (!isDraggingImages) return;
+
+    const clearDraggingImages = () => setIsDraggingImages(false);
+    window.addEventListener("dragend", clearDraggingImages);
+    window.addEventListener("drop", clearDraggingImages);
+    return () => {
+      window.removeEventListener("dragend", clearDraggingImages);
+      window.removeEventListener("drop", clearDraggingImages);
+    };
+  }, [isDraggingImages]);
+
   const getPlaceholder = () => {
     if (agentStatus === "waiting_answer")
       return t("writing.aiSidebar.inputPlaceholderWaitingAnswer");
     if (agentStatus === "waiting_approval")
       return t("writing.aiSidebar.inputPlaceholderWaitingApproval");
     return t("writing.aiSidebar.inputPlaceholder");
+  };
+
+  const handleFiles = async (files: File[]) => {
+    const error = validateAgentImageFiles(files, attachments.length);
+    if (error) {
+      toast.error(error);
+      return;
+    }
+    await onUploadAttachments(files);
+  };
+
+  const handleDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    const files = getAgentImageFiles(event.dataTransfer);
+    if (files.length === 0) return;
+    event.preventDefault();
+    setIsDraggingImages(false);
+    if (!canAttachImages) {
+      toast.error("当前模型不支持图片输入");
+      return;
+    }
+    void handleFiles(files);
+  };
+
+  const handlePastedFiles = (dataTransfer: DataTransfer) => {
+    const files = getAgentImageFiles(dataTransfer);
+    if (files.length === 0) return;
+    if (!canAttachImages) {
+      toast.error("当前模型不支持图片输入");
+      return;
+    }
+    void handleFiles(files);
+  };
+
+  const handleDroppedFiles = (dataTransfer: DataTransfer) => {
+    setIsDraggingImages(false);
+    handlePastedFiles(dataTransfer);
+  };
+
+  const handleRemoveAttachment = (id: string) => {
+    const attachment = attachments.find((item) => item.id === id);
+    if (attachment) URL.revokeObjectURL(attachment.previewUrl);
+    onAttachmentsChange(attachments.filter((item) => item.id !== id));
   };
 
   return (
@@ -203,6 +285,23 @@ export function AgentInput({
           ref={inputContainerRef}
           className="ai-sidebar-input-container"
           data-mode={bodyMode}
+          data-dragging-images={isDraggingImages || undefined}
+          onDragEnter={(event) => {
+            if (event.dataTransfer.types.includes("Files")) setIsDraggingImages(true);
+          }}
+          onDragOver={(event) => {
+            if (getAgentImageFiles(event.dataTransfer).length > 0) event.preventDefault();
+          }}
+          onDragLeave={(event) => {
+            if (
+              hasLeftAgentImageDropZone(event.relatedTarget, (target) =>
+                event.currentTarget.contains(target),
+              )
+            ) {
+              setIsDraggingImages(false);
+            }
+          }}
+          onDrop={handleDrop}
         >
           <AnimatePresence
             initial={false}
@@ -253,6 +352,32 @@ export function AgentInput({
                 exit={{ opacity: 0, y: -8 }}
                 transition={{ duration: 0.18, ease: "easeOut" }}
               >
+                {attachments.length > 0 ? (
+                  <div className="agent-image-attachment-strip">
+                    {attachments.map((attachment) => (
+                      <div
+                        key={attachment.id}
+                        className="agent-image-attachment-preview"
+                      >
+                        <img
+                          src={attachment.previewUrl}
+                          alt={
+                            attachment.file?.name ??
+                            attachment.uploadedAttachment?.fileName ??
+                            "图片"
+                          }
+                        />
+                        <button
+                          type="button"
+                          aria-label={`移除图片 ${attachment.file?.name ?? attachment.uploadedAttachment?.fileName ?? ""}`}
+                          onClick={() => handleRemoveAttachment(attachment.id)}
+                        >
+                          <X size={12} />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                ) : null}
                 <AgentComposerEditor
                   projectId={projectId}
                   placeholder={getPlaceholder()}
@@ -260,6 +385,8 @@ export function AgentInput({
                   disabled={isComposerLocked}
                   onOpenMentionChapter={onOpenMentionChapter}
                   onMentionSuggestionsChange={setMentionSuggestions}
+                  onPasteFiles={handlePastedFiles}
+                  onDropFiles={handleDroppedFiles}
                   onChange={onChange}
                   onSubmit={onSend}
                 />
@@ -411,6 +538,29 @@ export function AgentInput({
           >
             <AgentIndexStatusIndicator projectId={projectId} />
 
+            <input
+              ref={fileInputRef}
+              className="agent-image-attachment-input"
+              type="file"
+              accept="image/png,image/jpeg,image/webp"
+              multiple
+              onChange={(event) => {
+                void handleFiles(Array.from(event.target.files ?? []));
+                event.target.value = "";
+              }}
+            />
+            <Tooltip content={canAttachImages ? "添加图片" : "当前模型不支持图片输入"}>
+              <IconButton
+                type="button"
+                variant="ghost"
+                size="1"
+                onClick={() => fileInputRef.current?.click()}
+                disabled={!canAttachImages || isComposerLocked}
+                aria-label="添加图片"
+              >
+                <ImagePlus size={15} />
+              </IconButton>
+            </Tooltip>
             <Tooltip
               content={
                 toolApprovalBypassEnabled

--- a/frontend/src/features/assistant/components/agent/agent-sidebar.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-sidebar.tsx
@@ -4,6 +4,7 @@ import type React from "react";
 import { toast } from "@/components";
 import i18n from "@/i18n";
 import type {
+  AgentImageAttachment,
   AgentForkResponse,
   AgentSessionCreateResponse,
   ReasoningEffort,
@@ -11,6 +12,7 @@ import type {
 } from "@/lib/agent.types";
 
 import { useAgentSession } from "../../hooks/use-agent-session";
+import type { PendingAgentImageAttachment } from "../../lib/agent-image-attachments";
 import { AgentMessages } from "./agent-messages";
 import { AgentSpecialPanels } from "./agent-special-panels";
 import { getAgentSpecialPanels, type AgentSpecialPanel } from "./agent-special-panels-state";
@@ -22,7 +24,10 @@ interface AgentSidebarProps {
   reasoningEffort?: ReasoningEffort;
   agentKey?: string;
   inputValue: string;
+  attachments: PendingAgentImageAttachment[];
   onClearInput: () => void;
+  onClearAttachments: () => void;
+  onRestoreAttachments?: (attachments: AgentImageAttachment[]) => void;
   onSetInputValue?: (value: string) => void;
   onOpenMentionChapter?: (chapterId: string, chapterTitle: string) => void;
   onTokenUsage?: (sessionId: string, usage: TokenUsageState) => void;
@@ -55,7 +60,10 @@ export function useAgentSidebar({
   reasoningEffort,
   agentKey,
   inputValue,
+  attachments,
   onClearInput,
+  onClearAttachments,
+  onRestoreAttachments,
   onSetInputValue,
   onOpenMentionChapter,
   onTokenUsage,
@@ -116,7 +124,7 @@ export function useAgentSidebar({
       toast.error(i18n.t("writing.aiSidebar.cannotSendPendingMessage"));
       return;
     }
-    if (!inputValue.trim()) return;
+    if (!inputValue.trim() && attachments.length === 0) return;
     if (!modelId) {
       toast.error(i18n.t("writing.aiSidebar.noModelSelected"));
       return;
@@ -124,13 +132,14 @@ export function useAgentSidebar({
 
     const messageToSend = inputValue;
     onClearInput();
+    onClearAttachments();
 
     if (agentSessionId) {
-      await sendAgentMessage(messageToSend);
+      await sendAgentMessage(messageToSend, attachments);
       return;
     }
 
-    await startAgentSession(messageToSend);
+    await startAgentSession(messageToSend, attachments);
   }, [
     inputValue,
     agentStatus,
@@ -140,6 +149,8 @@ export function useAgentSidebar({
     sendAgentMessage,
     startAgentSession,
     pendingMessage,
+    attachments,
+    onClearAttachments,
   ]);
 
   const handleCancelPendingMessage = useCallback(async (): Promise<void> => {
@@ -152,12 +163,13 @@ export function useAgentSidebar({
   const handleRollback = useCallback(
     async (messageId: string): Promise<string | null> => {
       const result = await rollbackAgentRevision(messageId);
-      if (result && onSetInputValue) {
-        onSetInputValue(result);
+      if (result) {
+        onSetInputValue?.(result.content);
+        onRestoreAttachments?.(result.attachments);
       }
-      return result;
+      return result?.content ?? null;
     },
-    [rollbackAgentRevision, onSetInputValue],
+    [rollbackAgentRevision, onRestoreAttachments, onSetInputValue],
   );
 
   const handleFork = useCallback(

--- a/frontend/src/features/assistant/components/agent/message-blocks/messages/user/user-request-message.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/messages/user/user-request-message.tsx
@@ -1,6 +1,10 @@
 import { ChevronDown } from "lucide-react";
 import { motion } from "motion/react";
 import { useCallback, useLayoutEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { PhotoProvider, PhotoView } from "react-photo-view";
+
+import "react-photo-view/dist/react-photo-view.css";
 
 import type { AgentMessage } from "@/lib/agent.types";
 
@@ -29,6 +33,7 @@ interface UserMessageMeasurements {
 }
 
 export function UserRequestMessage({ message, onOpenMentionChapter }: UserRequestMessageProps) {
+  const { t } = useTranslation();
   const [isExpanded, setIsExpanded] = useState(false);
   const [isPointerInside, setIsPointerInside] = useState(false);
   const [suppressCollapsedOverlay, setSuppressCollapsedOverlay] = useState(false);
@@ -100,10 +105,6 @@ export function UserRequestMessage({ message, onOpenMentionChapter }: UserReques
     setIsPointerInside(false);
   }, []);
 
-  const handleImageClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
-    event.stopPropagation();
-  };
-
   return (
     <UserMessageShell>
       <MessageCardShell
@@ -121,22 +122,30 @@ export function UserRequestMessage({ message, onOpenMentionChapter }: UserReques
         aria-expanded={isClamped ? isExpanded : undefined}
       >
         {message.attachments?.length ? (
-          <div className="agent-user-message-images">
-            {message.attachments.map((attachment) => (
-              <a
-                key={attachment.id}
-                href={attachment.url}
-                target="_blank"
-                rel="noreferrer"
-                onClick={handleImageClick}
-              >
-                <img
+          <PhotoProvider>
+            <div className="agent-user-message-images">
+              {message.attachments.map((attachment) => (
+                <PhotoView
+                  key={attachment.id}
                   src={attachment.url}
-                  alt={attachment.fileName || "用户上传图片"}
-                />
-              </a>
-            ))}
-          </div>
+                >
+                  <button
+                    type="button"
+                    className="agent-image-preview-trigger"
+                    aria-label={t("writing.aiSidebar.viewImage", {
+                      fileName: attachment.fileName,
+                    })}
+                    onClick={(event) => event.stopPropagation()}
+                  >
+                    <img
+                      src={attachment.url}
+                      alt={attachment.fileName || t("writing.aiSidebar.userUploadedImage")}
+                    />
+                  </button>
+                </PhotoView>
+              ))}
+            </div>
+          </PhotoProvider>
         ) : null}
         <motion.div
           className="agent-user-message-content-viewport"

--- a/frontend/src/features/assistant/components/agent/message-blocks/messages/user/user-request-message.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/messages/user/user-request-message.tsx
@@ -100,6 +100,10 @@ export function UserRequestMessage({ message, onOpenMentionChapter }: UserReques
     setIsPointerInside(false);
   }, []);
 
+  const handleImageClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    event.stopPropagation();
+  };
+
   return (
     <UserMessageShell>
       <MessageCardShell
@@ -116,6 +120,24 @@ export function UserRequestMessage({ message, onOpenMentionChapter }: UserReques
         tabIndex={canToggle ? 0 : undefined}
         aria-expanded={isClamped ? isExpanded : undefined}
       >
+        {message.attachments?.length ? (
+          <div className="agent-user-message-images">
+            {message.attachments.map((attachment) => (
+              <a
+                key={attachment.id}
+                href={attachment.url}
+                target="_blank"
+                rel="noreferrer"
+                onClick={handleImageClick}
+              >
+                <img
+                  src={attachment.url}
+                  alt={attachment.fileName || "用户上传图片"}
+                />
+              </a>
+            ))}
+          </div>
+        ) : null}
         <motion.div
           className="agent-user-message-content-viewport"
           initial={false}

--- a/frontend/src/features/assistant/components/assistant-sidebar.css
+++ b/frontend/src/features/assistant/components/assistant-sidebar.css
@@ -267,6 +267,71 @@
   padding: 12px;
 }
 
+.ai-sidebar-input-container[data-dragging-images="true"] {
+  outline: 1px dashed var(--accent-8);
+  outline-offset: 3px;
+}
+
+.agent-image-attachment-input {
+  display: none;
+}
+
+.agent-image-attachment-strip,
+.agent-user-message-images {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.agent-image-attachment-strip {
+  padding: 2px 2px 8px;
+}
+
+.agent-image-attachment-preview {
+  position: relative;
+  width: 52px;
+  height: 52px;
+  overflow: hidden;
+  border: 1px solid var(--gray-6);
+  border-radius: 6px;
+  background: var(--gray-3);
+}
+
+.agent-image-attachment-preview img,
+.agent-user-message-images img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.agent-image-attachment-preview button {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  display: grid;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  color: white;
+  background: rgba(0, 0, 0, 0.64);
+  border: 0;
+  border-radius: 50%;
+  cursor: pointer;
+  place-items: center;
+}
+
+.agent-user-message-images {
+  margin-bottom: 8px;
+}
+
+.agent-user-message-images a {
+  display: block;
+  width: 96px;
+  height: 96px;
+  overflow: hidden;
+  border-radius: 6px;
+}
+
 .ai-sidebar-model-selector {
   border-radius: 999px;
   align-self: stretch;

--- a/frontend/src/features/assistant/components/assistant-sidebar.css
+++ b/frontend/src/features/assistant/components/assistant-sidebar.css
@@ -267,13 +267,37 @@
   padding: 12px;
 }
 
-.ai-sidebar-input-container[data-dragging-images="true"] {
-  outline: 1px dashed var(--accent-8);
-  outline-offset: 3px;
+.ai-sidebar-input-container {
+  position: relative;
 }
 
-.agent-image-attachment-input {
-  display: none;
+.agent-image-drop-overlay {
+  position: absolute;
+  z-index: 2;
+  inset: -4px;
+  display: grid;
+  pointer-events: none;
+  color: var(--accent-11);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  text-align: center;
+  background: color-mix(in srgb, var(--color-panel-solid) 82%, transparent);
+  border: 1px dashed var(--accent-8);
+  border-radius: 10px;
+  opacity: 0;
+  place-items: center;
+  transition: opacity 120ms ease-out;
+}
+
+.agent-image-drop-overlay-content {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.ai-sidebar-input-container[data-dragging-images="true"] .agent-image-drop-overlay {
+  opacity: 1;
 }
 
 .agent-image-attachment-strip,
@@ -284,10 +308,11 @@
 }
 
 .agent-image-attachment-strip {
-  padding: 2px 2px 8px;
+  padding: 4px 4px 0px;
 }
 
-.agent-image-attachment-preview {
+.agent-image-attachment-preview,
+.agent-user-message-images .agent-image-preview-trigger {
   position: relative;
   width: 52px;
   height: 52px;
@@ -304,7 +329,19 @@
   object-fit: cover;
 }
 
-.agent-image-attachment-preview button {
+.agent-image-preview-trigger {
+  display: block;
+  width: 100%;
+  height: 100%;
+  padding: 0;
+  overflow: hidden;
+  cursor: zoom-in;
+  background: transparent;
+  border: 0;
+  border-radius: inherit;
+}
+
+.agent-image-attachment-remove {
   position: absolute;
   top: 2px;
   right: 2px;
@@ -317,19 +354,24 @@
   border: 0;
   border-radius: 50%;
   cursor: pointer;
+  opacity: 0;
+  transition: opacity 120ms ease;
   place-items: center;
+}
+
+.agent-image-attachment-preview:hover .agent-image-attachment-remove,
+.agent-image-attachment-preview:focus-within .agent-image-attachment-remove {
+  opacity: 1;
+}
+
+@media (hover: none) {
+  .agent-image-attachment-remove {
+    opacity: 1;
+  }
 }
 
 .agent-user-message-images {
   margin-bottom: 8px;
-}
-
-.agent-user-message-images a {
-  display: block;
-  width: 96px;
-  height: 96px;
-  overflow: hidden;
-  border-radius: 6px;
 }
 
 .ai-sidebar-model-selector {

--- a/frontend/src/features/assistant/components/assistant-sidebar.tsx
+++ b/frontend/src/features/assistant/components/assistant-sidebar.tsx
@@ -51,6 +51,10 @@ import "./assistant-sidebar.css";
 
 import { useSubagentSession } from "../hooks/use-subagent-session";
 import { useTasks, useUpdateTask } from "../hooks/use-tasks";
+import {
+  createRestoredPendingAgentAttachments,
+  type PendingAgentImageAttachment,
+} from "../lib/agent-image-attachments";
 import { loadAgentTaskBundle } from "../lib/agent-task-bundle";
 import {
   createConversationStackState,
@@ -255,6 +259,7 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
     );
     const [activeSubagents, setActiveSubagents] = useState<ActiveSubagentState[]>([]);
     const [inputValue, setInputValue] = useState("");
+    const [pendingAttachments, setPendingAttachments] = useState<PendingAgentImageAttachment[]>([]);
     const [view, setView] = useState<AssistantView>("tasks");
     const [isLoadingTask, setIsLoadingTask] = useState(false);
     const [currentTaskTitle, setCurrentTaskTitle] = useState<string>("");
@@ -566,7 +571,22 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
       reasoningEffort,
       agentKey: effectiveAgentKey,
       inputValue,
+      attachments: pendingAttachments,
       onClearInput: () => setInputValue(""),
+      onClearAttachments: () => {
+        pendingAttachments.forEach((attachment) => {
+          if (attachment.file) URL.revokeObjectURL(attachment.previewUrl);
+        });
+        setPendingAttachments([]);
+      },
+      onRestoreAttachments: (attachments) => {
+        setPendingAttachments((current) => {
+          current.forEach((attachment) => {
+            if (attachment.file) URL.revokeObjectURL(attachment.previewUrl);
+          });
+          return createRestoredPendingAgentAttachments(attachments);
+        });
+      },
       onSetInputValue: (value) => setInputValue(value),
       onOpenMentionChapter,
       onTokenUsage: handleConversationTokenUsage,
@@ -1020,7 +1040,7 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
     }, [inputValue, agentSidebar]);
 
     const handleSend = useCallback(() => {
-      if (!inputValue.trim()) return;
+      if (!inputValue.trim() && pendingAttachments.length === 0) return;
       if (!hasIncompleteContextSummaries) {
         performSend();
         return;
@@ -1028,7 +1048,7 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
 
       pendingSendActionRef.current = performSend;
       setSummaryWarningOpen(true);
-    }, [hasIncompleteContextSummaries, inputValue, performSend]);
+    }, [hasIncompleteContextSummaries, inputValue, pendingAttachments.length, performSend]);
 
     const handleConfirmSummaryWarning = useCallback(() => {
       setSummaryWarningOpen(false);
@@ -1535,6 +1555,7 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
                 )
               }
               value={inputValue}
+              attachments={pendingAttachments}
               projectId={projectId}
               modelId={effectiveModelId}
               models={llmModelOptions}
@@ -1545,6 +1566,17 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
               isModelsLoading={isModelsLoading}
               modelsError={!!modelsError}
               onChange={setInputValue}
+              onAttachmentsChange={setPendingAttachments}
+              onUploadAttachments={async (files) => {
+                setPendingAttachments((current) => [
+                  ...current,
+                  ...files.map((file) => ({
+                    id: crypto.randomUUID(),
+                    file,
+                    previewUrl: URL.createObjectURL(file),
+                  })),
+                ]);
+              }}
               onSend={isViewingSubagent ? () => undefined : handleSend}
               onAbort={isViewingSubagent ? () => undefined : handleAbort}
               onCancelPendingMessage={

--- a/frontend/src/features/assistant/hooks/use-agent-session.ts
+++ b/frontend/src/features/assistant/hooks/use-agent-session.ts
@@ -14,6 +14,7 @@ import { invalidateWritingEditorEntityQueries } from "@/features/writing/hooks/u
 import { useTabsStore } from "@/features/writing/store/use-tabs-store";
 import i18n from "@/i18n";
 import type {
+  AgentImageAttachment,
   AgentMessage,
   AgentPendingMessage,
   AgentSessionCreateResponse,
@@ -32,6 +33,7 @@ import {
   submitAgentQuestionAnswer,
   rollbackAgentRevision,
   cancelAgentSession,
+  uploadAgentImageAttachment,
   submitAgentToolApproval,
 } from "@/lib/api-client";
 import type { CharacterListResponse } from "@/lib/character.types";
@@ -90,6 +92,11 @@ function createOptimisticUserMessage(content: string): AgentMessage {
     content,
     isDraft: true,
   };
+}
+
+interface RollbackInputRestore {
+  content: string;
+  attachments: AgentImageAttachment[];
 }
 
 function hasApprovalMessage(messages: AgentMessage[]): boolean {
@@ -668,7 +675,10 @@ export function useAgentSession({
   }, [agentKey, attachAgentSocket, commitTranscriptState, sessionId]);
 
   const startSession = useCallback(
-    async (userRequest: string) => {
+    async (
+      userRequest: string,
+      attachments?: Array<{ file?: File; uploadedAttachment?: AgentImageAttachment }>,
+    ) => {
       if (!modelId) {
         toast.error(i18n.t("writing.aiSidebar.noModelSelected"));
         return;
@@ -701,7 +711,23 @@ export function useAgentSession({
         attachAgentSocket(createResponse.session_id);
         await joinAgentSession(createResponse.session_id);
         if (projectIdRef.current !== projectId) return;
-        await sendAgentMessage(createResponse.session_id, userRequest);
+        const uploadedAttachments = attachments?.length
+          ? await Promise.all(
+              attachments.flatMap((attachment) =>
+                attachment.file
+                  ? [uploadAgentImageAttachment(createResponse.session_id, attachment.file)]
+                  : [],
+              ),
+            )
+          : undefined;
+        await sendAgentMessage(
+          createResponse.session_id,
+          userRequest,
+          undefined,
+          undefined,
+          undefined,
+          uploadedAttachments,
+        );
       } catch (error) {
         if (projectIdRef.current !== projectId) return;
         console.error("Failed to start agent session:", error);
@@ -729,7 +755,10 @@ export function useAgentSession({
   );
 
   const sendMessage = useCallback(
-    async (message: string) => {
+    async (
+      message: string,
+      attachments?: Array<{ file?: File; uploadedAttachment?: AgentImageAttachment }>,
+    ) => {
       const activeSessionId = sessionIdRef.current ?? sessionId;
       if (!activeSessionId) {
         toast.error(i18n.t("assistant.sessionNotFound"));
@@ -755,6 +784,19 @@ export function useAgentSession({
           attachAgentSocket(activeSessionId);
         }
         await joinAgentSession(activeSessionId);
+        const uploadedAttachments = attachments?.length
+          ? await Promise.all(
+              attachments.flatMap((attachment) =>
+                attachment.file
+                  ? [uploadAgentImageAttachment(activeSessionId, attachment.file)]
+                  : [],
+              ),
+            )
+          : undefined;
+        const existingAttachments = attachments?.flatMap((attachment) =>
+          attachment.uploadedAttachment ? [attachment.uploadedAttachment] : [],
+        );
+        const messageAttachments = [...(existingAttachments ?? []), ...(uploadedAttachments ?? [])];
         const nextModelId = modelId === activeModelIdRef.current ? undefined : modelId;
         const response = await sendAgentMessage(
           activeSessionId,
@@ -762,6 +804,7 @@ export function useAgentSession({
           nextModelId,
           reasoningEffort,
           agentKey,
+          messageAttachments.length > 0 ? messageAttachments : undefined,
         );
         if (response.model_updated && nextModelId) activeModelIdRef.current = nextModelId;
         if (response.queued && response.pending_message) {
@@ -1099,7 +1142,7 @@ export function useAgentSession({
   }, [sessionId, syncPendingMessageState]);
 
   const rollbackToRevision = useCallback(
-    async (messageId: string): Promise<string | null> => {
+    async (messageId: string): Promise<RollbackInputRestore | null> => {
       if (!sessionId || isRollbacking || isRunning || isCompactingRef.current) {
         toast.error(i18n.t("assistant.rollbackImpossible"));
         return null;
@@ -1137,7 +1180,10 @@ export function useAgentSession({
 
           toast.success(i18n.t("assistant.rollbackSuccess"));
 
-          return result.restored_message_content;
+          return {
+            content: result.restored_message_content,
+            attachments: result.restored_attachments,
+          };
         } else {
           toast.error(i18n.t("assistant.rollbackFailed"));
           return null;

--- a/frontend/src/features/assistant/lib/agent-image-attachments.ts
+++ b/frontend/src/features/assistant/lib/agent-image-attachments.ts
@@ -1,3 +1,4 @@
+import i18n from "@/i18n";
 import type { AgentImageAttachment } from "@/lib/agent.types";
 
 export const MAX_AGENT_IMAGE_ATTACHMENTS = 20;
@@ -42,13 +43,15 @@ export function hasLeftAgentImageDropZone(
 
 export function validateAgentImageFiles(files: File[], existingCount: number): string | null {
   if (existingCount + files.length > MAX_AGENT_IMAGE_ATTACHMENTS) {
-    return `单条消息最多添加 ${MAX_AGENT_IMAGE_ATTACHMENTS} 张图片`;
+    return i18n.t("writing.aiSidebar.imageAttachmentLimit", {
+      count: MAX_AGENT_IMAGE_ATTACHMENTS,
+    });
   }
   for (const file of files) {
     if (!SUPPORTED_AGENT_IMAGE_TYPES.has(file.type)) {
-      return "仅支持 PNG、JPEG 或 WebP 图片";
+      return i18n.t("writing.aiSidebar.unsupportedImageType");
     }
-    if (file.size > MAX_AGENT_IMAGE_BYTES) return "单张图片不能超过 10 MB";
+    if (file.size > MAX_AGENT_IMAGE_BYTES) return i18n.t("writing.aiSidebar.imageTooLarge");
   }
   return null;
 }

--- a/frontend/src/features/assistant/lib/agent-image-attachments.ts
+++ b/frontend/src/features/assistant/lib/agent-image-attachments.ts
@@ -1,0 +1,99 @@
+import type { AgentImageAttachment } from "@/lib/agent.types";
+
+export const MAX_AGENT_IMAGE_ATTACHMENTS = 20;
+export const MAX_AGENT_IMAGE_BYTES = 10 * 1024 * 1024;
+
+const SUPPORTED_AGENT_IMAGE_TYPES = new Set(["image/jpeg", "image/png", "image/webp"]);
+
+export interface PendingAgentImageAttachment {
+  id: string;
+  file?: File;
+  uploadedAttachment?: AgentImageAttachment;
+  previewUrl: string;
+}
+
+export function createRestoredPendingAgentAttachments(
+  attachments: AgentImageAttachment[],
+): PendingAgentImageAttachment[] {
+  return attachments.map((attachment) => ({
+    id: attachment.id,
+    previewUrl: attachment.url,
+    uploadedAttachment: attachment,
+  }));
+}
+
+export function getAgentImageFiles(dataTransfer: DataTransfer): File[] {
+  const files = Array.from(dataTransfer.files);
+  if (files.length > 0) return files;
+
+  return Array.from(dataTransfer.items).flatMap((item) => {
+    if (item.kind !== "file") return [];
+    const file = item.getAsFile();
+    return file ? [file] : [];
+  });
+}
+
+export function hasLeftAgentImageDropZone(
+  relatedTarget: EventTarget | null,
+  contains: (target: Node) => boolean,
+): boolean {
+  return relatedTarget === null || !contains(relatedTarget as Node);
+}
+
+export function validateAgentImageFiles(files: File[], existingCount: number): string | null {
+  if (existingCount + files.length > MAX_AGENT_IMAGE_ATTACHMENTS) {
+    return `单条消息最多添加 ${MAX_AGENT_IMAGE_ATTACHMENTS} 张图片`;
+  }
+  for (const file of files) {
+    if (!SUPPORTED_AGENT_IMAGE_TYPES.has(file.type)) {
+      return "仅支持 PNG、JPEG 或 WebP 图片";
+    }
+    if (file.size > MAX_AGENT_IMAGE_BYTES) return "单张图片不能超过 10 MB";
+  }
+  return null;
+}
+
+export function modelAllowsAgentImages(
+  inputModalities: string[] | undefined,
+  isCatalogMatched: boolean,
+): boolean {
+  if (!isCatalogMatched) return true;
+  return inputModalities?.some((modality) => modality.toLowerCase() === "image") ?? false;
+}
+
+export function isAgentImageAttachment(value: unknown): value is AgentImageAttachment {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const attachment = value as Record<string, unknown>;
+  return (
+    typeof attachment.id === "string" &&
+    typeof attachment.url === "string" &&
+    typeof attachment.mime_type === "string"
+  );
+}
+
+export function normalizeAgentImageAttachments(value: unknown): AgentImageAttachment[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (!item || typeof item !== "object" || Array.isArray(item)) return [];
+    const attachment = item as Record<string, unknown>;
+    if (
+      typeof attachment.id !== "string" ||
+      typeof attachment.url !== "string" ||
+      typeof attachment.mime_type !== "string"
+    )
+      return [];
+    return [
+      {
+        id: attachment.id,
+        sessionId: typeof attachment.session_id === "string" ? attachment.session_id : "",
+        storageName: typeof attachment.storage_name === "string" ? attachment.storage_name : "",
+        fileName: typeof attachment.file_name === "string" ? attachment.file_name : "",
+        mimeType: attachment.mime_type as AgentImageAttachment["mimeType"],
+        sizeBytes: typeof attachment.size_bytes === "number" ? attachment.size_bytes : 0,
+        width: typeof attachment.width === "number" ? attachment.width : 0,
+        height: typeof attachment.height === "number" ? attachment.height : 0,
+        url: attachment.url,
+      },
+    ];
+  });
+}

--- a/frontend/src/features/assistant/lib/agent-transcript-state.ts
+++ b/frontend/src/features/assistant/lib/agent-transcript-state.ts
@@ -6,6 +6,7 @@ import {
   stopStreamingReasoningForAgentEvent,
   stopStreamingToolMessages,
 } from "../hooks/use-agent-session-message-state";
+import { normalizeAgentImageAttachments } from "./agent-image-attachments";
 import { parseUtcTimestamp } from "./date-utils";
 import { clearRetryMessages, upsertRetryMessage } from "./retry-message-state";
 import { mergeStreamingMessage } from "./streaming-message-merge";
@@ -403,6 +404,7 @@ function normalizeTranscriptEvent(event: AgentEvent): AgentMessage | null {
     correlationId: event.correlation_id,
     timestamp,
     content: event.content,
+    attachments: normalizeAgentImageAttachments(payload.attachments),
     agent: (event.agent as AgentMessage["agent"]) || undefined,
     revisionId: event.revision_id,
     isCheckpoint: event.is_checkpoint ?? event.isCheckpoint,

--- a/frontend/src/features/assistant/lib/task-message-agent-mapping.ts
+++ b/frontend/src/features/assistant/lib/task-message-agent-mapping.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "@/lib/agent.types";
 import type { TaskListItem, TaskMessage } from "@/lib/task.types";
 
+import { normalizeAgentImageAttachments } from "./agent-image-attachments";
 import { parseUtcTimestamp } from "./date-utils";
 import { isRecord, normalizeToolResult } from "./tool-result-normalization";
 
@@ -225,6 +226,7 @@ export function buildAgentMessagesFromTaskMessages(
           correlationId: msg.correlationId,
           timestamp,
           content,
+          attachments: normalizeAgentImageAttachments(payload.attachments),
           agent: msg.agentId as AgentMessage["agent"],
         });
         return;
@@ -241,6 +243,7 @@ export function buildAgentMessagesFromTaskMessages(
           correlationId: msg.correlationId,
           timestamp: msg.role === "assistant" ? assistantTimestamp : timestamp,
           content,
+          attachments: normalizeAgentImageAttachments(payload.attachments),
           revisionId,
           isCheckpoint: Boolean(revisionId),
         });
@@ -369,6 +372,7 @@ export function buildAgentMessagesFromTaskMessages(
         correlationId: msg.correlationId,
         timestamp,
         content,
+        attachments: normalizeAgentImageAttachments(payload.attachments),
         revisionId,
         isCheckpoint: Boolean(revisionId),
       });

--- a/frontend/src/features/dashboard/components/dashboard-records-tab.tsx
+++ b/frontend/src/features/dashboard/components/dashboard-records-tab.tsx
@@ -24,7 +24,6 @@ import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { PromptChainDialog, Spinner } from "@/components";
-import type { PromptChainDialogEntry } from "@/components";
 import { fetchAgentDefinitions } from "@/features/settings/lib/agent-definitions-api";
 import { fetchSettings } from "@/features/settings/lib/settings-api";
 
@@ -37,6 +36,7 @@ import {
   getOperationLabel,
   getStatusLabel,
 } from "../lib/dashboard-formatters";
+import { getPromptEntries } from "../lib/dashboard-prompt-content";
 import type {
   DashboardAuditRecord,
   DashboardQueryParams,
@@ -83,34 +83,6 @@ function stringifyContent(value: unknown): string {
   }
   if (value === null || value === undefined) return "";
   return JSON.stringify(value, null, 2);
-}
-
-function getPromptEntries(requestMessages: string | null | undefined): PromptChainDialogEntry[] {
-  const parsed = parseJson(requestMessages ?? null);
-  if (!Array.isArray(parsed)) return [];
-
-  return parsed.map((item, index) => {
-    if (!isRecord(item)) {
-      return {
-        role: "unknown",
-        content: stringifyContent(item),
-        name: `#${index + 1}`,
-      };
-    }
-
-    const role = typeof item.role === "string" ? item.role : "unknown";
-    const content = stringifyContent(item.content);
-    const toolCalls =
-      Array.isArray(item.tool_calls) && item.tool_calls.length > 0
-        ? `\n\nTool calls:\n${JSON.stringify(item.tool_calls, null, 2)}`
-        : "";
-
-    return {
-      role,
-      content: `${content}${toolCalls}`,
-      name: `#${index + 1}`,
-    };
-  });
 }
 
 interface ToolCallEntry {

--- a/frontend/src/features/dashboard/lib/dashboard-prompt-content.ts
+++ b/frontend/src/features/dashboard/lib/dashboard-prompt-content.ts
@@ -1,0 +1,116 @@
+import type { PromptChainDialogEntry } from "@/components";
+
+function parseJson(value: string | null | undefined): unknown {
+  if (!value) return null;
+
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return value;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringifyContent(value: unknown): string {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (
+      (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+      (trimmed.startsWith("[") && trimmed.endsWith("]"))
+    ) {
+      try {
+        return JSON.stringify(JSON.parse(trimmed), null, 2);
+      } catch {
+        return value;
+      }
+    }
+    return value;
+  }
+  if (value === null || value === undefined) return "";
+  return JSON.stringify(value, null, 2);
+}
+
+function getImageDataUrl(block: Record<string, unknown>): string | null {
+  if (block.type === "image") {
+    const base64 = block.base64;
+    const mimeType = block.mime_type;
+    if (
+      typeof base64 === "string" &&
+      typeof mimeType === "string" &&
+      mimeType.startsWith("image/")
+    ) {
+      return `data:${mimeType};base64,${base64}`;
+    }
+  }
+
+  if (block.type === "image_url" && isRecord(block.image_url)) {
+    const url = block.image_url.url;
+    if (typeof url === "string" && url.startsWith("data:image/")) return url;
+  }
+
+  return null;
+}
+
+function getMultimodalContent(
+  content: unknown[],
+): Pick<PromptChainDialogEntry, "content" | "imageUrls"> {
+  const textParts: string[] = [];
+  const imageUrls: string[] = [];
+
+  for (const part of content) {
+    if (!isRecord(part)) {
+      textParts.push(stringifyContent(part));
+      continue;
+    }
+
+    if (part.type === "text" && typeof part.text === "string") {
+      textParts.push(part.text);
+      continue;
+    }
+
+    const imageUrl = getImageDataUrl(part);
+    if (imageUrl) {
+      imageUrls.push(imageUrl);
+      continue;
+    }
+
+    textParts.push(stringifyContent(part));
+  }
+
+  return { content: textParts.join("\n"), imageUrls };
+}
+
+export function getPromptEntries(
+  requestMessages: string | null | undefined,
+): PromptChainDialogEntry[] {
+  const parsed = parseJson(requestMessages);
+  if (!Array.isArray(parsed)) return [];
+
+  return parsed.map((item, index) => {
+    if (!isRecord(item)) {
+      return {
+        role: "unknown",
+        content: stringifyContent(item),
+        name: `#${index + 1}`,
+      };
+    }
+
+    const multimodalContent = Array.isArray(item.content)
+      ? getMultimodalContent(item.content)
+      : { content: stringifyContent(item.content), imageUrls: [] };
+    const toolCalls =
+      Array.isArray(item.tool_calls) && item.tool_calls.length > 0
+        ? `\n\nTool calls:\n${JSON.stringify(item.tool_calls, null, 2)}`
+        : "";
+
+    return {
+      role: typeof item.role === "string" ? item.role : "unknown",
+      content: `${multimodalContent.content}${toolCalls}`,
+      imageUrls: multimodalContent.imageUrls,
+      name: `#${index + 1}`,
+    };
+  });
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -322,6 +322,15 @@
       "attachmentDisabled": "Attachment coming soon",
       "webSearchDisabled": "Web search coming soon",
       "imageDisabled": "Image coming soon",
+      "modelImageInputUnsupported": "The current model does not support image input",
+      "imageAttachmentLimit": "A message can contain up to {{count}} images",
+      "unsupportedImageType": "Only PNG, JPEG, and WebP images are supported",
+      "imageTooLarge": "Each image must not exceed 10 MB",
+      "dropImageAttachments": "Drop here to add attachments",
+      "imageFallbackAlt": "Image",
+      "userUploadedImage": "User-uploaded image",
+      "viewImage": "View image {{fileName}}",
+      "removeImage": "Remove image {{fileName}}",
       "recentTasks": "Recent tasks",
       "viewAll": "View all",
       "noTasks": "No conversations yet",
@@ -1167,7 +1176,10 @@
     "summary": "{{count}} messages, about {{tokens}} tokens",
     "searchPlaceholder": "Search prompt content",
     "loading": "Loading prompt chain",
-    "emptyContent": "Empty content"
+    "emptyContent": "Empty content",
+    "imageAttachments": "Image attachments",
+    "viewImage": "View image #{{index}}",
+    "imageAlt": "Image attachment #{{index}}"
   },
   "dashboard": {
     "title": "Dashboard",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -322,6 +322,15 @@
       "attachmentDisabled": "附件功能即将推出",
       "webSearchDisabled": "联网功能即将推出",
       "imageDisabled": "图片功能即将推出",
+      "modelImageInputUnsupported": "当前模型不支持图片输入",
+      "imageAttachmentLimit": "单条消息最多添加 {{count}} 张图片",
+      "unsupportedImageType": "仅支持 PNG、JPEG 或 WebP 图片",
+      "imageTooLarge": "单张图片不能超过 10 MB",
+      "dropImageAttachments": "拖拽至此以添加附件",
+      "imageFallbackAlt": "图片",
+      "userUploadedImage": "用户上传图片",
+      "viewImage": "查看图片 {{fileName}}",
+      "removeImage": "移除图片 {{fileName}}",
       "recentTasks": "最近任务",
       "viewAll": "查看全部",
       "noTasks": "还没有任何会话记录",
@@ -1230,7 +1239,10 @@
     "summary": "共 {{count}} 条消息，约 {{tokens}} tokens",
     "searchPlaceholder": "搜索提示词内容",
     "loading": "正在载入提示词",
-    "emptyContent": "空内容"
+    "emptyContent": "空内容",
+    "imageAttachments": "图片附件",
+    "viewImage": "查看图片 #{{index}}",
+    "imageAlt": "图片附件 #{{index}}"
   },
   "dashboard": {
     "title": "仪表盘",

--- a/frontend/src/lib/agent.types.ts
+++ b/frontend/src/lib/agent.types.ts
@@ -174,6 +174,7 @@ export interface AgentMessage {
   isCheckpoint?: boolean;
 
   content?: string;
+  attachments?: AgentImageAttachment[];
   agent?: AgentType;
   isDraft?: boolean;
 
@@ -258,9 +259,22 @@ export interface AgentSessionStateResponse {
 
 export interface AgentSendMessageRequest {
   message: string;
+  attachments?: string[];
   model_id?: string;
   agent_key?: string;
   reasoning_effort?: ReasoningEffort;
+}
+
+export interface AgentImageAttachment {
+  id: string;
+  sessionId: string;
+  storageName: string;
+  fileName: string;
+  mimeType: "image/jpeg" | "image/png" | "image/webp";
+  sizeBytes: number;
+  width: number;
+  height: number;
+  url: string;
 }
 
 export type ReasoningEffort = "off" | "low" | "medium" | "high" | "xhigh" | "max";
@@ -351,6 +365,7 @@ export interface AgentRollbackResponse {
   affected_note_categories: string[];
   affected_world_entries: string[];
   restored_message_content: string;
+  restored_attachments: AgentImageAttachment[];
 }
 
 export interface AgentCancelResponse {

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -2168,6 +2168,7 @@ import type {
   AgentSessionCreateRequest,
   AgentSessionCreateResponse,
   AgentForkResponse,
+  AgentImageAttachment,
   AgentPendingMessage,
   AgentSendMessageRequest,
   AgentSendMessageResponse,
@@ -2286,12 +2287,14 @@ export async function sendAgentMessage(
   modelId?: string,
   reasoningEffort?: ReasoningEffort,
   agentKey?: string,
+  attachments?: AgentImageAttachment[],
 ): Promise<AgentSendMessageResponse> {
   const request: AgentSendMessageRequest = {
     message,
     ...(modelId ? { model_id: modelId } : {}),
     ...(reasoningEffort ? { reasoning_effort: reasoningEffort } : {}),
     ...(agentKey ? { agent_key: agentKey } : {}),
+    ...(attachments?.length ? { attachments: attachments.map((attachment) => attachment.id) } : {}),
   };
   const response = await apiClient.post(`/agent/sessions/${sessionId}/message`, request);
   const data = response.data as Record<string, unknown>;
@@ -2302,6 +2305,29 @@ export async function sendAgentMessage(
     queued: data.queued === true,
     model_updated: data.model_updated === true,
     pending_message: transformPendingAgentMessage(data.pending_message),
+  };
+}
+
+export async function uploadAgentImageAttachment(
+  sessionId: string,
+  image: File,
+): Promise<AgentImageAttachment> {
+  const formData = new FormData();
+  formData.append("image", image);
+  const response = await apiClient.post(`/agent/sessions/${sessionId}/attachments`, formData, {
+    headers: { "Content-Type": "multipart/form-data" },
+  });
+  const raw = response.data as Record<string, unknown>;
+  return {
+    id: String(raw.id ?? ""),
+    sessionId: String(raw.session_id ?? sessionId),
+    storageName: String(raw.storage_name ?? ""),
+    fileName: String(raw.file_name ?? ""),
+    mimeType: raw.mime_type as AgentImageAttachment["mimeType"],
+    sizeBytes: Number(raw.size_bytes ?? 0),
+    width: Number(raw.width ?? 0),
+    height: Number(raw.height ?? 0),
+    url: resolveBackendUrl(String(raw.url ?? "")) ?? "",
   };
 }
 
@@ -2341,7 +2367,49 @@ export async function rollbackAgentRevision(
   const response = await apiClient.post(`/agent/sessions/${sessionId}/rollback`, {
     revision_id: revisionId,
   });
-  return response.data;
+  const data = response.data as Record<string, unknown>;
+  return {
+    success: data.success === true,
+    session_id: String(data.session_id ?? sessionId),
+    revision_id: typeof data.revision_id === "string" ? data.revision_id : null,
+    affected_chapters: Array.isArray(data.affected_chapters)
+      ? data.affected_chapters.filter((item): item is string => typeof item === "string")
+      : [],
+    affected_notes: Array.isArray(data.affected_notes)
+      ? data.affected_notes.filter((item): item is string => typeof item === "string")
+      : [],
+    affected_note_categories: Array.isArray(data.affected_note_categories)
+      ? data.affected_note_categories.filter((item): item is string => typeof item === "string")
+      : [],
+    affected_world_entries: Array.isArray(data.affected_world_entries)
+      ? data.affected_world_entries.filter((item): item is string => typeof item === "string")
+      : [],
+    restored_message_content: String(data.restored_message_content ?? ""),
+    restored_attachments: Array.isArray(data.restored_attachments)
+      ? data.restored_attachments.flatMap((attachment) => {
+          if (!isRecord(attachment)) return [];
+          if (
+            typeof attachment.id !== "string" ||
+            typeof attachment.url !== "string" ||
+            typeof attachment.mime_type !== "string"
+          )
+            return [];
+          return [
+            {
+              id: attachment.id,
+              sessionId: String(attachment.session_id ?? sessionId),
+              storageName: String(attachment.storage_name ?? ""),
+              fileName: String(attachment.file_name ?? ""),
+              mimeType: attachment.mime_type as AgentImageAttachment["mimeType"],
+              sizeBytes: Number(attachment.size_bytes ?? 0),
+              width: Number(attachment.width ?? 0),
+              height: Number(attachment.height ?? 0),
+              url: resolveBackendUrl(attachment.url) ?? "",
+            },
+          ];
+        })
+      : [],
+  };
 }
 
 export async function forkAgentSession(

--- a/frontend/src/lib/use-llm-model-options.ts
+++ b/frontend/src/lib/use-llm-model-options.ts
@@ -88,7 +88,8 @@ export function useLlmModelOptions(): UseLlmModelOptionsResult {
         inputPricePerMillion: catalogModel?.inputPricePerMillion ?? null,
         outputPricePerMillion: catalogModel?.outputPricePerMillion ?? null,
         cacheReadPricePerMillion: catalogModel?.cacheReadPricePerMillion ?? null,
-        source: catalogModel?.source ?? "catalog",
+        source: catalogModel?.source ?? "remote",
+        isCatalogMatched: Boolean(catalogModel),
         providerIconPath,
       };
     });

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -65,6 +65,10 @@ export default defineConfig({
         target: "http://127.0.0.1:8000",
         changeOrigin: true,
       },
+      "/agent-attachments": {
+        target: "http://127.0.0.1:8000",
+        changeOrigin: true,
+      },
     },
   },
 });


### PR DESCRIPTION
## PR 标题

feat(agent): 支持用户消息图片附件输入

## 变更说明

- 问题: Agent 用户消息无法携带图片，图片上下文、历史恢复和查看路径缺失。
- 重要性: 视觉内容无法作为 Agent 输入，限制了图文协作和图片分析场景。
- 变化: 支持拖拽和粘贴 PNG、JPEG、WebP 图片，发送后将附件与文本一同传给模型，并支持消息历史、回滚恢复、分叉和上下文重建。
- 变化: 接入内置图片查看器、调用记录图片展示及模型能力校验；删除任务和启动时会清理失效附件文件与目录。

## 关联 Issue / PR (如有)

无

## 变更类型

- [x] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [x] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

原有 Agent 消息只支持文本，未建立图片附件的存储、消息传递、上下文恢复和清理链路。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无本次变更引入的报错
- [x] 已运行相关测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证记录：

- 前端：`pnpm format:check`、`pnpm type-check`、`pnpm lint`
- 后端相关测试：`uv run pytest tests/agent_runtime/persistence/test_loader.py tests/api/test_tasks.py tests/test_main.py tests/api/test_dashboard_writing.py tests/api/test_dashboard_llm.py -q`，48 passed
- 后端：`uv run ruff check app tests` 通过；本轮文件 `uv run ty check app/agent_runtime/attachments.py app/api/routers/tasks.py app/main.py` 通过
