### PR TITLE
fix(index): 修复分块配置保存使用旧输入值的问题

### DIFF
--- a/frontend/src/features/settings/components/index-settings-global-config.tsx
+++ b/frontend/src/features/settings/components/index-settings-global-config.tsx
@@ -35,6 +35,7 @@ interface IndexSettingsGlobalConfigProps {
   onEnabledProjectsChange: (projectIds: string[]) => void;
   onChunkSizeChange: (value: string) => void;
   onChunkOverlapChange: (value: string) => void;
+  onChunkConfigBlur: () => void;
   isAgentSettingsLocked: boolean;
 }
 
@@ -54,6 +55,7 @@ export function IndexSettingsGlobalConfig({
   onEnabledProjectsChange,
   onChunkSizeChange,
   onChunkOverlapChange,
+  onChunkConfigBlur,
   isAgentSettingsLocked,
 }: IndexSettingsGlobalConfigProps) {
   const { t } = useTranslation();
@@ -164,6 +166,7 @@ export function IndexSettingsGlobalConfig({
             min={1}
             unit={t("index.unitCharacters")}
             onChange={onChunkSizeChange}
+            onBlur={onChunkConfigBlur}
             disabled={isAgentSettingsLocked}
           />
           <LabeledNumberInput
@@ -172,6 +175,7 @@ export function IndexSettingsGlobalConfig({
             min={0}
             unit={t("index.unitCharacters")}
             onChange={onChunkOverlapChange}
+            onBlur={onChunkConfigBlur}
             disabled={isAgentSettingsLocked}
           />
         </Box>
@@ -186,6 +190,7 @@ function LabeledNumberInput({
   min,
   unit,
   onChange,
+  onBlur,
   disabled,
 }: {
   label: string;
@@ -193,6 +198,7 @@ function LabeledNumberInput({
   min: number;
   unit: string;
   onChange: (value: string) => void;
+  onBlur: () => void;
   disabled: boolean;
 }) {
   return (
@@ -210,6 +216,7 @@ function LabeledNumberInput({
         type="number"
         value={value}
         onChange={(event) => onChange(event.target.value)}
+        onBlur={onBlur}
         min={min}
         unit={unit}
         unitSide="right"

--- a/frontend/src/features/settings/components/index-settings.tsx
+++ b/frontend/src/features/settings/components/index-settings.tsx
@@ -380,7 +380,7 @@ export function IndexSettings({
     setChunkOverlap(String(settings.indexChunkOverlap));
   }
 
-  // 分块参数防抖自动保存：输入停止 800ms 后校验并保存。
+  // 分块参数防抖自动保存：输入停止 400ms 后校验并保存。
   const chunkSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
     return () => {
@@ -391,15 +391,15 @@ export function IndexSettings({
     };
   }, []);
 
-  const scheduleChunkSave = useCallback(() => {
-    if (isAgentSettingsLocked) return;
-    if (chunkSaveTimerRef.current !== null) {
-      clearTimeout(chunkSaveTimerRef.current);
-    }
-    chunkSaveTimerRef.current = setTimeout(() => {
-      chunkSaveTimerRef.current = null;
-      const size = Number.parseInt(chunkSize, 10);
-      const overlap = Number.parseInt(chunkOverlap, 10);
+  const saveChunkConfig = useCallback(
+    (nextChunkSize: string, nextChunkOverlap: string) => {
+      if (isAgentSettingsLocked) return;
+      if (chunkSaveTimerRef.current !== null) {
+        clearTimeout(chunkSaveTimerRef.current);
+        chunkSaveTimerRef.current = null;
+      }
+      const size = Number.parseInt(nextChunkSize, 10);
+      const overlap = Number.parseInt(nextChunkOverlap, 10);
       if (Number.isNaN(size) || size < 1) return;
       if (Number.isNaN(overlap) || overlap < 0 || overlap >= size) return;
       if (size === settings?.indexChunkSize && overlap === settings?.indexChunkOverlap) return;
@@ -407,15 +407,28 @@ export function IndexSettings({
         index_chunk_size: size,
         index_chunk_overlap: overlap,
       });
-    }, 800);
-  }, [
-    chunkSize,
-    chunkOverlap,
-    isAgentSettingsLocked,
-    settings?.indexChunkSize,
-    settings?.indexChunkOverlap,
-    updateSettingsMutation,
-  ]);
+    },
+    [
+      isAgentSettingsLocked,
+      settings?.indexChunkSize,
+      settings?.indexChunkOverlap,
+      updateSettingsMutation,
+    ],
+  );
+
+  const scheduleChunkSave = useCallback(
+    (nextChunkSize: string, nextChunkOverlap: string) => {
+      if (isAgentSettingsLocked) return;
+      if (chunkSaveTimerRef.current !== null) {
+        clearTimeout(chunkSaveTimerRef.current);
+      }
+      chunkSaveTimerRef.current = setTimeout(() => {
+        chunkSaveTimerRef.current = null;
+        saveChunkConfig(nextChunkSize, nextChunkOverlap);
+      }, 400);
+    },
+    [isAgentSettingsLocked, saveChunkConfig],
+  );
 
   useEffect(() => {
     if (!isAgentSettingsLocked) return;
@@ -549,13 +562,14 @@ export function IndexSettings({
           onChunkSizeChange={(value) => {
             if (isAgentSettingsLocked) return;
             setChunkSize(value);
-            scheduleChunkSave();
+            scheduleChunkSave(value, chunkOverlap);
           }}
           onChunkOverlapChange={(value) => {
             if (isAgentSettingsLocked) return;
             setChunkOverlap(value);
-            scheduleChunkSave();
+            scheduleChunkSave(chunkSize, value);
           }}
+          onChunkConfigBlur={() => saveChunkConfig(chunkSize, chunkOverlap)}
           isAgentSettingsLocked={isAgentSettingsLocked}
         />
 


### PR DESCRIPTION
## PR 标题

fix(index): 修复分块配置保存使用旧输入值的问题

## 变更说明

- 问题: 分块大小或分块重叠在连续输入时，防抖回调会读取上一次渲染的状态，导致保存值落后一位。
- 重要性: 配置值被错误保存会影响后续章节索引的实际分块行为。
- 变化: 保存函数改为使用触发事件提供的最新输入值，避免陈旧状态闭包。
- 变化: 防抖等待缩短至 400ms，并在输入框失焦时立即保存有效变更。
- 变化: 保存前对比当前配置，未发生实际变更时不发送请求。

## 关联 Issue / PR (如有)

无

## 变更类型

- [x] 错误修复 (fix)
- [ ] 新功能 (feat)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

输入事件先更新 React 状态，再按当前渲染闭包内的旧状态安排防抖保存。连续输入时，最后一次请求使用的是前一次输入值。

## 自查清单

- [ ] 已添加/更新必要的测试（前端当前未配置测试运行脚本）
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过（前端当前未配置测试运行脚本）
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 不涉及数据库变更
- [x] 提交信息符合规范

## 补充信息

- 已执行 `pnpm type-check`、`pnpm lint`。
- 已执行修改文件的 `pnpm exec oxfmt "src/features/settings/components/index-settings.tsx" "src/features/settings/components/index-settings-global-config.tsx" --check`。
