### PR TITLE
fix(desktop): 修复更新元数据缺失导致检查报错的问题

### DIFF
--- a/desktop/src/main/updater.ts
+++ b/desktop/src/main/updater.ts
@@ -23,6 +23,11 @@ function describeError(error: Error): string {
   return error.message || "更新服务暂时不可用";
 }
 
+function isMissingUpdateMetadataError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes(`${autoUpdater.channel}.yml`) && /\b404\b/.test(message);
+}
+
 function getUpdaterReleaseNotes(info: UpdateInfo): string | undefined {
   if (typeof info.releaseNotes === "string") return info.releaseNotes.trim() || undefined;
   if (!Array.isArray(info.releaseNotes)) return undefined;
@@ -146,6 +151,11 @@ export async function checkForUpdates(): Promise<void> {
   try {
     await autoUpdater.checkForUpdates();
   } catch (error) {
+    // A release may be visible before CI uploads its architecture-specific metadata.
+    if (isMissingUpdateMetadataError(error)) {
+      publishState({ status: "not-available" });
+      return;
+    }
     publishState({ status: "error", message: describeError(error instanceof Error ? error : new Error(String(error))) });
   }
 }


### PR DESCRIPTION
## 变更说明

- 问题: 新版本 Release 已发布、但 CI 尚未上传对应架构的 `latest-win-*.yml` 时，桌面端更新检查会因 HTTP 404 显示错误。
- 重要性: 该短暂发版窗口会向用户误报更新服务异常。
- 变化: 仅当当前更新通道 YAML 返回 HTTP 404 时，将状态按无可用更新处理；网络、代理、校验等其他错误仍正常显示。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

Release 可见与 Windows 自动更新产物上传是独立阶段。Release 已创建但 `latest-win-*.yml` 尚未上传时，`electron-updater` 请求当前通道元数据会收到 HTTP 404。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

未新增自动化测试；现有桌面端测试未覆盖 Electron 主进程的 `electron-updater` 网络异常分支。已执行 `pnpm type-check`、`pnpm lint` 与 `git diff --check`。
