### PR TITLE
fix(desktop): 修复 Socket 首次连接失败导致启动中断的问题

### DIFF
--- a/desktop/src/main/ipc.ts
+++ b/desktop/src/main/ipc.ts
@@ -7,6 +7,7 @@ import {
   type InspectLocalRuntimeRequest,
   type InspectLocalRuntimeResult,
   type InstallRuntimeRequest,
+  type LogFrontendDiagnosticRequest,
   type PingInstanceRequest,
   type PingInstanceResult,
   type SaveConfigRequest,
@@ -21,7 +22,7 @@ import { inspectLocalRuntime, installLocalRuntime, startLocalBackendFromInstall 
 import { getDefaultInstallDir } from "./runtime/python.js";
 import { cancelUpdateDownload, checkForUpdates, downloadUpdate, getUpdateState, installUpdate, openUpdateRelease } from "./updater.js";
 import { createStartupProgressTracker, getStartupProgress } from "./startup-progress.js";
-import { exportLogs } from "./logging.js";
+import { appendLog, exportLogs } from "./logging.js";
 import type { BackendProcessHandle } from "./process.js";
 import type { DesktopConfig, DesktopInstance } from "../shared/config.js";
 
@@ -124,6 +125,11 @@ export function registerIpc(context: IpcContext): void {
       dialog.showErrorBox("导出后端日志失败", message);
       throw error;
     }
+  });
+
+  ipcMain.handle(IpcChannels.logFrontendDiagnostic, (_event, request: LogFrontendDiagnosticRequest) => {
+    if (typeof request?.message !== "string") return;
+    appendLog("connect", request.message.slice(0, 4_000));
   });
 
   ipcMain.handle(IpcChannels.ensureInstanceSession, (_event, request: EnsureInstanceSessionRequest) => {

--- a/desktop/src/preload/frontend-host-preload.cts
+++ b/desktop/src/preload/frontend-host-preload.cts
@@ -64,4 +64,7 @@ contextBridge.exposeInMainWorld("openficDesktopHost", {
   publishLanguage: (language: unknown): void => {
     ipcRenderer.sendToHost("openfic:language", language);
   },
+  publishSocketDiagnostic: (payload: unknown): void => {
+    ipcRenderer.sendToHost("openfic:socket-diagnostic", payload);
+  },
 });

--- a/desktop/src/preload/preload.mts
+++ b/desktop/src/preload/preload.mts
@@ -7,6 +7,7 @@ import {
   type InspectLocalRuntimeRequest,
   type InspectLocalRuntimeResult,
   type InstallRuntimeRequest,
+  type LogFrontendDiagnosticRequest,
   type PingInstanceRequest,
   type PingInstanceResult,
   type SaveConfigRequest,
@@ -93,6 +94,8 @@ const desktopApi = {
   installUpdate: (): Promise<void> => ipcRenderer.invoke(IpcChannels.installUpdate),
   openUpdateRelease: (): Promise<void> => ipcRenderer.invoke(IpcChannels.openUpdateRelease),
   exportLogs: (): Promise<string | null> => ipcRenderer.invoke(IpcChannels.exportLogs),
+  logFrontendDiagnostic: (message: string): Promise<void> =>
+    ipcRenderer.invoke(IpcChannels.logFrontendDiagnostic, { message } satisfies LogFrontendDiagnosticRequest),
   openProjectHome: (): Promise<void> => ipcRenderer.invoke(IpcChannels.openProjectHome),
   reportBug: (): Promise<void> => ipcRenderer.invoke(IpcChannels.reportBug),
   suggestFeature: (): Promise<void> => ipcRenderer.invoke(IpcChannels.suggestFeature),

--- a/desktop/src/shared/ipc.ts
+++ b/desktop/src/shared/ipc.ts
@@ -30,6 +30,7 @@ export const IpcChannels = {
   openUpdateRelease: "update:open-release",
   updateState: "update:state",
   exportLogs: "logs:export",
+  logFrontendDiagnostic: "logs:frontend-diagnostic",
   openProjectHome: "help:open-project-home",
   reportBug: "help:report-bug",
   suggestFeature: "help:suggest-feature",
@@ -59,6 +60,10 @@ export interface SaveConfigRequest {
 
 export interface SaveZoomFactorRequest {
   zoomFactor: number;
+}
+
+export interface LogFrontendDiagnosticRequest {
+  message: string;
 }
 
 export interface EnsureInstanceSessionRequest {

--- a/desktop/src/ui/app.tsx
+++ b/desktop/src/ui/app.tsx
@@ -18,6 +18,16 @@ interface DesktopAppearancePayload {
   codeFontFamily?: string;
 }
 
+interface SocketDiagnosticPayload {
+  active?: boolean;
+  attempt?: number;
+  durationMs?: number;
+  event: string;
+  message?: string;
+  transport?: string;
+  url?: string;
+}
+
 interface ShellAppearance {
   appearance: Appearance;
   fontFamily?: string;
@@ -27,6 +37,26 @@ interface ShellAppearance {
 interface WebviewIpcMessageEvent extends Event {
   channel: string;
   args: unknown[];
+}
+
+interface WebviewConsoleMessageEvent extends Event {
+  level: number;
+  line: number;
+  message: string;
+  sourceId: string;
+}
+
+interface WebviewFailLoadEvent extends Event {
+  errorCode: number;
+  errorDescription: string;
+  validatedURL: string;
+}
+
+interface WebviewRenderProcessGoneEvent extends Event {
+  details: {
+    exitCode: number;
+    reason: string;
+  };
 }
 
 const MENU_SHORTCUTS = new Set([
@@ -41,6 +71,16 @@ const MENU_SHORTCUTS = new Set([
   "reset-zoom",
   "close-window",
   "toggle-dev-tools",
+]);
+
+const SOCKET_DIAGNOSTIC_EVENTS = new Set([
+  "connect-start",
+  "connect-error",
+  "reconnect-attempt",
+  "reconnect-failed",
+  "connected",
+  "disconnected",
+  "connection-timeout",
 ]);
 
 interface FrontendWebviewElement extends HTMLElement {
@@ -63,6 +103,37 @@ function isDesktopAppearancePayload(value: unknown): value is DesktopAppearanceP
     (candidate.fontFamily === undefined || typeof candidate.fontFamily === "string") &&
     (candidate.codeFontFamily === undefined || typeof candidate.codeFontFamily === "string")
   );
+}
+
+function isSocketDiagnosticPayload(value: unknown): value is SocketDiagnosticPayload {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as SocketDiagnosticPayload;
+  return (
+    SOCKET_DIAGNOSTIC_EVENTS.has(candidate.event) &&
+    (candidate.active === undefined || typeof candidate.active === "boolean") &&
+    (candidate.attempt === undefined || Number.isFinite(candidate.attempt)) &&
+    (candidate.durationMs === undefined || Number.isFinite(candidate.durationMs)) &&
+    (candidate.message === undefined || typeof candidate.message === "string") &&
+    (candidate.transport === undefined || typeof candidate.transport === "string") &&
+    (candidate.url === undefined || typeof candidate.url === "string")
+  );
+}
+
+function writeFrontendDiagnostic(message: string): void {
+  void window.openficDesktop.logFrontendDiagnostic(message).catch(() => undefined);
+}
+
+function formatSocketDiagnostic(payload: SocketDiagnosticPayload): string {
+  const details = [
+    `event=${payload.event}`,
+    payload.url ? `url=${payload.url}` : null,
+    payload.transport ? `transport=${payload.transport}` : null,
+    payload.active === undefined ? null : `active=${payload.active}`,
+    payload.attempt === undefined ? null : `attempt=${payload.attempt}`,
+    payload.durationMs === undefined ? null : `durationMs=${payload.durationMs}`,
+    payload.message ? `message=${payload.message}` : null,
+  ].filter((value): value is string => value !== null);
+  return `socket ${details.join(" ")}`;
 }
 
 function normalizeRemoteUrl(url: string): string {
@@ -196,6 +267,10 @@ export function App() {
         void i18n.changeLanguage(payload);
         return;
       }
+      if (channel === "openfic:socket-diagnostic" && isSocketDiagnosticPayload(payload)) {
+        writeFrontendDiagnostic(formatSocketDiagnostic(payload));
+        return;
+      }
       if (channel === "openfic:zoom-factor" && isZoomFactor(payload)) {
         void window.openficDesktop.saveZoomFactor(payload);
         return;
@@ -217,6 +292,33 @@ export function App() {
     return () => {
       frontendWebview.removeEventListener("ipc-message", handleIpcMessage);
       frontendWebview.removeEventListener("did-finish-load", restoreZoomFactor);
+    };
+  }, [frontendWebview]);
+
+  useEffect(() => {
+    if (!frontendWebview) return;
+
+    const handleConsoleMessage = (event: Event) => {
+      const { level, line, message, sourceId } = event as WebviewConsoleMessageEvent;
+      if (!/\b(socket|websocket|engine\.io)\b/i.test(message)) return;
+      writeFrontendDiagnostic(`webview console level=${level} source=${sourceId}:${line} message=${message}`);
+    };
+    const handleFailLoad = (event: Event) => {
+      const { errorCode, errorDescription, validatedURL } = event as WebviewFailLoadEvent;
+      writeFrontendDiagnostic(`webview did-fail-load code=${errorCode} url=${validatedURL} error=${errorDescription}`);
+    };
+    const handleRenderProcessGone = (event: Event) => {
+      const { details } = event as WebviewRenderProcessGoneEvent;
+      writeFrontendDiagnostic(`webview render-process-gone reason=${details.reason} exitCode=${details.exitCode}`);
+    };
+
+    frontendWebview.addEventListener("console-message", handleConsoleMessage);
+    frontendWebview.addEventListener("did-fail-load", handleFailLoad);
+    frontendWebview.addEventListener("render-process-gone", handleRenderProcessGone);
+    return () => {
+      frontendWebview.removeEventListener("console-message", handleConsoleMessage);
+      frontendWebview.removeEventListener("did-fail-load", handleFailLoad);
+      frontendWebview.removeEventListener("render-process-gone", handleRenderProcessGone);
     };
   }, [frontendWebview]);
 

--- a/desktop/src/ui/global.d.ts
+++ b/desktop/src/ui/global.d.ts
@@ -39,6 +39,7 @@ declare global {
       installUpdate: () => Promise<void>;
       openUpdateRelease: () => Promise<void>;
       exportLogs: () => Promise<string | null>;
+      logFrontendDiagnostic: (message: string) => Promise<void>;
       openProjectHome: () => Promise<void>;
       reportBug: () => Promise<void>;
       suggestFeature: () => Promise<void>;

--- a/frontend/src/lib/desktop-appearance-bridge.ts
+++ b/frontend/src/lib/desktop-appearance-bridge.ts
@@ -7,11 +7,29 @@ export interface DesktopAppearancePayload {
   codeFontFamily?: string;
 }
 
+export interface SocketDiagnosticPayload {
+  event:
+    | "connect-start"
+    | "connect-error"
+    | "reconnect-attempt"
+    | "reconnect-failed"
+    | "connected"
+    | "disconnected"
+    | "connection-timeout";
+  active?: boolean;
+  attempt?: number;
+  durationMs?: number;
+  message?: string;
+  transport?: string;
+  url?: string;
+}
+
 declare global {
   interface Window {
     openficDesktopHost?: {
       publishAppearance: (payload: DesktopAppearancePayload) => void;
       publishLanguage: (language: LanguageCode) => void;
+      publishSocketDiagnostic: (payload: SocketDiagnosticPayload) => void;
     };
   }
 }
@@ -22,4 +40,8 @@ export function publishDesktopAppearance(payload: DesktopAppearancePayload): voi
 
 export function publishDesktopLanguage(language: LanguageCode): void {
   window.openficDesktopHost?.publishLanguage(language);
+}
+
+export function publishSocketDiagnostic(payload: SocketDiagnosticPayload): void {
+  window.openficDesktopHost?.publishSocketDiagnostic?.(payload);
 }

--- a/frontend/src/lib/socket-client.ts
+++ b/frontend/src/lib/socket-client.ts
@@ -1,13 +1,17 @@
 import { io, type Socket } from "socket.io-client";
 
+import { publishSocketDiagnostic, type SocketDiagnosticPayload } from "./desktop-appearance-bridge";
 import { getRuntimeConfig } from "./runtime-config";
 
 export type SocketConnectionStatus = "connected" | "disconnected";
+
+const DEFAULT_CONNECTION_TIMEOUT_MS = 30_000;
 
 interface SocketClientState {
   socket: Socket | null;
   socketUrl: string | undefined;
   connectPromise: Promise<Socket> | null;
+  connectionStartedAt: number | null;
   connectionStatus: SocketConnectionStatus;
   statusListeners: Set<() => void>;
   statusBoundSocket: Socket | null;
@@ -24,6 +28,7 @@ function getSocketState(): SocketClientState {
     socket: null,
     socketUrl: undefined,
     connectPromise: null,
+    connectionStartedAt: null,
     connectionStatus: "disconnected",
     statusListeners: new Set<() => void>(),
     statusBoundSocket: null,
@@ -48,13 +53,58 @@ export function subscribeSocketConnectionStatus(listener: () => void): () => voi
   return () => state.statusListeners.delete(listener);
 }
 
+function getSocketTransport(socket: Socket): string | undefined {
+  return socket.io.engine?.transport.name;
+}
+
+function getConnectionDuration(): number | undefined {
+  const startedAt = getSocketState().connectionStartedAt;
+  return startedAt === null ? undefined : Date.now() - startedAt;
+}
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function reportSocketDiagnostic(
+  event: SocketDiagnosticPayload["event"],
+  socket: Socket,
+  details: Omit<SocketDiagnosticPayload, "event" | "transport" | "url"> = {},
+): void {
+  publishSocketDiagnostic({
+    event,
+    url: getSocketState().socketUrl ?? window.location.origin,
+    transport: getSocketTransport(socket),
+    ...details,
+  });
+}
+
 function bindConnectionStatus(socket: Socket): void {
   const state = getSocketState();
   if (state.statusBoundSocket === socket) return;
   state.statusBoundSocket = socket;
-  socket.on("connect", () => setConnectionStatus("connected"));
-  socket.on("disconnect", () => setConnectionStatus("disconnected"));
-  socket.on("connect_error", () => setConnectionStatus("disconnected"));
+  socket.on("connect", () => {
+    setConnectionStatus("connected");
+    reportSocketDiagnostic("connected", socket, { durationMs: getConnectionDuration() });
+    state.connectionStartedAt = null;
+  });
+  socket.on("disconnect", (reason) => {
+    setConnectionStatus("disconnected");
+    reportSocketDiagnostic("disconnected", socket, { active: socket.active, message: reason });
+  });
+  socket.on("connect_error", (error) => {
+    setConnectionStatus("disconnected");
+    reportSocketDiagnostic("connect-error", socket, {
+      active: socket.active,
+      message: getErrorMessage(error),
+    });
+  });
+  socket.io.on("reconnect_attempt", (attempt) => {
+    reportSocketDiagnostic("reconnect-attempt", socket, { attempt });
+  });
+  socket.io.on("reconnect_failed", () => {
+    reportSocketDiagnostic("reconnect-failed", socket, { active: socket.active });
+  });
 }
 
 function getSocketUrl(): string | undefined {
@@ -81,6 +131,7 @@ export function getSocket(): Socket {
     state.socket = null;
     state.socketUrl = undefined;
     state.connectPromise = null;
+    state.connectionStartedAt = null;
     state.statusBoundSocket = null;
     setConnectionStatus("disconnected");
   }
@@ -91,11 +142,13 @@ export function getSocket(): Socket {
           path: "/socket.io",
           autoConnect: false,
           transports: ["websocket", "polling"],
+          tryAllTransports: true,
         })
       : io({
           path: "/socket.io",
           autoConnect: false,
           transports: ["websocket", "polling"],
+          tryAllTransports: true,
         });
     state.socketUrl = nextSocketUrl;
     bindConnectionStatus(state.socket);
@@ -105,7 +158,13 @@ export function getSocket(): Socket {
   return state.socket;
 }
 
-export function connectSocket({ force = false }: { force?: boolean } = {}): Promise<Socket> {
+export function connectSocket({
+  force = false,
+  timeoutMs = DEFAULT_CONNECTION_TIMEOUT_MS,
+}: {
+  force?: boolean;
+  timeoutMs?: number;
+} = {}): Promise<Socket> {
   const state = getSocketState();
   const activeSocket = getSocket();
   if (activeSocket.connected) return Promise.resolve(activeSocket);
@@ -113,16 +172,19 @@ export function connectSocket({ force = false }: { force?: boolean } = {}): Prom
     if (force && activeSocket.active) {
       // Cancel a pending automatic backoff before an explicit user action.
       activeSocket.disconnect();
+      state.connectionStartedAt = Date.now();
+      reportSocketDiagnostic("connect-start", activeSocket, { active: activeSocket.active });
       activeSocket.connect();
     }
     return state.connectPromise;
   }
 
-  state.connectPromise = new Promise<Socket>((resolve, reject) => {
+  state.connectionStartedAt = Date.now();
+  reportSocketDiagnostic("connect-start", activeSocket, { active: activeSocket.active });
+  const connectPromise = new Promise<Socket>((resolve, reject) => {
     const cleanup = () => {
       window.clearTimeout(timeout);
       activeSocket.off("connect", onConnect);
-      activeSocket.off("connect_error", onError);
     };
 
     const onConnect = () => {
@@ -130,22 +192,31 @@ export function connectSocket({ force = false }: { force?: boolean } = {}): Prom
       resolve(activeSocket);
     };
 
-    const onError = (error: Error) => {
-      cleanup();
-      reject(error);
-    };
-
-    activeSocket.once("connect", onConnect);
-    activeSocket.once("connect_error", onError);
     const timeout = window.setTimeout(() => {
       cleanup();
-      reject(new Error("WebSocket 连接超时"));
-    }, 5000);
+      const error = new Error(`Socket 连接超时（${Math.ceil(timeoutMs / 1000)} 秒）`);
+      reportSocketDiagnostic("connection-timeout", activeSocket, {
+        active: activeSocket.active,
+        durationMs: getConnectionDuration(),
+        message: error.message,
+      });
+      activeSocket.disconnect();
+      reject(error);
+    }, timeoutMs);
+
+    activeSocket.once("connect", onConnect);
     if (force && activeSocket.active) activeSocket.disconnect();
     activeSocket.connect();
-  }).finally(() => {
-    state.connectPromise = null;
   });
+  state.connectPromise = connectPromise;
+  void connectPromise.then(
+    () => {
+      if (state.connectPromise === connectPromise) state.connectPromise = null;
+    },
+    () => {
+      if (state.connectPromise === connectPromise) state.connectPromise = null;
+    },
+  );
 
-  return state.connectPromise;
+  return connectPromise;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -40,6 +40,7 @@ const queryClient = new QueryClient({
 });
 
 const FRONTEND_VERSION = __OPENFIC_FRONTEND_VERSION__;
+const INITIALIZATION_TIMEOUT_MS = 30_000;
 
 const DashboardPage = lazy(() =>
   import("./features/dashboard/pages/dashboard-page").then((module) => ({
@@ -131,7 +132,7 @@ function Root() {
             queryFn: fetchSettings,
           }),
           preloadTiktokenEncoding(),
-          connectSocket(),
+          connectSocket({ timeoutMs: INITIALIZATION_TIMEOUT_MS }),
         ]);
 
         applyFontFamily(settings.fontFamily);
@@ -145,8 +146,8 @@ function Root() {
         }
       } catch {
         if (mounted) {
-          // Check for timeout (30s)
-          if (Date.now() - startTime > 30000) {
+          // Socket.IO retries transports and reconnects within this deadline.
+          if (Date.now() - startTime >= INITIALIZATION_TIMEOUT_MS) {
             setError(true);
             return;
           }


### PR DESCRIPTION
## PR 标题

fix(desktop): 修复 Socket 首次连接失败导致启动中断的问题

## 变更说明

- 问题: 桌面端 Socket 首次 `connect_error` 会立即中断前端初始化，即使健康检查正常且 Socket.IO 仍可自动重连。
- 重要性: 影响桌面端启动稳定性，可能出现 HTTP 服务可用但无法进入前端的情况。
- 变化: 启用 transport 回退，在 30 秒总时限内等待 Socket 重连成功，仍将 Socket 作为前端启动准入条件。
- 变化: 新增 `connect.log`，记录 Socket 连接状态、失败原因、实际 transport 及 WebView 网络诊断事件。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

Socket 客户端固定优先 WebSocket，但未启用失败后 transport 回退；首个连接错误直接拒绝初始化 Promise，导致 Socket.IO 的自动重连和后备 polling 无法作为前端启动恢复路径。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

测试证据：

- `frontend`: `pnpm lint`、`pnpm type-check`、`pnpm build`
- `frontend`: 本轮文件定向 `pnpm exec oxfmt --check src/lib/desktop-appearance-bridge.ts src/lib/socket-client.ts src/main.tsx`
- `desktop`: `pnpm lint`、`pnpm type-check`、`pnpm build`
- `desktop`: `pnpm exec node --test tests/main/archive.test.mjs`，5/5 通过

`frontend` 全量 `pnpm format:check` 未通过，报告为基线中约 402 个未格式化文件；本 PR 涉及的前端文件已通过定向格式校验。
