### PR TITLE
fix(storage): 清理数据库关联运行时数据

### DIFF
--- a/backend/app/agent_runtime/runner/checkpointer.py
+++ b/backend/app/agent_runtime/runner/checkpointer.py
@@ -13,7 +13,8 @@ from sqlmodel import col
 
 import app.settings as app_settings
 from app.agent_runtime.model_config import without_api_key
-from app.agent_runtime.persistence.model import AgentChildRun
+from app.agent_runtime.persistence.model import AgentChildRun, AgentChildRunRequest
+from app.storage.models.revision import Revision
 from app.storage.models.task import Task
 
 _checkpointer: AsyncSqliteSaver | None = None
@@ -25,6 +26,7 @@ _ALLOWED_MSGPACK_MODULES = (
 _LEGACY_API_KEY_MARKER = b"api_key"
 _LEGACY_API_KEY_MIGRATION = "remove_plaintext_api_keys_v1"
 _CHECKPOINT_CLEANUP_BATCH_SIZE = 500
+_VACUUM_MIN_FREE_BYTES = 64 * 1024 * 1024
 
 
 def _default_db_path() -> Path:
@@ -223,6 +225,50 @@ async def delete_checkpoints_after_for_thread(
         await conn.close()
 
 
+async def prune_checkpoints_for_thread(
+    checkpointer: AsyncSqliteSaver,
+    thread_id: str,
+    retained_checkpoint_ids: set[str],
+) -> int:
+    """Retain the latest checkpoint in each namespace and explicit rollback points."""
+    if not thread_id:
+        return 0
+
+    cursor = await checkpointer.conn.execute(
+        "SELECT checkpoint_ns, checkpoint_id FROM checkpoints WHERE thread_id = ?",
+        (thread_id,),
+    )
+    try:
+        checkpoint_rows = await cursor.fetchall()
+    finally:
+        await cursor.close()
+    if not checkpoint_rows:
+        return 0
+
+    latest_by_namespace: dict[str, str] = {}
+    for checkpoint_ns, checkpoint_id in checkpoint_rows:
+        if checkpoint_id and checkpoint_id > latest_by_namespace.get(checkpoint_ns, ""):
+            latest_by_namespace[checkpoint_ns] = checkpoint_id
+    retained_ids = set(latest_by_namespace.values()) | retained_checkpoint_ids
+    placeholders = ", ".join("?" for _ in retained_ids)
+    before = checkpointer.conn.total_changes
+    await checkpointer.conn.execute("BEGIN")
+    try:
+        await checkpointer.conn.execute(
+            f"DELETE FROM writes WHERE thread_id = ? AND checkpoint_id NOT IN ({placeholders})",
+            (thread_id, *retained_ids),
+        )
+        await checkpointer.conn.execute(
+            f"DELETE FROM checkpoints WHERE thread_id = ? AND checkpoint_id NOT IN ({placeholders})",
+            (thread_id, *retained_ids),
+        )
+        await checkpointer.conn.commit()
+    except Exception:
+        await checkpointer.conn.rollback()
+        raise
+    return checkpointer.conn.total_changes - before
+
+
 async def cleanup_unreachable_checkpoints(
     session: AsyncSession,
     checkpointer: AsyncSqliteSaver,
@@ -271,7 +317,7 @@ async def _list_reachable_checkpoint_thread_ids(session: AsyncSession) -> set[st
         select(
             col(AgentChildRun.parent_session_id),
             col(AgentChildRun.child_thread_id),
-        )
+        ).where(col(AgentChildRun.is_active).is_(True))
     )
     children_by_parent: dict[str, set[str]] = {}
     for parent_session_id, child_thread_id in child_run_result.all():
@@ -289,6 +335,107 @@ async def _list_reachable_checkpoint_thread_ids(session: AsyncSession) -> set[st
             pending_thread_ids.append(child_thread_id)
 
     return reachable_thread_ids
+
+
+async def prune_reachable_checkpoints(
+    session: AsyncSession,
+    checkpointer: AsyncSqliteSaver,
+) -> int:
+    """Prune internal history while preserving recovery and rollback checkpoints."""
+    reachable_thread_ids = await _list_reachable_checkpoint_thread_ids(session)
+    return await _prune_checkpoint_threads(session, checkpointer, reachable_thread_ids)
+
+
+async def _prune_checkpoint_threads(
+    session: AsyncSession,
+    checkpointer: AsyncSqliteSaver,
+    thread_ids: set[str],
+) -> int:
+    if not thread_ids:
+        return 0
+
+    retained_checkpoint_ids = await _list_retained_checkpoint_ids(session, thread_ids)
+    deleted_rows = 0
+    for thread_id in thread_ids:
+        deleted_rows += await prune_checkpoints_for_thread(
+            checkpointer,
+            thread_id,
+            retained_checkpoint_ids.get(thread_id, set()),
+        )
+    return deleted_rows
+
+
+async def _list_retained_checkpoint_ids(
+    session: AsyncSession,
+    thread_ids: set[str],
+) -> dict[str, set[str]]:
+    retained_ids: dict[str, set[str]] = {}
+    if not thread_ids:
+        return retained_ids
+
+    revision_result = await session.execute(
+        select(
+            col(Revision.graph_thread_id),
+            col(Revision.pre_run_checkpoint_id),
+        ).where(
+            col(Revision.graph_thread_id).in_(thread_ids),
+            col(Revision.pre_run_checkpoint_id).is_not(None),
+        )
+    )
+    for thread_id, checkpoint_id in revision_result.all():
+        if thread_id and checkpoint_id:
+            retained_ids.setdefault(thread_id, set()).add(checkpoint_id)
+
+    child_request_result = await session.execute(
+        select(
+            col(AgentChildRun.child_thread_id),
+            col(AgentChildRunRequest.pre_request_checkpoint_id),
+        )
+        .join(
+            AgentChildRunRequest,
+            col(AgentChildRunRequest.child_run_id) == col(AgentChildRun.id),
+        )
+        .where(
+            col(AgentChildRun.is_active).is_(True),
+            col(AgentChildRun.child_thread_id).in_(thread_ids),
+            col(AgentChildRunRequest.pre_request_checkpoint_id).is_not(None),
+        )
+    )
+    for thread_id, checkpoint_id in child_request_result.all():
+        if thread_id and checkpoint_id:
+            retained_ids.setdefault(thread_id, set()).add(checkpoint_id)
+
+    return retained_ids
+
+
+async def vacuum_checkpoint_database(
+    min_free_bytes: int = _VACUUM_MIN_FREE_BYTES,
+) -> bool:
+    """Reclaim file space after cleanup when enough SQLite pages are free."""
+    db_path = _get_db_path()
+    if not Path(db_path).exists():
+        return False
+
+    conn = await aiosqlite.connect(db_path)
+    try:
+        page_size_cursor = await conn.execute("PRAGMA page_size")
+        try:
+            page_size_row = await page_size_cursor.fetchone()
+        finally:
+            await page_size_cursor.close()
+        free_list_cursor = await conn.execute("PRAGMA freelist_count")
+        try:
+            free_list_row = await free_list_cursor.fetchone()
+        finally:
+            await free_list_cursor.close()
+        page_size = int(page_size_row[0]) if page_size_row else 0
+        free_pages = int(free_list_row[0]) if free_list_row else 0
+        if page_size * free_pages < min_free_bytes:
+            return False
+        await conn.execute("VACUUM")
+        return True
+    finally:
+        await conn.close()
 
 
 async def _list_checkpoint_thread_ids(checkpointer: AsyncSqliteSaver) -> set[str]:

--- a/backend/app/api/routers/projects.py
+++ b/backend/app/api/routers/projects.py
@@ -7,8 +7,13 @@ from typing import Annotated
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
 from loguru import logger
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
 
+from app.agent_runtime.attachments import delete_attachments_for_task
+from app.agent_runtime.persistence.model import AgentChildRun
+from app.agent_runtime.runner.checkpointer import delete_checkpoints_for_thread
 from app.api.schemas.project import (
     ProjectListResponse,
     ProjectResponse,
@@ -16,9 +21,38 @@ from app.api.schemas.project import (
 from app.core.errors import NotFoundError
 from app.core.storage import get_cover_url
 from app.storage.database import get_session
-from app.storage.services import project_service
+from app.storage.models.task import Task
+from app.storage.services import project_service, task_service
 
 router = APIRouter(prefix="/projects", tags=["projects"])
+
+
+async def _list_project_checkpoint_thread_ids(
+    session: AsyncSession,
+    project_id: str,
+) -> list[str]:
+    task_result = await session.execute(
+        select(col(Task.agent_session_id)).where(col(Task.project_id) == project_id)
+    )
+    child_result = await session.execute(
+        select(col(AgentChildRun.child_thread_id)).where(
+            col(AgentChildRun.parent_task_id).in_(
+                select(col(Task.id)).where(col(Task.project_id) == project_id)
+            )
+        )
+    )
+    return [
+        *(
+            session_id
+            for session_id in task_result.scalars().all()
+            if session_id
+        ),
+        *(
+            thread_id
+            for thread_id in child_result.scalars().all()
+            if thread_id
+        ),
+    ]
 
 
 @router.post(
@@ -177,7 +211,23 @@ async def delete_project(
     """
     try:
         logger.info(f"删除项目: {project_id}")
+        tasks = (await task_service.list_tasks(session, project_id)).items
+        if any(task.is_running for task in tasks):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="项目存在运行中任务，不能删除",
+            )
+        checkpoint_thread_ids = await _list_project_checkpoint_thread_ids(session, project_id)
+        for task in tasks:
+            await delete_attachments_for_task(session, task_id=task.id)
         await project_service.delete_project(session, project_id)
+        await session.commit()
+        for thread_id in checkpoint_thread_ids:
+            deleted_rows = await delete_checkpoints_for_thread(thread_id)
+            logger.bind(project_id=project_id, thread_id=thread_id).info(
+                "Deleted {} checkpoint rows for project cleanup",
+                deleted_rows,
+            )
     except NotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
 

--- a/backend/app/api/routers/tasks.py
+++ b/backend/app/api/routers/tasks.py
@@ -45,13 +45,19 @@ async def _list_descendant_child_thread_ids(
     return child_thread_ids
 
 
-async def _cleanup_task_checkpoints(
+async def _list_task_checkpoint_thread_ids(
     session: AsyncSession,
     session_id: str | None,
-) -> None:
+) -> list[str]:
     if not session_id:
-        return
-    thread_ids = [*await _list_descendant_child_thread_ids(session, session_id), session_id]
+        return []
+    return [*await _list_descendant_child_thread_ids(session, session_id), session_id]
+
+
+async def _delete_checkpoint_threads(
+    session_id: str | None,
+    thread_ids: list[str],
+) -> None:
     for thread_id in thread_ids:
         deleted_rows = await delete_checkpoints_for_thread(thread_id)
         logger.bind(session_id=session_id, thread_id=thread_id).info(
@@ -209,10 +215,14 @@ async def delete_task(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="任务运行中，不能删除",
             )
+        checkpoint_thread_ids = await _list_task_checkpoint_thread_ids(
+            session,
+            task.agent_session_id,
+        )
         await delete_attachments_for_task(session, task_id=task.id)
         await task_service.delete_task(session, task_id)
         await session.commit()
-        await _cleanup_task_checkpoints(session, task.agent_session_id)
+        await _delete_checkpoint_threads(task.agent_session_id, checkpoint_thread_ids)
     except HTTPException:
         raise
     except NotFoundError as e:
@@ -236,13 +246,24 @@ async def delete_all_tasks(
         deletable_tasks = [task for task in tasks if not task.is_running]
         skipped_running_count = len(tasks) - len(deletable_tasks)
 
+        checkpoint_thread_ids_by_session = {
+            task.agent_session_id: await _list_task_checkpoint_thread_ids(
+                session,
+                task.agent_session_id,
+            )
+            for task in deletable_tasks
+            if task.agent_session_id
+        }
         for task in deletable_tasks:
             await delete_attachments_for_task(session, task_id=task.id)
             await task_service.delete_task(session, task.id)
 
         await session.commit()
         for task in deletable_tasks:
-            await _cleanup_task_checkpoints(session, task.agent_session_id)
+            await _delete_checkpoint_threads(
+                task.agent_session_id,
+                checkpoint_thread_ids_by_session.get(task.agent_session_id, []),
+            )
         deleted_count = len(deletable_tasks)
         logger.info(
             f"已删除项目 {project_id} 下的 {deleted_count} 个任务，跳过 {skipped_running_count} 个运行中任务"

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -77,7 +77,7 @@ from app.models.builtin import seed_builtin_models
 from app.models.catalog import ModelProviderCatalogService
 from app.settings import settings as app_settings
 from app.socket import init_socketio
-from app.storage.database import close_db, create_session, init_db
+from app.storage.database import close_db, create_session, init_db, vacuum_database_if_needed
 from app.storage.services import task_service
 
 
@@ -181,6 +181,23 @@ async def _cleanup_orphaned_agent_attachment_files() -> None:
             logger.info(f"Deleted {deleted_files} orphaned agent attachment files at startup")
     finally:
         await session.close()
+
+
+async def _cleanup_orphaned_task_data() -> None:
+    session = await create_session()
+    try:
+        deleted_rows = await task_service.cleanup_orphaned_task_data(session)
+        await session.commit()
+        if deleted_rows:
+            logger.info(f"Deleted {deleted_rows} orphaned task runtime rows at startup")
+    finally:
+        await session.close()
+
+
+async def _vacuum_main_database() -> None:
+    await close_db()
+    if await vacuum_database_if_needed():
+        logger.info("Vacuumed main database after startup cleanup")
 
 
 def _get_server_bind() -> tuple[str, int]:
@@ -342,6 +359,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     await _cleanup_unreachable_checkpoints()
     await _cleanup_chapter_export_files()
     await _cleanup_orphaned_agent_attachment_files()
+    await _cleanup_orphaned_task_data()
+    await _vacuum_main_database()
     await load_audit_details_persistence()
     start_audit_queue()
     await start_background_runtime()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -59,6 +59,8 @@ from app.agent_runtime.runner.checkpointer import (
     close_checkpointer,
     get_checkpointer,
     init_checkpointer,
+    prune_reachable_checkpoints,
+    vacuum_checkpoint_database,
 )
 from app.agent_runtime.runner.run_registry import get_agent_run_registry
 from app.background.runtime.supervisor import (
@@ -147,15 +149,18 @@ async def _seed_builtin_models() -> None:
 async def _cleanup_unreachable_checkpoints() -> None:
     session = await create_session()
     try:
-        deleted_rows = await cleanup_unreachable_checkpoints(
-            session,
-            await get_checkpointer(),
-        )
+        checkpointer = await get_checkpointer()
+        deleted_rows = await cleanup_unreachable_checkpoints(session, checkpointer)
+        deleted_rows += await prune_reachable_checkpoints(session, checkpointer)
     finally:
         await session.close()
 
     if deleted_rows:
-        logger.info(f"Deleted {deleted_rows} unreachable checkpoint rows at startup")
+        logger.info(f"Deleted {deleted_rows} checkpoint rows during startup cleanup")
+    await close_checkpointer()
+    if await vacuum_checkpoint_database():
+        logger.info("Vacuumed checkpoint database after startup cleanup")
+    await init_checkpointer()
 
 
 async def _cleanup_chapter_export_files() -> None:

--- a/backend/app/storage/database.py
+++ b/backend/app/storage/database.py
@@ -18,6 +18,7 @@ from app.settings import settings
 
 _engine = None
 _async_session_factory = None
+_VACUUM_MIN_FREE_BYTES = 64 * 1024 * 1024
 ALEMBIC_INI_PATH = Path(
     os.getenv("OPENFIC_ALEMBIC_INI", str(Path(__file__).resolve().parents[2] / "alembic.ini"))
 )
@@ -84,6 +85,38 @@ async def close_db() -> None:
         await _engine.dispose()
         _engine = None
         _async_session_factory = None
+
+
+async def vacuum_database_if_needed(
+    min_free_bytes: int = _VACUUM_MIN_FREE_BYTES,
+) -> bool:
+    """Reclaim main database file space when deletion leaves enough free pages."""
+    db_path = settings.database_url.removeprefix("sqlite+aiosqlite:///")
+    if not Path(db_path).exists():
+        return False
+
+    import aiosqlite
+
+    conn = await aiosqlite.connect(db_path)
+    try:
+        page_size_cursor = await conn.execute("PRAGMA page_size")
+        try:
+            page_size_row = await page_size_cursor.fetchone()
+        finally:
+            await page_size_cursor.close()
+        freelist_cursor = await conn.execute("PRAGMA freelist_count")
+        try:
+            freelist_row = await freelist_cursor.fetchone()
+        finally:
+            await freelist_cursor.close()
+        page_size = int(page_size_row[0]) if page_size_row else 0
+        free_pages = int(freelist_row[0]) if freelist_row else 0
+        if page_size * free_pages < min_free_bytes:
+            return False
+        await conn.execute("VACUUM")
+        return True
+    finally:
+        await conn.close()
 
 
 async def create_session() -> AsyncSession:

--- a/backend/app/storage/repos/task_message_repo.py
+++ b/backend/app/storage/repos/task_message_repo.py
@@ -64,6 +64,15 @@ async def delete_by_task(session: AsyncSession, task_id: str) -> None:
     await session.flush()
 
 
+async def delete_by_task_ids(session: AsyncSession, task_ids: list[str]) -> None:
+    if not task_ids:
+        return
+    await session.execute(
+        sql_delete(TaskMessage).where(col(TaskMessage.task_id).in_(task_ids))
+    )
+    await session.flush()
+
+
 async def delete_after_created_at(
     session: AsyncSession,
     task_id: str,

--- a/backend/app/storage/services/project_service.py
+++ b/backend/app/storage/services/project_service.py
@@ -13,7 +13,7 @@ from app.core.errors import NotFoundError
 from app.core.storage import delete_cover_file, save_cover_file
 from app.storage.models.project import Project
 from app.storage.repos import chapter_repo, project_repo, volume_repo
-from app.storage.services import volume_service
+from app.storage.services import task_service, volume_service
 
 
 @dataclass
@@ -154,6 +154,8 @@ async def delete_project(session: AsyncSession, project_id: str) -> None:
         NotFoundError: 项目不存在。
     """
     project = await get_project(session, project_id)
+
+    await task_service.delete_all_tasks(session, project_id)
 
     # 删除项目下的所有章节
     await chapter_repo.delete_by_project(session, project_id)

--- a/backend/app/storage/services/task_service.py
+++ b/backend/app/storage/services/task_service.py
@@ -7,9 +7,21 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
 
+from app.agent_runtime.attachments import delete_attachments_for_task
 from app.agent_runtime.modes import AgentMode
+from app.agent_runtime.persistence.model import (
+    AgentAttachment,
+    AgentChildRun,
+    AgentChildRunRequest,
+    AgentContextCompaction,
+    AgentRunMessage,
+    PlanRecord,
+    PlanTodoRecord,
+)
 from app.core.errors import NotFoundError
 from app.storage.models.task import Task
 from app.storage.models.task_message import TaskMessage
@@ -160,7 +172,7 @@ async def delete_task(session: AsyncSession, task_id: str) -> None:
     if task is None:
         raise NotFoundError(f"任务不存在：{task_id}")
 
-    await task_message_repo.delete_by_task(session, task.id)
+    await _delete_runtime_data_for_tasks(session, [task])
     await task_repo.delete(session, task)
 
 
@@ -170,12 +182,160 @@ async def delete_all_tasks(session: AsyncSession, project_id: str) -> int:
     if project is None:
         raise NotFoundError(f"项目不存在：{project_id}")
 
-    total = await task_repo.count_by_project(session, project_id)
     tasks = await task_repo.list_by_project(session, project_id)
-    for task in tasks:
-        await task_message_repo.delete_by_task(session, task.id)
+    await _delete_runtime_data_for_tasks(session, tasks)
     await task_repo.delete_by_project(session, project_id)
-    return total
+    return len(tasks)
+
+
+async def cleanup_orphaned_task_data(session: AsyncSession) -> int:
+    """Delete runtime records whose owning Task has already been deleted."""
+    existing_task_ids = select(col(Task.id))
+    orphan_task_ids = await _list_orphan_task_ids(session, existing_task_ids)
+    orphan_plan_session_ids = await _list_orphan_plan_session_ids(
+        session,
+        existing_task_ids,
+    )
+    orphan_child_run_ids = select(col(AgentChildRun.id)).where(
+        col(AgentChildRun.parent_task_id).not_in(existing_task_ids)
+    )
+    deleted_rows = 0
+    for task_id in orphan_task_ids:
+        deleted_rows += await delete_attachments_for_task(session, task_id=task_id)
+    request_result = await session.execute(
+        delete(AgentChildRunRequest).where(
+            col(AgentChildRunRequest.parent_task_id).not_in(existing_task_ids)
+            | col(AgentChildRunRequest.child_run_id).in_(orphan_child_run_ids)
+        )
+    )
+    deleted_rows += int(getattr(request_result, "rowcount", 0) or 0)
+    for model, task_column in (
+        (TaskMessage, TaskMessage.task_id),
+        (AgentRunMessage, AgentRunMessage.task_id),
+        (AgentContextCompaction, AgentContextCompaction.task_id),
+        (AgentChildRun, AgentChildRun.parent_task_id),
+    ):
+        result = await session.execute(
+            delete(model).where(col(task_column).not_in(existing_task_ids))
+        )
+        deleted_rows += int(getattr(result, "rowcount", 0) or 0)
+    deleted_rows += await _delete_plans_for_sessions(session, orphan_plan_session_ids)
+    await session.flush()
+    return deleted_rows
+
+
+async def _delete_runtime_data_for_tasks(
+    session: AsyncSession,
+    tasks: list[Task],
+) -> None:
+    task_ids = [task.id for task in tasks]
+    if not task_ids:
+        return
+    session_ids = [
+        task.agent_session_id
+        for task in tasks
+        if task.agent_session_id
+    ]
+    child_session_result = await session.execute(
+        select(col(AgentChildRun.child_thread_id)).where(
+            col(AgentChildRun.parent_task_id).in_(task_ids)
+        )
+    )
+    session_ids.extend(
+        child_thread_id
+        for child_thread_id in child_session_result.scalars().all()
+        if child_thread_id
+    )
+    await session.execute(
+        delete(AgentChildRunRequest).where(
+            col(AgentChildRunRequest.parent_task_id).in_(task_ids)
+        )
+    )
+    await session.execute(
+        delete(AgentChildRun).where(col(AgentChildRun.parent_task_id).in_(task_ids))
+    )
+    await session.execute(
+        delete(AgentContextCompaction).where(
+            col(AgentContextCompaction.task_id).in_(task_ids)
+        )
+    )
+    await session.execute(
+        delete(AgentRunMessage).where(col(AgentRunMessage.task_id).in_(task_ids))
+    )
+    await task_message_repo.delete_by_task_ids(session, task_ids)
+    await _delete_plans_for_sessions(session, session_ids)
+    await session.flush()
+
+
+async def _delete_plans_for_sessions(
+    session: AsyncSession,
+    session_ids: list[str],
+) -> int:
+    if not session_ids:
+        return 0
+    plan_ids = select(col(PlanRecord.id)).where(
+        col(PlanRecord.session_id).in_(session_ids)
+    )
+    todo_result = await session.execute(
+        delete(PlanTodoRecord).where(col(PlanTodoRecord.plan_id).in_(plan_ids))
+    )
+    plan_result = await session.execute(
+        delete(PlanRecord).where(col(PlanRecord.session_id).in_(session_ids))
+    )
+    return int(getattr(todo_result, "rowcount", 0) or 0) + int(
+        getattr(plan_result, "rowcount", 0) or 0
+    )
+
+
+async def _list_orphan_plan_session_ids(
+    session: AsyncSession,
+    existing_task_ids: Any,
+) -> list[str]:
+    root_session_result = await session.execute(
+        select(col(Task.agent_session_id)).where(
+            col(Task.agent_session_id).is_not(None),
+            col(Task.agent_session_id) != "",
+        )
+    )
+    reachable_session_ids = {
+        session_id
+        for session_id in root_session_result.scalars().all()
+        if session_id
+    }
+    child_session_result = await session.execute(
+        select(col(AgentChildRun.child_thread_id)).where(
+            col(AgentChildRun.parent_task_id).in_(existing_task_ids)
+        )
+    )
+    reachable_session_ids.update(
+        session_id for session_id in child_session_result.scalars().all() if session_id
+    )
+    result = await session.execute(
+        select(col(PlanRecord.session_id)).where(
+            col(PlanRecord.session_id).not_in(reachable_session_ids)
+        )
+    )
+    return [session_id for session_id in result.scalars().all() if session_id]
+
+
+async def _list_orphan_task_ids(
+    session: AsyncSession,
+    existing_task_ids: Any,
+) -> list[str]:
+    task_ids: set[str] = set()
+    for task_column in (
+        AgentAttachment.task_id,
+        TaskMessage.task_id,
+        AgentRunMessage.task_id,
+        AgentContextCompaction.task_id,
+        AgentChildRun.parent_task_id,
+        AgentChildRunRequest.parent_task_id,
+    ):
+        result = await session.execute(
+            select(col(task_column)).where(col(task_column).not_in(existing_task_ids))
+        )
+        task_ids.update(task_id for task_id in result.scalars().all() if task_id)
+    return list(task_ids)
 
 
 async def clear_running_tasks(session: AsyncSession) -> int:

--- a/backend/tests/agent_runtime/test_checkpointer.py
+++ b/backend/tests/agent_runtime/test_checkpointer.py
@@ -12,6 +12,7 @@ from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import Checkpoint
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 import pytest
+from sqlalchemy import select
 from app.agent_runtime.runner.checkpointer import (
     cleanup_unreachable_checkpoints,
     close_checkpointer,
@@ -19,10 +20,15 @@ from app.agent_runtime.runner.checkpointer import (
     delete_checkpoints_for_thread,
     get_checkpointer,
     init_checkpointer,
+    prune_checkpoints_for_thread,
+    prune_reachable_checkpoints,
     reset_checkpointer,
+    vacuum_checkpoint_database,
 )
 from app.agent_runtime.tools.impls.interaction.ask_user import Question, QuestionOption
 from app.agent_runtime.persistence.child_runs import create_child_run
+from app.agent_runtime.persistence.model import AgentChildRunRequest
+from app.storage.models.revision import Revision
 from app.storage.models.task import Task
 
 
@@ -495,6 +501,282 @@ async def test_cleanup_unreachable_checkpoints_noops_for_empty_checkpoint_store(
         assert await cleanup_unreachable_checkpoints(session, await get_checkpointer()) == 0
     finally:
         await reset_checkpointer()
+
+
+async def test_prune_checkpoints_for_thread_keeps_latest_and_rollback_boundaries(
+    client,
+    session,
+    monkeypatch,
+    tmp_path,
+):
+    db_path = tmp_path / "test_checkpoints.db"
+    monkeypatch.setenv("AGENT_CHECKPOINT_DB", str(db_path))
+    await reset_checkpointer()
+    task = Task(
+        id="task-root",
+        project_id="project-root",
+        title="Root session",
+        mode="agent",
+        agent_session_id="agent-root",
+    )
+    session.add(task)
+    await session.commit()
+
+    checkpointer = await get_checkpointer()
+    rows = [
+        ("", "cp-001", None),
+        ("", "cp-002", "cp-001"),
+        ("", "cp-003", "cp-002"),
+        ("primary:child", "cp-004", None),
+        ("primary:child", "cp-005", "cp-004"),
+    ]
+    for namespace, checkpoint_id, parent_checkpoint_id in rows:
+        await checkpointer.conn.execute(
+            "INSERT INTO checkpoints(thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id) "
+            "VALUES (?, ?, ?, ?)",
+            ("agent-root", namespace, checkpoint_id, parent_checkpoint_id),
+        )
+        await checkpointer.conn.execute(
+            "INSERT INTO writes(thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            ("agent-root", namespace, checkpoint_id, "task", 0, "messages"),
+        )
+    await checkpointer.conn.commit()
+
+    deleted_rows = await prune_checkpoints_for_thread(
+        checkpointer,
+        "agent-root",
+        {"cp-002"},
+    )
+
+    assert deleted_rows == 4
+    cursor = await checkpointer.conn.execute(
+        "SELECT checkpoint_ns, checkpoint_id FROM checkpoints "
+        "WHERE thread_id = ? ORDER BY checkpoint_id",
+        ("agent-root",),
+    )
+    try:
+        assert await cursor.fetchall() == [
+            ("", "cp-002"),
+            ("", "cp-003"),
+            ("primary:child", "cp-005"),
+        ]
+    finally:
+        await cursor.close()
+    cursor = await checkpointer.conn.execute(
+        "SELECT checkpoint_ns, checkpoint_id FROM writes "
+        "WHERE thread_id = ? ORDER BY checkpoint_id",
+        ("agent-root",),
+    )
+    try:
+        assert await cursor.fetchall() == [
+            ("", "cp-002"),
+            ("", "cp-003"),
+            ("primary:child", "cp-005"),
+        ]
+    finally:
+        await cursor.close()
+    await reset_checkpointer()
+
+
+async def test_prune_reachable_checkpoints_keeps_revision_and_child_boundaries(
+    client,
+    session,
+    monkeypatch,
+    tmp_path,
+):
+    db_path = tmp_path / "test_checkpoints.db"
+    monkeypatch.setenv("AGENT_CHECKPOINT_DB", str(db_path))
+    await reset_checkpointer()
+    task = Task(
+        id="task-root",
+        project_id="project-root",
+        title="Root session",
+        mode="agent",
+        agent_session_id="agent-root",
+    )
+    session.add(task)
+    revision = Revision(
+        id="revision-root",
+        project_id=task.project_id,
+        task_id=task.id,
+        message="root boundary",
+        agent_session_id="agent-root",
+        status="completed",
+        revision_type="agent",
+        pre_run_checkpoint_id="root-002",
+        graph_thread_id="agent-root",
+        is_checkpoint=True,
+        project_snapshot_title="Root session",
+    )
+    session.add(revision)
+    await session.commit()
+    child = await create_child_run(
+        session,
+        parent_session_id="agent-root",
+        parent_task_id=task.id,
+        parent_thread_id="agent-root",
+        child_thread_id="agent-root:child:writer",
+        agent_key="writer",
+        dispatch_id="writer",
+        tool_call_id="tool-writer",
+        request={"task": "write", "input": {}, "metadata": {}},
+    )
+    request_result = await session.execute(
+        select(AgentChildRunRequest).where(
+            AgentChildRunRequest.child_run_id == child.id
+        )
+    )
+    child_request = request_result.scalar_one()
+    child_request.pre_request_checkpoint_id = "child-002"
+    await session.commit()
+
+    checkpointer = await get_checkpointer()
+    for thread_id, checkpoint_ids in {
+        "agent-root": ("root-001", "root-002", "root-003"),
+        child.child_thread_id: ("child-001", "child-002", "child-003"),
+    }.items():
+        for checkpoint_id in checkpoint_ids:
+            await checkpointer.conn.execute(
+                "INSERT INTO checkpoints(thread_id, checkpoint_ns, checkpoint_id) VALUES (?, ?, ?)",
+                (thread_id, "", checkpoint_id),
+            )
+    await checkpointer.conn.commit()
+
+    deleted_rows = await prune_reachable_checkpoints(session, checkpointer)
+
+    assert deleted_rows == 2
+    cursor = await checkpointer.conn.execute(
+        "SELECT thread_id, checkpoint_id FROM checkpoints ORDER BY thread_id, checkpoint_id"
+    )
+    try:
+        assert await cursor.fetchall() == [
+            ("agent-root", "root-002"),
+            ("agent-root", "root-003"),
+            (child.child_thread_id, "child-002"),
+            (child.child_thread_id, "child-003"),
+        ]
+    finally:
+        await cursor.close()
+    await reset_checkpointer()
+
+
+async def test_cleanup_unreachable_checkpoints_removes_inactive_child_thread(
+    client,
+    session,
+    monkeypatch,
+    tmp_path,
+):
+    db_path = tmp_path / "test_checkpoints.db"
+    monkeypatch.setenv("AGENT_CHECKPOINT_DB", str(db_path))
+    await reset_checkpointer()
+    task = Task(
+        id="task-root",
+        project_id="project-root",
+        title="Root session",
+        mode="agent",
+        agent_session_id="agent-root",
+    )
+    session.add(task)
+    await session.commit()
+    active_child = await create_child_run(
+        session,
+        parent_session_id="agent-root",
+        parent_task_id=task.id,
+        parent_thread_id="agent-root",
+        child_thread_id="agent-root:child:active",
+        agent_key="writer",
+        dispatch_id="active",
+        tool_call_id="tool-active",
+        request={"task": "write", "input": {}, "metadata": {}},
+    )
+    inactive_child = await create_child_run(
+        session,
+        parent_session_id="agent-root",
+        parent_task_id=task.id,
+        parent_thread_id="agent-root",
+        child_thread_id="agent-root:child:inactive",
+        agent_key="writer",
+        dispatch_id="inactive",
+        tool_call_id="tool-inactive",
+        request={"task": "write", "input": {}, "metadata": {}},
+    )
+    inactive_child.is_active = False
+    await session.commit()
+
+    checkpointer = await get_checkpointer()
+    for thread_id in ("agent-root", active_child.child_thread_id, inactive_child.child_thread_id):
+        await checkpointer.conn.execute(
+            "INSERT INTO checkpoints(thread_id, checkpoint_ns, checkpoint_id) VALUES (?, ?, ?)",
+            (thread_id, "", f"checkpoint-{thread_id}"),
+        )
+        await checkpointer.conn.execute(
+            "INSERT INTO writes(thread_id, checkpoint_ns, checkpoint_id, task_id, idx, channel) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (thread_id, "", f"checkpoint-{thread_id}", "task", 0, "messages"),
+        )
+    await checkpointer.conn.commit()
+
+    deleted_rows = await cleanup_unreachable_checkpoints(session, checkpointer)
+
+    assert deleted_rows == 2
+    cursor = await checkpointer.conn.execute(
+        "SELECT thread_id FROM checkpoints ORDER BY thread_id"
+    )
+    try:
+        assert await cursor.fetchall() == [
+            ("agent-root",),
+            (active_child.child_thread_id,),
+        ]
+    finally:
+        await cursor.close()
+    cursor = await checkpointer.conn.execute("SELECT thread_id FROM writes ORDER BY thread_id")
+    try:
+        assert await cursor.fetchall() == [
+            ("agent-root",),
+            (active_child.child_thread_id,),
+        ]
+    finally:
+        await cursor.close()
+    await reset_checkpointer()
+
+
+async def test_vacuum_checkpoint_database_only_runs_above_free_space_threshold(
+    monkeypatch,
+    tmp_path,
+):
+    db_path = tmp_path / "test_checkpoints.db"
+    monkeypatch.setenv("AGENT_CHECKPOINT_DB", str(db_path))
+    await reset_checkpointer()
+    checkpointer = await get_checkpointer()
+    await checkpointer.conn.execute("PRAGMA page_size = 4096")
+    await checkpointer.conn.execute("PRAGMA journal_mode = DELETE")
+    await checkpointer.conn.execute("CREATE TABLE test_data (value BLOB)")
+    await checkpointer.conn.execute(
+        "INSERT INTO test_data(value) VALUES (zeroblob(131072))"
+    )
+    await checkpointer.conn.execute("DELETE FROM test_data")
+    await checkpointer.conn.commit()
+    await reset_checkpointer()
+
+    assert await vacuum_checkpoint_database(min_free_bytes=1) is True
+
+
+async def test_vacuum_checkpoint_database_skips_small_free_space(
+    monkeypatch,
+    tmp_path,
+):
+    db_path = tmp_path / "test_checkpoints.db"
+    monkeypatch.setenv("AGENT_CHECKPOINT_DB", str(db_path))
+    await reset_checkpointer()
+    checkpointer = await get_checkpointer()
+    await checkpointer.conn.execute("CREATE TABLE test_data (value BLOB)")
+    await checkpointer.conn.execute("INSERT INTO test_data(value) VALUES (zeroblob(4096))")
+    await checkpointer.conn.execute("DELETE FROM test_data")
+    await checkpointer.conn.commit()
+    await reset_checkpointer()
+
+    assert await vacuum_checkpoint_database() is False
 
 
 async def test_reset_checkpointer_closes_existing_connection(monkeypatch):

--- a/backend/tests/api/test_projects.py
+++ b/backend/tests/api/test_projects.py
@@ -3,8 +3,25 @@
 Project API 测试。
 """
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
+
+from app.agent_runtime.persistence import repo as agent_run_repo
+from app.agent_runtime.persistence.child_runs import create_child_run
+from app.agent_runtime.persistence.model import (
+    AgentChildRun,
+    AgentChildRunRequest,
+    AgentContextCompaction,
+    AgentRunMessage,
+    PlanRecord,
+    PlanTodoRecord,
+)
+from app.storage.models.task import Task
+from app.storage.models.task_message import TaskMessage
+from app.storage.services import task_service
 
 
 @pytest.mark.asyncio
@@ -198,6 +215,111 @@ async def test_delete_project(client: AsyncClient) -> None:
     # 确认已删除
     get_response = await client.get(f"/api/v1/projects/{project_id}")
     assert get_response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_project_deletes_tasks_and_runtime_data(client, session) -> None:
+    create_response = await client.post("/api/v1/projects", data={"title": "待删除项目"})
+    project_id = create_response.json()["id"]
+    task = await task_service.create_task(
+        session,
+        project_id=project_id,
+        title="待删除任务",
+        mode="agent",
+        agent_session_id="project-delete-session",
+    )
+    await create_child_run(
+        session,
+        parent_session_id="project-delete-session",
+        parent_task_id=task.id,
+        parent_thread_id="project-delete-session",
+        child_thread_id="project-delete-session:child:writer",
+        agent_key="writer",
+        dispatch_id="writer",
+        tool_call_id="tool-writer",
+        request={"task": "write", "input": {}, "metadata": {}},
+    )
+    await agent_run_repo.insert_message(
+        session,
+        session_id="project-delete-session",
+        task_id=task.id,
+        project_id=project_id,
+        role="assistant",
+        content="runtime message",
+        status="completed",
+    )
+    session.add(
+        TaskMessage(
+            id="project-delete-message",
+            task_id=task.id,
+            role="assistant",
+            content="legacy runtime message",
+            tool_calls="[]",
+            message_metadata="{}",
+        )
+    )
+    session.add_all(
+        [
+            AgentContextCompaction(
+                session_id="project-delete-session",
+                task_id=task.id,
+                project_id=project_id,
+                start_seq=0,
+                end_seq=1,
+                summary="runtime summary",
+                trigger="manual",
+            ),
+            PlanRecord(id="project-delete-plan", session_id="project-delete-session"),
+            PlanTodoRecord(
+                id="project-delete-todo",
+                plan_id="project-delete-plan",
+                content="runtime todo",
+                sort_index=0,
+            ),
+        ]
+    )
+    await session.commit()
+
+    with patch(
+        "app.api.routers.projects.delete_checkpoints_for_thread",
+        new=AsyncMock(return_value=0),
+    ) as delete_checkpoints:
+        response = await client.delete(f"/api/v1/projects/{project_id}")
+
+    assert response.status_code == 204
+    assert delete_checkpoints.await_count == 2
+    for model in (
+        Task,
+        TaskMessage,
+        AgentRunMessage,
+        AgentChildRun,
+        AgentChildRunRequest,
+        AgentContextCompaction,
+        PlanRecord,
+        PlanTodoRecord,
+    ):
+        result = await session.execute(select(model))
+        assert result.scalars().all() == []
+
+
+@pytest.mark.asyncio
+async def test_delete_project_rejects_running_tasks(client, session) -> None:
+    create_response = await client.post("/api/v1/projects", data={"title": "运行中项目"})
+    project_id = create_response.json()["id"]
+    task = await task_service.create_task(
+        session,
+        project_id=project_id,
+        title="运行中任务",
+        mode="agent",
+        agent_session_id="running-project-session",
+    )
+    task.is_running = True
+    await session.commit()
+
+    response = await client.delete(f"/api/v1/projects/{project_id}")
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "项目存在运行中任务，不能删除"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_tasks.py
+++ b/backend/tests/api/test_tasks.py
@@ -6,11 +6,21 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from fastapi import status
 from httpx import AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.modes import AgentMode
 from app.agent_runtime.persistence.child_runs import create_child_run
 from app.agent_runtime.persistence import repo as agent_run_repo
+from app.agent_runtime.persistence.model import (
+    AgentChildRun,
+    AgentChildRunRequest,
+    AgentContextCompaction,
+    AgentRunMessage,
+    PlanRecord,
+    PlanTodoRecord,
+)
+from app.storage.models.llm_audit_log import LLMAuditLog
 from app.storage.services import task_service
 
 
@@ -275,6 +285,85 @@ class TestTaskAPI:
         get_response = await client.get(f"/api/v1/tasks/{task.id}")
         assert get_response.status_code == status.HTTP_404_NOT_FOUND
 
+    async def test_delete_task_cleans_runtime_data_but_keeps_audit_logs(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+    ) -> None:
+        task, project_id, _chapter_id = await self.create_agent_task(client, session)
+        await create_child_run(
+            session,
+            parent_session_id=task.agent_session_id or "",
+            parent_task_id=task.id,
+            parent_thread_id=task.agent_session_id or "",
+            child_thread_id="session-task-api:child:writer",
+            agent_key="writer",
+            dispatch_id="writer",
+            tool_call_id="tool-writer",
+            request={"task": "write", "input": {}, "metadata": {}},
+        )
+        await agent_run_repo.insert_message(
+            session,
+            session_id=task.agent_session_id or "",
+            task_id=task.id,
+            project_id=project_id,
+            role="assistant",
+            content="runtime message",
+            status="completed",
+        )
+        session.add_all(
+            [
+                AgentContextCompaction(
+                    session_id=task.agent_session_id or "",
+                    task_id=task.id,
+                    project_id=project_id,
+                    start_seq=0,
+                    end_seq=1,
+                    summary="runtime summary",
+                    trigger="manual",
+                ),
+                PlanRecord(id="plan-task", session_id=task.agent_session_id or ""),
+                PlanTodoRecord(
+                    id="todo-task",
+                    plan_id="plan-task",
+                    content="runtime todo",
+                    sort_index=0,
+                ),
+                LLMAuditLog(
+                    id="audit-task",
+                    task_id=task.id,
+                    session_id=task.agent_session_id,
+                    project_id=project_id,
+                    operation="build",
+                    model_id="test-model",
+                    status="success",
+                ),
+            ]
+        )
+        await session.commit()
+
+        with patch(
+            "app.api.routers.tasks.delete_checkpoints_for_thread",
+            new=AsyncMock(return_value=0),
+        ):
+            response = await client.delete(f"/api/v1/tasks/{task.id}")
+
+        assert response.status_code == status.HTTP_204_NO_CONTENT
+        for model in (
+            AgentRunMessage,
+            AgentChildRun,
+            AgentChildRunRequest,
+            AgentContextCompaction,
+            PlanRecord,
+            PlanTodoRecord,
+        ):
+            result = await session.execute(select(model))
+            assert result.scalars().all() == []
+        audit_result = await session.execute(
+            select(LLMAuditLog).where(LLMAuditLog.id == "audit-task")
+        )
+        assert audit_result.scalar_one_or_none() is not None
+
     async def test_delete_task_deletes_descendant_subagent_checkpoints(
         self,
         client: AsyncClient,
@@ -360,6 +449,46 @@ class TestTaskAPI:
             mode="agent",
             agent_session_id="session-idle",
         )
+        await agent_run_repo.insert_message(
+            session,
+            session_id="session-idle",
+            task_id=idle_task.id,
+            project_id=project_id,
+            role="assistant",
+            content="idle runtime message",
+            status="completed",
+        )
+        await create_child_run(
+            session,
+            parent_session_id="session-idle",
+            parent_task_id=idle_task.id,
+            parent_thread_id="session-idle",
+            child_thread_id="session-idle:child:writer",
+            agent_key="writer",
+            dispatch_id="idle-writer",
+            tool_call_id="idle-tool-writer",
+            request={"task": "write", "input": {}, "metadata": {}},
+        )
+        session.add_all(
+            [
+                AgentContextCompaction(
+                    session_id="session-idle",
+                    task_id=idle_task.id,
+                    project_id=project_id,
+                    start_seq=0,
+                    end_seq=1,
+                    summary="idle summary",
+                    trigger="manual",
+                ),
+                PlanRecord(id="idle-plan", session_id="session-idle"),
+                PlanTodoRecord(
+                    id="idle-todo",
+                    plan_id="idle-plan",
+                    content="idle todo",
+                    sort_index=0,
+                ),
+            ]
+        )
         await session.commit()
 
         with patch(
@@ -373,9 +502,22 @@ class TestTaskAPI:
             "deleted_count": 1,
             "skipped_running_count": 1,
         }
-        delete_checkpoints.assert_awaited_once_with(idle_task.agent_session_id)
+        assert delete_checkpoints.await_args_list == [
+            (("session-idle:child:writer",), {}),
+            ((idle_task.agent_session_id,), {}),
+        ]
 
         running_response = await client.get(f"/api/v1/tasks/{running_task.id}")
         idle_response = await client.get(f"/api/v1/tasks/{idle_task.id}")
         assert running_response.status_code == status.HTTP_200_OK
         assert idle_response.status_code == status.HTTP_404_NOT_FOUND
+        for model in (
+            AgentRunMessage,
+            AgentChildRun,
+            AgentChildRunRequest,
+            AgentContextCompaction,
+            PlanRecord,
+            PlanTodoRecord,
+        ):
+            result = await session.execute(select(model))
+            assert result.scalars().all() == []

--- a/backend/tests/storage/test_database_cleanup.py
+++ b/backend/tests/storage/test_database_cleanup.py
@@ -1,0 +1,49 @@
+from types import SimpleNamespace
+
+import aiosqlite
+
+import app.storage.database as database
+
+
+async def test_vacuum_database_if_needed_reclaims_large_free_space(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    db_path = tmp_path / "openfic.db"
+    monkeypatch.setattr(
+        database,
+        "settings",
+        SimpleNamespace(database_url=f"sqlite+aiosqlite:///{db_path}"),
+    )
+    conn = await aiosqlite.connect(db_path)
+    try:
+        await conn.execute("CREATE TABLE test_data (value BLOB)")
+        await conn.execute("INSERT INTO test_data(value) VALUES (zeroblob(131072))")
+        await conn.execute("DELETE FROM test_data")
+        await conn.commit()
+    finally:
+        await conn.close()
+
+    assert await database.vacuum_database_if_needed(min_free_bytes=1) is True
+
+
+async def test_vacuum_database_if_needed_skips_small_free_space(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    db_path = tmp_path / "openfic.db"
+    monkeypatch.setattr(
+        database,
+        "settings",
+        SimpleNamespace(database_url=f"sqlite+aiosqlite:///{db_path}"),
+    )
+    conn = await aiosqlite.connect(db_path)
+    try:
+        await conn.execute("CREATE TABLE test_data (value BLOB)")
+        await conn.execute("INSERT INTO test_data(value) VALUES (zeroblob(4096))")
+        await conn.execute("DELETE FROM test_data")
+        await conn.commit()
+    finally:
+        await conn.close()
+
+    assert await database.vacuum_database_if_needed() is False

--- a/backend/tests/storage/test_task_cleanup.py
+++ b/backend/tests/storage/test_task_cleanup.py
@@ -1,0 +1,125 @@
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.agent_runtime.persistence.model import (
+    AgentAttachment,
+    AgentChildRun,
+    AgentChildRunRequest,
+    AgentContextCompaction,
+    AgentRunMessage,
+    PlanRecord,
+    PlanTodoRecord,
+)
+from app.storage.models.llm_audit_log import LLMAuditLog
+from app.storage.models.task_message import TaskMessage
+from app.storage.services import task_service
+
+
+async def test_cleanup_orphaned_task_data_keeps_audit_logs(
+    session: AsyncSession,
+) -> None:
+    session.add_all(
+        [
+            AgentAttachment(
+                id="orphan-attachment",
+                session_id="orphan-session",
+                task_id="missing-task",
+                project_id="project",
+                storage_name="orphan-session/orphan-attachment.png",
+                file_name="orphan.png",
+                mime_type="image/png",
+                size_bytes=1,
+                width=1,
+                height=1,
+            ),
+            TaskMessage(
+                id="orphan-task-message",
+                task_id="missing-task",
+                role="assistant",
+                content="orphan task message",
+                tool_calls="[]",
+                message_metadata="{}",
+            ),
+            AgentRunMessage(
+                id="orphan-message",
+                session_id="orphan-session",
+                task_id="missing-task",
+                project_id="project",
+                role="assistant",
+                status="completed",
+                seq=0,
+            ),
+            AgentChildRun(
+                id="orphan-child",
+                parent_session_id="orphan-session",
+                parent_task_id="missing-task",
+                parent_thread_id="orphan-session",
+                child_thread_id="orphan-child-thread",
+                agent_key="writer",
+                dispatch_id="writer",
+                tool_call_id="tool-writer",
+            ),
+            AgentChildRunRequest(
+                id="orphan-request",
+                child_run_id="orphan-child",
+                parent_session_id="orphan-session",
+                parent_task_id="missing-task",
+                request_kind="dispatch",
+                seq=0,
+            ),
+            AgentContextCompaction(
+                id="orphan-compaction",
+                session_id="orphan-session",
+                task_id="missing-task",
+                project_id="project",
+                start_seq=0,
+                end_seq=1,
+                summary="orphan summary",
+                trigger="manual",
+            ),
+            PlanRecord(id="orphan-plan", session_id="orphan-session"),
+            PlanTodoRecord(
+                id="orphan-todo",
+                plan_id="orphan-plan",
+                content="orphan todo",
+                sort_index=0,
+            ),
+            PlanRecord(id="plan-only-orphan", session_id="plan-only-session"),
+            PlanTodoRecord(
+                id="plan-only-orphan-todo",
+                plan_id="plan-only-orphan",
+                content="orphan-only todo",
+                sort_index=0,
+            ),
+            LLMAuditLog(
+                id="orphan-audit",
+                task_id="missing-task",
+                session_id="orphan-session",
+                project_id="project",
+                operation="build",
+                model_id="test-model",
+                status="success",
+            ),
+        ]
+    )
+    await session.commit()
+
+    deleted_rows = await task_service.cleanup_orphaned_task_data(session)
+
+    assert deleted_rows == 10
+    for model in (
+        AgentAttachment,
+        TaskMessage,
+        AgentRunMessage,
+        AgentChildRun,
+        AgentChildRunRequest,
+        AgentContextCompaction,
+        PlanRecord,
+        PlanTodoRecord,
+    ):
+        result = await session.execute(select(model))
+        assert result.scalars().all() == []
+    audit_result = await session.execute(
+        select(LLMAuditLog).where(LLMAuditLog.id == "orphan-audit")
+    )
+    assert audit_result.scalar_one_or_none() is not None

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -62,6 +62,8 @@ async def test_lifespan_refreshes_catalog_in_background_and_cancels_on_shutdown(
     monkeypatch.setattr(main, "_cleanup_unreachable_checkpoints", do_nothing)
     monkeypatch.setattr(main, "_cleanup_chapter_export_files", do_nothing)
     monkeypatch.setattr(main, "_cleanup_orphaned_agent_attachment_files", do_nothing)
+    monkeypatch.setattr(main, "_cleanup_orphaned_task_data", do_nothing)
+    monkeypatch.setattr(main, "_vacuum_main_database", do_nothing)
     monkeypatch.setattr(main, "load_audit_details_persistence", do_nothing)
     monkeypatch.setattr(main, "start_audit_queue", lambda: None)
     monkeypatch.setattr(main, "start_background_runtime", do_nothing)


### PR DESCRIPTION
## PR 标题

fix(storage): 清理数据库关联运行时数据

## 变更说明

- 问题: 删除任务或项目后，Agent 运行时消息、子 Agent、上下文压缩和计划数据会残留；SQLite 文件也不会主动回收已删除数据占用的空间。
- 重要性: 残留数据会持续增大 `openfic.db` 和 `checkpoints.db`，并可能在已删除会话后留下孤儿运行时记录。
- 变化: 删除 Task 与项目时同步删除关联的运行时数据、附件与 checkpoint；审计日志保持保留。
- 变化: 启动时清理不可达 checkpoint、孤儿 Task 运行时数据，并在 SQLite 空闲页达到 64 MiB 时执行 VACUUM。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [x] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

Task 和项目删除路径未完整清理关联的 Agent 运行时数据；SQLite 默认只复用空闲页，不会自动缩小数据库文件。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

已执行 `timeout 90s uv run pytest tests/agent_runtime/test_checkpointer.py`、`timeout 30s uv run pytest tests/test_main.py`，以及 `timeout 70s uv run pytest tests/api/test_tasks.py tests/api/test_projects.py tests/storage/test_task_cleanup.py tests/storage/test_database_cleanup.py tests/test_main.py`。共覆盖 checkpoint 留存与 VACUUM、Task/项目删除、孤儿运行时数据清理和启动生命周期。
