### PR TITLE
fix(backend): 修复测试夹具重复初始化导致后端测试耗时过长的问题

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+backend/app/core/resources/tiktoken/*.tiktoken -text

--- a/backend/tests/agent_runtime/test_checkpointer.py
+++ b/backend/tests/agent_runtime/test_checkpointer.py
@@ -1,3 +1,4 @@
+from contextlib import closing
 import os
 import sqlite3
 import tempfile
@@ -238,12 +239,14 @@ async def test_get_checkpointer_migrates_legacy_db_and_removes_old_backend_file(
         data_dir.mkdir(parents=True, exist_ok=True)
 
         legacy_runtime_path = legacy_root_dir / "langgraph_checkpoints.db"
-        sqlite3.connect(legacy_runtime_path).execute("CREATE TABLE marker (id INTEGER)")
-        sqlite3.connect(legacy_runtime_path).close()
+        with closing(sqlite3.connect(legacy_runtime_path)) as conn:
+            conn.execute("CREATE TABLE marker (id INTEGER)")
+            conn.commit()
 
         legacy_backend_path = data_dir / "agent_checkpoints.db"
-        sqlite3.connect(legacy_backend_path).execute("CREATE TABLE stale (id INTEGER)")
-        sqlite3.connect(legacy_backend_path).close()
+        with closing(sqlite3.connect(legacy_backend_path)) as conn:
+            conn.execute("CREATE TABLE stale (id INTEGER)")
+            conn.commit()
 
         monkeypatch.delenv("AGENT_CHECKPOINT_DB", raising=False)
         monkeypatch.setattr(checkpointer_mod.app_settings, "BACKEND_DIR", backend_dir)
@@ -257,7 +260,7 @@ async def test_get_checkpointer_migrates_legacy_db_and_removes_old_backend_file(
         assert not legacy_runtime_path.exists()
         assert not legacy_backend_path.exists()
 
-        with sqlite3.connect(target_path) as conn:
+        with closing(sqlite3.connect(target_path)) as conn:
             assert conn.execute(
                 "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'marker'"
             ).fetchone() == ("marker",)
@@ -288,7 +291,7 @@ async def test_delete_checkpoints_for_thread_removes_matching_rows_only():
         await reset_checkpointer()
         await get_checkpointer()
 
-        with sqlite3.connect(db_path) as conn:
+        with closing(sqlite3.connect(db_path)) as conn:
             conn.execute(
                 "INSERT INTO checkpoints(thread_id, checkpoint_ns, checkpoint_id) VALUES (?, ?, ?)",
                 ("session-a", "", "cp-a"),
@@ -310,7 +313,7 @@ async def test_delete_checkpoints_for_thread_removes_matching_rows_only():
         deleted_rows = await delete_checkpoints_for_thread("session-a")
 
         assert deleted_rows == 2
-        with sqlite3.connect(db_path) as conn:
+        with closing(sqlite3.connect(db_path)) as conn:
             assert conn.execute(
                 "SELECT COUNT(*) FROM checkpoints WHERE thread_id = ?",
                 ("session-a",),
@@ -339,7 +342,7 @@ async def test_delete_checkpoints_after_for_thread_keeps_cutoff_and_clears_subgr
         await reset_checkpointer()
         await get_checkpointer()
 
-        with sqlite3.connect(db_path) as conn:
+        with closing(sqlite3.connect(db_path)) as conn:
             conn.execute(
                 "INSERT INTO checkpoints(thread_id, checkpoint_ns, checkpoint_id) VALUES (?, ?, ?)",
                 ("session-a", "", "cp-001"),
@@ -370,7 +373,7 @@ async def test_delete_checkpoints_after_for_thread_keeps_cutoff_and_clears_subgr
         deleted_rows = await delete_checkpoints_after_for_thread("session-a", "cp-001")
 
         assert deleted_rows == 4
-        with sqlite3.connect(db_path) as conn:
+        with closing(sqlite3.connect(db_path)) as conn:
             remaining = conn.execute(
                 "SELECT checkpoint_ns, checkpoint_id FROM checkpoints WHERE thread_id = ? ORDER BY checkpoint_id",
                 ("session-a",),

--- a/backend/tests/api/test_model_icons.py
+++ b/backend/tests/api/test_model_icons.py
@@ -5,8 +5,24 @@ Catalog model icon API tests.
 
 import httpx
 import pytest
+import pytest_asyncio
 import respx
 from httpx import AsyncClient
+
+from app.models.catalog import CatalogIconProxyService
+
+
+@pytest_asyncio.fixture(autouse=True)
+async def live_catalog_icon_proxy(_test_app):
+    """Use a real HTTP client only for tests that intercept icon requests."""
+    previous_service = _test_app.state.catalog_icon_proxy_service
+    service = CatalogIconProxyService()
+    _test_app.state.catalog_icon_proxy_service = service
+    try:
+        yield
+    finally:
+        _test_app.state.catalog_icon_proxy_service = previous_service
+        await service.aclose()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -10,6 +10,7 @@ from collections.abc import AsyncGenerator
 from pathlib import Path
 import shutil
 
+import httpx
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
@@ -56,9 +57,21 @@ TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
 _per_test_session: AsyncSession | None = None
 
 
+class _NotFoundIconHttpClient:
+    """Avoid network-client setup for tests that do not exercise icon fetching."""
+
+    async def get(self, url: str) -> httpx.Response:
+        return httpx.Response(404, request=httpx.Request("GET", url))
+
+    async def aclose(self) -> None:
+        pass
+
+
 def _create_test_app() -> FastAPI:
     test_app = FastAPI()
-    test_app.state.catalog_icon_proxy_service = CatalogIconProxyService()
+    test_app.state.catalog_icon_proxy_service = CatalogIconProxyService(
+        client=_NotFoundIconHttpClient()
+    )
     test_app.include_router(model_icons.router)
     test_app.include_router(health.router, prefix="/api/v1")
     test_app.include_router(projects.router, prefix="/api/v1")
@@ -146,15 +159,7 @@ async def client(_test_app: FastAPI, db_engine) -> AsyncGenerator[AsyncClient, N
         _per_test_session = None
 
 
-@pytest_asyncio.fixture(autouse=True)
-async def _reset_icon_proxy(_test_app: FastAPI):
-    """每次测试前重置图标代理，避免 session-shared 状态泄漏。"""
-    _test_app.state.catalog_icon_proxy_service = CatalogIconProxyService()
-    yield
-    await _test_app.state.catalog_icon_proxy_service.aclose()
-
-
-@pytest_asyncio.fixture(autouse=True)
+@pytest_asyncio.fixture
 async def isolated_prompts_dir(monkeypatch, tmp_path: Path) -> AsyncGenerator[Path, None]:
     """每个测试使用隔离的 prompts 目录，避免污染仓库内 YAML。"""
     import app.prompts.loader as prompt_loader


### PR DESCRIPTION
## PR 标题

fix(backend): 修复测试夹具重复初始化导致后端测试耗时过长的问题

## 变更说明

- 问题: 全局测试夹具会为每个用例初始化图标 HTTP 客户端并复制 prompts 目录，造成大量固定开销；Windows 下 SQLite 测试连接未完全关闭，且 tiktoken 词表会被 CRLF 转换破坏。
- 重要性: 后端全量测试在 Windows 上此前约 10 分钟仅执行至 12%，并会产生 8 个平台相关失败，降低本地回归效率和可信度。
- 变化: 非图标测试使用无网络的图标客户端，图标路由测试保留真实客户端；prompts 隔离改为按需启用；显式关闭 SQLite 测试连接；将内置 tiktoken 资源声明为二进制文件。
- 结果: Windows 全量后端测试由未能在 10 分钟内完成，降至 1336 项全部通过、耗时 228.17 秒。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [x] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

全局 `autouse` fixture 在每个测试用例中重复创建 `httpx.AsyncClient`。Windows 上 TLS 上下文初始化约需 1.6 秒，且 prompts 目录复制同样发生在全部用例中。SQLite 测试使用的同步连接未被正确关闭，Windows 无法删除仍被占用的数据库文件。仓库缺少 Git 属性，启用 `core.autocrlf` 时会改写 `.tiktoken` 词表的字节，导致哈希校验和离线加载失败。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令：

```text
uv run pytest --durations=50
uv run ruff check tests/conftest.py tests/api/test_model_icons.py tests/agent_runtime/test_checkpointer.py
uv run ty check app
```
