### PR TITLE
fix(desktop): 修复启动时窗口延迟显示的问题

### DIFF
--- a/desktop/src/main/windows.ts
+++ b/desktop/src/main/windows.ts
@@ -10,6 +10,7 @@ const DEFAULT_HEIGHT = 800;
 const MIN_WIDTH = 960;
 const MIN_HEIGHT = 640;
 const SAVE_DEBOUNCE_MS = 500;
+const WINDOW_SHOW_FALLBACK_MS = 600;
 
 function writeWindowLog(message: string): void {
   appendLog("startup", message);
@@ -141,6 +142,7 @@ export function createMainWindow(): BrowserWindow {
     height: layout.height,
     frame: false,
     show: false,
+    backgroundColor: "#ffffff",
     titleBarStyle: "hidden",
     webPreferences: {
       contextIsolation: true,
@@ -166,13 +168,30 @@ export function createMainWindow(): BrowserWindow {
   });
   attachWindowDiagnostics(window, "main");
 
-  window.once("ready-to-show", () => {
+  let showTimer: ReturnType<typeof setTimeout> | null = null;
+  let hasShown = false;
+  const showWindow = () => {
+    if (window.isDestroyed() || hasShown) return;
+
+    hasShown = true;
+    if (showTimer) {
+      clearTimeout(showTimer);
+      showTimer = null;
+    }
     if (layout.isMaximized) window.maximize();
     window.show();
+  };
+
+  window.once("ready-to-show", () => {
+    showWindow();
+  });
+  window.once("closed", () => {
+    if (showTimer) clearTimeout(showTimer);
   });
 
   attachWindowStateTracking(window);
 
   loadMainApp(window);
+  showTimer = setTimeout(showWindow, WINDOW_SHOW_FALLBACK_MS);
   return window;
 }


### PR DESCRIPTION
## 变更说明

- 问题: 主窗口仅在 Electron 的 `ready-to-show` 事件触发后才显示；在 v0.9.0 的启动流程中，该事件可能延迟至 frontend webview 挂载后，导致用户无法看到壳层启动进度。
- 重要性: 本地 runtime 启动期间窗口不可见，用户会误以为桌面应用无响应。
- 变化: 保留 `ready-to-show` 的优先显示路径，并在 600ms 后兜底显示窗口；同时设定浅色窗口背景，避免兜底显示时闪烁。

## 关联 Issue / PR (如有)

无

## 变更类型

- [x] 错误修复 (fix)

## 问题原因

隐藏窗口的 `ready-to-show` 被作为唯一显示条件。该事件在本次启动中发生在 Boot 页卸载和 frontend webview 挂载之后，因此启动进度虽已在渲染器内更新，但始终没有机会对用户可见。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

已执行 `pnpm type-check` 和 `pnpm lint -- src/main/windows.ts src/ui/app.tsx src/ui/pages/boot/page.tsx src/ui/pages/frontend/page.tsx`。