### PR TITLE
perf(frontend): 虚拟化 Agent 消息列表并合并流式增量渲染

### DIFF
--- a/frontend/src/features/assistant/components/agent/agent-markdown-content.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-markdown-content.tsx
@@ -1,0 +1,34 @@
+import { StreamingMarkdown } from "@/components";
+
+import { VirtualizedMarkdownContent } from "./virtualized-message-content";
+
+const VIRTUALIZE_CONTENT_THRESHOLD = 100_000;
+
+interface AgentMarkdownContentProps {
+  content: string;
+  isStreaming?: boolean;
+  className?: string;
+}
+
+export function AgentMarkdownContent({
+  content,
+  isStreaming = false,
+  className,
+}: AgentMarkdownContentProps) {
+  if (content.length > VIRTUALIZE_CONTENT_THRESHOLD) {
+    return (
+      <VirtualizedMarkdownContent
+        content={content}
+        isStreaming={isStreaming}
+        className={className}
+      />
+    );
+  }
+  return (
+    <StreamingMarkdown
+      content={content}
+      isStreaming={isStreaming}
+      className={className}
+    />
+  );
+}

--- a/frontend/src/features/assistant/components/agent/agent-messages.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-messages.tsx
@@ -8,6 +8,7 @@ import { Box, Flex, IconButton, Text, Tooltip } from "@radix-ui/themes";
 import { Check, Copy, GitFork, RotateCcw } from "lucide-react";
 import { memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Virtuoso } from "react-virtuoso";
 
 import { ConfirmDialog, toast } from "@/components";
 import type { AgentMessage as AgentMessageType } from "@/lib/agent.types";
@@ -33,11 +34,12 @@ import {
   getVisibleAgentMessageBlocks,
   type AgentRoundToolbarTarget,
 } from "./display/agent-message-blocks";
+import type { AgentMessageBlock } from "./display/agent-message-blocks";
 import { buildAgentDisplayItems } from "./display/agent-message-display-items";
-import { normalizeDisplayMessages } from "./display/display-message-normalization";
 
 import "./agent-message-blocks.css";
 
