### PR TITLE
fix(frontend): 修复移动端编辑器菜单点击无效导致复制粘贴不可用的问题

### DIFF
--- a/frontend/src/components/context-menu.tsx
+++ b/frontend/src/components/context-menu.tsx
@@ -11,9 +11,13 @@ import type { Editor } from "@tiptap/react";
 import { Scissors, Copy, Clipboard } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { motion, AnimatePresence } from "motion/react";
-import { useState, useCallback, useEffect, useLayoutEffect, useId, useRef } from "react";
+import { useState, useCallback, useEffect, useLayoutEffect, useId, useMemo, useRef } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
+
+import { readClipboardText, writeClipboardText } from "@/lib/clipboard";
+
+import { toast } from "./toast";
 
 const MOBILE_POINTER_LONG_PRESS_MS = 280;
 const MOBILE_POINTER_MOVE_TOLERANCE = 8;
@@ -92,6 +96,12 @@ export function ContextMenu({
   // 判断使用哪种模式
   const isEditorMode = !!editor && !!containerRef;
 
+  // 触摸设备（coarse pointer）上编辑器直接使用系统菜单，不启用自定义编辑器菜单
+  const editorMenuDisabled = useMemo(
+    () => isEditorMode && window.matchMedia("(pointer: coarse)").matches,
+    [isEditorMode],
+  );
+
   // 使用内部位置（编辑器模式）或外部位置（手动模式）
   const position = isEditorMode ? internalPosition : (externalPosition ?? null);
   const onClose = useCallback(() => {
@@ -125,7 +135,7 @@ export function ContextMenu({
   // 编辑器模式：处理右键点击
   const handleContextMenu = useCallback(
     (e: MouseEvent) => {
-      if (!isEditorMode || !containerRef?.current) return;
+      if (!isEditorMode || editorMenuDisabled || !containerRef?.current) return;
       if (suppressNextEditorContextMenuRef.current) {
         suppressNextEditorContextMenuRef.current = false;
         e.preventDefault();
@@ -140,12 +150,12 @@ export function ContextMenu({
       e.preventDefault();
       setInternalPosition({ x: e.clientX, y: e.clientY });
     },
-    [isEditorMode, containerRef],
+    [isEditorMode, editorMenuDisabled, containerRef],
   );
 
   // 编辑器模式：监听容器右键事件
   useEffect(() => {
-    if (!isEditorMode || !containerRef?.current) return;
+    if (!isEditorMode || editorMenuDisabled || !containerRef?.current) return;
 
     const container = containerRef.current;
     container.addEventListener("contextmenu", handleContextMenu);
@@ -153,7 +163,7 @@ export function ContextMenu({
     return () => {
       container.removeEventListener("contextmenu", handleContextMenu);
     };
-  }, [isEditorMode, containerRef, handleContextMenu]);
+  }, [isEditorMode, editorMenuDisabled, containerRef, handleContextMenu]);
 
   const clearMobileLongPressTimer = useCallback(() => {
     if (mobileLongPressTimerRef.current !== null) {
@@ -199,7 +209,7 @@ export function ContextMenu({
   );
 
   useEffect(() => {
-    if (!isEditorMode || !containerRef?.current) return;
+    if (!isEditorMode || editorMenuDisabled || !containerRef?.current) return;
 
     const container = containerRef.current;
 
@@ -294,6 +304,7 @@ export function ContextMenu({
     clearMobilePointer,
     containerRef,
     editor,
+    editorMenuDisabled,
     isEditorMode,
     restoreEditorKeyboard,
     suppressEditorKeyboard,
@@ -307,39 +318,44 @@ export function ContextMenu({
     const hasSelection = editor.state.selection.from !== editor.state.selection.to;
 
     // 处理剪切
-    const handleCut = () => {
+    const handleCut = async () => {
       const { from, to } = editor.state.selection;
       const selectedText = editor.state.doc.textBetween(from, to, " ");
 
       if (selectedText) {
-        navigator.clipboard.writeText(selectedText);
-        editor.chain().focus().deleteSelection().run();
+        const copied = await writeClipboardText(selectedText);
+        if (!copied) {
+          toast.error(t("editor.copyFailed"));
+          return;
+        }
+        editor.chain().deleteSelection().run();
       }
-      onClose();
     };
 
     // 处理复制
-    const handleCopy = () => {
+    const handleCopy = async () => {
       const { from, to } = editor.state.selection;
       const selectedText = editor.state.doc.textBetween(from, to, " ");
 
       if (selectedText) {
-        navigator.clipboard.writeText(selectedText);
+        const copied = await writeClipboardText(selectedText);
+        if (!copied) {
+          toast.error(t("editor.copyFailed"));
+        }
       }
-      onClose();
     };
 
     // 处理粘贴
     const handlePaste = async () => {
-      try {
-        const text = await navigator.clipboard.readText();
-        if (text) {
-          editor.chain().focus().insertContent(text).run();
-        }
-      } catch {
-        // 剪贴板访问被拒绝
+      const result = await readClipboardText();
+      if (!result.ok) {
+        toast.error(
+          result.reason === "unavailable" ? t("editor.pasteUnavailable") : t("editor.pasteFailed"),
+        );
+        return;
       }
-      onClose();
+      if (!result.text) return;
+      editor.chain().insertContent(result.text).run();
     };
 
     const baseItems = [
@@ -415,10 +431,12 @@ export function ContextMenu({
 
   // 点击菜单项
   const handleItemClick = useCallback(
-    (item: ContextMenuItem, e: React.MouseEvent) => {
-      e.stopPropagation();
-      if (!item.disabled) {
+    (item: ContextMenuItem, event: { stopPropagation: () => void }) => {
+      event.stopPropagation();
+      if (item.disabled) return;
+      try {
         item.onClick();
+      } finally {
         onClose();
       }
     },
@@ -519,7 +537,7 @@ export function ContextMenu({
                   }}
                   onMouseEnter={() => !item.disabled && setHoveredItem(item.id)}
                   onMouseLeave={() => setHoveredItem(null)}
-                  onClick={(e) => handleItemClick(item, e)}
+                  onPointerUp={(e) => handleItemClick(item, e)}
                 >
                   <Flex
                     align="center"

--- a/frontend/src/features/writing/components/chapter-editor.tsx
+++ b/frontend/src/features/writing/components/chapter-editor.tsx
@@ -63,6 +63,8 @@ interface ChapterEditorProps {
   projectId?: string;
   isAgentLocked?: boolean;
   onOpenSummary?: () => void;
+  onSelectionChange?: (hasSelection: boolean) => void;
+  addSelectionToConversationRef?: React.MutableRefObject<(() => void) | null>;
 }
 
 interface ChapterEditorContentProps {
@@ -77,6 +79,8 @@ interface ChapterEditorContentProps {
   projectId?: string;
   isAgentLocked?: boolean;
   onOpenSummary?: () => void;
+  onSelectionChange?: (hasSelection: boolean) => void;
+  addSelectionToConversationRef?: React.MutableRefObject<(() => void) | null>;
 }
 
 function ChapterEditorContent({
@@ -91,6 +95,8 @@ function ChapterEditorContent({
   projectId,
   isAgentLocked = false,
   onOpenSummary,
+  onSelectionChange,
+  addSelectionToConversationRef,
 }: ChapterEditorContentProps) {
   const { t } = useTranslation();
   const updateMutation = useUpdateChapter();
@@ -526,6 +532,58 @@ function ChapterEditorContent({
     updateTabTitle(chapter.id, newTitle);
   };
 
+  const addSelectionToConversation = useCallback(() => {
+    if (!editor || !onAddToConversation) return;
+
+    const chapterLabel = chapter.title.trim() || t("writing.untitledChapter");
+    const { from, to } = editor.state.selection;
+    const selectedText =
+      from === to ? "" : editor.state.doc.textBetween(from, to, "\n", "\n").trim();
+    if (!selectedText) return;
+
+    const textBeforeSelection = editor.state.doc.textBetween(0, from, "\n", "\n");
+    const textBeforeSelectionEnd = editor.state.doc.textBetween(0, to, "\n", "\n");
+    const startLine = textBeforeSelection.split("\n").length;
+    const endLine = textBeforeSelectionEnd.split("\n").length;
+
+    onAddToConversation(
+      buildLineRangeMentionTag({
+        chapterId: chapter.id,
+        startLine,
+        endLine,
+        label: `${chapterLabel} L${startLine}-${endLine}`,
+        snapshotText: selectedText,
+      }),
+    );
+
+    editor.commands.setTextSelection(from);
+    const domSelection = window.getSelection();
+    if (domSelection?.anchorNode && editor.view.dom.contains(domSelection.anchorNode)) {
+      domSelection.removeAllRanges();
+    }
+  }, [chapter.id, chapter.title, editor, onAddToConversation, t]);
+
+  useEffect(() => {
+    if (!editor) return;
+    const reportSelection = () => {
+      onSelectionChange?.(editor.state.selection.from !== editor.state.selection.to);
+    };
+    reportSelection();
+    editor.on("selectionUpdate", reportSelection);
+    return () => {
+      editor.off("selectionUpdate", reportSelection);
+      onSelectionChange?.(false);
+    };
+  }, [editor, onSelectionChange]);
+
+  useEffect(() => {
+    if (!addSelectionToConversationRef) return;
+    addSelectionToConversationRef.current = addSelectionToConversation;
+    return () => {
+      addSelectionToConversationRef.current = null;
+    };
+  }, [addSelectionToConversation, addSelectionToConversationRef]);
+
   const editorExtraItems = useCallback(() => {
     if (!editor || !onAddToConversation) return [];
 
@@ -550,25 +608,11 @@ function ChapterEditorContent({
             );
             return;
           }
-
-          const textBeforeSelection = editor.state.doc.textBetween(0, from, "\n", "\n");
-          const textBeforeSelectionEnd = editor.state.doc.textBetween(0, to, "\n", "\n");
-          const startLine = textBeforeSelection.split("\n").length;
-          const endLine = textBeforeSelectionEnd.split("\n").length;
-
-          onAddToConversation(
-            buildLineRangeMentionTag({
-              chapterId: chapter.id,
-              startLine,
-              endLine,
-              label: `${chapterLabel} L${startLine}-${endLine}`,
-              snapshotText: selectedText,
-            }),
-          );
+          addSelectionToConversation();
         },
       },
     ];
-  }, [chapter.id, chapter.title, editor, onAddToConversation, t]);
+  }, [addSelectionToConversation, chapter.id, chapter.title, editor, onAddToConversation, t]);
 
   const editorMaxWidth = 800;
 
@@ -690,6 +734,8 @@ export function ChapterEditor({
   projectId,
   isAgentLocked = false,
   onOpenSummary,
+  onSelectionChange,
+  addSelectionToConversationRef,
 }: ChapterEditorProps) {
   const { t } = useTranslation();
   const { data } = useWritingEditorEntity({
@@ -740,6 +786,8 @@ export function ChapterEditor({
       projectId={projectId}
       isAgentLocked={isAgentLocked}
       onOpenSummary={onOpenSummary}
+      onSelectionChange={onSelectionChange}
+      addSelectionToConversationRef={addSelectionToConversationRef}
     />
   );
 }
@@ -755,6 +803,8 @@ function ChapterEditorWorkingCopy({
   projectId,
   isAgentLocked,
   onOpenSummary,
+  onSelectionChange,
+  addSelectionToConversationRef,
 }: Omit<ChapterEditorContentProps, "workingCopy">) {
   const workingCopy = useWritingWorkingCopy({
     type: "chapter",
@@ -775,6 +825,8 @@ function ChapterEditorWorkingCopy({
       projectId={projectId}
       isAgentLocked={isAgentLocked}
       onOpenSummary={onOpenSummary}
+      onSelectionChange={onSelectionChange}
+      addSelectionToConversationRef={addSelectionToConversationRef}
     />
   );
 }

--- a/frontend/src/features/writing/pages/writing-page.tsx
+++ b/frontend/src/features/writing/pages/writing-page.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex, IconButton, Tooltip } from "@radix-ui/themes";
-import { Bot, List } from "lucide-react";
+import { Bot, List, MessageSquareQuote } from "lucide-react";
 import { motion } from "motion/react";
 import { Suspense, lazy, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -78,6 +78,8 @@ export function WritingPage() {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isSummaryOpen, setIsSummaryOpen] = useState(false);
   const [hasOpenedSummary, setHasOpenedSummary] = useState(false);
+  const [hasEditorSelection, setHasEditorSelection] = useState(false);
+  const addSelectionToConversationRef = useRef<(() => void) | null>(null);
   const [assistantState, setAssistantState] = useState<AssistantSidebarState>({
     agentStatus: "idle",
     isAgentRunning: false,
@@ -486,16 +488,33 @@ export function WritingPage() {
                   </Tooltip>
                 </Flex>
 
-                <Tooltip content={t("assistant.mobileTitle")}>
-                  <IconButton
-                    variant="ghost"
-                    size="2"
-                    aria-label={t("assistant.mobileTitle")}
-                    onClick={openAssistantSidebar}
-                  >
-                    <Bot size={18} />
-                  </IconButton>
-                </Tooltip>
+                <Flex
+                  align="center"
+                  gap="1"
+                >
+                  {!isViewingSubagent && hasEditorSelection && (
+                    <Tooltip content={t("editor.addSelectedToConversation")}>
+                      <IconButton
+                        variant="ghost"
+                        size="2"
+                        aria-label={t("editor.addSelectedToConversation")}
+                        onClick={() => addSelectionToConversationRef.current?.()}
+                      >
+                        <MessageSquareQuote size={18} />
+                      </IconButton>
+                    </Tooltip>
+                  )}
+                  <Tooltip content={t("assistant.mobileTitle")}>
+                    <IconButton
+                      variant="ghost"
+                      size="2"
+                      aria-label={t("assistant.mobileTitle")}
+                      onClick={openAssistantSidebar}
+                    >
+                      <Bot size={18} />
+                    </IconButton>
+                  </Tooltip>
+                </Flex>
               </Flex>
 
               <Box className="writing-page-content-fill">
@@ -516,6 +535,9 @@ export function WritingPage() {
                       isAgentLocked={isAgentLocked}
                       onScrollPositionChange={handleChapterScrollPositionChange}
                       onOpenSummary={handleOpenSummary}
+                      onAddToConversation={isViewingSubagent ? undefined : handleAddToConversation}
+                      onSelectionChange={setHasEditorSelection}
+                      addSelectionToConversationRef={addSelectionToConversationRef}
                     />
                   )
                 ) : (

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -480,6 +480,9 @@
     "cut": "Cut",
     "copy": "Copy",
     "paste": "Paste",
+    "copyFailed": "Copy failed, check clipboard permission",
+    "pasteFailed": "Unable to read clipboard, check clipboard permission",
+    "pasteUnavailable": "Clipboard reading requires HTTPS, access the app over HTTPS",
     "addToConversation": "Add to Conversation",
     "addSelectedToConversation": "Add Selected Content to Conversation"
   },

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -480,6 +480,9 @@
     "cut": "剪切",
     "copy": "复制",
     "paste": "粘贴",
+    "copyFailed": "复制失败，请检查剪贴板权限",
+    "pasteFailed": "无法读取剪贴板，请检查剪贴板权限",
+    "pasteUnavailable": "当前环境不支持读取剪贴板，请使用 HTTPS 访问",
     "addToConversation": "添加到对话",
     "addSelectedToConversation": "添加所选内容到对话"
   },

--- a/frontend/src/lib/clipboard.ts
+++ b/frontend/src/lib/clipboard.ts
@@ -1,0 +1,58 @@
+/**
+ * Clipboard Utilities
+ *
+ * navigator.clipboard 仅在安全上下文(https/localhost)中可用,
+ * 在非安全上下文(如 http 局域网部署)或权限被拒时降级为 execCommand。
+ */
+
+export type ClipboardReadResult =
+  | { ok: true; text: string }
+  | { ok: false; reason: "unavailable" | "denied" };
+
+export async function readClipboardText(): Promise<ClipboardReadResult> {
+  if (typeof navigator === "undefined" || !navigator.clipboard?.readText) {
+    return { ok: false, reason: "unavailable" };
+  }
+  try {
+    return { ok: true, text: await navigator.clipboard.readText() };
+  } catch {
+    return { ok: false, reason: "denied" };
+  }
+}
+
+export async function writeClipboardText(text: string): Promise<boolean> {
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // 权限被拒,继续尝试降级方案
+    }
+  }
+  return copyWithExecCommand(text);
+}
+
+function copyWithExecCommand(text: string): boolean {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.setAttribute("inputmode", "none");
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "0";
+  textarea.style.opacity = "0";
+  textarea.style.pointerEvents = "none";
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  let copied = false;
+  try {
+    copied = document.execCommand("copy");
+  } catch {
+    copied = false;
+  } finally {
+    textarea.blur();
+    document.body.removeChild(textarea);
+  }
+  return copied;
+}


### PR DESCRIPTION
## PR 标题

fix(frontend): 修复移动端编辑器菜单点击无效导致复制粘贴不可用的问题

## 变更说明

- 问题: 移动端长按编辑器文本呼出的自定义菜单点击无反应;其复制/粘贴依赖 `navigator.clipboard`,在 http 部署下不可用
- 原因: 菜单容器对 pointerdown 调用 preventDefault,触摸设备上浏览器不再合成 click 事件,导致菜单项点击无效;`navigator.clipboard` 仅在安全上下文暴露
- 变化:
  - 移动端(coarse pointer)编辑器内不再拦截系统菜单,长按直接使用系统原生菜单,系统级剪贴板操作在非 HTTPS 部署下也可用,并消除误弹键盘等问题
  - 桌面端右键菜单保持不变,菜单项点击改用 pointerup 触发,并增加剪贴板降级(`execCommand`)与失败提示
  - 连带方案: 改用系统菜单后,移动端以顶栏“添加到对话”按钮补回原右键菜单入口——编辑器中选中文本后,顶栏 Agent 按钮左侧显示引用按钮,点击后按行范围引用加入助手对话并清除选中状态

## 关联 Issue / PR (如有)

Related to #251

## 变更类型

- [x] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

移动端自定义菜单:菜单容器对 pointerdown 调用 preventDefault,触摸设备上浏览器不再合成 click 事件,导致菜单项点击无效;同时自定义菜单的剪贴板操作依赖 `navigator.clipboard`,该 API 仅在安全上下文暴露,http 部署下不可用。

## 自查清单

- [x] 已添加/更新必要的测试(无前端测试基础设施,以 Playwright 触摸模拟验证事件链与焦点行为)
- [x] 已运行 lint 和类型检查,无报错
- [x] 已运行测试用例,全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理(无数据库变更)
- [x] 提交信息符合规范

## 补充信息

验证命令: `pnpm type-check`、`pnpm lint`、`pnpm format:check` 均通过。移动端触摸行为经 Playwright 触摸模拟验证(菜单项点击可触发、点击后焦点不回到编辑器)。
