### PR TITLE
fix(agent): 修复 ask_user 问题面板内容无法滚动的问题

### DIFF
--- a/frontend/src/features/assistant/components/agent/message-blocks/panels/special-panel-shell.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/panels/special-panel-shell.tsx
@@ -56,7 +56,7 @@ export function SpecialPanelShell({
           {summary}
         </Text>
       ) : null}
-      {content ? <Box>{content}</Box> : null}
+      {content ? <Box className="agent-special-panel-content">{content}</Box> : null}
       {actions ? (
         <Flex
           gap="2"

--- a/frontend/src/features/assistant/components/assistant-sidebar.css
+++ b/frontend/src/features/assistant/components/assistant-sidebar.css
@@ -704,6 +704,25 @@
   background: var(--color-surface);
 }
 
+.agent-special-panel-stack[data-embedded="true"] .agent-special-panel-question {
+  display: flex;
+  max-height: calc(100dvh - 220px);
+  flex-direction: column;
+}
+
+.agent-special-panel-question .agent-special-panel-content {
+  display: flex;
+  min-height: 0;
+  flex: 1 1 auto;
+}
+
+.agent-special-panel-stack[data-embedded="true"] .agent-special-question-content {
+  min-height: 0;
+  flex: 1 1 auto;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
 .agent-special-panel-heading {
   margin-bottom: 8px;
   color: var(--gray-12);


### PR DESCRIPTION
## PR 标题

fix(agent): 修复 ask_user 问题面板内容无法滚动的问题

## 变更说明

- 问题: ask_user 问题内容超出可视区域时，内容区未正确继承受限高度，无法在面板内部滚动。
- 重要性: 提交回答操作可能被挤出可视区域，用户无法完成问答。
- 变化: 为特殊面板内容增加布局包装器，并为嵌入式问答面板建立受限高度与内部滚动链。

## 关联 Issue / PR (如有)

Closes #242 

## 变更类型

- [x] 错误修复 (fix)

## 问题原因(如有)

问答内容区缺少可收缩的父级布局容器，`overflow-y: auto` 没有可用的滚动高度范围。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- 验证命令: `pnpm exec oxfmt ... --check`、`pnpm type-check`、`pnpm lint`、`pnpm build`。
- `pnpm build` 通过，仅保留项目既有的大体积 chunk 警告。