+import { normalizeDisplayMessages } from "./display/display-message-normalization";
 import type {
   AgentBlockDisplayMessage,
   BlockDisplayMessage,
@@ -45,6 +47,14 @@ import type {
 import { ExplorationMessage } from "./message-blocks/blocks/exploration/exploration-message";
 
 const COPY_FEEDBACK_MS = 1200;
+const MIN_BOTTOM_RESTORE_ATTEMPTS = 6;
+const MAX_BOTTOM_RESTORE_ATTEMPTS = 120;
+
+function estimateAgentBlockHeight(block: AgentMessageBlock): number {
+  if (block.type === "node") return 120;
+  if (block.type === "user") return 100;
+  return 120 + block.messages.length * 90;
+}
 
 function getTimestampParts(timestamp: number, timeZone?: string): Record<string, string> {
   const formatter = new Intl.DateTimeFormat("en-CA", {
@@ -157,6 +167,28 @@ const AgentBlockContent = memo(
     prev.onOpenMentionChapter === next.onOpenMentionChapter,
 );
 
+interface AgentMessagesFooterContext {
+  statusMessage: string;
+  showStatus: boolean;
+  bottomRef: React.RefObject<HTMLDivElement | null>;
+}
+
+const AgentMessagesFooter = memo(function AgentMessagesFooter({
+  context,
+}: {
+  context: AgentMessagesFooterContext;
+}) {
+  return (
+    <>
+      {context.showStatus ? <AgentStatusMessage content={context.statusMessage} /> : null}
+      <Box
+        ref={context.bottomRef}
+        className="agent-message-bottom-anchor"
+      />
+    </>
+  );
+});
+
 export function AgentMessages({
   messages,
   isRunning,
@@ -178,6 +210,7 @@ export function AgentMessages({
   const isRestoringLoadedSessionBottomRef = useRef(false);
   const pendingLoadedSessionRestoreKeyRef = useRef<string | null | undefined>(null);
   const restoreAttemptRef = useRef(0);
+  const lastRestoreScrollHeightRef = useRef(0);
   const resizeFrameRef = useRef<{ scrollHeight: number; clientHeight: number } | null>(null);
   const viewportMetricsRef = useRef<ScrollViewportMetrics | null>(null);
   const previousIsRunningRef = useRef(isRunning);
@@ -236,13 +269,22 @@ export function AgentMessages({
       const activeContainer = getScrollContainer();
       if (!(activeContainer instanceof HTMLElement)) return;
       restoreAttemptRef.current += 1;
+      const previousScrollHeight = lastRestoreScrollHeightRef.current;
       scrollContainerToBottom(activeContainer);
+      lastRestoreScrollHeightRef.current = activeContainer.scrollHeight;
       const isAtBottom = shouldFollowBottom({
         scrollHeight: activeContainer.scrollHeight,
         scrollTop: activeContainer.scrollTop,
         clientHeight: activeContainer.clientHeight,
       });
-      if (isAtBottom) {
+      const isStable = previousScrollHeight === activeContainer.scrollHeight;
+      const hasContent = activeContainer.scrollHeight > 0;
+      if (
+        isAtBottom &&
+        hasContent &&
+        restoreAttemptRef.current >= MIN_BOTTOM_RESTORE_ATTEMPTS &&
+        (isStable || restoreAttemptRef.current >= MAX_BOTTOM_RESTORE_ATTEMPTS)
+      ) {
         isRestoringLoadedSessionBottomRef.current = false;
         pendingLoadedSessionRestoreKeyRef.current = null;
         return;
@@ -253,10 +295,9 @@ export function AgentMessages({
   }, [getScrollContainer, scrollContainerToBottom, scrollToBottomKey]);
 
   useEffect(() => {
-    const sentinel = bottomRef.current;
-    const container = sentinel?.closest(".ai-sidebar-messages");
+    const container =
+      scrollContainerRef.current ?? contentRef.current?.closest(".ai-sidebar-messages");
     if (!(container instanceof HTMLElement)) return;
-    scrollContainerRef.current = container;
 
     const handleScroll = () => {
       const nextViewport = {
@@ -542,6 +583,149 @@ export function AgentMessages({
     );
   };
 
+  const renderBlock = (block: AgentMessageBlock) => {
+    const toolbarTarget = toolbarTargetByAnchorId.get(block.id);
+    if (block.type === "node") {
+      const message = block.messages[0];
+      if (!message || message.type !== "node_start") return null;
+      const nodeId = block.nodeId ?? message.id;
+      const isCollapsed = collapsedNodeIds.has(nodeId);
+      return (
+        <Box
+          className="agent-message-block-stack"
+          data-block-type="node"
+        >
+          <Box
+            className="agent-message-block"
+            data-block-type="node"
+          >
+            <AgentMessageRenderer
+              message={message}
+              nodeStartedAt={block.nodeStartedAt}
+              nodeEndedAt={block.nodeEndedAt}
+              nodeElapsedBaseMs={block.nodeElapsedBaseMs}
+              isNodeCollapsed={isCollapsed}
+              onToggleNode={() => toggleNodeCollapsed(nodeId)}
+              onOpenMentionChapter={onOpenMentionChapter}
+            />
+          </Box>
+          {toolbarTarget ? renderAgentRoundToolbar(toolbarTarget) : null}
+        </Box>
+      );
+    }
+
+    if (block.type === "user") {
+      const message = block.messages[0];
+      if (!message || message.type !== "user_request") return null;
+      const canShowRollback = isRollbackableUserMessage(message) && !isRollbacking && !isRunning;
+      const copyActionId = `copy:${block.id}`;
+      const isCopied = copiedActionId === copyActionId;
+      const timestampText = formatAgentToolbarTimestamp(message.timestamp);
+      return (
+        <Box
+          className="agent-message-block"
+          data-block-type="user"
+        >
+          <AgentMessageRenderer
+            message={message}
+            onOpenMentionChapter={onOpenMentionChapter}
+          />
+          <Flex
+            className="agent-message-block-toolbar"
+            data-align="right"
+            align="center"
+            gap="1"
+          >
+            {timestampText ? (
+              <Text
+                size="1"
+                className="agent-message-block-toolbar-timestamp"
+              >
+                {timestampText}
+              </Text>
+            ) : null}
+            <Tooltip content={isCopied ? t("common.copied") : t("common.copy")}>
+              <IconButton
+                size="1"
+                variant="ghost"
+                color={isCopied ? "green" : "gray"}
+                aria-label={
+                  isCopied ? t("assistant.userMessageCopied") : t("assistant.copyUserMessage")
+                }
+                className="agent-message-block-toolbar-button"
+                data-copied={isCopied ? "true" : undefined}
+                onClick={() =>
+                  copyText(message.content ?? "", t("assistant.noUserMessageToCopy"), copyActionId)
+                }
+              >
+                {isCopied ? <Check size={13} /> : <Copy size={13} />}
+              </IconButton>
+            </Tooltip>
+            {canShowRollback && (
+              <Tooltip content={t("assistant.rollbackToHere")}>
+                <IconButton
+                  size="1"
+                  variant="ghost"
+                  color="gray"
+                  aria-label={t("assistant.rollbackToHere")}
+                  className="agent-message-block-toolbar-button"
+                  onClick={() => setPendingRollbackMessage(message)}
+                >
+                  <RotateCcw size={13} />
+                </IconButton>
+              </Tooltip>
+            )}
+          </Flex>
+        </Box>
+      );
+    }
+
+    return (
+      <Box
+        className="agent-message-block-stack"
+        data-block-type="agent"
+      >
+        <Box
+          className="agent-message-block"
+          data-block-type="agent"
+        >
+          <AgentBlockContent
+            messages={block.messages}
+            onOpenMentionChapter={onOpenMentionChapter}
+          />
+        </Box>
+        {toolbarTarget ? renderAgentRoundToolbar(toolbarTarget) : null}
+      </Box>
+    );
+  };
+
+  const [scrollParent, setScrollParent] = useState<HTMLElement | null>(null);
+  useLayoutEffect(() => {
+    const container = contentRef.current?.closest(".ai-sidebar-messages");
+    if (!(container instanceof HTMLElement)) return;
+    scrollContainerRef.current = container;
+    setScrollParent(container);
+    if (isRestoringLoadedSessionBottomRef.current) {
+      scheduleLoadedSessionBottomRestore();
+    }
+  }, [scheduleLoadedSessionBottomRestore]);
+
+  const heightEstimates = useMemo(
+    () => visibleMessageBlocks.map(estimateAgentBlockHeight),
+    [visibleMessageBlocks],
+  );
+
+  const footerContext = useMemo<AgentMessagesFooterContext>(
+    () => ({
+      statusMessage,
+      showStatus:
+        (status === "running" || status === "waiting_answer" || status === "waiting_approval") &&
+        Boolean(statusMessage),
+      bottomRef,
+    }),
+    [status, statusMessage],
+  );
+
   return (
     <Box
       className="agent-messages-root"
@@ -551,136 +735,18 @@ export function AgentMessages({
         ref={contentRef}
         className="agent-message-scroll-content"
       >
-        {visibleMessageBlocks.map((block) => {
-          const toolbarTarget = toolbarTargetByAnchorId.get(block.id);
-          if (block.type === "node") {
-            const message = block.messages[0];
-            if (!message || message.type !== "node_start") return null;
-            const nodeId = block.nodeId ?? message.id;
-            const isCollapsed = collapsedNodeIds.has(nodeId);
-            return (
-              <Box
-                key={block.id}
-                className="agent-message-block-stack"
-                data-block-type="node"
-              >
-                <Box
-                  className="agent-message-block"
-                  data-block-type="node"
-                >
-                  <AgentMessageRenderer
-                    message={message}
-                    nodeStartedAt={block.nodeStartedAt}
-                    nodeEndedAt={block.nodeEndedAt}
-                    nodeElapsedBaseMs={block.nodeElapsedBaseMs}
-                    isNodeCollapsed={isCollapsed}
-                    onToggleNode={() => toggleNodeCollapsed(nodeId)}
-                    onOpenMentionChapter={onOpenMentionChapter}
-                  />
-                </Box>
-                {toolbarTarget ? renderAgentRoundToolbar(toolbarTarget) : null}
-              </Box>
-            );
-          }
-
-          if (block.type === "user") {
-            const message = block.messages[0];
-            if (!message || message.type !== "user_request") return null;
-            const canShowRollback =
-              isRollbackableUserMessage(message) && !isRollbacking && !isRunning;
-            const copyActionId = `copy:${block.id}`;
-            const isCopied = copiedActionId === copyActionId;
-            const timestampText = formatAgentToolbarTimestamp(message.timestamp);
-            return (
-              <Box
-                key={block.id}
-                className="agent-message-block"
-                data-block-type="user"
-              >
-                <AgentMessageRenderer
-                  message={message}
-                  onOpenMentionChapter={onOpenMentionChapter}
-                />
-                <Flex
-                  className="agent-message-block-toolbar"
-                  data-align="right"
-                  align="center"
-                  gap="1"
-                >
-                  {timestampText ? (
-                    <Text
-                      size="1"
-                      className="agent-message-block-toolbar-timestamp"
-                    >
-                      {timestampText}
-                    </Text>
-                  ) : null}
-                  <Tooltip content={isCopied ? t("common.copied") : t("common.copy")}>
-                    <IconButton
-                      size="1"
-                      variant="ghost"
-                      color={isCopied ? "green" : "gray"}
-                      aria-label={
-                        isCopied ? t("assistant.userMessageCopied") : t("assistant.copyUserMessage")
-                      }
-                      className="agent-message-block-toolbar-button"
-                      data-copied={isCopied ? "true" : undefined}
-                      onClick={() =>
-                        copyText(
-                          message.content ?? "",
-                          t("assistant.noUserMessageToCopy"),
-                          copyActionId,
-                        )
-                      }
-                    >
-                      {isCopied ? <Check size={13} /> : <Copy size={13} />}
-                    </IconButton>
-                  </Tooltip>
-                  {canShowRollback && (
-                    <Tooltip content={t("assistant.rollbackToHere")}>
-                      <IconButton
-                        size="1"
-                        variant="ghost"
-                        color="gray"
-                        aria-label={t("assistant.rollbackToHere")}
-                        className="agent-message-block-toolbar-button"
-                        onClick={() => setPendingRollbackMessage(message)}
-                      >
-                        <RotateCcw size={13} />
-                      </IconButton>
-                    </Tooltip>
-                  )}
-                </Flex>
-              </Box>
-            );
-          }
-
-          return (
-            <Box
-              key={block.id}
-              className="agent-message-block-stack"
-              data-block-type="agent"
-            >
-              <Box
-                className="agent-message-block"
-                data-block-type="agent"
-              >
-                <AgentBlockContent
-                  messages={block.messages}
-                  onOpenMentionChapter={onOpenMentionChapter}
-                />
-              </Box>
-              {toolbarTarget ? renderAgentRoundToolbar(toolbarTarget) : null}
-            </Box>
-          );
-        })}
-
-        {(status === "running" || status === "waiting_answer" || status === "waiting_approval") &&
-          statusMessage && <AgentStatusMessage content={statusMessage} />}
-        <Box
-          ref={bottomRef}
-          className="agent-message-bottom-anchor"
-        />
+        {scrollParent ? (
+          <Virtuoso
+            customScrollParent={scrollParent}
+            data={visibleMessageBlocks}
+            computeItemKey={(_index, block) => block.id}
+            itemContent={(_index, block) => renderBlock(block)}
+            heightEstimates={heightEstimates}
+            increaseViewportBy={{ top: 600, bottom: 600 }}
+            context={footerContext}
+            components={{ Footer: AgentMessagesFooter }}
+          />
+        ) : null}
       </Box>
       <ConfirmDialog
         open={Boolean(pendingRollbackMessage)}

--- a/frontend/src/features/assistant/components/agent/agent-status-message.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-status-message.tsx
@@ -10,6 +10,7 @@ export function AgentStatusMessage({ content }: AgentStatusMessageProps) {
       <Flex
         align="center"
         gap="2"
+        className="agent-status-message"
       >
         <span
           className="text-shimmer"

--- a/frontend/src/features/assistant/components/agent/message-blocks/blocks/reasoning/agent-thinking-message.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/blocks/reasoning/agent-thinking-message.tsx
@@ -3,10 +3,10 @@ import { Brain } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { StreamingMarkdown } from "@/components";
 import type { AgentMessage } from "@/lib/agent.types";
 
 import { getReasoningDurationMs } from "../../../../../lib/streaming-message-merge";
+import { AgentMarkdownContent } from "../../../agent-markdown-content";
 import { formatElapsedDuration } from "../../shared/message-duration";
 import {
   MessageBlockContent,
@@ -128,7 +128,7 @@ export function AgentThinkingMessage({ message }: AgentThinkingMessageProps) {
       >
         <Box className="agent-tool-body agent-reasoning-body">
           <Box className="agent-tool-block-content agent-reasoning-content">
-            <StreamingMarkdown
+            <AgentMarkdownContent
               content={content}
               isStreaming={isRunning}
               className="agent-markdown-content"

--- a/frontend/src/features/assistant/components/agent/message-blocks/messages/special/agent-output-message.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/messages/special/agent-output-message.tsx
@@ -1,9 +1,9 @@
 import { Box } from "@radix-ui/themes";
 import { memo } from "react";
 
-import { StreamingMarkdown } from "@/components";
 import type { AgentMessage } from "@/lib/agent.types";
 
+import { AgentMarkdownContent } from "../../../agent-markdown-content";
 import { MessageCardShell } from "../../shared/message-shell";
 
 interface AgentOutputMessageProps {
@@ -15,7 +15,7 @@ function AgentOutputMessageView({ message }: AgentOutputMessageProps) {
     <MessageCardShell isStreaming={message.isStreaming || undefined}>
       {message.content ? (
         <Box className="agent-output-content">
-          <StreamingMarkdown
+          <AgentMarkdownContent
             content={message.content}
             isStreaming={message.isStreaming}
             className="agent-markdown-content"

--- a/frontend/src/features/assistant/components/agent/virtualized-message-content.css
+++ b/frontend/src/features/assistant/components/agent/virtualized-message-content.css
@@ -1,0 +1,10 @@
+.virtualized-markdown {
+  position: relative;
+  width: 100%;
+}
+
+.virtualized-markdown-block {
+  position: absolute;
+  left: 0;
+  right: 0;
+}

--- a/frontend/src/features/assistant/components/agent/virtualized-message-content.tsx
+++ b/frontend/src/features/assistant/components/agent/virtualized-message-content.tsx
@@ -1,0 +1,277 @@
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { StreamingMarkdown } from "@/components";
+
+import {
+  appendStreamingBlockContent,
+  createStreamingBlockState,
+} from "../../lib/streaming-block-splitter";
+
+import "./virtualized-message-content.css";
+
+const VIEWPORT_PADDING_PX = 1_600;
+const ESTIMATED_LINE_HEIGHT_PX = 22;
+const MIN_BLOCK_HEIGHT_PX = 44;
+
+interface VirtualizedMarkdownContentProps {
+  content: string;
+  isStreaming?: boolean;
+  className?: string;
+}
+
+interface BlockRange {
+  first: number;
+  last: number;
+}
+
+function estimateBlockHeight(text: string): number {
+  if (text.length === 0) return 0;
+  let lines = 1;
+  for (let index = 0; index < text.length; index += 1) {
+    if (text.charCodeAt(index) === 10) lines += 1;
+  }
+  return Math.max(lines * ESTIMATED_LINE_HEIGHT_PX, MIN_BLOCK_HEIGHT_PX);
+}
+
+function findBlockIndex(offsets: number[], px: number): number {
+  if (offsets.length === 0) return -1;
+  let low = 0;
+  let high = offsets.length;
+  while (low < high) {
+    const mid = (low + high) >> 1;
+    if (offsets[mid] <= px) low = mid + 1;
+    else high = mid;
+  }
+  return Math.min(low - 1, offsets.length - 1);
+}
+
+interface VirtualizedBlockProps {
+  block: string;
+  top: number;
+  isStreaming: boolean;
+  className?: string;
+  blockIndex: number;
+  measureBlock: (index: number, el: HTMLDivElement | null) => void;
+}
+
+const VirtualizedBlock = memo(
+  function VirtualizedBlock({
+    block,
+    top,
+    isStreaming,
+    className,
+    blockIndex,
+    measureBlock,
+  }: VirtualizedBlockProps) {
+    const handleMeasure = useCallback(
+      (el: HTMLDivElement | null) => measureBlock(blockIndex, el),
+      [blockIndex, measureBlock],
+    );
+    return (
+      <div
+        ref={handleMeasure}
+        className="virtualized-markdown-block"
+        style={{ top }}
+      >
+        <StreamingMarkdown
+          content={block}
+          isStreaming={isStreaming}
+          className={className}
+        />
+      </div>
+    );
+  },
+  (prev, next) =>
+    prev.block === next.block &&
+    prev.top === next.top &&
+    prev.isStreaming === next.isStreaming &&
+    prev.className === next.className &&
+    prev.blockIndex === next.blockIndex &&
+    prev.measureBlock === next.measureBlock,
+);
+
+export function VirtualizedMarkdownContent({
+  content,
+  isStreaming = false,
+  className,
+}: VirtualizedMarkdownContentProps) {
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const prevContentRef = useRef("");
+  const splitterStateRef = useRef(createStreamingBlockState());
+  const [heights, setHeights] = useState<ReadonlyMap<number, number>>(() => new Map());
+  const [range, setRange] = useState<BlockRange | null>(null);
+  const rangeRef = useRef<BlockRange | null>(null);
+
+  const splitState = useMemo(() => {
+    const prevContent = prevContentRef.current;
+    if (prevContent === content) return splitterStateRef.current;
+    if (content.startsWith(prevContent)) {
+      splitterStateRef.current = appendStreamingBlockContent(
+        splitterStateRef.current,
+        content.slice(prevContent.length),
+      );
+    } else {
+      splitterStateRef.current = appendStreamingBlockContent(createStreamingBlockState(), content);
+    }
+    prevContentRef.current = content;
+    return splitterStateRef.current;
+  }, [content]);
+
+  const { blocks, active } = splitState;
+
+  const blockHeights = useMemo(
+    () => blocks.map((block, index) => heights.get(index) ?? estimateBlockHeight(block)),
+    [blocks, heights],
+  );
+  const offsets = useMemo(() => {
+    const result: number[] = [];
+    let acc = 0;
+    for (let index = 0; index < blockHeights.length; index += 1) {
+      result.push(acc);
+      acc += blockHeights[index];
+    }
+    return result;
+  }, [blockHeights]);
+  const activeOffset =
+    offsets.length > 0 ? offsets[offsets.length - 1] + blockHeights[blockHeights.length - 1] : 0;
+  const activeHeight = heights.get(blocks.length) ?? estimateBlockHeight(active);
+  const totalHeight = activeOffset + activeHeight;
+
+  const viewportStateRef = useRef({ offsets, totalHeight, blockCount: blocks.length });
+  viewportStateRef.current = { offsets, totalHeight, blockCount: blocks.length };
+  const computeRef = useRef<() => void>(() => {});
+
+  useEffect(() => {
+    const root = rootRef.current;
+    const container = root?.closest(".ai-sidebar-messages");
+    if (!root || !(container instanceof HTMLElement)) return;
+
+    const compute = () => {
+      const {
+        offsets: blockOffsets,
+        totalHeight: rootHeight,
+        blockCount,
+      } = viewportStateRef.current;
+      let nextRange: BlockRange | null = null;
+      if (blockCount > 0 && rootHeight > 0) {
+        const containerRect = container.getBoundingClientRect();
+        const rootRect = root.getBoundingClientRect();
+        const elTop = rootRect.top - containerRect.top + container.scrollTop;
+        const viewStart = container.scrollTop;
+        const viewEnd = viewStart + container.clientHeight;
+        const start = Math.max(0, viewStart - elTop);
+        const end = Math.min(rootHeight, viewEnd - elTop);
+        if (end > 0 && start < rootHeight && blockOffsets.length > 0) {
+          const first = Math.max(
+            0,
+            findBlockIndex(blockOffsets, Math.max(0, start - VIEWPORT_PADDING_PX)),
+          );
+          const last = Math.min(
+            blockCount - 1,
+            findBlockIndex(blockOffsets, Math.min(rootHeight, end + VIEWPORT_PADDING_PX)),
+          );
+          nextRange = { first, last };
+        }
+      }
+      const previousRange = rangeRef.current;
+      if (
+        nextRange === previousRange ||
+        (nextRange !== null &&
+          previousRange !== null &&
+          nextRange.first === previousRange.first &&
+          nextRange.last === previousRange.last)
+      ) {
+        return;
+      }
+      rangeRef.current = nextRange;
+      setRange(nextRange);
+    };
+
+    computeRef.current = compute;
+    compute();
+    container.addEventListener("scroll", compute, { passive: true });
+    const resizeObserver = new ResizeObserver(compute);
+    resizeObserver.observe(container);
+    resizeObserver.observe(root);
+    return () => {
+      computeRef.current = () => {};
+      container.removeEventListener("scroll", compute);
+      resizeObserver.disconnect();
+      if (heightsFlushRafRef.current !== null) {
+        window.cancelAnimationFrame(heightsFlushRafRef.current);
+        heightsFlushRafRef.current = null;
+      }
+    };
+  }, []);
+
+  useEffect(() => {
+    computeRef.current();
+  }, [blocks, heights]);
+
+  const pendingHeightsRef = useRef<Map<number, number>>(new Map());
+  const heightsFlushRafRef = useRef<number | null>(null);
+
+  const measureBlock = useCallback((index: number, el: HTMLDivElement | null) => {
+    if (!el) return;
+    const height = el.offsetHeight;
+    pendingHeightsRef.current.set(index, height);
+    if (heightsFlushRafRef.current === null) {
+      heightsFlushRafRef.current = window.requestAnimationFrame(() => {
+        heightsFlushRafRef.current = null;
+        const pending = pendingHeightsRef.current;
+        pendingHeightsRef.current = new Map();
+        setHeights((previous) => {
+          let changed = false;
+          const next = new Map(previous);
+          for (const [indexToSet, heightToSet] of pending) {
+            if (next.get(indexToSet) !== heightToSet) {
+              next.set(indexToSet, heightToSet);
+              changed = true;
+            }
+          }
+          return changed ? next : previous;
+        });
+      });
+    }
+  }, []);
+
+  const windowBlocks = useMemo(() => {
+    if (!range) return [];
+    const result: number[] = [];
+    for (let index = range.first; index <= range.last; index += 1) {
+      result.push(index);
+    }
+    return result;
+  }, [range]);
+
+  return (
+    <div
+      ref={rootRef}
+      className="virtualized-markdown"
+      style={{ height: totalHeight }}
+    >
+      {" "}
+      {windowBlocks.map((index) => (
+        <VirtualizedBlock
+          key={index}
+          block={blocks[index]}
+          top={offsets[index]}
+          isStreaming={false}
+          className={className}
+          blockIndex={index}
+          measureBlock={measureBlock}
+        />
+      ))}
+      {active.length > 0 ? (
+        <VirtualizedBlock
+          block={active}
+          top={activeOffset}
+          isStreaming={isStreaming}
+          className={className}
+          blockIndex={blocks.length}
+          measureBlock={measureBlock}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/features/assistant/components/assistant-sidebar.css
+++ b/frontend/src/features/assistant/components/assistant-sidebar.css
@@ -221,7 +221,8 @@
   overflow-y: auto;
   padding: 12px;
   box-sizing: border-box;
-  scrollbar-width: none;
+  scrollbar-width: thin;
+  scrollbar-color: var(--gray-6) transparent;
 }
 
 .ai-sidebar-messages > :not(.agent-message-bottom-anchor) + :not(.agent-message-bottom-anchor) {
@@ -229,7 +230,20 @@
 }
 
 .ai-sidebar-messages::-webkit-scrollbar {
-  display: none;
+  width: 6px;
+}
+
+.ai-sidebar-messages::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.ai-sidebar-messages::-webkit-scrollbar-thumb {
+  background-color: var(--gray-6);
+  border-radius: 3px;
+}
+
+.ai-sidebar-messages::-webkit-scrollbar-thumb:hover {
+  background-color: var(--gray-7);
 }
 
 .ai-sidebar-messages > * {
@@ -1031,6 +1045,10 @@
 .ai-sidebar-loading-state {
   height: 100%;
   gap: 12px;
+}
+
+.agent-status-message .text-shimmer {
+  margin-top: 8px;
 }
 
 .ai-sidebar-textarea {

--- a/frontend/src/features/assistant/components/assistant-sidebar.tsx
+++ b/frontend/src/features/assistant/components/assistant-sidebar.tsx
@@ -1532,7 +1532,7 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
             >
               <IconButton
                 size="2"
-                variant="soft"
+                variant="solid"
                 color="gray"
                 onClick={() => scrollToBottomFnRef.current?.()}
                 aria-label={t("assistant.scrollToBottom")}

--- a/frontend/src/features/assistant/hooks/use-agent-session.ts
+++ b/frontend/src/features/assistant/hooks/use-agent-session.ts
@@ -61,6 +61,10 @@ import {
   createPendingUserMessage,
 } from "../lib/pending-user-message-state";
 import { clearRetryMessages } from "../lib/retry-message-state";
+import {
+  createStreamingDeltaCoalescer,
+  isStreamingDeltaEvent,
+} from "../lib/streaming-delta-coalescer";
 import { applyTransportReconnectState } from "./agent-session-transport-state";
 import {
   cancelStreamingAgentMessages,
@@ -210,6 +214,8 @@ export function useAgentSession({
     return () => {
       socketUnsubscribeRef.current?.();
       socketUnsubscribeRef.current = null;
+      deltaCoalescerRef.current?.dispose();
+      deltaCoalescerRef.current = null;
     };
   }, []);
 
@@ -324,6 +330,34 @@ export function useAgentSession({
     setIsCompacting(nextIsCompacting);
   }, []);
 
+  const applyTranscriptEvent = useCallback(
+    (event: AgentEvent) => {
+      const result = applyAgentTranscriptEventToLiveState(transcriptStateRef.current, event, {
+        approvalPreviewFactory: createApprovalPreviewToolMessage,
+        defaultRunningStage: agentKey || AGENT_STAGE_TEXT.build,
+        fallbackAgent: agentKey || "build",
+        getStageTextForAgent: getStageTextForAgentKey,
+        getStageTextForStage: getStageTextForStageKey,
+        keepRunningOnCompleted: hasRunningAsyncSubagent,
+      });
+      commitTranscriptState(result.state);
+      return result;
+    },
+    [agentKey, commitTranscriptState],
+  );
+
+  const applyTranscriptEventRef = useRef(applyTranscriptEvent);
+  applyTranscriptEventRef.current = applyTranscriptEvent;
+
+  const deltaCoalescerRef = useRef<ReturnType<typeof createStreamingDeltaCoalescer> | null>(null);
+  if (deltaCoalescerRef.current === null) {
+    deltaCoalescerRef.current = createStreamingDeltaCoalescer((events) => {
+      for (const event of events) {
+        applyTranscriptEventRef.current(event);
+      }
+    });
+  }
+
   const handleEvent = useCallback(
     (event: AgentEvent) => {
       if (suppressSocketEventsAfterAbortRef.current && shouldSuppressAgentEventAfterAbort(event))
@@ -338,6 +372,12 @@ export function useAgentSession({
       ) {
         return;
       }
+
+      if (isStreamingDeltaEvent(event)) {
+        deltaCoalescerRef.current?.push(event);
+        return;
+      }
+      deltaCoalescerRef.current?.flush();
 
       if (event.type === "pending_message") {
         const action = typeof payload.action === "string" ? payload.action : "";
@@ -412,16 +452,7 @@ export function useAgentSession({
         return;
       }
 
-      const result = applyAgentTranscriptEventToLiveState(transcriptStateRef.current, event, {
-        approvalPreviewFactory: createApprovalPreviewToolMessage,
-        defaultRunningStage: agentKey || AGENT_STAGE_TEXT.build,
-        fallbackAgent: agentKey || "build",
-        getStageTextForAgent: getStageTextForAgentKey,
-        getStageTextForStage: getStageTextForStageKey,
-        keepRunningOnCompleted: hasRunningAsyncSubagent,
-      });
-
-      commitTranscriptState(result.state);
+      const result = applyTranscriptEvent(event);
 
       if (event.type === "compaction") {
         syncCompactingState(event.status === "running");
@@ -580,8 +611,7 @@ export function useAgentSession({
       }
     },
     [
-      agentKey,
-      commitTranscriptState,
+      applyTranscriptEvent,
       invalidateChapterQueries,
       invalidateCharacterQueries,
       invalidateNoteQueries,

--- a/frontend/src/features/assistant/hooks/use-subagent-session.ts
+++ b/frontend/src/features/assistant/hooks/use-subagent-session.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "@/components";
 import i18n from "@/i18n";
 import type {
+  AgentEvent,
   AgentMessage,
   AgentSessionStatus,
   SubagentSessionPayload,
@@ -23,6 +24,10 @@ import {
   type AgentTranscriptState,
 } from "../lib/agent-transcript-state";
 import { createApprovalPreviewToolMessage } from "../lib/chapter-tool-preview";
+import {
+  createStreamingDeltaCoalescer,
+  isStreamingDeltaEvent,
+} from "../lib/streaming-delta-coalescer";
 import { createPendingApprovalEvent } from "../lib/subagent-session-approval";
 import { joinSubagentSession, subscribeSubagentSessionEvents } from "../lib/subagent-socket";
 import { buildAgentMessagesFromTaskMessages } from "../lib/task-message-agent-mapping";
@@ -126,6 +131,51 @@ export function useSubagentSession(
     setIsRunning(nextState.isRunning);
     setCurrentStage(nextState.currentStage);
   }, []);
+
+  const applySubagentEvent = useCallback(
+    (event: AgentEvent) => {
+      const result = applyAgentTranscriptEventToLiveState(transcriptStateRef.current, event, {
+        approvalPreviewFactory: createApprovalPreviewToolMessage,
+        defaultRunningStage: getStageTextForAgentKey(session?.agentKey) || session?.agentKey || "",
+        fallbackAgent: session?.agentKey,
+        getStageTextForAgent: getStageTextForAgentKey,
+        getStageTextForStage: getStageTextForStageKey,
+      });
+      commitTranscriptState(result.state);
+      setSession((current) => {
+        if (!current) return current;
+        const nextStatus = toPayloadStatus(result.state.status, current.status);
+        const isTerminal = result.state.status === "completed" || result.state.status === "error";
+        const nextPendingApproval =
+          result.message?.type === "approval"
+            ? (result.message.payload ?? current.pendingApproval)
+            : nextStatus === "waiting_user"
+              ? current.pendingApproval
+              : null;
+        return {
+          ...current,
+          status: nextStatus,
+          isRunning: result.state.isRunning,
+          isActive: isTerminal ? false : current.isActive || result.state.isRunning,
+          pendingApproval: nextPendingApproval,
+        };
+      });
+      return result;
+    },
+    [commitTranscriptState, session?.agentKey],
+  );
+
+  const applySubagentEventRef = useRef(applySubagentEvent);
+  applySubagentEventRef.current = applySubagentEvent;
+
+  const deltaCoalescerRef = useRef<ReturnType<typeof createStreamingDeltaCoalescer> | null>(null);
+  if (deltaCoalescerRef.current === null) {
+    deltaCoalescerRef.current = createStreamingDeltaCoalescer((events) => {
+      for (const event of events) {
+        applySubagentEventRef.current(event);
+      }
+    });
+  }
 
   const handleToolApproval = useCallback(
     async (approvalId: string, approved: boolean) => {
@@ -249,6 +299,12 @@ export function useSubagentSession(
     const cleanup = subscribeSubagentSessionEvents(
       targetThreadId,
       (event) => {
+        if (isStreamingDeltaEvent(event)) {
+          deltaCoalescerRef.current?.push(event);
+          return;
+        }
+        deltaCoalescerRef.current?.flush();
+
         if (event.type === "compaction_error") {
           suppressNextErrorAfterCompactionErrorRef.current = true;
           const payload = event.payload ?? {};
@@ -310,34 +366,7 @@ export function useSubagentSession(
           );
         }
 
-        const result = applyAgentTranscriptEventToLiveState(transcriptStateRef.current, event, {
-          approvalPreviewFactory: createApprovalPreviewToolMessage,
-          defaultRunningStage:
-            getStageTextForAgentKey(session?.agentKey) || session?.agentKey || "",
-          fallbackAgent: session?.agentKey,
-          getStageTextForAgent: getStageTextForAgentKey,
-          getStageTextForStage: getStageTextForStageKey,
-        });
-
-        commitTranscriptState(result.state);
-        setSession((current) => {
-          if (!current) return current;
-          const nextStatus = toPayloadStatus(result.state.status, current.status);
-          const isTerminal = result.state.status === "completed" || result.state.status === "error";
-          const nextPendingApproval =
-            result.message?.type === "approval"
-              ? (result.message.payload ?? current.pendingApproval)
-              : nextStatus === "waiting_user"
-                ? current.pendingApproval
-                : null;
-          return {
-            ...current,
-            status: nextStatus,
-            isRunning: result.state.isRunning,
-            isActive: isTerminal ? false : current.isActive || result.state.isRunning,
-            pendingApproval: nextPendingApproval,
-          };
-        });
+        applySubagentEvent(event);
       },
       (error) => {
         setSession((current) =>
@@ -368,8 +397,10 @@ export function useSubagentSession(
 
     return () => {
       cleanup();
+      deltaCoalescerRef.current?.dispose();
     };
   }, [
+    applySubagentEvent,
     childRunId,
     childThreadId,
     commitTranscriptState,

--- a/frontend/src/features/assistant/lib/streaming-block-splitter.ts
+++ b/frontend/src/features/assistant/lib/streaming-block-splitter.ts
@@ -1,0 +1,96 @@
+export interface StreamingBlockState {
+  readonly blocks: readonly string[];
+  readonly active: string;
+  readonly fenceMarker: string | null;
+  readonly mathOpen: boolean;
+}
+
+export function createStreamingBlockState(): StreamingBlockState {
+  return { blocks: [], active: "", fenceMarker: null, mathOpen: false };
+}
+
+const FENCE_OPEN_RE = /^\s*(`{3,}|~{3,})(.*)$/;
+const FENCE_CLOSE_RE = /^\s*(`{3,}|~{3,})\s*$/;
+const MATH_BOUNDARY_RE = /^\s*\$\$\s*$/;
+const HEADING_RE = /^\s{0,3}#{1,6}\s/;
+const BLANK_LINE_RE = /^\s*$/;
+
+export function appendStreamingBlockContent(
+  state: StreamingBlockState,
+  delta: string,
+): StreamingBlockState {
+  if (delta.length === 0) return state;
+
+  const pending = state.active + delta;
+  const endsWithNewline = pending.endsWith("\n");
+  const segments = pending.split("\n");
+  if (endsWithNewline && segments[segments.length - 1] === "") {
+    segments.pop();
+  }
+  const incomplete = endsWithNewline ? "" : (segments.pop() ?? "");
+
+  let blocks = state.blocks;
+  let current = "";
+  let fenceMarker = state.fenceMarker;
+  let mathOpen = state.mathOpen;
+
+  const finalize = () => {
+    if (current.length > 0) {
+      blocks = [...blocks, `${current}\n`];
+      current = "";
+    }
+  };
+
+  for (const rawLine of segments) {
+    const line = rawLine.replace(/\r$/, "");
+
+    if (fenceMarker !== null) {
+      current += `${line}\n`;
+      const close = FENCE_CLOSE_RE.exec(line);
+      if (close && close[1] === fenceMarker) {
+        fenceMarker = null;
+        finalize();
+      }
+      continue;
+    }
+
+    if (mathOpen) {
+      current += `${line}\n`;
+      if (MATH_BOUNDARY_RE.test(line)) {
+        mathOpen = false;
+        finalize();
+      }
+      continue;
+    }
+
+    if (BLANK_LINE_RE.test(line)) {
+      finalize();
+      continue;
+    }
+
+    const fenceOpen = FENCE_OPEN_RE.exec(line);
+    if (fenceOpen && fenceOpen[1].length >= 3) {
+      finalize();
+      fenceMarker = fenceOpen[1];
+      current = `${line}\n`;
+      continue;
+    }
+
+    if (MATH_BOUNDARY_RE.test(line)) {
+      finalize();
+      mathOpen = true;
+      current = `${line}\n`;
+      continue;
+    }
+
+    if (HEADING_RE.test(line)) {
+      finalize();
+      current = `${line}\n`;
+      continue;
+    }
+
+    current += `${line}\n`;
+  }
+
+  return { blocks, active: `${current}${incomplete}`, fenceMarker, mathOpen };
+}

--- a/frontend/src/features/assistant/lib/streaming-delta-coalescer.ts
+++ b/frontend/src/features/assistant/lib/streaming-delta-coalescer.ts
@@ -1,0 +1,68 @@
+import type { AgentEvent } from "@/lib/agent.types";
+
+const DEFAULT_MAX_DELAY_MS = 50;
+
+export function isStreamingDeltaEvent(event: AgentEvent): boolean {
+  return Boolean(event.payload?.is_delta && ["text", "reasoning", "tool"].includes(event.type));
+}
+
+export interface StreamingDeltaCoalescer {
+  push(event: AgentEvent): void;
+  flush(): void;
+  readonly pendingCount: number;
+  dispose(): void;
+}
+
+export function createStreamingDeltaCoalescer(
+  applyEvents: (events: AgentEvent[]) => void,
+  maxDelayMs: number = DEFAULT_MAX_DELAY_MS,
+): StreamingDeltaCoalescer {
+  let queue: AgentEvent[] = [];
+  let rafId: number | null = null;
+  let timerId: number | null = null;
+
+  const flush = () => {
+    if (rafId !== null) {
+      window.cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+    if (timerId !== null) {
+      window.clearTimeout(timerId);
+      timerId = null;
+    }
+    const events = queue;
+    queue = [];
+    if (events.length > 0) {
+      applyEvents(events);
+    }
+  };
+
+  const schedule = () => {
+    if (rafId === null) {
+      rafId = window.requestAnimationFrame(() => {
+        rafId = null;
+        flush();
+      });
+    }
+    if (timerId === null) {
+      timerId = window.setTimeout(() => {
+        timerId = null;
+        flush();
+      }, maxDelayMs);
+    }
+  };
+
+  return {
+    push(event) {
+      queue.push(event);
+      schedule();
+    },
+    flush,
+    get pendingCount() {
+      return queue.length;
+    },
+    dispose() {
+      flush();
+    },
+  };
+}


### PR DESCRIPTION
## PR 标题

perf(frontend): 虚拟化 Agent 消息列表并合并流式增量渲染

## 变更说明

- 问题: Agent 消息在单条内容超大（如 50 万字符 reasoning）或会话消息达数百条时，前端逐 chunk 全量解析导致主线程冻结
- 重要性: 高性能，直接影响 Agent 会话的可用性
- 变化:
  - 状态层合并流式 delta（rAF/50ms 双调度），全量解析频率从每 chunk 降至每帧
  - 新增消息内视口虚拟化：超长消息按 markdown 安全边界增量切块（代码围栏/数学块/空行/标题），仅渲染可视区域块，未渲染块用高度估算撑起滚动
  - Agent 消息列表接入 react-virtuoso 块级虚拟化（customScrollParent 复用现有滚动容器），保留现有滚动跟随逻辑
  - 保留流式逐词 blurIn 动画（动画只作用于新增字符）
  - 修复加载历史会话无法自动回到底部的问题（restore 时序与终止条件）
  - 修复流式长文渲染触发 React 嵌套更新上限（Maximum update depth exceeded）导致整页崩溃的问题（测量提交改为 rAF 合并）
  - UI 细节：消息列表滚动条改为细滚动条显示、流式状态 shimmer 文本上方 8px 间距、回到底部按钮 solid 变体

## 关联 Issue / PR (如有)

无

## 变更类型

- [x] 性能优化 (perf)

## 问题原因(如有)

1. StreamingMarkdown 内 streamdown 每次内容变化都对全量累积文本重新解析（remend + Lexer.lex，O(total)），流式期间每 chunk 一次
2. 消息列表与单条超长消息均无虚拟化，DOM 节点与解析成本随内容线性膨胀
3. 加载历史回底：scrollToBottomKey 触发早于滚动容器绑定、restore 在 Virtuoso 初始渲染完成前过早终止
4. 崩溃：测量→窗口重算→新块挂载→再测量的同步反馈链，在块多且高度估算偏差大时单次 flush 内链式渲染超 50 次

## 自查清单

- [x] 已添加/更新必要的测试（切块器 12 个单测，验证后按项目规则清理）
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过（前端无常驻测试套件）
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖（react-virtuoso 已存在于依赖中）
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理（无数据库变更）
- [x] 提交信息符合规范

## 补充信息

Playwright 实测验证：加载历史回底、任务切换回底、上滚/回底按钮、真实模型流式输出、虚拟化视口外不渲染与滚动窗口动态更新、崩溃场景修复前后对比（修复前同 prompt 30 秒内必崩，修复后 70 秒稳定）。
