### PR TITLE
chore(agent): 添加会话计时器

### DIFF
--- a/frontend/src/features/assistant/components/agent/agent-messages.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-messages.tsx
@@ -112,6 +112,19 @@ function isRollbackableUserMessage(message: AgentMessageType): boolean {
   );
 }
 
+function getCurrentRoundStartedAt(messages: AgentMessageType[]): number | undefined {
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (
+      (message.type === "user_request" || (message.type === "text" && message.role === "user")) &&
+      Number.isFinite(message.timestamp)
+    ) {
+      return message.timestamp;
+    }
+  }
+  return undefined;
+}
+
 function isAgentBlockDisplayMessage(
   message: BlockDisplayMessage,
 ): message is AgentBlockDisplayMessage {
@@ -178,6 +191,7 @@ const AgentBlockContent = memo(
 interface AgentMessagesFooterContext {
   statusMessage: string;
   showStatus: boolean;
+  roundStartedAt?: number;
   bottomRef: React.RefObject<HTMLDivElement | null>;
 }
 
@@ -188,7 +202,12 @@ const AgentMessagesFooter = memo(function AgentMessagesFooter({
 }) {
   return (
     <>
-      {context.showStatus ? <AgentStatusMessage content={context.statusMessage} /> : null}
+      {context.showStatus ? (
+        <AgentStatusMessage
+          content={context.statusMessage}
+          startedAt={context.roundStartedAt}
+        />
+      ) : null}
       <Box
         ref={context.bottomRef}
         className="agent-message-bottom-anchor"
@@ -236,9 +255,10 @@ export function AgentMessages({
   const [collapsedNodeIds, setCollapsedNodeIds] = useState<Set<string>>(() => new Set());
   const streamFollowSignal = getStreamingFollowSignal(messages);
   const runningStatus = useMemo(() => getAgentRunningStatus(messages), [messages]);
+  const roundStartedAt = useMemo(() => getCurrentRoundStartedAt(messages), [messages]);
   const statusMessage =
-    status === "running" && runningStatus
-      ? t(`assistant.runningStatus.${runningStatus}`)
+    status === "running"
+      ? t(`assistant.runningStatus.${runningStatus ?? "considering"}`)
       : currentStage;
 
   const getScrollContainer = useCallback(
@@ -731,9 +751,10 @@ export function AgentMessages({
       showStatus:
         (status === "running" || status === "waiting_answer" || status === "waiting_approval") &&
         Boolean(statusMessage),
+      roundStartedAt,
       bottomRef,
     }),
-    [status, statusMessage],
+    [roundStartedAt, status, statusMessage],
   );
 
   return (

--- a/frontend/src/features/assistant/components/agent/agent-status-message.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-status-message.tsx
@@ -1,10 +1,26 @@
-import { Box, Flex } from "@radix-ui/themes";
+import { Box, Flex, Text } from "@radix-ui/themes";
+import { useEffect, useState } from "react";
+
+import { formatElapsedDuration } from "./message-blocks/shared/message-duration";
 
 interface AgentStatusMessageProps {
   content: string;
+  startedAt?: number;
 }
 
-export function AgentStatusMessage({ content }: AgentStatusMessageProps) {
+export function AgentStatusMessage({ content, startedAt }: AgentStatusMessageProps) {
+  const [now, setNow] = useState(() => Date.now());
+
+  useEffect(() => {
+    if (startedAt === undefined) return;
+
+    setNow(Date.now());
+    const intervalId = window.setInterval(() => setNow(Date.now()), 500);
+    return () => window.clearInterval(intervalId);
+  }, [startedAt]);
+
+  const elapsedMs = startedAt === undefined ? null : Math.max(0, now - startedAt);
+
   return (
     <Box className="agent-message-card">
       <Flex
@@ -18,6 +34,15 @@ export function AgentStatusMessage({ content }: AgentStatusMessageProps) {
         >
           {content}
         </span>
+        {elapsedMs !== null ? (
+          <Text
+            size="1"
+            color="gray"
+            className="agent-status-message-timer"
+          >
+            {formatElapsedDuration(elapsedMs)}
+          </Text>
+        ) : null}
       </Flex>
     </Box>
   );

--- a/frontend/src/features/assistant/components/assistant-sidebar.css
+++ b/frontend/src/features/assistant/components/assistant-sidebar.css
@@ -1047,8 +1047,20 @@
   gap: 12px;
 }
 
-.agent-status-message .text-shimmer {
+.agent-status-message {
+  width: 100%;
   margin-top: 8px;
+}
+
+.agent-status-message .text-shimmer {
+  min-width: 0;
+  flex: 0 1 auto;
+}
+
+.agent-status-message-timer {
+  flex: 0 0 auto;
+  margin-left: auto;
+  font-variant-numeric: tabular-nums;
 }
 
 .ai-sidebar-textarea {

--- a/frontend/src/features/assistant/hooks/use-subagent-session.ts
+++ b/frontend/src/features/assistant/hooks/use-subagent-session.ts
@@ -38,9 +38,7 @@ import { joinSubagentSession, subscribeSubagentSessionEvents } from "../lib/suba
 import { buildAgentMessagesFromTaskMessages } from "../lib/task-message-agent-mapping";
 import { shouldSuppressAgentErrorAfterCompactionError } from "./use-agent-session-message-state";
 
-function resolveStageText(stage?: string): string {
-  return getStageTextForAgentKey(stage) || stage || "";
-}
+const DEFAULT_RUNNING_STAGE = i18n.t("assistant.runningStatus.considering");
 
 function toSessionStatus(payload: SubagentSessionPayload | null): AgentSessionStatus {
   if (!payload) return "idle";
@@ -141,7 +139,7 @@ export function useSubagentSession(
     (event: AgentEvent) => {
       const result = applyAgentTranscriptEventToLiveState(transcriptStateRef.current, event, {
         approvalPreviewFactory: createApprovalPreviewToolMessage,
-        defaultRunningStage: getStageTextForAgentKey(session?.agentKey) || session?.agentKey || "",
+        defaultRunningStage: DEFAULT_RUNNING_STAGE,
         fallbackAgent: session?.agentKey,
         getStageTextForAgent: getStageTextForAgentKey,
         getStageTextForStage: getStageTextForStageKey,
@@ -284,7 +282,7 @@ export function useSubagentSession(
       messages: nextMessages,
       status: toSessionStatus(payload),
       isRunning: payload.isRunning,
-      currentStage: payload.isRunning ? resolveStageText(payload.agentKey) : "",
+      currentStage: payload.isRunning ? DEFAULT_RUNNING_STAGE : "",
     });
     const pendingApprovalEvent = createPendingApprovalEvent(
       payload.pendingApproval,
@@ -295,7 +293,7 @@ export function useSubagentSession(
       pendingApprovalEvent
         ? applyAgentTranscriptEventToLiveState(nextState, pendingApprovalEvent, {
             approvalPreviewFactory: createApprovalPreviewToolMessage,
-            defaultRunningStage: getStageTextForAgentKey(payload.agentKey) || payload.agentKey,
+            defaultRunningStage: DEFAULT_RUNNING_STAGE,
             fallbackAgent: payload.agentKey,
             getStageTextForAgent: getStageTextForAgentKey,
             getStageTextForStage: getStageTextForStageKey,


### PR DESCRIPTION
## PR 标题

chore(agent): 添加会话计时器

## 变更说明

- 问题: Agent 运行状态缺少本轮会话累计耗时，子代理在未知阶段可能显示原始 agent_key。
- 重要性: 便于确认 Agent 当前轮次的执行时长，并使主会话与子代理状态文案保持一致。
- 变化: 在状态消息右侧显示从本轮用户请求开始累计的时长，复用 formatElapsedDuration 格式化。
- 变化: 运行状态统一显示“正在 xxx”，无法推导阶段时回退为“正在考虑下一步”；调整状态文本 shimmer 宽度与计时器右对齐。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因(如有)

子代理会话初始化与事件回退路径将未知 agent_key 直接写入状态文本；状态消息原本没有累计时长展示。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令：

- pnpm format:check
- pnpm type-check
- pnpm lint
- git diff --check
