### PR TITLE
fix(agent): 修复工具调用未并行执行的问题

### DIFF
--- a/backend/app/agent_runtime/graph/react_agent.py
+++ b/backend/app/agent_runtime/graph/react_agent.py
@@ -8,6 +8,7 @@ factory to get its own loop instance.
 from __future__ import annotations
 
 import asyncio
+import copy
 import inspect
 import json
 import time
@@ -27,7 +28,7 @@ from langchain_core.tools import BaseTool
 from langgraph._internal._constants import CONF
 from langgraph.errors import GraphInterrupt
 from langgraph.graph import END, START, StateGraph
-from langgraph.types import RetryPolicy
+from langgraph.types import Overwrite, RetryPolicy, Send
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.content_blocks import extract_text_content
@@ -78,12 +79,18 @@ def _add_messages(
     return left + right
 
 
-class ReactState(TypedDict):
+class ReactState(TypedDict, total=False):
     messages: Annotated[list[BaseMessage], _add_messages]
     iteration_count: int
     is_done: bool
     final_output: Any
-    tool_call_cursor: int
+    tool_index: int
+    tool_call: ToolCall
+    tool_batch_offset: int
+    tool_dispatch_denied: bool
+    tool_phase: Literal["prepare", "execute"]
+    tool_outcomes: Annotated[list[dict[str, Any]], _add_messages]
+    tool_prepared_outcomes: Annotated[list[dict[str, Any]], _add_messages]
 
 
 # ---------------------------------------------------------------------------
@@ -132,6 +139,7 @@ async def _invoke_model(
 # 节点级重试已禁用：超时与重试统一由模型调用层（invoke_model_with_retry）处理，
 # 避免双层重试叠加。保留常量名以便测试禁用兜底重试。
 LLM_RETRY_POLICY = RetryPolicy(max_attempts=1)
+TOOL_BATCH_SIZE = 10
 
 
 def _get_configurable(config: RunnableConfig | None) -> dict[str, Any]:
@@ -377,6 +385,22 @@ def _clone_agent_tool_for_dispatch(tool_instance: BaseTool) -> BaseTool:
         hasattr(tool_instance, attr) for attr in ("_state", "_pre_hooks", "_post_hooks")
     ):
         return tool_instance
+    try:
+        cloned = copy.copy(tool_instance)
+        runtime_state = getattr(tool_instance, "runtime_state", None)
+        pre_hooks = getattr(tool_instance, "pre_hooks", None)
+        post_hooks = getattr(tool_instance, "post_hooks", None)
+        if isinstance(runtime_state, dict):
+            object.__setattr__(cloned, "runtime_state", dict(runtime_state))
+        if isinstance(pre_hooks, list):
+            object.__setattr__(cloned, "pre_hooks", list(pre_hooks))
+        if isinstance(post_hooks, list):
+            object.__setattr__(cloned, "post_hooks", list(post_hooks))
+        object.__setattr__(cloned, "_config", None)
+        object.__setattr__(cloned, "_tool_call_id", None)
+        return cloned
+    except Exception:
+        pass
     try:
         return tool_instance.__class__(
             _state=getattr(tool_instance, "_state", {}) or {},
@@ -795,17 +819,280 @@ def create_react_agent(
         update: dict[str, Any] = {
             "messages": [response],
             "iteration_count": state["iteration_count"] + 1,
-            "tool_call_cursor": 0,
+            "tool_outcomes": Overwrite([]),
+            "tool_prepared_outcomes": Overwrite([]),
+            "tool_phase": "prepare",
         }
         if drained_injected_user_message:
             update["is_done"] = False
             update["final_output"] = None
         return update
 
-    async def tools_exec(
+    async def tool_exec(
         state: ReactState, config: Optional[RunnableConfig] = None
     ) -> dict:
-        """Execute tool calls from the last AI message."""
+        """Execute one tool call in an isolated fan-out branch."""
+        tool_call = state.get("tool_call")
+        if not isinstance(tool_call, dict):
+            return {"tool_outcomes": []}
+
+        tool_name = str(tool_call.get("name") or "")
+        tool_args = tool_call.get("args")
+        tool_args = tool_args if isinstance(tool_args, dict) else {}
+        tool_id = str(tool_call.get("id") or "")
+        tool_index = int(state.get("tool_index") or 0)
+        started_at = time.perf_counter()
+        phase = state.get("tool_phase") or "execute"
+        source_outcomes = (
+            state.get("tool_prepared_outcomes", [])
+            if phase == "execute"
+            else []
+        )
+        prepared_outcome = next(
+            (
+                outcome
+                for outcome in source_outcomes
+                if outcome.get("tool_call_id") == tool_id
+            ),
+            None,
+        )
+
+        def outcome_update(outcome: dict[str, Any]) -> dict[str, Any]:
+            key = "tool_prepared_outcomes" if phase == "prepare" else "tool_outcomes"
+            return {key: [outcome]}
+
+        if state.get("tool_dispatch_denied"):
+            payload = {
+                "error": "dispatch_subagent allows at most 10 dispatches per PA turn"
+            }
+            result = json.dumps(payload, ensure_ascii=False)
+            return outcome_update(
+                {
+                        "index": tool_index,
+                        "tool_call_id": tool_id,
+                        "tool_name": tool_name,
+                        "tool_args": tool_args,
+                        "message": ToolMessage(
+                            content=result,
+                            tool_call_id=tool_id,
+                            name=tool_name,
+                        ),
+                        "payload": payload,
+                        "success": False,
+                        "latency_ms": int((time.perf_counter() - started_at) * 1000),
+                }
+            )
+
+        if is_malformed_tool_call(tool_call):
+            payload = build_malformed_tool_call_error(tool_call)
+            result = json.dumps(payload, ensure_ascii=False)
+            return outcome_update(
+                {
+                        "index": tool_index,
+                        "tool_call_id": tool_id,
+                        "tool_name": tool_name,
+                        "tool_args": tool_args,
+                        "message": ToolMessage(
+                            content=result,
+                            tool_call_id=tool_id,
+                            name=tool_name,
+                        ),
+                        "payload": payload,
+                        "success": False,
+                        "latency_ms": int((time.perf_counter() - started_at) * 1000),
+                }
+            )
+
+        tool_instance = tool_map.get(tool_name)
+        if tool_instance is None:
+            payload = {"error": f"tool '{tool_name}' not found."}
+            result = f"Error: tool '{tool_name}' not found."
+            return outcome_update(
+                {
+                        "index": tool_index,
+                        "tool_call_id": tool_id,
+                        "tool_name": tool_name,
+                        "tool_args": tool_args,
+                        "message": ToolMessage(
+                            content=result,
+                            tool_call_id=tool_id,
+                            name=tool_name,
+                        ),
+                        "payload": payload,
+                        "success": False,
+                        "latency_ms": int((time.perf_counter() - started_at) * 1000),
+                }
+            )
+
+        if phase == "prepare" and not getattr(tool_instance, "_pre_hooks", []):
+            payload = {"__openfic_prepared": True}
+            result = json.dumps(payload)
+            return outcome_update(
+                {
+                    "index": tool_index,
+                    "tool_call_id": tool_id,
+                    "tool_name": tool_name,
+                    "tool_args": tool_args,
+                    "message": ToolMessage(
+                        content=result,
+                        tool_call_id=tool_id,
+                        name=tool_name,
+                    ),
+                    "payload": payload,
+                    "success": True,
+                    "latency_ms": int((time.perf_counter() - started_at) * 1000),
+                }
+            )
+
+        if (
+            phase == "execute"
+            and prepared_outcome is not None
+            and (
+                getattr(tool_instance, "execute_during_prepare", False)
+                or not bool(prepared_outcome.get("success"))
+            )
+        ):
+            return {"tool_outcomes": [prepared_outcome]}
+
+        tool_instance = _clone_agent_tool_for_dispatch(tool_instance)
+        isolated_config, isolated_session = await _isolate_tool_config(config)
+        try:
+            invoke_config = dict(isolated_config or {})
+            metadata = dict(invoke_config.get("metadata") or {})
+            metadata["tool_call_id"] = tool_id
+            metadata["tool_call"] = tool_call
+            metadata["openfic_phase"] = phase
+            if phase == "execute":
+                metadata["openfic_skip_pre_hooks"] = True
+            invoke_config["metadata"] = metadata
+            if phase == "prepare" and not getattr(
+                tool_instance, "emit_prepare_events", False
+            ):
+                if hasattr(tool_instance, "_pre_hooks"):
+                    result = await tool_instance._arun(
+                        config=cast(RunnableConfig, invoke_config),
+                        **tool_args,
+                    )
+                else:
+                    result = json.dumps({"__openfic_prepared": True})
+            else:
+                result = await _invoke_tool(
+                    tool_instance,
+                    tool_args,
+                    tool_call,
+                    cast(RunnableConfig, invoke_config),
+                )
+        except GraphInterrupt as interrupt:
+            preview_builder = getattr(tool_instance, "build_interrupt_preview", None)
+            if callable(preview_builder) and interrupt.args and interrupt.args[0]:
+                interrupt_value = interrupt.args[0][0].value
+                if isinstance(interrupt_value, dict):
+                    preview = await preview_builder(tool_args)
+                    if isinstance(preview, dict):
+                        interrupt_value["tool_result_preview"] = preview
+                        interrupt_value.setdefault("tool_call_id", tool_id)
+                        interrupt_value.setdefault("tool_name", tool_name)
+                        interrupt_value.setdefault("args", tool_args)
+                        interrupt_value.setdefault("tool_index", tool_index)
+            await _finish_active_audit()
+            raise
+        except Exception as exc:
+            if active_audit is not None:
+                _record_audit_error(active_audit, exc)
+            await _finish_active_audit(status="error")
+            raise
+        finally:
+            if isolated_session is not None:
+                await _close_maybe(isolated_session)
+
+        payload, success = _tool_result_payload(result)
+        if phase == "prepare" and not getattr(
+            tool_instance, "execute_during_prepare", False
+        ):
+            if not success:
+                prepared_payload = payload
+                prepared_result = result
+            else:
+                prepared_payload = {"__openfic_prepared": True}
+                prepared_result = json.dumps(prepared_payload)
+            payload = prepared_payload
+            result = prepared_result
+        outcome = {
+                    "index": tool_index,
+                    "tool_call_id": tool_id,
+                    "tool_name": tool_name,
+                    "tool_args": tool_args,
+                    "message": ToolMessage(
+                        content=str(result),
+                        tool_call_id=tool_id,
+                        name=tool_name,
+                    ),
+                    "payload": payload,
+                    "success": success,
+                    "latency_ms": int((time.perf_counter() - started_at) * 1000),
+                }
+        if phase == "prepare" and not success:
+            return outcome_update(outcome)
+        return outcome_update(outcome)
+
+    async def tools_join(
+        state: ReactState, _config: Optional[RunnableConfig] = None
+    ) -> dict:
+        """Join parallel tool results and restore model call order."""
+        outcomes = sorted(
+            state.get("tool_outcomes", []), key=lambda outcome: outcome["index"]
+        )
+        if state.get("tool_phase") == "prepare":
+            return {
+                "tool_outcomes": Overwrite([]),
+                "tool_phase": "execute",
+            }
+        messages = [outcome["message"] for outcome in outcomes]
+        is_done = False
+        final_output = None
+        for outcome in outcomes:
+            tool_name = outcome["tool_name"]
+            success = bool(outcome["success"])
+            if (
+                not is_done
+                and termination.mode == "tool_success"
+                and termination.tool_name == tool_name
+                and success
+            ):
+                is_done = True
+                final_output = outcome["tool_args"]
+            if active_audit is not None:
+                active_audit.record_tool_call(
+                    tool_name=tool_name,
+                    tool_args=outcome["tool_args"],
+                    tool_result=outcome["payload"],
+                    success=success,
+                    latency_ms=outcome["latency_ms"],
+                )
+
+        await _finish_active_audit()
+        update: dict[str, Any] = {
+            "messages": messages,
+            "tool_outcomes": Overwrite([]),
+            "tool_prepared_outcomes": Overwrite([]),
+            "tool_phase": "prepare",
+        }
+        if is_done:
+            update["is_done"] = True
+            update["final_output"] = final_output
+        return update
+
+    # ------------------------------------------------------------------
+    # Routing
+    # ------------------------------------------------------------------
+
+    async def dispatch_tools(
+        state: ReactState, config: Optional[RunnableConfig] = None
+    ) -> dict:
+        del state, config
+        return {}
+
+    def route_tool_batch(state: ReactState) -> list[Send]:
         last_message = next(
             (
                 message
@@ -815,169 +1102,49 @@ def create_react_agent(
             None,
         )
         if last_message is None:
-            return {"messages": [], "tool_call_cursor": 0}
-        tool_calls: list[ToolCall] = list(last_message.tool_calls)
-        cursor = state.get("tool_call_cursor", 0)
-        if cursor >= len(tool_calls):
-            return {"messages": [], "tool_call_cursor": 0}
-        new_messages: list[BaseMessage] = []
-        is_done = False
-        final_output = None
-        audit_finished = False
-        dispatch_tool = tool_map.get("dispatch_subagent")
-        dispatch_state = getattr(dispatch_tool, "_state", None)
-        if isinstance(dispatch_state, dict):
-            dispatch_state["_dispatch_subagent_count"] = 0
+            return []
+        if len(last_message.tool_calls) > TOOL_BATCH_SIZE:
+            raise RuntimeError(
+                f"Agent 单轮最多调用 {TOOL_BATCH_SIZE} 个工具，实际收到 "
+                f"{len(last_message.tool_calls)} 个"
+            )
 
-        async def execute_one(tc: ToolCall) -> dict[str, Any]:
-            tool_name = tc["name"]
-            tool_args = tc["args"]
-            tool_id = tc["id"]
-            started_at = time.perf_counter()
-            tool_result_payload: dict[str, Any] = {}
-            tool_success = False
-            message: ToolMessage
-            if is_malformed_tool_call(tc):
-                tool_result_payload = build_malformed_tool_call_error(tc)
-                message = ToolMessage(
-                    content=json.dumps(tool_result_payload, ensure_ascii=False),
-                    tool_call_id=tool_id,
-                    name=tool_name,
+        dispatch_count = 0
+        sends: list[Send] = []
+        for slot in range(TOOL_BATCH_SIZE):
+            index = slot
+            tool_call = (
+                last_message.tool_calls[index]
+                if index < len(last_message.tool_calls)
+                else None
+            )
+            denied = False
+            if tool_call is not None and tool_call["name"] == "dispatch_subagent":
+                denied = dispatch_count >= 10
+                dispatch_count += 1
+            sends.append(
+                Send(
+                    f"tool_exec_{slot}",
+                    {
+                        "tool_index": index,
+                        "tool_call": tool_call,
+                        "tool_dispatch_denied": denied,
+                        "tool_phase": state.get("tool_phase", "prepare"),
+                        "tool_prepared_outcomes": state.get(
+                            "tool_prepared_outcomes", []
+                        ),
+                    },
                 )
-                return {
-                    "tool_name": tool_name,
-                    "tool_args": tool_args,
-                    "message": message,
-                    "payload": tool_result_payload,
-                    "success": False,
-                    "latency_ms": int((time.perf_counter() - started_at) * 1000),
-                }
-
-            tool_instance = tool_map.get(tool_name)
-            if tool_instance:
-                result = await _invoke_tool(tool_instance, tool_args, tc, config)
-                tool_result_payload, tool_success = _tool_result_payload(result)
-                message = ToolMessage(content=str(result), tool_call_id=tool_id)
-            else:
-                tool_result_payload = {"error": f"tool '{tool_name}' not found."}
-                message = ToolMessage(
-                    content=f"Error: tool '{tool_name}' not found.",
-                    tool_call_id=tool_id,
-                )
-            return {
-                "tool_name": tool_name,
-                "tool_args": tool_args,
-                "message": message,
-                "payload": tool_result_payload,
-                "success": tool_success,
-                "latency_ms": int((time.perf_counter() - started_at) * 1000),
-            }
-
-        async def build_pending_previews(
-            tool_calls: list[ToolCall],
-        ) -> list[dict[str, Any]]:
-            previews: list[dict[str, Any]] = []
-            for tool_call in tool_calls:
-                tool_instance = tool_map.get(tool_call["name"])
-                if not isinstance(tool_instance, BaseTool):
-                    continue
-                preview_builder = getattr(
-                    tool_instance, "build_interrupt_preview", None
-                )
-                if not callable(preview_builder):
-                    continue
-                tool_instance = _clone_agent_tool_for_dispatch(tool_instance)
-                invoke_config, isolated_session = await _isolate_tool_config(config)
-                try:
-                    object.__setattr__(tool_instance, "_config", invoke_config)
-                    preview_builder = getattr(
-                        tool_instance, "build_interrupt_preview", None
-                    )
-                    preview = (
-                        await preview_builder(tool_call["args"])
-                        if callable(preview_builder)
-                        else None
-                    )
-                finally:
-                    if isolated_session is not None:
-                        await _close_maybe(isolated_session)
-                if isinstance(preview, dict):
-                    previews.append(
-                        {
-                            "tool_call_id": tool_call["id"],
-                            "tool_name": tool_call["name"],
-                            "args": tool_call["args"],
-                            "preview": preview,
-                        }
-                    )
-            return previews
-
-        async def record_outcome(outcome: dict[str, Any]) -> None:
-            nonlocal is_done, final_output
-            new_messages.append(outcome["message"])
-            tool_name = outcome["tool_name"]
-            tool_success = bool(outcome["success"])
-            if (
-                termination.mode == "tool_success"
-                and termination.tool_name == tool_name
-                and tool_success
-            ):
-                is_done = True
-                final_output = outcome["tool_args"]
-            if active_audit is not None:
-                active_audit.record_tool_call(
-                    tool_name=tool_name,
-                    tool_args=outcome["tool_args"],
-                    tool_result=outcome["payload"],
-                    success=tool_success,
-                    latency_ms=outcome["latency_ms"],
-                )
-
-        try:
-            try:
-                await record_outcome(await execute_one(tool_calls[cursor]))
-            except GraphInterrupt as interrupt:
-                if cursor == 0:
-                    previews = await build_pending_previews(tool_calls)
-                    if previews and interrupt.args and interrupt.args[0]:
-                        interrupt_value = interrupt.args[0][0].value
-                        if isinstance(interrupt_value, dict):
-                            interrupt_value["tool_result_previews"] = previews
-                raise
-
-            update: dict[str, Any] = {
-                "messages": new_messages,
-                "tool_call_cursor": cursor + 1,
-            }
-            if is_done:
-                update["is_done"] = True
-                update["final_output"] = final_output
-            await _finish_active_audit()
-            audit_finished = True
-            return update
-        except GraphInterrupt:
-            raise
-        except Exception as exc:
-            if active_audit is not None:
-                _record_audit_error(active_audit, exc)
-            await _finish_active_audit(status="error")
-            audit_finished = True
-            raise
-        finally:
-            if not audit_finished:
-                await _finish_active_audit()
-
-    # ------------------------------------------------------------------
-    # Routing
-    # ------------------------------------------------------------------
+            )
+        return sends
 
     async def route_after_llm(
         state: ReactState,
-    ) -> Literal["llm_call", "tools_exec", "__end__"]:
+    ) -> Literal["dispatch_tools", "llm_call", "__end__"]:
         """Route after LLM call."""
         last_message = state["messages"][-1]
         if hasattr(last_message, "tool_calls") and last_message.tool_calls:
-            return "tools_exec"
+            return "dispatch_tools"
 
         if inject_queue is not None and not inject_queue.empty():
             return "llm_call"
@@ -995,22 +1162,14 @@ def create_react_agent(
 
     async def route_after_tools(
         state: ReactState,
-    ) -> Literal["tools_exec", "llm_call", "__end__"]:
-        last_message = next(
-            (
-                message
-                for message in reversed(state["messages"])
-                if isinstance(message, AIMessage) and message.tool_calls
-            ),
-            None,
-        )
-        if last_message is not None and state.get("tool_call_cursor", 0) < len(
-            last_message.tool_calls
-        ):
-            return "tools_exec"
+    ) -> Literal["dispatch_tools", "llm_call", "__end__"]:
+        if state.get("tool_phase") == "execute":
+            return "dispatch_tools"
         if inject_queue is not None and not inject_queue.empty():
             return "llm_call"
-        if state.get("is_done"):
+        if state.get("is_done") and inject_queue is None:
+            return "__end__"
+        if state.get("is_done") and inject_queue is not None and inject_queue.empty():
             return "__end__"
         if state["iteration_count"] >= max_iterations:
             return "__end__"
@@ -1027,18 +1186,34 @@ def create_react_agent(
         llm_call,
         retry_policy=LLM_RETRY_POLICY,
     )
-    graph.add_node("tools_exec", tools_exec)
+    graph.add_node("dispatch_tools", dispatch_tools)
+    for slot in range(TOOL_BATCH_SIZE):
+        graph.add_node(f"tool_exec_{slot}", tool_exec)
+    graph.add_node("tools_join", tools_join)
 
     graph.add_edge(START, "llm_call")
     graph.add_conditional_edges(
         "llm_call",
         route_after_llm,
-        {"llm_call": "llm_call", "tools_exec": "tools_exec", "__end__": END},
+        {
+            "llm_call": "llm_call",
+            "dispatch_tools": "dispatch_tools",
+            "__end__": END,
+        },
+    )
+    graph.add_conditional_edges("dispatch_tools", route_tool_batch)
+    graph.add_edge(
+        [f"tool_exec_{slot}" for slot in range(TOOL_BATCH_SIZE)],
+        "tools_join",
     )
     graph.add_conditional_edges(
-        "tools_exec",
+        "tools_join",
         route_after_tools,
-        {"tools_exec": "tools_exec", "llm_call": "llm_call", "__end__": END},
+        {
+            "llm_call": "llm_call",
+            "dispatch_tools": "dispatch_tools",
+            "__end__": END,
+        },
     )
 
     compiled = graph.compile(checkpointer=checkpointer)
@@ -1049,6 +1224,20 @@ def create_react_agent(
     async def _wrapped_ainvoke(*args, **kwargs):
         result = await _original_ainvoke(*args, **kwargs)
         if "__interrupt__" in result:
+            outcomes = sorted(
+                result.get("tool_outcomes", []),
+                key=lambda outcome: outcome["index"],
+            )
+            if active_audit is not None:
+                for outcome in outcomes:
+                    active_audit.record_tool_call(
+                        tool_name=outcome["tool_name"],
+                        tool_args=outcome["tool_args"],
+                        tool_result=outcome["payload"],
+                        success=bool(outcome["success"]),
+                        latency_ms=outcome["latency_ms"],
+                    )
+                await _finish_active_audit()
             return result
         if termination.mode == "tool_success" and not result.get("is_done"):
             expected_tool = termination.tool_name or "the configured termination tool"

--- a/backend/app/agent_runtime/graph/react_agent.py
+++ b/backend/app/agent_runtime/graph/react_agent.py
@@ -952,6 +952,30 @@ def create_react_agent(
                 or not bool(prepared_outcome.get("success"))
             )
         ):
+            if not bool(prepared_outcome.get("success")):
+                tool_result_sink = _get_configurable(config).get("tool_result_sink")
+                if callable(tool_result_sink):
+                    rejected_payload = dict(prepared_outcome.get("payload") or {})
+                    rejected_payload.update(
+                        {
+                            "type": "fail",
+                            "success": False,
+                            "reason": "tool_error",
+                            "tool_call_id": tool_id,
+                            "tool_name": tool_name,
+                        }
+                    )
+                    await _maybe_await(
+                        tool_result_sink(
+                            {
+                                "session_id": _get_configurable(config).get("session_id"),
+                                "tool_call_id": tool_id,
+                                "tool_name": tool_name,
+                                "input": tool_args,
+                                "output": rejected_payload,
+                            }
+                        )
+                    )
             return {"tool_outcomes": [prepared_outcome]}
 
         tool_instance = _clone_agent_tool_for_dispatch(tool_instance)

--- a/backend/app/agent_runtime/persistence/persister.py
+++ b/backend/app/agent_runtime/persistence/persister.py
@@ -404,6 +404,43 @@ class MessagePersister:
         finally:
             await session.close()
 
+    async def apply_tool_result(self, payload: dict) -> None:
+        tool_call_id = payload.get("tool_call_id")
+        output = payload.get("output")
+        if not isinstance(tool_call_id, str) or not tool_call_id:
+            return
+        if not isinstance(output, dict):
+            return
+
+        session = self._make_session()
+        try:
+            content = json.dumps(output, ensure_ascii=False)
+            try:
+                await repo.update_latest_tool_message_content(
+                    session,
+                    session_id=self.session_id,
+                    tool_call_id=tool_call_id,
+                    content=content,
+                )
+            except PersistenceWriteError as exc:
+                if "tool message not found" not in str(exc):
+                    raise
+                await repo.insert_message(
+                    session,
+                    session_id=self.session_id,
+                    task_id=self.task_id,
+                    project_id=self.project_id,
+                    role="tool",
+                    status="complete",
+                    content=content,
+                    tool_call_id=tool_call_id,
+                    tool_name=payload.get("tool_name")
+                    if isinstance(payload.get("tool_name"), str)
+                    else None,
+                )
+        finally:
+            await session.close()
+
     async def finalize(self, reason: Literal["done", "cancelled", "error"]) -> None:
         """run/resume 结束时把 buffer 里未提交的 partial / aborted 写库。"""
         try:

--- a/backend/app/agent_runtime/runner/session_runner.py
+++ b/backend/app/agent_runtime/runner/session_runner.py
@@ -252,6 +252,12 @@ class SessionRunner:
             buffer.record_unlocked(name, payload)
             await emit(name, payload, room=self._room)
 
+    async def _emit_tool_result(self, payload: dict[str, Any]) -> None:
+        payload = {"session_id": self.session_id, **payload}
+        if self._persister is not None:
+            await self._persister.apply_tool_result(payload)
+        await self._emit_agent_event("agent:tool_result", payload)
+
     async def _emit_retry_event(self, payload: dict[str, Any]) -> None:
         retry_payload = dict(payload)
         retry_payload["session_id"] = self.session_id
@@ -531,6 +537,7 @@ class SessionRunner:
                 "node_event_sink": node_event_sink,
                 "retry_event_sink": self._emit_retry_event,
                 "agent_event_sink": self._emit_agent_event,
+                "tool_result_sink": self._emit_tool_result,
                 "compaction_usage_sink": self._emit_persisted_task_usage_events,
                 "inject_queue": self._inject_queue,
                 "inject_message_consumed_sink": self._mark_injected_user_message_sent,

--- a/backend/app/agent_runtime/runner/session_runner.py
+++ b/backend/app/agent_runtime/runner/session_runner.py
@@ -64,24 +64,43 @@ def _format_utc_iso_datetime(value: datetime | str | None) -> str:
 def _interrupt_payloads(state: object) -> list[dict[str, Any]]:
     tasks = getattr(state, "tasks", None) or []
     payloads: list[dict[str, Any]] = []
-    for task in tasks:
+    for task_index, task in enumerate(tasks):
         interrupts = getattr(task, "interrupts", None) or []
-        for interrupt_obj in interrupts:
+        for interrupt_index, interrupt_obj in enumerate(interrupts):
             value = getattr(interrupt_obj, "value", None)
             if not isinstance(value, dict):
                 continue
             payload = dict(value)
-            if payload.get("type") == "tool_approval":
-                interrupt_id = getattr(interrupt_obj, "id", None)
-                if (
-                    isinstance(interrupt_id, str)
-                    and interrupt_id
-                ):
-                    payload["interrupt_id"] = interrupt_id
+            interrupt_id = getattr(interrupt_obj, "id", None)
+            if isinstance(interrupt_id, str) and interrupt_id:
+                payload["interrupt_id"] = interrupt_id
+                payload_type = payload.get("type")
+                if payload_type == "tool_approval":
                     payload["approval_id"] = interrupt_id
                     payload["id"] = interrupt_id
+                elif payload_type == "ask_user":
+                    payload["action_id"] = interrupt_id
+                    payload["id"] = interrupt_id
+            payload["_interrupt_order"] = (
+                payload.get("tool_index")
+                if isinstance(payload.get("tool_index"), int)
+                else task_index * 100 + interrupt_index
+            )
             payloads.append(payload)
-    return payloads
+    ordered_payloads = sorted(
+        payloads,
+        key=lambda payload: int(payload.get("_interrupt_order") or 0),
+    )
+    for payload in ordered_payloads:
+        payload.pop("_interrupt_order", None)
+    return ordered_payloads
+
+
+def _interrupt_resume_id(payload: dict[str, Any]) -> str | None:
+    action_type = payload.get("action_type")
+    key = "approval_id" if action_type == "tool_approval" else "action_id"
+    value = payload.get(key)
+    return value if isinstance(value, str) and value else None
 
 
 class SessionRunner:
@@ -284,6 +303,12 @@ class SessionRunner:
 
     async def _emit_pending_interrupts(self, state: object) -> None:
         interrupt_payloads = _interrupt_payloads(state)
+        batch_id = generate_id()
+        batch_total = len(interrupt_payloads)
+        for batch_index, interrupt_payload in enumerate(interrupt_payloads):
+            interrupt_payload["batch_id"] = batch_id
+            interrupt_payload["batch_index"] = batch_index
+            interrupt_payload["batch_total"] = batch_total
         for interrupt_payload in interrupt_payloads:
             preview_items = interrupt_payload.get("tool_result_previews")
             previewed_tool_call_ids: set[str] = set()
@@ -337,8 +362,7 @@ class SessionRunner:
                     },
                 )
 
-        if interrupt_payloads:
-            interrupt_payload = interrupt_payloads[0]
+        for interrupt_payload in interrupt_payloads:
             await emit(
                 "agent:interrupt",
                 {
@@ -498,6 +522,7 @@ class SessionRunner:
         )
         return {
             "recursion_limit": DEFAULT_AGENT_RECURSION_LIMIT,
+            "max_concurrency": 10,
             "configurable": {
                 "thread_id": self.session_id,
                 "db_session": runtime_session,
@@ -1030,6 +1055,17 @@ class SessionRunner:
         self._cancelled_user_message_ids.clear()
         self._inject_queue = asyncio.Queue()
 
+    async def resume_interrupt_batch(
+        self, batch_id: str, responses: list[dict[str, Any]]
+    ) -> None:
+        await self.resume(
+            {
+                "action_type": "interrupt_batch",
+                "batch_id": batch_id,
+                "responses": responses,
+            }
+        )
+
     async def resume(self, payload: dict) -> None:
         graph = await self._get_graph()
         runtime_session = await create_session()
@@ -1059,15 +1095,66 @@ class SessionRunner:
         reason: Literal["done", "cancelled", "error"] = "done"
         try:
             resume_value: dict[str, Any] | dict[str, dict[str, Any]] = payload
-            if payload.get("action_type") == "tool_approval":
+            if payload.get("action_type") == "interrupt_batch":
+                state = await graph.aget_state(
+                    {"configurable": {"thread_id": self.session_id}}
+                )
+                pending = _interrupt_payloads(state)
+                pending_by_id = {
+                    item["interrupt_id"]: item
+                    for item in pending
+                    if isinstance(item.get("interrupt_id"), str)
+                }
+                responses = payload.get("responses")
+                if not isinstance(responses, list) or not responses:
+                    raise ValueError("并行中断响应不能为空")
+                if any(
+                    not isinstance(response, dict)
+                    or response.get("interrupt_id") not in pending_by_id
+                    for response in responses
+                ):
+                    raise ValueError("存在无效或已处理的并行中断响应")
+                if set(response["interrupt_id"] for response in responses) != set(
+                    pending_by_id
+                ):
+                    raise ValueError("必须一次提交本批全部并行中断响应")
+                resume_value = {
+                    response["interrupt_id"]: response for response in responses
+                }
+            elif payload.get("action_type") == "tool_approval":
                 state = await graph.aget_state(
                     {"configurable": {"thread_id": self.session_id}}
                 )
                 interrupt_payloads = _interrupt_payloads(state)
-                if interrupt_payloads:
-                    resume_value = {
-                        interrupt_payloads[0]["approval_id"]: payload,
-                    }
+                resume_id = _interrupt_resume_id(payload)
+                matching = next(
+                    (
+                        item
+                        for item in interrupt_payloads
+                        if item.get("approval_id") == resume_id
+                    ),
+                    None,
+                )
+                if matching is None or not resume_id:
+                    raise ValueError("待恢复的工具审批不存在或已处理")
+                resume_value = {resume_id: payload}
+            elif payload.get("action_type") == "clarification":
+                state = await graph.aget_state(
+                    {"configurable": {"thread_id": self.session_id}}
+                )
+                interrupt_payloads = _interrupt_payloads(state)
+                resume_id = _interrupt_resume_id(payload)
+                matching = next(
+                    (
+                        item
+                        for item in interrupt_payloads
+                        if item.get("action_id") == resume_id
+                    ),
+                    None,
+                )
+                if matching is None or not resume_id:
+                    raise ValueError("待恢复的问题不存在或已处理")
+                resume_value = {resume_id: payload}
             async for event in graph.astream_events(
                 Command(resume=resume_value), config=config, version="v2"
             ):

--- a/backend/app/agent_runtime/runner/subagent_runner.py
+++ b/backend/app/agent_runtime/runner/subagent_runner.py
@@ -213,6 +213,13 @@ def _interrupt_id(interrupt_obj: Any, value: dict[str, Any]) -> str:
     return "child-approval"
 
 
+def _interrupt_resume_id(payload: dict[str, Any]) -> str | None:
+    action_type = payload.get("action_type")
+    key = "approval_id" if action_type == "tool_approval" else "action_id"
+    value = payload.get(key)
+    return value if isinstance(value, str) and value else None
+
+
 def _last_assistant_content(messages: list[BaseMessage]) -> str | None:
     for message in reversed(messages):
         if isinstance(message, AIMessage) and isinstance(message.content, str):
@@ -402,6 +409,7 @@ class SubagentRunner:
                 graph_input,
                 config={
                     "recursion_limit": DEFAULT_AGENT_RECURSION_LIMIT,
+                    "max_concurrency": 10,
                     "tags": [SUBAGENT_CHILD_EVENT_TAG],
                     "configurable": {
                         "thread_id": row.child_thread_id,
@@ -818,6 +826,8 @@ class SubagentRunner:
             "agent_key": row.agent_key,
             "dispatch_id": row.dispatch_id,
         }
+        if value.get("type") == "ask_user":
+            approval_request["action_id"] = approval_id
         session = await _open_session(self.session_factory)
         try:
             updated_row = await record_child_run_pending_approval(
@@ -939,7 +949,8 @@ class SubagentRunner:
             approval_request = pending_result.get("approval_request")
             if isinstance(approval_request, dict) and approval_request:
                 await self._emit_child_interrupt(row, approval_request)
-            return pending_result
+                return pending_result
+            return {"error": "subagent interrupt payload missing"}
 
         assistant_content = _last_assistant_content(result_state.get("messages") or [])
         if assistant_content is None:

--- a/backend/app/agent_runtime/tools/base.py
+++ b/backend/app/agent_runtime/tools/base.py
@@ -71,6 +71,8 @@ class AgentTool(BaseTool):
     )
     _config: RunnableConfig | None = None
     _tool_call_id: str | None = None
+    execute_during_prepare: bool = False
+    emit_prepare_events: bool = False
 
     @property
     def _state(self) -> dict[str, Any]:
@@ -151,6 +153,8 @@ class AgentTool(BaseTool):
         validated_args = dict(kwargs)
         metadata = runtime_config.get("metadata") if isinstance(runtime_config, dict) else None
         metadata_dict = metadata if isinstance(metadata, dict) else {}
+        phase = metadata_dict.get("openfic_phase")
+        skip_pre_hooks = metadata_dict.get("openfic_skip_pre_hooks") is True
         tool_call_id = metadata_dict.get("tool_call_id")
         tool_call = metadata_dict.get("tool_call")
         hook_args = (
@@ -173,31 +177,35 @@ class AgentTool(BaseTool):
             tool_call_id=self.tool_call_id,
         )
 
-        for hook in self._pre_hooks:
-            hook_result = await hook(hook_ctx)
-            if not hook_result.proceed:
-                from langgraph.types import interrupt
+        if not skip_pre_hooks:
+            for hook in self._pre_hooks:
+                hook_result = await hook(hook_ctx)
+                if not hook_result.proceed:
+                    from langgraph.types import interrupt
 
-                resume_value = interrupt(
-                    await self._finalize_interrupt_payload(
-                        hook_result.interrupt_payload,
-                        args=validated_args,
+                    resume_value = interrupt(
+                        await self._finalize_interrupt_payload(
+                            hook_result.interrupt_payload,
+                            args=validated_args,
+                        )
                     )
-                )
-                if (
-                    isinstance(hook_result.interrupt_payload, dict)
-                    and hook_result.interrupt_payload.get("type") == "tool_approval"
-                    and isinstance(resume_value, dict)
-                    and resume_value.get("approved") is False
-                ):
-                    return json.dumps(
-                        {
-                            "error": "工具调用已被用户拒绝",
-                            "approval_id": resume_value.get("approval_id"),
-                            "tool_name": self.name,
-                        },
-                        ensure_ascii=False,
-                    )
+                    if (
+                        isinstance(hook_result.interrupt_payload, dict)
+                        and hook_result.interrupt_payload.get("type") == "tool_approval"
+                        and isinstance(resume_value, dict)
+                        and resume_value.get("approved") is False
+                    ):
+                        return json.dumps(
+                            {
+                                "error": "工具调用已被用户拒绝",
+                                "approval_id": resume_value.get("approval_id"),
+                                "tool_name": self.name,
+                            },
+                            ensure_ascii=False,
+                        )
+
+        if phase == "prepare" and not self.execute_during_prepare:
+            return json.dumps({"__openfic_prepared": True}, ensure_ascii=False)
 
         try:
             execute = getattr(self, "_execute", None)

--- a/backend/app/agent_runtime/tools/impls/interaction/ask_user.py
+++ b/backend/app/agent_runtime/tools/impls/interaction/ask_user.py
@@ -41,6 +41,8 @@ class AskUserTool(AgentTool):
         "- 无论是否给出选项，系统都会自动添加`自行输入答案`的选项提供给用户，因此在提出一个开放式问题时，不要包含`其它`或类似的兜底选项"
     )
     access_level: str = "readonly"
+    execute_during_prepare: bool = True
+    emit_prepare_events: bool = True
     args_schema: type[BaseModel] = AskUserInput
 
     async def _execute(self, questions: list[Question]) -> str:

--- a/backend/app/agent_runtime/tools/impls/orchestration/dispatch_subagent.py
+++ b/backend/app/agent_runtime/tools/impls/orchestration/dispatch_subagent.py
@@ -120,13 +120,6 @@ class DispatchSubagentTool(AgentTool):
         if primary_def is None or primary_def.kind != "primary":
             raise ToolExecutionError("dispatch_subagent may only be called by primary")
 
-        count = int(self._state.get("_dispatch_subagent_count") or 0)
-        if count >= MAX_DISPATCHES_PER_TURN:
-            raise ToolExecutionError(
-                "dispatch_subagent allows at most 10 dispatches per PA turn"
-            )
-        self._state["_dispatch_subagent_count"] = count + 1
-
         try:
             definition = await self._load_definition(agent_key, configurable)
         except KeyError as exc:

--- a/backend/app/api/routers/agent_runtime.py
+++ b/backend/app/api/routers/agent_runtime.py
@@ -60,6 +60,7 @@ from app.api.schemas.agent import (
     AgentForkResponse,
     AgentPendingMessageResponse,
     AgentQuestionAnswerRequest,
+    AgentInterruptResumeRequest,
     AgentRollbackRequest,
     AgentRollbackResponse,
     ActiveSubagentStateResponse,
@@ -1002,6 +1003,25 @@ async def submit_agent_question_answer(
         coro=runner.resume(payload),
     )
     return {"success": True, "session_id": session_id, "message": "已提交澄清回答"}
+
+
+@router.post("/sessions/{session_id}/interrupt-resume")
+async def submit_agent_interrupt_resume(
+    session_id: str,
+    body: AgentInterruptResumeRequest,
+    session: AsyncSession = Depends(get_session),
+) -> dict:
+    runner = await _get_runner(session_id, session)
+    status_session_factory = _make_status_session_factory(session)
+    responses = [item.model_dump(mode="json", exclude_none=True) for item in body.responses]
+    await _launch_task(
+        db_session_factory=status_session_factory,
+        session_id=session_id,
+        task_id=runner.task_id,
+        project_id=runner.project_id,
+        coro=runner.resume_interrupt_batch(body.batch_id, responses),
+    )
+    return {"success": True, "session_id": session_id, "message": "已提交并行中断响应"}
 
 
 @router.post("/sessions/{session_id}/tool-approval")

--- a/backend/app/api/schemas/agent.py
+++ b/backend/app/api/schemas/agent.py
@@ -146,6 +146,32 @@ class AgentToolApprovalRequest(BaseModel):
     approved: bool = Field(..., description="是否批准")
 
 
+class AgentInterruptResponseItem(BaseModel):
+    """单个并行中断响应。"""
+
+    interrupt_id: str = Field(..., description="LangGraph 中断ID")
+    action_type: str = Field(..., description="中断响应类型")
+    approval_id: str | None = Field(default=None, description="工具审批ID")
+    approved: bool | None = Field(default=None, description="是否批准工具")
+    action_id: str | None = Field(default=None, description="澄清请求ID")
+    answer: list[AgentQuestionAnswerItem] | None = Field(
+        default=None,
+        description="澄清问题回答",
+    )
+
+
+class AgentInterruptResumeRequest(BaseModel):
+    """批量恢复同一轮并行中断。"""
+
+    batch_id: str = Field(..., description="中断批次ID")
+    responses: list[AgentInterruptResponseItem] = Field(
+        ...,
+        min_length=1,
+        max_length=10,
+        description="本批全部中断响应",
+    )
+
+
 class AgentToolMetadataResponse(BaseModel):
     """Agent 工具权限元数据。"""
 

--- a/backend/tests/agent_runtime/graph/test_react_agent_context.py
+++ b/backend/tests/agent_runtime/graph/test_react_agent_context.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.tools import BaseTool
+from langchain_core.tools import StructuredTool
 
 from app.agent_runtime.context.compaction.service import CompactionError
 from app.agent_runtime.context.compaction.window import CompactionNoWindowError
@@ -100,6 +101,157 @@ def test_llm_call_uses_build_context_when_config_provided() -> None:
     assert kwargs["agent_name"] == "writer"
     assert kwargs["state"]["transient_context_key"] == "v2"
     assert "transient_context_key" not in runtime_state
+
+
+@pytest.mark.asyncio
+async def test_react_agent_executes_tool_calls_in_parallel() -> None:
+    started: set[str] = set()
+    all_started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def run_tool(name: str) -> str:
+        started.add(name)
+        if len(started) == 2:
+            all_started.set()
+        await release.wait()
+        return name
+
+    async def first_tool() -> str:
+        return await run_tool("first")
+
+    async def second_tool() -> str:
+        return await run_tool("second")
+
+    tools = [
+        StructuredTool.from_function(
+            coroutine=first_tool,
+            name="first_tool",
+            description="first",
+        ),
+        StructuredTool.from_function(
+            coroutine=second_tool,
+            name="second_tool",
+            description="second",
+        ),
+    ]
+    model = Mock()
+    model.bind_tools.return_value = model
+    responses = iter(
+        [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {"id": "call-1", "name": "first_tool", "args": {}},
+                    {"id": "call-2", "name": "second_tool", "args": {}},
+                ],
+            ),
+            AIMessage(content="finished"),
+        ]
+    )
+
+    async def invoke_model(*_args, **_kwargs):
+        return next(responses)
+
+    config = ReactAgentConfig(
+        name="writer",
+        tools=tools,
+        termination=TerminationCondition(mode="no_tool_call"),
+        max_iterations=3,
+    )
+
+    with patch(
+        "app.agent_runtime.graph.react_agent._invoke_model",
+        side_effect=invoke_model,
+    ):
+        graph = create_react_agent(config, model=model)
+        task = asyncio.create_task(
+            graph.ainvoke(
+                {
+                    "messages": [HumanMessage(content="go")],
+                    "iteration_count": 0,
+                    "is_done": False,
+                    "final_output": None,
+                }
+            )
+        )
+        await asyncio.wait_for(all_started.wait(), timeout=1)
+        release.set()
+        result = await asyncio.wait_for(task, timeout=1)
+
+    tool_messages = [
+        message
+        for message in result["messages"]
+        if isinstance(message, ToolMessage)
+    ]
+    assert [message.tool_call_id for message in tool_messages] == ["call-1", "call-2"]
+
+
+@pytest.mark.asyncio
+async def test_react_agent_preserves_tool_call_order_when_tools_finish_out_of_order() -> None:
+    async def first_tool() -> str:
+        await asyncio.sleep(0.02)
+        return "first"
+
+    async def second_tool() -> str:
+        await asyncio.sleep(0)
+        return "second"
+
+    tools = [
+        StructuredTool.from_function(
+            coroutine=first_tool,
+            name="first_tool",
+            description="first",
+        ),
+        StructuredTool.from_function(
+            coroutine=second_tool,
+            name="second_tool",
+            description="second",
+        ),
+    ]
+    model = Mock()
+    model.bind_tools.return_value = model
+    responses = iter(
+        [
+            AIMessage(
+                content="",
+                tool_calls=[
+                    {"id": "call-1", "name": "first_tool", "args": {}},
+                    {"id": "call-2", "name": "second_tool", "args": {}},
+                ],
+            ),
+            AIMessage(content="finished"),
+        ]
+    )
+
+    async def invoke_model(*_args, **_kwargs):
+        return next(responses)
+
+    config = ReactAgentConfig(
+        name="writer",
+        tools=tools,
+        termination=TerminationCondition(mode="no_tool_call"),
+        max_iterations=3,
+    )
+
+    with patch(
+        "app.agent_runtime.graph.react_agent._invoke_model",
+        side_effect=invoke_model,
+    ):
+        result = await create_react_agent(config, model=model).ainvoke(
+            {
+                "messages": [HumanMessage(content="go")],
+                "iteration_count": 0,
+                "is_done": False,
+                "final_output": None,
+            }
+        )
+
+    tool_messages = [
+        message
+        for message in result["messages"]
+        if isinstance(message, ToolMessage)
+    ]
+    assert [message.tool_call_id for message in tool_messages] == ["call-1", "call-2"]
 
 
 async def _noop_event_sink(_name: str, _payload: dict) -> None:

--- a/backend/tests/agent_runtime/persistence/test_persister.py
+++ b/backend/tests/agent_runtime/persistence/test_persister.py
@@ -184,6 +184,52 @@ async def test_persister_inserts_missing_batch_approval_preview_tool_messages(
 
 
 @pytest.mark.asyncio
+async def test_persister_replaces_approval_preview_with_rejected_result(
+    db_session: AsyncSession, db_session_factory, sample_task
+):
+    session_id = "session-rejected-approval"
+    persister = MessagePersister(
+        session_id=session_id,
+        task_id=sample_task.id,
+        project_id=sample_task.project_id,
+        db_session_factory=db_session_factory,
+    )
+    await persister.apply_interrupt_preview(
+        {
+            "tool_call_id": "call-rejected",
+            "tool_name": "edit_note",
+            "tool_result_preview": {
+                "type": "preview",
+                "success": True,
+                "reason": "approval_preview",
+            },
+        }
+    )
+
+    await persister.apply_tool_result(
+        {
+            "tool_call_id": "call-rejected",
+            "tool_name": "edit_note",
+            "output": {
+                "type": "fail",
+                "success": False,
+                "reason": "tool_error",
+                "error": "工具调用已被用户拒绝",
+            },
+        }
+    )
+
+    messages = await repo.list_by_session(db_session, session_id)
+    assert len(messages) == 1
+    assert json.loads(messages[0].content) == {
+        "type": "fail",
+        "success": False,
+        "reason": "tool_error",
+        "error": "工具调用已被用户拒绝",
+    }
+
+
+@pytest.mark.asyncio
 async def test_persister_ignores_subagent_child_events(
     db_session: AsyncSession, db_session_factory, sample_task
 ):

--- a/backend/tests/agent_runtime/test_orchestrator_graph.py
+++ b/backend/tests/agent_runtime/test_orchestrator_graph.py
@@ -217,14 +217,18 @@ async def test_orchestrator_resumes_all_parallel_tool_approvals_once() -> None:
                 for task in state.tasks
                 for interrupt in getattr(task, "interrupts", ())
             ]
-            assert [interrupt.value["tool_call_id"] for interrupt in interrupts] == ["call_1"]
+            assert {
+                interrupt.value["tool_call_id"] for interrupt in interrupts
+            } == {f"call_{index}" for index in range(1, 6)}
+            pending_interrupts = list(interrupts)
             for index in range(1, 6):
+                interrupt = pending_interrupts.pop(0)
                 async for _event in graph.astream_events(
                     Command(
                         resume={
-                            interrupts[0].id: {
+                            interrupt.id: {
                                 "action_type": "tool_approval",
-                                "approval_id": interrupts[0].id,
+                                "approval_id": interrupt.id,
                                 "approved": True,
                             }
                         }
@@ -240,9 +244,7 @@ async def test_orchestrator_resumes_all_parallel_tool_approvals_once() -> None:
                     for interrupt in getattr(task, "interrupts", ())
                 ]
                 if index < 5:
-                    assert [interrupt.value["tool_call_id"] for interrupt in interrupts] == [
-                        f"call_{index + 1}"
-                    ]
+                    assert len(interrupts) == 5 - index
                 else:
                     assert resumed_state.next == ()
     finally:

--- a/backend/tests/agent_runtime/test_react_agent.py
+++ b/backend/tests/agent_runtime/test_react_agent.py
@@ -944,6 +944,7 @@ class ApprovalTool(AgentTool):
 @pytest.mark.asyncio
 async def test_react_agent_does_not_execute_tool_after_approval_is_rejected() -> None:
     executed: list[str] = []
+    tool_results: list[dict] = []
 
     class RejectableTool(ApprovalTool):
         async def _execute(self, value: str) -> str:
@@ -969,6 +970,7 @@ async def test_react_agent_does_not_execute_tool_after_approval_is_rejected() ->
         )
 
     config = {"configurable": {"thread_id": "reject-approval"}}
+    config["configurable"]["tool_result_sink"] = tool_results.append
     with patch(
         "app.agent_runtime.graph.react_agent._invoke_model",
         side_effect=invoke_model,
@@ -1002,6 +1004,10 @@ async def test_react_agent_does_not_execute_tool_after_approval_is_rejected() ->
         )
 
     assert executed == []
+    assert len(tool_results) == 1
+    assert tool_results[0]["tool_call_id"] == "call_reject"
+    assert tool_results[0]["output"]["success"] is False
+    assert tool_results[0]["output"]["type"] == "fail"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/test_react_agent.py
+++ b/backend/tests/agent_runtime/test_react_agent.py
@@ -942,6 +942,116 @@ class ApprovalTool(AgentTool):
 
 
 @pytest.mark.asyncio
+async def test_react_agent_does_not_execute_tool_after_approval_is_rejected() -> None:
+    executed: list[str] = []
+
+    class RejectableTool(ApprovalTool):
+        async def _execute(self, value: str) -> str:
+            executed.append(value)
+            return await super()._execute(value)
+
+    graph = create_react_agent(
+        ReactAgentConfig(
+            name="test",
+            tools=[RejectableTool(_pre_hooks=[_approval_hook])],
+            termination=TerminationCondition(mode="no_tool_call"),
+            max_iterations=1,
+        ),
+        checkpointer=InMemorySaver(),
+    )
+
+    async def invoke_model(*_args, **_kwargs):
+        return AIMessage(
+            content="",
+            tool_calls=[
+                {"id": "call_reject", "name": "approval_tool", "args": {"value": "x"}}
+            ],
+        )
+
+    config = {"configurable": {"thread_id": "reject-approval"}}
+    with patch(
+        "app.agent_runtime.graph.react_agent._invoke_model",
+        side_effect=invoke_model,
+    ):
+        await graph.ainvoke(
+            {
+                "messages": [HumanMessage(content="run")],
+                "iteration_count": 0,
+                "is_done": False,
+                "final_output": None,
+            },
+            config=config,
+        )
+        state = await graph.aget_state(config)
+        pending = [
+            interrupt
+            for task in state.tasks
+            for interrupt in getattr(task, "interrupts", ())
+        ]
+        await graph.ainvoke(
+            Command(
+                resume={
+                    pending[0].id: {
+                        "action_type": "tool_approval",
+                        "approval_id": pending[0].id,
+                        "approved": False,
+                    }
+                }
+            ),
+            config=config,
+        )
+
+    assert executed == []
+
+
+@pytest.mark.asyncio
+async def test_react_agent_rejects_more_than_ten_tool_calls_before_execution() -> None:
+    executed: list[str] = []
+
+    class CountingTool(AgentTool):
+        name: str = "counting_tool"
+        description: str = "counting"
+        args_schema: type[BaseModel] = ApprovalInput
+
+        async def _execute(self, value: str) -> str:
+            executed.append(value)
+            return json.dumps({"success": True, "value": value})
+
+    graph = create_react_agent(
+        ReactAgentConfig(
+            name="test",
+            tools=[CountingTool()],
+            termination=TerminationCondition(mode="no_tool_call"),
+            max_iterations=1,
+        )
+    )
+
+    async def invoke_model(*_args, **_kwargs):
+        return AIMessage(
+            content="",
+            tool_calls=[
+                {"id": f"call_{index}", "name": "counting_tool", "args": {"value": str(index)}}
+                for index in range(11)
+            ],
+        )
+
+    with patch(
+        "app.agent_runtime.graph.react_agent._invoke_model",
+        side_effect=invoke_model,
+    ), pytest.raises(RuntimeError, match="最多调用 10 个工具"):
+        await graph.ainvoke(
+            {
+                "messages": [HumanMessage(content="run")],
+                "iteration_count": 0,
+                "is_done": False,
+                "final_output": None,
+            }
+        )
+
+    assert executed == []
+
+
+@pytest.mark.asyncio
 async def test_react_agent_previews_all_parallel_tool_calls_and_resumes_each_approval() -> (
     None
 ):
@@ -989,20 +1099,20 @@ async def test_react_agent_previews_all_parallel_tool_calls_and_resumes_each_app
         for task in state.tasks
         for interrupt in getattr(task, "interrupts", ())
     ]
-    assert [interrupt.value["tool_call_id"] for interrupt in interrupts] == ["call_1"]
-    assert len({interrupt.id for interrupt in interrupts}) == 1
-    assert [
-        preview["tool_call_id"]
-        for preview in interrupts[0].value["tool_result_previews"]
-    ] == [f"call_{index}" for index in range(1, 6)]
+    assert {
+        interrupt.value["tool_call_id"] for interrupt in interrupts
+    } == {f"call_{index}" for index in range(1, 6)}
+    assert len({interrupt.id for interrupt in interrupts}) == 5
+    pending_interrupts = list(interrupts)
 
-    for index in range(1, 6):
+    for _index in range(1, 6):
+        interrupt = pending_interrupts.pop(0)
         await graph.ainvoke(
             Command(
                 resume={
-                    interrupts[0].id: {
+                    interrupt.id: {
                         "action_type": "tool_approval",
-                        "approval_id": interrupts[0].id,
+                        "approval_id": interrupt.id,
                         "approved": True,
                     }
                 }
@@ -1015,10 +1125,8 @@ async def test_react_agent_previews_all_parallel_tool_calls_and_resumes_each_app
             for task in resumed_state.tasks
             for interrupt in getattr(task, "interrupts", ())
         ]
-        if index < 5:
-            assert [interrupt.value["tool_call_id"] for interrupt in interrupts] == [
-                f"call_{index + 1}"
-            ]
+        if _index < 5:
+            assert len(resumed_state.next) == 5 - _index
         else:
             assert resumed_state.next == ()
 

--- a/backend/tests/agent_runtime/test_session_runner.py
+++ b/backend/tests/agent_runtime/test_session_runner.py
@@ -255,13 +255,24 @@ async def test_run_emits_preview_for_each_parallel_tool_approval_interrupt():
         for call in emit_mock.await_args_list
         if call.args and call.args[0] == "agent:interrupt"
     ]
-    assert [payload["approval_id"] for payload in interrupt_payloads] == ["shared-interrupt"]
+    assert [payload["tool_call_id"] for payload in interrupt_payloads] == [
+        "call-note",
+        "call-character",
+    ]
+    assert [payload["batch_index"] for payload in interrupt_payloads] == [0, 1]
+    assert {payload["batch_total"] for payload in interrupt_payloads} == {2}
+    assert len({payload["batch_id"] for payload in interrupt_payloads}) == 1
     approval_flow_events = [
         call.args[0]
         for call in emit_mock.await_args_list
         if call.args and call.args[0] in {"agent:tool_result", "agent:interrupt"}
     ]
-    assert approval_flow_events == ["agent:tool_result", "agent:tool_result", "agent:interrupt"]
+    assert approval_flow_events == [
+        "agent:tool_result",
+        "agent:tool_result",
+        "agent:interrupt",
+        "agent:interrupt",
+    ]
 
 
 @pytest.mark.asyncio
@@ -427,7 +438,7 @@ async def test_resume_targets_the_approved_parallel_tool_interrupt():
 
     with patch.object(runner, "_get_graph", AsyncMock(return_value=_Graph())), \
          patch("app.agent_runtime.runner.session_runner.finalize_revision_status", AsyncMock()), \
-         patch("app.agent_runtime.runner.session_runner.emit", new=AsyncMock()) as emit_mock, \
+         patch("app.agent_runtime.runner.session_runner.emit", new=AsyncMock()), \
          patch(
              "app.agent_runtime.runner.session_runner.create_session",
              AsyncMock(return_value=fake_session),
@@ -449,18 +460,82 @@ async def test_resume_targets_the_approved_parallel_tool_interrupt():
             "approved": True,
         }
     }
-    preview_result_payloads = [
-        call.args[1]
-        for call in emit_mock.await_args_list
-        if call.args and call.args[0] == "agent:tool_result"
+
+
+@pytest.mark.asyncio
+async def test_resume_restores_all_parallel_interrupts_in_one_command() -> None:
+    runner = SessionRunner(
+        session_id="sess_resume_batch",
+        task_id="task_resume_batch",
+        model_config={
+            "provider_type": "openai",
+            "model_id": "gpt",
+            "api_key": "k",
+            "base_url": "",
+            "max_context_tokens": 8000,
+        },
+    )
+    captured: dict = {}
+
+    class _Graph:
+        async def astream_events(self, command, *args, **kwargs):
+            captured["command"] = command
+            if False:
+                yield None
+
+        async def aget_state(self, *args, **kwargs):
+            return SimpleNamespace(
+                next=("tools",),
+                tasks=(
+                    SimpleNamespace(
+                        interrupts=(
+                            SimpleNamespace(
+                                id="approval-1",
+                                value={"type": "tool_approval", "tool_call_id": "call-1"},
+                            ),
+                            SimpleNamespace(
+                                id="question-1",
+                                value={"type": "ask_user", "tool_call_id": "call-2"},
+                            ),
+                        )
+                    ),
+                ),
+                values={"current_revision_id": "rev-batch"},
+                config={"configurable": {}},
+            )
+
+    fake_session = MagicMock(close=AsyncMock(), commit=AsyncMock())
+    fake_persister = MagicMock(
+        handle=AsyncMock(),
+        finalize=AsyncMock(),
+        apply_interrupt_preview=AsyncMock(),
+    )
+    responses = [
+        {
+            "interrupt_id": "approval-1",
+            "action_type": "tool_approval",
+            "approval_id": "approval-1",
+            "approved": True,
+        },
+        {
+            "interrupt_id": "question-1",
+            "action_type": "clarification",
+            "action_id": "question-1",
+            "answer": [{"question": "风格", "answer": "正式"}],
+        },
     ]
-    assert [payload["output"] for payload in preview_result_payloads] == [second_preview]
-    interrupt_payloads = [
-        call.args[1]
-        for call in emit_mock.await_args_list
-        if call.args and call.args[0] == "agent:interrupt"
-    ]
-    assert [payload["approval_id"] for payload in interrupt_payloads] == ["shared-interrupt"]
+
+    with patch.object(runner, "_get_graph", AsyncMock(return_value=_Graph())), \
+         patch("app.agent_runtime.runner.session_runner.finalize_revision_status", AsyncMock()), \
+         patch("app.agent_runtime.runner.session_runner.create_session", AsyncMock(return_value=fake_session)), \
+         patch.object(runner, "_make_persister", MagicMock(return_value=fake_persister)):
+        await runner.resume_interrupt_batch("batch-1", responses)
+
+    assert isinstance(captured["command"], Command)
+    assert captured["command"].resume == {
+        "approval-1": responses[0],
+        "question-1": responses[1],
+    }
 
 
 @pytest.mark.asyncio

--- a/backend/tests/api/test_agent.py
+++ b/backend/tests/api/test_agent.py
@@ -2622,6 +2622,46 @@ class TestAgentAPI:
                 "answer": [{"question": "风格选择", "answer": "正式"}],
             })
 
+    async def test_submit_interrupt_batch_launches_single_resume(self, client: AsyncClient) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={
+                "project_id": target["project_id"],
+                "model_id": target["model_id"],
+                "max_iterations": 5,
+            },
+        )
+        session_id = session_response.json()["session_id"]
+        responses = [
+            {
+                "interrupt_id": "approval-1",
+                "action_type": "tool_approval",
+                "approval_id": "approval-1",
+                "approved": True,
+            },
+            {
+                "interrupt_id": "question-1",
+                "action_type": "clarification",
+                "action_id": "question-1",
+                "answer": [{"question": "风格", "answer": "正式"}],
+            },
+        ]
+
+        with patch(
+            "app.api.routers.agent_runtime.SessionRunner.resume_interrupt_batch",
+            new=AsyncMock(return_value=None),
+        ) as mock_resume:
+            response = await client.post(
+                f"/api/v1/agent/sessions/{session_id}/interrupt-resume",
+                json={"batch_id": "batch-1", "responses": responses},
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["success"] is True
+        await asyncio.sleep(0.05)
+        mock_resume.assert_awaited_once_with("batch-1", responses)
+
     async def test_rollback_session_uses_revision_id_and_restores_data(
         self,
         client: AsyncClient,

--- a/frontend/src/features/assistant/components/agent/agent-sidebar.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-sidebar.tsx
@@ -97,6 +97,7 @@ export function useAgentSidebar({
     forkFromRevision: forkAgentFromRevision,
     handleToolApproval: handleAgentToolApproval,
     submitQuestionAnswer: submitAgentQuestionAnswer,
+    handleBatchDecision,
     abortSession: abortAgentSession,
   } = useAgentSession({
     projectId,
@@ -228,6 +229,10 @@ export function useAgentSidebar({
             : undefined
         }
         onSubmitQuestionAnswer={submitAgentQuestionAnswer}
+        onBatchDecision={(panel, decision) => {
+          const message = agentMessages.find((item) => item.id === panel.id);
+          if (message) void handleBatchDecision(message, decision);
+        }}
       />
     ),
   };

--- a/frontend/src/features/assistant/components/agent/agent-special-panels-state.ts
+++ b/frontend/src/features/assistant/components/agent/agent-special-panels-state.ts
@@ -13,6 +13,9 @@ export interface AgentApprovalSpecialPanel {
   kind: "approval";
   approval: ToolApprovalData;
   summary: string;
+  batchIndex?: number;
+  batchTotal?: number;
+  batchId?: string;
 }
 
 export interface AgentQuestionSpecialPanel {
@@ -20,6 +23,9 @@ export interface AgentQuestionSpecialPanel {
   kind: "question";
   prompt: ClarificationPromptData;
   summary: string;
+  batchIndex?: number;
+  batchTotal?: number;
+  batchId?: string;
 }
 
 export type AgentSpecialPanel = AgentApprovalSpecialPanel | AgentQuestionSpecialPanel;
@@ -74,33 +80,51 @@ function getQuestionSummary(prompt: ClarificationPromptData): string {
 }
 
 export function getAgentSpecialPanels(messages: AgentMessage[]): AgentSpecialPanel[] {
-  return messages.reduce<AgentSpecialPanel[]>((panels, message) => {
-    if (!isVisibleActiveSpecialPanelMessage(message)) return panels;
+  return messages
+    .reduce<AgentSpecialPanel[]>((panels, message) => {
+      if (!isVisibleActiveSpecialPanelMessage(message)) return panels;
 
-    if (message.type === "question") {
-      const prompt = getClarificationPromptData(message);
-      if (prompt.questions.length === 0) return panels;
+      if (message.type === "question") {
+        const prompt = getClarificationPromptData(message);
+        if (prompt.questions.length === 0) return panels;
 
-      panels.push({
-        id: message.id,
-        kind: "question",
-        prompt,
-        summary: getQuestionSummary(prompt),
-      });
+        panels.push({
+          id: message.id,
+          kind: "question",
+          prompt,
+          summary: getQuestionSummary(prompt),
+          batchIndex: message.interruptBatchIndex,
+          batchTotal: message.interruptBatchTotal,
+          batchId: message.interruptBatchId,
+        });
+        return panels;
+      }
+
+      if (
+        (message.type === "approval" || message.type === "tool_approval") &&
+        message.toolApproval
+      ) {
+        panels.push({
+          id: message.id,
+          kind: "approval",
+          approval: message.toolApproval,
+          summary: getApprovalSummary(
+            message.toolApproval.tool_name,
+            message.toolApproval.tool_args,
+          ),
+          batchIndex: message.interruptBatchIndex,
+          batchTotal: message.interruptBatchTotal,
+          batchId: message.interruptBatchId,
+        });
+      }
+
       return panels;
-    }
-
-    if ((message.type === "approval" || message.type === "tool_approval") && message.toolApproval) {
-      panels.push({
-        id: message.id,
-        kind: "approval",
-        approval: message.toolApproval,
-        summary: getApprovalSummary(message.toolApproval.tool_name, message.toolApproval.tool_args),
-      });
-    }
-
-    return panels;
-  }, []);
+    }, [])
+    .sort(
+      (left, right) =>
+        (left.batchIndex ?? Number.MAX_SAFE_INTEGER) -
+        (right.batchIndex ?? Number.MAX_SAFE_INTEGER),
+    );
 }
 
 export function getAgentSpecialPanelVariant(embedded: boolean): AgentSpecialPanelVariant {

--- a/frontend/src/features/assistant/components/agent/agent-special-panels.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-special-panels.tsx
@@ -10,6 +10,10 @@ interface AgentSpecialPanelsProps {
   embedded?: boolean;
   onApproveTool?: (approvalId: string, approved: boolean) => void;
   onSubmitQuestionAnswer?: (actionId: string, answer: ClarificationAnswerItem[]) => void;
+  onBatchDecision?: (
+    panel: AgentSpecialPanel,
+    decision: { approved?: boolean; answer?: ClarificationAnswerItem[] },
+  ) => void;
   readOnly?: boolean;
 }
 
@@ -18,15 +22,14 @@ export function AgentSpecialPanels({
   embedded = false,
   onApproveTool,
   onSubmitQuestionAnswer,
+  onBatchDecision,
   readOnly = false,
 }: AgentSpecialPanelsProps) {
   const variant = getAgentSpecialPanelVariant(embedded);
 
   if (panels.length === 0) return null;
-  const firstApprovalIndex = panels.findIndex((panel) => panel.kind === "approval");
-  const visiblePanels = panels.filter(
-    (panel, index) => panel.kind !== "approval" || index === firstApprovalIndex,
-  );
+  const batchPanels = panels.filter((panel) => panel.batchId);
+  const visiblePanels = batchPanels.length > 0 ? batchPanels.slice(0, 1) : panels.slice(0, 1);
 
   return (
     <Flex
@@ -53,6 +56,7 @@ export function AgentSpecialPanels({
               panel={panel}
               readOnly={readOnly}
               onSubmitQuestionAnswer={onSubmitQuestionAnswer}
+              onBatchDecision={panel.batchId ? onBatchDecision : undefined}
             />
           );
         }
@@ -63,6 +67,7 @@ export function AgentSpecialPanels({
             panel={panel}
             readOnly={readOnly}
             onApproveTool={onApproveTool}
+            onBatchDecision={panel.batchId ? onBatchDecision : undefined}
           />
         );
       })}

--- a/frontend/src/features/assistant/components/agent/display/agent-message-display-items.ts
+++ b/frontend/src/features/assistant/components/agent/display/agent-message-display-items.ts
@@ -60,9 +60,17 @@ function hasPendingDisplayMessage(messages: AgentBlockDisplayMessage[]): boolean
   );
 }
 
+function getDisplayMessageIdentity(message: AgentBlockDisplayMessage): string {
+  if (message.id) return message.id;
+  if (message.correlationId) return `correlation:${message.correlationId}`;
+  const toolCallId = message.payload?.tool_call_id;
+  if (typeof toolCallId === "string" && toolCallId) return `tool-call:${toolCallId}`;
+  return `${message.type}:${message.timestamp}`;
+}
+
 function pushMessageItem(items: AgentDisplayItem[], message: AgentBlockDisplayMessage): void {
   items.push({
-    id: `message:${items.length}`,
+    id: `message:${getDisplayMessageIdentity(message)}`,
     type: "message",
     message,
   });
@@ -131,7 +139,7 @@ function pushExplorationItem(
     return;
   }
   items.push({
-    id: `exploration:${items.length}`,
+    id: `exploration:${getDisplayMessageIdentity(explorationMessages[0])}`,
     type: "exploration",
     messages: explorationMessages,
     summary: buildExplorationSummary(explorationMessages),

--- a/frontend/src/features/assistant/components/agent/message-blocks/panels/clarification-special-panel.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/panels/clarification-special-panel.tsx
@@ -3,6 +3,7 @@ import { HelpCircle } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import type { AgentQuestionSpecialPanel } from "../../agent-special-panels-state";
+import type { AgentSpecialPanel } from "../../agent-special-panels-state";
 import {
   getClarificationPromptKey,
   type ClarificationAnswerItem,
@@ -18,40 +19,62 @@ import { SpecialPanelShell } from "./special-panel-shell";
 interface ClarificationSpecialPanelProps {
   panel: AgentQuestionSpecialPanel;
   onSubmitQuestionAnswer?: (actionId: string, answer: ClarificationAnswerItem[]) => void;
+  onBatchDecision?: (
+    panel: AgentSpecialPanel,
+    decision: { answer: ClarificationAnswerItem[] },
+  ) => void;
   readOnly?: boolean;
 }
 
 export function ClarificationSpecialPanel({
   panel,
   onSubmitQuestionAnswer,
+  onBatchDecision,
   readOnly = false,
 }: ClarificationSpecialPanelProps) {
   return (
     <ClarificationSpecialPanelContent
       key={getClarificationPromptKey(panel.prompt)}
+      panel={panel}
       prompt={panel.prompt}
       summary={panel.summary}
       readOnly={readOnly}
       onSubmitQuestionAnswer={onSubmitQuestionAnswer}
+      onBatchDecision={onBatchDecision}
     />
   );
 }
 
 interface ClarificationSpecialPanelContentProps {
+  panel: AgentQuestionSpecialPanel;
   prompt: ClarificationPromptData;
   summary: string;
   onSubmitQuestionAnswer?: (actionId: string, answer: ClarificationAnswerItem[]) => void;
+  onBatchDecision?: (
+    panel: AgentSpecialPanel,
+    decision: { answer: ClarificationAnswerItem[] },
+  ) => void;
   readOnly?: boolean;
 }
 
 function ClarificationSpecialPanelContent({
+  panel,
   prompt,
   summary,
   onSubmitQuestionAnswer,
+  onBatchDecision,
   readOnly = false,
 }: ClarificationSpecialPanelContentProps) {
   const { t } = useTranslation();
-  const model = useClarificationQuestionFlow(prompt, { onSubmitQuestionAnswer });
+  const model = useClarificationQuestionFlow(prompt, {
+    onSubmitQuestionAnswer: (actionId, answer) => {
+      if (onBatchDecision) {
+        onBatchDecision(panel, { answer });
+        return;
+      }
+      onSubmitQuestionAnswer?.(actionId, answer);
+    },
+  });
   const content = readOnly ? (
     <Flex
       direction="column"
@@ -106,6 +129,11 @@ function ClarificationSpecialPanelContent({
       icon={<HelpCircle size={15} />}
       title={t("assistant.specialPanels.clarificationTitle")}
       summary={summary}
+      progress={
+        panel.batchIndex !== undefined && panel.batchTotal !== undefined
+          ? `${panel.batchIndex + 1}/${panel.batchTotal}`
+          : undefined
+      }
       content={content}
       actions={readOnly ? undefined : <ClarificationQuestionActions model={model} />}
     />

--- a/frontend/src/features/assistant/components/agent/message-blocks/panels/special-panel-shell.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/panels/special-panel-shell.tsx
@@ -9,6 +9,7 @@ interface SpecialPanelShellProps {
   kind: "approval" | "question";
   summary?: ReactNode;
   title: string;
+  progress?: string;
 }
 
 export function SpecialPanelShell({
@@ -19,6 +20,7 @@ export function SpecialPanelShell({
   kind,
   summary,
   title,
+  progress,
 }: SpecialPanelShellProps) {
   const panelClassName = ["agent-special-panel", `agent-special-panel-${kind}`, className]
     .filter(Boolean)
@@ -46,6 +48,14 @@ export function SpecialPanelShell({
           >
             {title}
           </Text>
+          {progress ? (
+            <Text
+              size="1"
+              color="gray"
+            >
+              {progress}
+            </Text>
+          ) : null}
         </Flex>
       </Flex>
       {summary ? (

--- a/frontend/src/features/assistant/components/agent/message-blocks/panels/tool-approval-special-panel.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/panels/tool-approval-special-panel.tsx
@@ -3,17 +3,20 @@ import { ShieldAlert } from "lucide-react";
 import { useTranslation } from "react-i18next";
 
 import type { AgentApprovalSpecialPanel } from "../../agent-special-panels-state";
+import type { AgentSpecialPanel } from "../../agent-special-panels-state";
 import { SpecialPanelShell } from "./special-panel-shell";
 
 interface ToolApprovalSpecialPanelProps {
   panel: AgentApprovalSpecialPanel;
   onApproveTool?: (approvalId: string, approved: boolean) => void;
+  onBatchDecision?: (panel: AgentSpecialPanel, decision: { approved: boolean }) => void;
   readOnly?: boolean;
 }
 
 export function ToolApprovalSpecialPanel({
   panel,
   onApproveTool,
+  onBatchDecision,
   readOnly = false,
 }: ToolApprovalSpecialPanelProps) {
   const { t } = useTranslation();
@@ -24,20 +27,33 @@ export function ToolApprovalSpecialPanel({
       icon={<ShieldAlert size={15} />}
       title={t("assistant.specialPanels.approvalTitle")}
       summary={panel.summary}
+      progress={
+        panel.batchIndex !== undefined && panel.batchTotal !== undefined
+          ? `${panel.batchIndex + 1}/${panel.batchTotal}`
+          : undefined
+      }
       actions={
-        !onApproveTool ? undefined : (
+        !onApproveTool && !onBatchDecision ? undefined : (
           <>
             <Button
               size="1"
               variant="soft"
               color="gray"
-              onClick={() => onApproveTool(panel.approval.approval_id, false)}
+              onClick={() =>
+                onBatchDecision
+                  ? onBatchDecision(panel, { approved: false })
+                  : onApproveTool?.(panel.approval.approval_id, false)
+              }
             >
               {t("assistant.specialPanels.deny")}
             </Button>
             <Button
               size="1"
-              onClick={() => onApproveTool(panel.approval.approval_id, true)}
+              onClick={() =>
+                onBatchDecision
+                  ? onBatchDecision(panel, { approved: true })
+                  : onApproveTool?.(panel.approval.approval_id, true)
+              }
             >
               {t("assistant.specialPanels.approve")}
             </Button>

--- a/frontend/src/features/assistant/hooks/use-agent-session.ts
+++ b/frontend/src/features/assistant/hooks/use-agent-session.ts
@@ -31,6 +31,7 @@ import {
   forkAgentSession,
   sendAgentMessage,
   submitAgentQuestionAnswer,
+  submitAgentInterruptBatch,
   rollbackAgentRevision,
   cancelAgentSession,
   uploadAgentImageAttachment,
@@ -187,6 +188,11 @@ export function useAgentSession({
   const queryClient = useQueryClient();
   const socketUnsubscribeRef = useRef<(() => void) | null>(null);
   const ignoredApprovalIdsRef = useRef<Set<string>>(new Set());
+  const interruptBatchRef = useRef<{
+    batchId: string;
+    panels: AgentMessage[];
+    decisions: Record<string, Record<string, unknown>>;
+  } | null>(null);
   const suppressSocketEventsAfterAbortRef = useRef(false);
   const sessionIdRef = useRef<string | null>(null);
   const activeModelIdRef = useRef<string | null>(null);
@@ -453,6 +459,24 @@ export function useAgentSession({
       }
 
       const result = applyTranscriptEvent(event);
+      const message = result.message;
+
+      if (message?.interruptBatchId && typeof message.interruptBatchTotal === "number") {
+        const batchId = message.interruptBatchId;
+        const batchMessages = transcriptStateRef.current.messages
+          .filter((item) => item.interruptBatchId === batchId)
+          .sort(
+            (left, right) => (left.interruptBatchIndex ?? 0) - (right.interruptBatchIndex ?? 0),
+          );
+        interruptBatchRef.current = {
+          batchId,
+          panels: batchMessages,
+          decisions:
+            interruptBatchRef.current?.batchId === batchId
+              ? interruptBatchRef.current.decisions
+              : {},
+        };
+      }
 
       if (event.type === "compaction") {
         syncCompactingState(event.status === "running");
@@ -512,7 +536,6 @@ export function useAgentSession({
         }
       }
 
-      const message = result.message;
       if (message?.type === "chapter_refresh") {
         const targetChapterId =
           typeof message.payload?.chapter_id === "string" ? message.payload.chapter_id : undefined;
@@ -1032,6 +1055,66 @@ export function useAgentSession({
     [agentKey, attachAgentSocket, sessionId, updateTranscriptState],
   );
 
+  const handleBatchDecision = useCallback(
+    async (
+      panel: AgentMessage,
+      decision: { approved?: boolean; answer?: ClarificationAnswerItem[] },
+    ) => {
+      const batchId = panel.interruptBatchId;
+      if (!batchId || panel.interruptBatchTotal === undefined) return;
+      const current = interruptBatchRef.current;
+      if (!current || current.batchId !== batchId) return;
+      const interruptId = panel.correlationId || panel.id;
+      current.decisions[interruptId] = {
+        interrupt_id: interruptId,
+        action_type: panel.type === "approval" ? "tool_approval" : "clarification",
+        ...(panel.type === "approval"
+          ? { approval_id: interruptId, approved: decision.approved }
+          : { action_id: interruptId, answer: decision.answer }),
+      };
+      const decisionCount = Object.keys(current.decisions).length;
+      const batchTotal = panel.interruptBatchTotal ?? current.panels.length;
+      updateTranscriptState((state) => ({
+        ...state,
+        messages: state.messages.map((item) =>
+          item.id === panel.id ? { ...item, status: "completed" } : item,
+        ),
+        status: decisionCount < batchTotal ? state.status : "running",
+        isRunning: decisionCount >= batchTotal,
+      }));
+      if (current.panels.length < batchTotal || decisionCount < batchTotal) return;
+      try {
+        await submitAgentInterruptBatch(
+          sessionId || "",
+          batchId,
+          Object.values(current.decisions).map((item) => ({
+            interrupt_id: String(item.interrupt_id),
+            action_type: item.action_type as "tool_approval" | "clarification",
+            approval_id: typeof item.approval_id === "string" ? item.approval_id : undefined,
+            approved: typeof item.approved === "boolean" ? item.approved : undefined,
+            action_id: typeof item.action_id === "string" ? item.action_id : undefined,
+            answer: Array.isArray(item.answer) ? item.answer : undefined,
+          })),
+        );
+        interruptBatchRef.current = null;
+      } catch (error) {
+        console.error("Interrupt batch resume failed:", error);
+        updateTranscriptState((state) => ({
+          ...state,
+          messages: state.messages.map((item) =>
+            item.interruptBatchId === batchId ? { ...item, status: "pending" } : item,
+          ),
+          status: current.panels.some((item) => item.type === "approval")
+            ? "waiting_approval"
+            : "waiting_answer",
+          isRunning: false,
+        }));
+        toast.error(i18n.t("assistant.toolApprovalFailed"));
+      }
+    },
+    [sessionId, updateTranscriptState],
+  );
+
   const resetSession = useCallback(() => {
     sessionIdRef.current = null;
     activeModelIdRef.current = null;
@@ -1295,6 +1378,7 @@ export function useAgentSession({
     forkFromRevision,
     handleToolApproval,
     submitQuestionAnswer,
+    handleBatchDecision,
     abortSession,
   };
 }

--- a/frontend/src/features/assistant/lib/agent-socket-events.ts
+++ b/frontend/src/features/assistant/lib/agent-socket-events.ts
@@ -475,6 +475,9 @@ export function toAgentEvent(
         payload: {
           action_id: actionId,
           questions: Array.isArray(data.questions) ? data.questions : [],
+          batch_id: getString(data.batch_id),
+          batch_index: typeof data.batch_index === "number" ? data.batch_index : undefined,
+          batch_total: typeof data.batch_total === "number" ? data.batch_total : undefined,
         },
       };
     }
@@ -507,6 +510,9 @@ export function toAgentEvent(
         message:
           getString(data.message) || i18n.t("assistant.tools.toolApprovalQuestion", { toolName }),
         interrupt_behavior: data.interrupt_behavior === "cancel" ? "cancel" : "block",
+        batch_id: getString(data.batch_id),
+        batch_index: typeof data.batch_index === "number" ? data.batch_index : undefined,
+        batch_total: typeof data.batch_total === "number" ? data.batch_total : undefined,
         payload: {
           approval_id: approvalId,
           tool_name: toolName,
@@ -516,6 +522,9 @@ export function toAgentEvent(
           message:
             getString(data.message) || i18n.t("assistant.tools.toolApprovalQuestion", { toolName }),
           interrupt_behavior: data.interrupt_behavior === "cancel" ? "cancel" : "block",
+          batch_id: getString(data.batch_id),
+          batch_index: typeof data.batch_index === "number" ? data.batch_index : undefined,
+          batch_total: typeof data.batch_total === "number" ? data.batch_total : undefined,
         },
       };
     }

--- a/frontend/src/features/assistant/lib/agent-transcript-state.ts
+++ b/frontend/src/features/assistant/lib/agent-transcript-state.ts
@@ -463,6 +463,11 @@ function normalizeTranscriptEvent(event: AgentEvent): AgentMessage | null {
             : event.content || i18n.t("assistant.toolApprovalRequiredFallback"),
         interrupt_behavior: payload.interrupt_behavior === "block" ? "block" : "cancel",
       },
+      interruptBatchId: typeof payload.batch_id === "string" ? payload.batch_id : undefined,
+      interruptBatchIndex:
+        typeof payload.batch_index === "number" ? payload.batch_index : undefined,
+      interruptBatchTotal:
+        typeof payload.batch_total === "number" ? payload.batch_total : undefined,
     };
   }
   if (event.type === "question") {
@@ -470,6 +475,11 @@ function normalizeTranscriptEvent(event: AgentEvent): AgentMessage | null {
       ...base,
       type: "question",
       questions: normalizeClarificationQuestions(payload.questions),
+      interruptBatchId: typeof payload.batch_id === "string" ? payload.batch_id : undefined,
+      interruptBatchIndex:
+        typeof payload.batch_index === "number" ? payload.batch_index : undefined,
+      interruptBatchTotal:
+        typeof payload.batch_total === "number" ? payload.batch_total : undefined,
     };
   }
   if (event.type === "tool") {
@@ -677,13 +687,19 @@ export function applyAgentTranscriptEvent(
     }
 
     if (message.type === "question") {
+      const batchId = message.interruptBatchId;
       return {
         state: {
           ...state,
           messages: upsertTranscriptMessage(
             clearRetryMessages(
               stopStreamingReasoning(stopStreamingAssistantOutput(baseMessages)),
-            ).filter((item) => item.type !== "question" && item.type !== "clarification"),
+            ).filter(
+              (item) =>
+                item.type !== "clarification" &&
+                (item.type !== "question" ||
+                  (batchId !== undefined && item.interruptBatchId === batchId)),
+            ),
             message,
           ),
           status: "waiting_answer",

--- a/frontend/src/lib/agent.types.ts
+++ b/frontend/src/lib/agent.types.ts
@@ -199,6 +199,9 @@ export interface AgentMessage {
   toolResult?: Record<string, unknown>;
   toolSuccess?: boolean;
   toolApproval?: ToolApprovalData;
+  interruptBatchId?: string;
+  interruptBatchIndex?: number;
+  interruptBatchTotal?: number;
 
   isStreaming?: boolean;
   thinkingDurationMs?: number;
@@ -339,6 +342,9 @@ export interface AgentEvent {
   approval_id?: string;
   message?: string;
   interrupt_behavior?: "cancel" | "block";
+  batch_id?: string;
+  batch_index?: number;
+  batch_total?: number;
   error?: string;
   error_type?: string;
   error_node?: string;
@@ -348,6 +354,15 @@ export interface AgentEvent {
   is_checkpoint?: boolean;
   isCheckpoint?: boolean;
   is_continuation?: boolean;
+}
+
+export interface AgentInterruptBatchResponse {
+  interrupt_id: string;
+  action_type: "tool_approval" | "clarification";
+  approval_id?: string;
+  approved?: boolean;
+  action_id?: string;
+  answer?: ClarificationAnswerItem[];
 }
 
 export interface AgentQuestionAnswerResponse {

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -2162,6 +2162,7 @@ import type {
   AgentSessionStateResponse,
   AgentRollbackResponse,
   AgentCancelResponse,
+  AgentInterruptBatchResponse,
   AgentQuestionAnswerResponse,
   ClarificationAnswerItem,
   ReasoningEffort,
@@ -2439,6 +2440,17 @@ export async function submitAgentToolApproval(
   await apiClient.post(`/agent/sessions/${sessionId}/tool-approval`, {
     approval_id: approvalId,
     approved,
+  });
+}
+
+export async function submitAgentInterruptBatch(
+  sessionId: string,
+  batchId: string,
+  responses: AgentInterruptBatchResponse[],
+): Promise<void> {
+  await apiClient.post(`/agent/sessions/${sessionId}/interrupt-resume`, {
+    batch_id: batchId,
+    responses,
   });
 }
 


### PR DESCRIPTION
## PR 标题

fix(agent): 修复工具未并行执行并批量恢复中断

## 变更说明

- 问题: Agent 单轮工具调用通过游标串行执行，多个审批或提问中断无法作为一批稳定恢复。
- 重要性: 串行执行会拉长 Agent 响应时间；逐项恢复并行中断可能重放已完成分支。
- 变化: 使用固定 10 槽 fan-out/fan-in 并行执行工具，并按原始调用顺序合并结果。
- 变化: 增加批量中断事件和统一恢复接口，前端按批次轮播审批/提问面板。
- 变化: 审批拒绝结果持久化为失败工具结果，避免重载后显示为成功。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [x] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

工具执行图使用 `tool_call_cursor` 逐个派发工具调用；并行中断逐项恢复时会触发 LangGraph 分支重放，导致已完成分支可能重复执行。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证记录：

- `uv run ruff check .`
- `uv run ty check app`
- `uv run pytest tests/agent_runtime tests/api/test_agent.py -q`：`722 passed`
- `pnpm type-check`
- `pnpm format:check`
- `pnpm lint`
