### PR TITLE
fix(providers): 修复目录中部分提供商端点 URL 缺失的问题

### DIFF
--- a/backend/app/models/catalog/service.py
+++ b/backend/app/models/catalog/service.py
@@ -34,6 +34,21 @@ _CACHE_DIR = BACKEND_DATA_DIR / "model_provider_catalog"
 _MODELS_DEV_API_URL = "https://models.dev/api.json"
 _CATALOG_ICON_PATH_TEMPLATE = "/icons/model/catalog/{provider_id}.svg"
 _SNAPSHOT_SCHEMA_VERSION = 4
+_STATIC_PROVIDER_URLS: dict[str, str] = {
+    "anthropic": "https://api.anthropic.com",
+    "cerebras": "https://api.cerebras.ai/v1",
+    "cohere": "https://api.cohere.com/v2",
+    "deepinfra": "https://api.deepinfra.com/v1/openai",
+    "google-genai": "https://generativelanguage.googleapis.com",
+    "groq": "https://api.groq.com/openai/v1",
+    "mistral": "https://api.mistral.ai/v1",
+    "openai": "https://api.openai.com/v1",
+    "togetherai": "https://api.together.ai/v1",
+    "v0": "https://api.v0.dev/v1",
+    "venice": "https://api.venice.ai/api/v1",
+    "vercel": "https://ai-gateway.vercel.sh/v1",
+    "xai": "https://api.x.ai/v1",
+}
 
 _PROVIDER_DEFINITIONS: tuple[_ProviderDefinition, ...] = (
     _ProviderDefinition("openai", "openai"),
@@ -94,7 +109,7 @@ class ModelProviderCatalogService:
     async def list_providers(self) -> list[CatalogProviderSummary]:
         snapshot, _, _ = self._load_current_snapshot()
         providers = [
-            self._provider_summary_from_payload(provider)
+            self._provider_summary_from_payload(provider, resolve_static_url=True)
             for provider in snapshot.get("providers", [])
         ]
         return sorted(providers, key=lambda provider: provider.provider_type)
@@ -150,7 +165,13 @@ class ModelProviderCatalogService:
     async def refresh(self) -> None:
         try:
             raw_payload = await self._load_refresh_payload()
-            normalized_snapshot = self._build_normalized_snapshot(raw_payload)
+            normalized_snapshot = self._build_normalized_snapshot(
+                raw_payload,
+                {
+                    **self._bundled_provider_urls(),
+                    **_STATIC_PROVIDER_URLS,
+                },
+            )
             last_refreshed_at = datetime.now(UTC).isoformat()
             self._write_json_atomic(self.cache_snapshot_path, normalized_snapshot)
             self._write_json_atomic(
@@ -254,16 +275,21 @@ class ModelProviderCatalogService:
         return None
 
     def _provider_summary_from_payload(
-        self, provider_payload: dict[str, Any]
+        self,
+        provider_payload: dict[str, Any],
+        resolve_static_url: bool = False,
     ) -> CatalogProviderSummary:
         counts = dict(provider_payload.get("model_counts") or {})
         provider_type = str(provider_payload.get("provider_type") or "")
+        api_url = provider_payload.get("api") or provider_payload.get("default_url")
+        if resolve_static_url and (not isinstance(api_url, str) or not api_url.strip()):
+            api_url = _STATIC_PROVIDER_URLS.get(provider_type)
         models_dev_provider_id = provider_payload.get("models_dev_provider_id")
         return CatalogProviderSummary(
             provider_type=provider_type,
             display_name=str(provider_payload.get("display_name") or provider_type),
-            default_url=provider_payload.get("api"),
-            api=provider_payload.get("api"),
+            default_url=api_url,
+            api=api_url,
             icon_path=(
                 self._icon_path_for(str(models_dev_provider_id))
                 if models_dev_provider_id
@@ -274,8 +300,13 @@ class ModelProviderCatalogService:
             model_counts=counts,
         )
 
-    def _build_normalized_snapshot(self, raw_payload: dict[str, Any]) -> dict[str, Any]:
+    def _build_normalized_snapshot(
+        self,
+        raw_payload: dict[str, Any],
+        bundled_provider_urls: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
         providers: list[dict[str, Any]] = []
+        bundled_provider_urls = bundled_provider_urls or {}
 
         for raw_provider_key, raw_provider in sorted(raw_payload.items()):
             if not isinstance(raw_provider, dict):
@@ -289,6 +320,9 @@ class ModelProviderCatalogService:
                 else models_dev_provider_id
             )
             display_name = str(raw_provider.get("name") or provider_type)
+            api_url = raw_provider.get("api")
+            if not isinstance(api_url, str) or not api_url.strip():
+                api_url = bundled_provider_urls.get(provider_type)
             models_payload = raw_provider.get("models")
             if not isinstance(models_payload, dict):
                 models_payload = {}
@@ -305,8 +339,8 @@ class ModelProviderCatalogService:
             provider_payload = {
                 "provider_type": provider_type,
                 "display_name": display_name,
-                "default_url": raw_provider.get("api"),
-                "api": raw_provider.get("api"),
+                "default_url": api_url,
+                "api": api_url,
                 "icon_path": self._icon_path_for(models_dev_provider_id),
                 "models_dev_provider_id": models_dev_provider_id,
                 "supported_task_types": self._supported_task_types_for(
@@ -321,6 +355,20 @@ class ModelProviderCatalogService:
             "schema_version": _SNAPSHOT_SCHEMA_VERSION,
             "providers": providers,
         }
+
+    def _bundled_provider_urls(self) -> dict[str, str]:
+        bundled_snapshot = self._read_json(self.bundled_snapshot_path)
+        provider_urls: dict[str, str] = {}
+
+        for provider in bundled_snapshot.get("providers", []):
+            if not isinstance(provider, dict):
+                continue
+            provider_type = provider.get("provider_type")
+            api_url = provider.get("api") or provider.get("default_url")
+            if isinstance(provider_type, str) and isinstance(api_url, str) and api_url.strip():
+                provider_urls[provider_type] = api_url
+
+        return provider_urls
 
     def _normalize_model(self, model_id: str, raw_model: dict[str, Any]) -> dict[str, Any]:
         display_name = str(raw_model.get("name") or model_id)

--- a/backend/app/models/catalog/service.py
+++ b/backend/app/models/catalog/service.py
@@ -119,7 +119,7 @@ class ModelProviderCatalogService:
         provider = self._find_provider(snapshot, provider_type)
         if provider is None:
             raise KeyError(provider_type)
-        return self._provider_summary_from_payload(provider)
+        return self._provider_summary_from_payload(provider, resolve_static_url=True)
 
     async def get_provider_models(
         self, provider_type: str, task_type: str

--- a/backend/tests/api/test_model_providers.py
+++ b/backend/tests/api/test_model_providers.py
@@ -30,7 +30,7 @@ async def test_create_provider(client: AsyncClient, session: AsyncSession):
 
     data = response.json()
     assert data["name"] == "Test OpenAI"
-    assert data["url"] == "https://api.openai.com"
+    assert data["url"] == "https://api.openai.com/v1"
     assert data["provider_type"] == "openai"
     assert data["catalog_match"]["catalog_provider_type"] == "openai"
     assert data["catalog_match"]["matched_via"] == "provider_type"

--- a/backend/tests/models/test_model_provider_catalog_service.py
+++ b/backend/tests/models/test_model_provider_catalog_service.py
@@ -18,7 +18,7 @@ def _write_json(path: Path, payload: object) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
-def _sample_modelsdev_payload() -> dict[str, object]:
+def _sample_modelsdev_payload() -> dict[str, dict[str, object]]:
     return {
         "openai": {
             "id": "openai",
@@ -249,6 +249,113 @@ async def test_catalog_service_refreshes_cache_and_keeps_last_successful_cache_o
     openai_provider = await service.get_provider("openai")
     assert openai_provider.default_url == "https://api.openai.com/v1"
     assert openai_provider.model_counts == {"llm": 2, "embedding": 1, "rerank": 0}
+
+
+@pytest.mark.asyncio
+async def test_catalog_service_preserves_bundled_urls_when_refresh_payload_omits_them(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path)
+    expected_urls = {
+        provider.provider_type: provider.default_url
+        for provider in await service.list_providers()
+    }
+
+    source_payload = _sample_modelsdev_payload()
+    for provider in source_payload.values():
+        provider.pop("api")
+
+    assert service.source_snapshot_path is not None
+    _write_json(service.source_snapshot_path, source_payload)
+    await service.refresh()
+
+    refreshed_providers = await service.list_providers()
+    assert {
+        provider.provider_type: provider.default_url for provider in refreshed_providers
+    } == expected_urls
+    assert {provider.provider_type: provider.api for provider in refreshed_providers} == expected_urls
+
+
+@pytest.mark.asyncio
+async def test_catalog_service_fills_known_static_url_when_refresh_payload_omits_api(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path)
+    source_payload = {
+        "cerebras": {
+            "id": "cerebras",
+            "name": "Cerebras",
+            "models": {},
+        }
+    }
+
+    assert service.source_snapshot_path is not None
+    _write_json(service.source_snapshot_path, source_payload)
+    await service.refresh()
+
+    provider = next(
+        provider
+        for provider in await service.list_providers()
+        if provider.provider_type == "cerebras"
+    )
+    assert provider.default_url == "https://api.cerebras.ai/v1"
+    assert provider.api == "https://api.cerebras.ai/v1"
+
+
+@pytest.mark.asyncio
+async def test_catalog_service_fills_known_static_url_from_existing_cache(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path)
+    _write_json(
+        service.cache_snapshot_path,
+        {
+            "schema_version": 4,
+            "providers": [
+                {
+                    "provider_type": "cerebras",
+                    "display_name": "Cerebras",
+                    "default_url": None,
+                    "api": None,
+                    "icon_path": None,
+                    "models_dev_provider_id": "cerebras",
+                    "supported_task_types": ["llm"],
+                    "model_counts": {"llm": 0, "embedding": 0, "rerank": 0},
+                    "models": [],
+                }
+            ],
+        },
+    )
+
+    provider = next(
+        provider
+        for provider in await service.list_providers()
+        if provider.provider_type == "cerebras"
+    )
+    assert provider.default_url == "https://api.cerebras.ai/v1"
+    assert provider.api == "https://api.cerebras.ai/v1"
+
+
+@pytest.mark.asyncio
+async def test_catalog_service_keeps_dynamic_provider_url_empty_when_refresh_payload_omits_api(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path)
+    source_payload = {
+        "azure": {
+            "id": "azure",
+            "name": "Azure",
+            "models": {},
+        }
+    }
+
+    assert service.source_snapshot_path is not None
+    _write_json(service.source_snapshot_path, source_payload)
+    await service.refresh()
+
+    provider = await service.get_provider("azure")
+    assert provider.default_url is None
+    assert provider.api is None
 
 
 @pytest.mark.asyncio

--- a/frontend/src/features/settings/components/connection-form-dialog.tsx
+++ b/frontend/src/features/settings/components/connection-form-dialog.tsx
@@ -13,30 +13,19 @@ import { validateProvider } from "../lib/model-api";
 import { ProviderIcon } from "../lib/provider-icons";
 import { getProviderUrl } from "../lib/provider-utils";
 
-function isCustomUrlProvider(providerType: string): boolean {
-  return providerType === "openai-compatible" || providerType === "anthropic-compatible";
+function requiresProviderUrl(
+  providerType: string,
+  catalogProviders?: ModelProviderCatalogProvider[],
+): boolean {
+  return Boolean(providerType) && !getProviderUrl(providerType, catalogProviders);
 }
 
-const connectionSchema = z
-  .object({
-    name: z.string().optional(),
-    url: z.string().optional(), // URL 现在是可选的，因为固定提供商会自动填充
-    apiKey: z.string().optional(),
-    providerType: z.string().min(1, "providerTypeRequired"),
-  })
-  .refine(
-    (data) => {
-      if (isCustomUrlProvider(data.providerType)) {
-        return data.url && data.url.trim().length > 0;
-      }
-      // 其他模式，URL 会自动填充，不需要验证
-      return true;
-    },
-    {
-      message: "urlRequired",
-      path: ["url"],
-    },
-  );
+const connectionSchema = z.object({
+  name: z.string().optional(),
+  url: z.string().optional(),
+  apiKey: z.string().optional(),
+  providerType: z.string().min(1, "providerTypeRequired"),
+});
 
 type ConnectionFormData = z.infer<typeof connectionSchema>;
 
@@ -100,20 +89,20 @@ export function ConnectionFormDialog({
     [catalogProviders, providerType],
   );
 
-  // 切换到 OpenAI-compatible 时只清空一次 URL，不要在每次输入时重置。
+  // 切换到需要用户提供地址的提供商时，只清空一次 URL。
   useEffect(() => {
     if (!providerType) return;
 
-    if (isCustomUrlProvider(providerType)) {
+    if (requiresProviderUrl(providerType, catalogProviders)) {
       if (!isEditing || connection?.providerType !== providerType) {
         setValue("url", "");
       }
     }
-  }, [providerType, setValue, isEditing, connection]);
+  }, [providerType, catalogProviders, setValue, isEditing, connection]);
 
   // 当提供商类型改变时，自动设置固定 URL
   useEffect(() => {
-    if (!providerType || isCustomUrlProvider(providerType)) {
+    if (!providerType || requiresProviderUrl(providerType, catalogProviders)) {
       return;
     }
 
@@ -236,10 +225,10 @@ export function ConnectionFormDialog({
 
   const canValidate = useMemo(() => {
     if (!providerType) return false;
-    if (isCustomUrlProvider(providerType) && (!url || !url.trim())) return false;
+    if (requiresProviderUrl(providerType, catalogProviders) && (!url || !url.trim())) return false;
     if (!isEditing && !apiKey) return false;
     return true;
-  }, [providerType, url, isEditing, apiKey]);
+  }, [providerType, catalogProviders, url, isEditing, apiKey]);
 
   return (
     <Dialog.Root
@@ -361,7 +350,7 @@ export function ConnectionFormDialog({
               </Flex>
             </Flex>
 
-            {isCustomUrlProvider(providerType) && (
+            {requiresProviderUrl(providerType, catalogProviders) && (
               <Flex
                 direction="column"
                 gap="2"


### PR DESCRIPTION
## PR 标题

fix(providers): 修复目录中部分提供商端点 URL 缺失的问题

## 变更说明

- 问题: Models.dev 目录刷新后，部分提供商缺失 `api` 字段，前端无法解析端点 URL，导致验证连接前直接失败。
- 重要性: 影响 OpenAI 等固定端点提供商的新增、验证和模型访问配置。
- 变化: 为已确认具备固定端点且兼容现有调用链的提供商补充内置 URL，并在刷新和读取历史缓存时回退。
- 变化: 对无安全默认地址的提供商展示并要求填写 URL，避免目录缺字段时无法新增连接。

## 关联 Issue / PR (如有)

Closes #235 

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [x] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

Models.dev 的 `api` 字段对部分提供商可选或缺失。原实现直接使用该字段覆盖本地目录缓存，并且仅允许两类兼容提供商手动填写 URL，导致固定端点丢失后前端无法发起验证请求。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令：

```text
uv run pytest tests/models/test_model_provider_catalog_service.py tests/api/test_model_provider_catalog.py tests/api/test_model_providers.py -q
30 passed

uv run ruff check app/models/catalog/service.py tests/models/test_model_provider_catalog_service.py
All checks passed!

uv run ty check app/models/catalog/service.py tests/models/test_model_provider_catalog_service.py
All checks passed!

pnpm format:check
pnpm type-check
pnpm lint
```
