### PR TITLE
ci(desktop): 修复多架构构建导致发布包损坏的问题

### DIFF
--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -192,6 +192,81 @@ jobs:
           for dmg_file in "${dmg_files[@]}"; do
             hdiutil verify "$dmg_file"
           done
+      - name: Install and launch Windows application
+        if: runner.os == 'Windows'
+        working-directory: desktop
+        timeout-minutes: 5
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $installer = @(Get-ChildItem -LiteralPath 'dist-electron' -Filter 'OpenFic-*-win-${{ matrix.arch }}-setup.exe')
+          if ($installer.Count -ne 1) { throw "Expected one Windows installer, found $($installer.Count)" }
+
+          $installDirectory = Join-Path $env:RUNNER_TEMP "openfic-${{ matrix.arch }}-$env:GITHUB_RUN_ID"
+          $userDataDirectory = Join-Path $env:RUNNER_TEMP "openfic-user-data-${{ matrix.arch }}-$env:GITHUB_RUN_ID"
+          $standardOutput = Join-Path $env:RUNNER_TEMP "openfic-${{ matrix.arch }}.out.log"
+          $standardError = Join-Path $env:RUNNER_TEMP "openfic-${{ matrix.arch }}.err.log"
+          $application = Join-Path $installDirectory 'OpenFic.exe'
+          $process = $null
+
+          try {
+            & $installer[0].FullName /S "/D=$installDirectory"
+            if ($LASTEXITCODE -ne 0) { throw "Windows installer exited with code $LASTEXITCODE" }
+            if (-not (Test-Path -LiteralPath $application)) { throw "Installed application was not found: $application" }
+
+            $process = Start-Process -FilePath $application -ArgumentList "--user-data-dir=$userDataDirectory" -RedirectStandardOutput $standardOutput -RedirectStandardError $standardError -PassThru
+            Start-Sleep -Seconds 10
+            if ($process.HasExited) {
+              Get-Content -LiteralPath $standardOutput, $standardError -ErrorAction SilentlyContinue
+              throw "Installed application exited before the startup check completed with code $($process.ExitCode)"
+            }
+          } finally {
+            if ($null -ne $process -and -not $process.HasExited) {
+              Stop-Process -Id $process.Id -Force
+              $process.WaitForExit(10000) | Out-Null
+            }
+            Remove-Item -LiteralPath $installDirectory, $userDataDirectory, $standardOutput, $standardError -Recurse -Force -ErrorAction SilentlyContinue
+          }
+      - name: Launch Linux AppImage
+        if: runner.os == 'Linux'
+        working-directory: desktop
+        timeout-minutes: 5
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          app_images=(dist-electron/OpenFic-*-linux-*.AppImage)
+          ((${#app_images[@]} == 1))
+          if ! command -v xvfb-run >/dev/null; then
+            sudo apt-get update
+            sudo apt-get install --yes xvfb
+          fi
+
+          user_data_dir=$(mktemp -d)
+          app_log=$(mktemp)
+          app_pid=""
+
+          cleanup() {
+            if [[ -n "$app_pid" ]] && kill -0 "$app_pid" 2>/dev/null; then
+              kill "$app_pid" || true
+              wait "$app_pid" || true
+            fi
+            rm -rf "$user_data_dir" "$app_log"
+          }
+          trap cleanup EXIT
+
+          chmod +x "${app_images[0]}"
+
+          xvfb-run --auto-servernum "${app_images[0]}" --appimage-extract-and-run --user-data-dir="$user_data_dir" > "$app_log" 2>&1 &
+          app_pid=$!
+          for _ in {1..10}; do
+            if ! kill -0 "$app_pid" 2>/dev/null; then
+              cat "$app_log"
+              wait "$app_pid"
+              exit 1
+            fi
+            sleep 1
+          done
       - name: Install and launch macOS application
         if: runner.os == 'macOS'
         working-directory: desktop

--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -210,8 +210,8 @@ jobs:
           $process = $null
 
           try {
-            & $installer[0].FullName /S "/D=$installDirectory"
-            if ($LASTEXITCODE -ne 0) { throw "Windows installer exited with code $LASTEXITCODE" }
+            $installerProcess = Start-Process -FilePath $installer[0].FullName -ArgumentList @('/S', '/currentuser', "/D=$installDirectory") -Wait -PassThru
+            if ($installerProcess.ExitCode -ne 0) { throw "Windows installer exited with code $($installerProcess.ExitCode)" }
             if (-not (Test-Path -LiteralPath $application)) { throw "Installed application was not found: $application" }
 
             $process = Start-Process -FilePath $application -ArgumentList "--user-data-dir=$userDataDirectory" -RedirectStandardOutput $standardOutput -RedirectStandardError $standardError -PassThru
@@ -257,7 +257,7 @@ jobs:
 
           chmod +x "${app_images[0]}"
 
-          xvfb-run --auto-servernum "${app_images[0]}" --appimage-extract-and-run --user-data-dir="$user_data_dir" > "$app_log" 2>&1 &
+          xvfb-run --auto-servernum "${app_images[0]}" --appimage-extract-and-run --no-sandbox --user-data-dir="$user_data_dir" > "$app_log" 2>&1 &
           app_pid=$!
           for _ in {1..10}; do
             if ! kill -0 "$app_pid" 2>/dev/null; then

--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -109,12 +109,24 @@ jobs:
           - os: windows-11-arm
             target: --win
             arch: arm64
+          - os: ubuntu-22.04
+            target: --linux
+            arch: x64
+            linux_appimage_args: ''
+            linux_application_args: ''
+            linux_appimage_uses_fuse: true
           - os: ubuntu-24.04
             target: --linux
             arch: x64
+            linux_appimage_args: --appimage-extract-and-run --no-sandbox
+            linux_application_args: --no-sandbox
+            linux_appimage_uses_fuse: false
           - os: ubuntu-24.04-arm
             target: --linux
             arch: arm64
+            linux_appimage_args: --appimage-extract-and-run --no-sandbox
+            linux_application_args: --no-sandbox
+            linux_appimage_uses_fuse: false
           - os: macos-15-intel
             target: --mac
             arch: x64
@@ -227,7 +239,7 @@ jobs:
             }
             Remove-Item -LiteralPath $installDirectory, $userDataDirectory, $standardOutput, $standardError -Recurse -Force -ErrorAction SilentlyContinue
           }
-      - name: Launch Linux AppImage
+      - name: Launch Linux packages
         if: runner.os == 'Linux'
         working-directory: desktop
         timeout-minutes: 5
@@ -236,37 +248,86 @@ jobs:
           set -euo pipefail
           shopt -s nullglob
           app_images=(dist-electron/OpenFic-*-linux-*.AppImage)
+          tar_files=(dist-electron/OpenFic-*-linux-*.tar.gz)
           ((${#app_images[@]} == 1))
-          if ! command -v xvfb-run >/dev/null; then
+          ((${#tar_files[@]} == 1))
+          packages=()
+          if ! command -v Xvfb >/dev/null; then packages+=(xvfb); fi
+          if ! command -v xdotool >/dev/null; then packages+=(xdotool); fi
+          if [[ '${{ matrix.linux_appimage_uses_fuse }}' == true ]]; then packages+=(fuse libfuse2); fi
+          if ((${#packages[@]})); then
             sudo apt-get update
-            sudo apt-get install --yes xvfb
+            sudo apt-get install --yes "${packages[@]}"
           fi
 
-          user_data_dir=$(mktemp -d)
-          app_log=$(mktemp)
-          app_pid=""
+          read -r -a app_image_args <<< "${{ matrix.linux_appimage_args }}"
+          read -r -a application_args <<< "${{ matrix.linux_application_args }}"
+          install_dir=$(mktemp -d)
+          app_image_user_data_dir=$(mktemp -d)
+          tarball_user_data_dir=$(mktemp -d)
+          app_image_log=$(mktemp)
+          tarball_log=$(mktemp)
+          xvfb_log=$(mktemp)
+          xvfb_pid=""
+          app_pids=()
 
           cleanup() {
-            if [[ -n "$app_pid" ]] && kill -0 "$app_pid" 2>/dev/null; then
-              kill "$app_pid" || true
+            for app_pid in "${app_pids[@]}"; do
+              if kill -0 "$app_pid" 2>/dev/null; then kill -- "-$app_pid" || true; fi
               wait "$app_pid" || true
-            fi
-            rm -rf "$user_data_dir" "$app_log"
+            done
+            if [[ -n "$xvfb_pid" ]] && kill -0 "$xvfb_pid" 2>/dev/null; then kill "$xvfb_pid" || true; fi
+            wait "$xvfb_pid" 2>/dev/null || true
+            rm -rf "$install_dir" "$app_image_user_data_dir" "$tarball_user_data_dir" "$app_image_log" "$tarball_log" "$xvfb_log"
           }
           trap cleanup EXIT
 
-          chmod +x "${app_images[0]}"
+          export DISPLAY=:99
+          Xvfb "$DISPLAY" -screen 0 1280x800x24 > "$xvfb_log" 2>&1 &
+          xvfb_pid=$!
+          sleep 1
+          if ! kill -0 "$xvfb_pid" 2>/dev/null; then
+            cat "$xvfb_log"
+            exit 1
+          fi
 
-          xvfb-run --auto-servernum "${app_images[0]}" --appimage-extract-and-run --no-sandbox --user-data-dir="$user_data_dir" > "$app_log" 2>&1 &
-          app_pid=$!
-          for _ in {1..10}; do
-            if ! kill -0 "$app_pid" 2>/dev/null; then
-              cat "$app_log"
-              wait "$app_pid"
+          launch_and_verify() {
+            local package_name="$1"
+            local log_path="$2"
+            local user_data_dir="$3"
+            shift 3
+
+            setsid "$@" > "$log_path" 2>&1 &
+            local app_pid=$!
+            app_pids+=("$app_pid")
+            local window_visible=false
+            for _ in {1..10}; do
+              if ! kill -0 "$app_pid" 2>/dev/null; then
+                cat "$log_path"
+                if [[ -d "$user_data_dir/logs" ]]; then find "$user_data_dir/logs" -type f -name '*.log' -exec sh -c 'echo "--- $1"; cat "$1"' _ {} \;; fi
+                wait "$app_pid"
+                exit 1
+              fi
+              if xdotool search --onlyvisible --name 'OpenFic' >/dev/null 2>&1; then window_visible=true; fi
+              sleep 1
+            done
+            if [[ "$window_visible" != true ]]; then
+              cat "$log_path"
+              if [[ -d "$user_data_dir/logs" ]]; then find "$user_data_dir/logs" -type f -name '*.log' -exec sh -c 'echo "--- $1"; cat "$1"' _ {} \;; fi
+              echo "$package_name started but did not show an OpenFic window"
               exit 1
             fi
-            sleep 1
-          done
+            kill -- "-$app_pid"
+            wait "$app_pid" || true
+          }
+
+          chmod +x "${app_images[0]}"
+          launch_and_verify AppImage "$app_image_log" "$app_image_user_data_dir" "${app_images[0]}" "${app_image_args[@]}" --user-data-dir="$app_image_user_data_dir"
+
+          tar -xzf "${tar_files[0]}" -C "$install_dir"
+          mapfile -t tarball_applications < <(find "$install_dir" -type f -name OpenFic -perm -111)
+          ((${#tarball_applications[@]} == 1))
+          launch_and_verify tar.gz "$tarball_log" "$tarball_user_data_dir" "${tarball_applications[0]}" "${application_args[@]}" --user-data-dir="$tarball_user_data_dir"
       - name: Install and launch macOS application
         if: runner.os == 'macOS'
         working-directory: desktop

--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -334,8 +334,12 @@ jobs:
           launch_and_verify AppImage "$app_image_log" "$app_image_user_data_dir" "${app_images[0]}" "${app_image_args[@]}" --user-data-dir="$app_image_user_data_dir"
 
           tar -xzf "${tar_files[0]}" -C "$install_dir"
-          mapfile -t tarball_applications < <(find "$install_dir" -type f -name OpenFic -perm -111)
-          ((${#tarball_applications[@]} == 1))
+          mapfile -t tarball_applications < <(find "$install_dir" -type f -name openfic-desktop -perm -111)
+          if ((${#tarball_applications[@]} != 1)); then
+            echo "Expected one executable named openfic-desktop, found ${#tarball_applications[@]}"
+            find "$install_dir" -maxdepth 3 -type f -printf '%m %p\n' | sort
+            exit 1
+          fi
           launch_and_verify tar.gz "$tarball_log" "$tarball_user_data_dir" "${tarball_applications[0]}" "${application_args[@]}" --user-data-dir="$tarball_user_data_dir"
       - name: Install and launch macOS application
         if: runner.os == 'macOS'

--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -112,21 +112,13 @@ jobs:
           - os: ubuntu-22.04
             target: --linux
             arch: x64
-            linux_appimage_args: ''
-            linux_application_args: ''
-            linux_appimage_uses_fuse: true
-          - os: ubuntu-24.04
-            target: --linux
-            arch: x64
             linux_appimage_args: --appimage-extract-and-run --no-sandbox
             linux_application_args: --no-sandbox
-            linux_appimage_uses_fuse: false
           - os: ubuntu-24.04-arm
             target: --linux
             arch: arm64
             linux_appimage_args: --appimage-extract-and-run --no-sandbox
             linux_application_args: --no-sandbox
-            linux_appimage_uses_fuse: false
           - os: macos-15-intel
             target: --mac
             arch: x64
@@ -254,7 +246,6 @@ jobs:
           packages=()
           if ! command -v Xvfb >/dev/null; then packages+=(xvfb); fi
           if ! command -v xdotool >/dev/null; then packages+=(xdotool); fi
-          if [[ '${{ matrix.linux_appimage_uses_fuse }}' == true ]]; then packages+=(fuse libfuse2); fi
           if ((${#packages[@]})); then
             sudo apt-get update
             sudo apt-get install --yes "${packages[@]}"
@@ -271,10 +262,29 @@ jobs:
           xvfb_pid=""
           app_pids=()
 
+          stop_application() {
+            local app_pid="$1"
+            if kill -0 "$app_pid" 2>/dev/null; then kill "$app_pid" || true; fi
+            for _ in {1..5}; do
+              if ! kill -0 "$app_pid" 2>/dev/null; then break; fi
+              sleep 1
+            done
+            if kill -0 "$app_pid" 2>/dev/null; then kill -9 "$app_pid" || true; fi
+            wait "$app_pid" || true
+          }
+
+          print_diagnostics() {
+            local log_path="$1"
+            local user_data_dir="$2"
+            cat "$log_path" || true
+            if [[ -d "$user_data_dir/logs" ]]; then
+              find "$user_data_dir/logs" -type f -name '*.log' -exec sh -c 'echo "--- $1"; cat "$1"' _ {} \;
+            fi
+          }
+
           cleanup() {
             for app_pid in "${app_pids[@]}"; do
-              if kill -0 "$app_pid" 2>/dev/null; then kill -- "-$app_pid" || true; fi
-              wait "$app_pid" || true
+              stop_application "$app_pid"
             done
             if [[ -n "$xvfb_pid" ]] && kill -0 "$xvfb_pid" 2>/dev/null; then kill "$xvfb_pid" || true; fi
             wait "$xvfb_pid" 2>/dev/null || true
@@ -297,28 +307,27 @@ jobs:
             local user_data_dir="$3"
             shift 3
 
-            setsid "$@" > "$log_path" 2>&1 &
+            "$@" > "$log_path" 2>&1 &
             local app_pid=$!
             app_pids+=("$app_pid")
             local window_visible=false
             for _ in {1..10}; do
               if ! kill -0 "$app_pid" 2>/dev/null; then
-                cat "$log_path"
-                if [[ -d "$user_data_dir/logs" ]]; then find "$user_data_dir/logs" -type f -name '*.log' -exec sh -c 'echo "--- $1"; cat "$1"' _ {} \;; fi
-                wait "$app_pid"
-                exit 1
+                local exit_code=0
+                wait "$app_pid" || exit_code=$?
+                print_diagnostics "$log_path" "$user_data_dir"
+                echo "$package_name exited before the startup check completed with code $exit_code"
+                return 1
               fi
               if xdotool search --onlyvisible --name 'OpenFic' >/dev/null 2>&1; then window_visible=true; fi
               sleep 1
             done
             if [[ "$window_visible" != true ]]; then
-              cat "$log_path"
-              if [[ -d "$user_data_dir/logs" ]]; then find "$user_data_dir/logs" -type f -name '*.log' -exec sh -c 'echo "--- $1"; cat "$1"' _ {} \;; fi
+              print_diagnostics "$log_path" "$user_data_dir"
               echo "$package_name started but did not show an OpenFic window"
-              exit 1
+              return 1
             fi
-            kill -- "-$app_pid"
-            wait "$app_pid" || true
+            stop_application "$app_pid"
           }
 
           chmod +x "${app_images[0]}"

--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -160,13 +160,37 @@ jobs:
       - name: Build desktop package
         working-directory: desktop
         run: pnpm exec electron-builder --config electron-builder.yml ${{ matrix.target }} --${{ matrix.arch }} --publish never
+      - name: Verify Windows ZIP archives
+        if: runner.os == 'Windows'
+        working-directory: desktop
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          zip_files=(dist-electron/*.zip)
+          ((${#zip_files[@]}))
+          for zip_file in "${zip_files[@]}"; do 7z t "$zip_file"; done
+      - name: Verify Linux archives
+        if: runner.os == 'Linux'
+        working-directory: desktop
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          zip_files=(dist-electron/*.zip)
+          tar_files=(dist-electron/*.tar.gz)
+          ((${#zip_files[@]} && ${#tar_files[@]}))
+          for zip_file in "${zip_files[@]}"; do unzip -t "$zip_file"; done
+          for tar_file in "${tar_files[@]}"; do tar -tzf "$tar_file" >/dev/null; done
       - name: Verify macOS disk images
         if: runner.os == 'macOS'
         working-directory: desktop
         run: |
           shopt -s nullglob
+          zip_files=(dist-electron/*.zip)
           dmg_files=(dist-electron/*.dmg)
-          ((${#dmg_files[@]}))
+          ((${#zip_files[@]} && ${#dmg_files[@]}))
+          for zip_file in "${zip_files[@]}"; do unzip -t "$zip_file"; done
           for dmg_file in "${dmg_files[@]}"; do
             hdiutil verify "$dmg_file"
           done

--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -177,10 +177,8 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s nullglob
-          zip_files=(dist-electron/*.zip)
           tar_files=(dist-electron/*.tar.gz)
-          ((${#zip_files[@]} && ${#tar_files[@]}))
-          for zip_file in "${zip_files[@]}"; do unzip -t "$zip_file"; done
+          ((${#tar_files[@]}))
           for tar_file in "${tar_files[@]}"; do tar -tzf "$tar_file" >/dev/null; done
       - name: Verify macOS disk images
         if: runner.os == 'macOS'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -319,10 +319,8 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s nullglob
-          zip_files=(desktop/dist-electron/*.zip)
           tar_files=(desktop/dist-electron/*.tar.gz)
-          ((${#zip_files[@]} && ${#tar_files[@]}))
-          for zip_file in "${zip_files[@]}"; do unzip -t "$zip_file"; done
+          ((${#tar_files[@]}))
           for tar_file in "${tar_files[@]}"; do tar -tzf "$tar_file" >/dev/null; done
       - name: 校验 macOS 安装包完整性
         if: runner.os == 'macOS'

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -302,6 +302,39 @@ jobs:
       - name: 统一安装包架构命名
         working-directory: desktop
         run: node scripts/normalize-artifact-names.mjs
+      - name: 校验 Windows 安装包完整性
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          archives=(desktop/dist-electron/*.zip)
+          ((${#archives[@]}))
+          for archive in "${archives[@]}"; do
+            7z t "$archive"
+          done
+      - name: 校验 Linux 安装包完整性
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          zip_files=(desktop/dist-electron/*.zip)
+          tar_files=(desktop/dist-electron/*.tar.gz)
+          ((${#zip_files[@]} && ${#tar_files[@]}))
+          for zip_file in "${zip_files[@]}"; do unzip -t "$zip_file"; done
+          for tar_file in "${tar_files[@]}"; do tar -tzf "$tar_file" >/dev/null; done
+      - name: 校验 macOS 安装包完整性
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          zip_files=(desktop/dist-electron/*.zip)
+          dmg_files=(desktop/dist-electron/*.dmg)
+          ((${#zip_files[@]} && ${#dmg_files[@]}))
+          for zip_file in "${zip_files[@]}"; do unzip -t "$zip_file"; done
+          for dmg_file in "${dmg_files[@]}"; do hdiutil verify "$dmg_file"; done
 
       - uses: actions/upload-artifact@v7
         with:

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -25,14 +25,8 @@ extraResources:
 win:
   artifactName: OpenFic-${version}-win-${arch}.${ext}
   target:
-    - target: nsis
-      arch:
-        - x64
-        - arm64
-    - target: zip
-      arch:
-        - x64
-        - arm64
+    - nsis
+    - zip
 
 nsis:
   oneClick: false
@@ -42,26 +36,14 @@ nsis:
 mac:
   artifactName: OpenFic-${version}-mac-${arch}.${ext}
   target:
-    - target: dmg
-      arch:
-        - x64
-        - arm64
-    - target: zip
-      arch:
-        - x64
-        - arm64
+    - dmg
+    - zip
   category: public.app-category.productivity
   identity: null
 
 linux:
   artifactName: OpenFic-${version}-linux-${arch}.${ext}
   target:
-    - target: AppImage
-      arch:
-        - x64
-        - arm64
-    - target: tar.gz
-      arch:
-        - x64
-        - arm64
+    - AppImage
+    - tar.gz
   category: Utility

--- a/desktop/tests/main/runtime-smoke.mjs
+++ b/desktop/tests/main/runtime-smoke.mjs
@@ -8,6 +8,8 @@ import { startLocalOpenFicBackend } from "../../dist/main/runtime/openfic.js";
 import { ensurePortablePython } from "../../dist/main/runtime/python.js";
 
 const BACKEND_STOP_TIMEOUT_MS = 15_000;
+const TEMP_DIRECTORY_REMOVE_RETRIES = 5;
+const TEMP_DIRECTORY_REMOVE_RETRY_DELAY_MS = 200;
 
 function run(command, args, cwd) {
   return new Promise((resolve, reject) => {
@@ -96,7 +98,12 @@ async function smokeTestRuntime() {
     if (backend) {
       await stopBackend(backend);
     }
-    await rm(userDataDir, { recursive: true, force: true });
+    await rm(userDataDir, {
+      recursive: true,
+      force: true,
+      maxRetries: TEMP_DIRECTORY_REMOVE_RETRIES,
+      retryDelay: TEMP_DIRECTORY_REMOVE_RETRY_DELAY_MS,
+    });
   }
 }
 


### PR DESCRIPTION
## PR 标题

`ci(desktop): 修复多架构构建导致发布包损坏的问题`

## 变更说明

- 问题: v0.9.0 的 Windows ZIP 在解压 `app.asar` 时发生 `Data Error`，无法使用；Linux 发行包此前未覆盖用户默认启动路径及窗口可见性。
- 重要性: 受损 ZIP 已发布给 Windows 用户，且原发布流程无法阻止同类损坏产物进入 Release；Ubuntu 22.04 的 AppImage 无响应问题也需要在 CI 中提前发现。
- 变化: electron-builder 的目标配置不再固定构建全部架构；每个 CI 矩阵任务仅按 `--x64` 或 `--arm64` 构建自身架构，避免合并工件时同名文件并发覆盖。
- 变化: 在发布和 PR 打包校验工作流中校验 Windows ZIP、Linux tar.gz、macOS ZIP/DMG 的归档完整性。
- 变化: Package Check 在 Windows 静默安装 NSIS 包、Linux 启动 AppImage 和 tar.gz、macOS 挂载 DMG 后启动应用，分别确认进程持续运行。
- 变化: Linux 增加 Ubuntu 22.04 x64 默认 AppImage/FUSE/沙箱启动路径，Ubuntu 24.04 x64/ARM64 保留无沙箱 CI 兼容路径；所有 Linux 包测试均通过 Xvfb 与 xdotool 断言窗口可见，并在失败时输出应用日志。
- 变化: 为 Windows 运行时冒烟测试的临时目录清理加入重试，降低文件句柄延迟释放引起的偶发失败。

## 关联 Issue / PR (如有)

关联 #244

## 变更类型

- [x] 错误修复 (fix)
- [x] 杂项 (chore)

## 问题原因(如有)

Windows x64 与 ARM64 矩阵任务均因 `electron-builder.yml` 内固定的 `arch: [x64, arm64]` 生成了两套同名产物。发布任务以 `merge-multiple: true` 合并工件到同一目录时发生并发覆盖，导致 ZIP 中 `app.asar` 的 Deflate 数据流损坏。NSIS 安装包未受影响。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 已运行 `git diff --check`。
- 已验证 electron-builder 配置与 GitHub Actions 工作流的脚本逻辑。
- 本地无法模拟 Windows / Linux / macOS 交付物的安装启动；PR CI 将在对应 Runner 上执行实际验证。