### PR TITLE
fix(agent): 修复中断暂停状态的会话无法恢复的问题

### DIFF
--- a/backend/app/agent_runtime/graph/react_agent.py
+++ b/backend/app/agent_runtime/graph/react_agent.py
@@ -1008,16 +1008,17 @@ def create_react_agent(
                 )
         except GraphInterrupt as interrupt:
             preview_builder = getattr(tool_instance, "build_interrupt_preview", None)
-            if callable(preview_builder) and interrupt.args and interrupt.args[0]:
+            if interrupt.args and interrupt.args[0]:
                 interrupt_value = interrupt.args[0][0].value
                 if isinstance(interrupt_value, dict):
-                    preview = await preview_builder(tool_args)
-                    if isinstance(preview, dict):
-                        interrupt_value["tool_result_preview"] = preview
-                        interrupt_value.setdefault("tool_call_id", tool_id)
-                        interrupt_value.setdefault("tool_name", tool_name)
-                        interrupt_value.setdefault("args", tool_args)
-                        interrupt_value.setdefault("tool_index", tool_index)
+                    interrupt_value.setdefault("tool_call_id", tool_id)
+                    interrupt_value.setdefault("tool_name", tool_name)
+                    interrupt_value.setdefault("args", tool_args)
+                    interrupt_value.setdefault("tool_index", tool_index)
+                    if callable(preview_builder):
+                        preview = await preview_builder(tool_args)
+                        if isinstance(preview, dict):
+                            interrupt_value["tool_result_preview"] = preview
             await _finish_active_audit()
             raise
         except Exception as exc:

--- a/backend/app/agent_runtime/persistence/persister.py
+++ b/backend/app/agent_runtime/persistence/persister.py
@@ -372,6 +372,18 @@ class MessagePersister:
         tool_call_id = payload.get("tool_call_id")
         tool_result_preview = payload.get("tool_result_preview")
         tool_name = payload.get("tool_name")
+        if payload.get("type") == "ask_user" and not isinstance(tool_result_preview, dict):
+            questions = payload.get("questions")
+            if not isinstance(questions, list):
+                args = payload.get("args")
+                questions = args.get("questions") if isinstance(args, dict) else None
+            if isinstance(questions, list):
+                tool_result_preview = {
+                    "type": "preview",
+                    "success": True,
+                    "reason": "ask_user_pending",
+                    "questions": questions,
+                }
         if not isinstance(tool_call_id, str) or not tool_call_id:
             return
         if not isinstance(tool_result_preview, dict):

--- a/backend/app/agent_runtime/persistence/task_projection.py
+++ b/backend/app/agent_runtime/persistence/task_projection.py
@@ -74,6 +74,8 @@ def _tool_result(row: PersistedMessage) -> dict[str, Any]:
 
 
 def _tool_message_status(row: PersistedMessage, tool_result: dict[str, Any]) -> str:
+    if tool_result.get("reason") == "ask_user_pending":
+        return "running"
     if tool_result.get("reason") == "approval_preview":
         return "completed"
     return _message_status(row.status)
@@ -357,6 +359,12 @@ def _project_rows(
         if row.role == "tool":
             tool_args = tool_args_by_id.get(row.tool_call_id or "", {})
             tool_result = _tool_result(row)
+            if (
+                row.tool_name == "ask_user"
+                and not tool_args
+                and isinstance(tool_result.get("questions"), list)
+            ):
+                tool_args = {"questions": tool_result["questions"]}
             tool_result = _with_subagent_identity(
                 tool_result,
                 tool_args,

--- a/backend/app/agent_runtime/runner/session_runner.py
+++ b/backend/app/agent_runtime/runner/session_runner.py
@@ -341,6 +341,8 @@ class SessionRunner:
                                 "tool": tool_name,
                                 "input": preview_item.get("args") or {},
                                 "output": preview,
+                                "is_preview": True,
+                                "is_interrupt_preview": True,
                             },
                         )
             if self._persister is not None:
@@ -365,6 +367,8 @@ class SessionRunner:
                         "tool": tool_name,
                         "input": interrupt_payload.get("args") or {},
                         "output": tool_result_preview,
+                        "is_preview": True,
+                        "is_interrupt_preview": True,
                     },
                 )
 

--- a/backend/app/api/routers/agent_runtime.py
+++ b/backend/app/api/routers/agent_runtime.py
@@ -1084,12 +1084,35 @@ async def get_agent_session_state(
     checkpoint_values = checkpoint.checkpoint.get("channel_values") if checkpoint else None
     state_values = dict(checkpoint_values) if isinstance(checkpoint_values, dict) else {}
     is_running = await get_agent_run_registry().is_running(session_id)
-    if not state_values and not is_running:
+    interrupts: list[dict] = []
+    if checkpoint is not None:
+        for pending_write in checkpoint.pending_writes or []:
+            if len(pending_write) < 3 or pending_write[1] != "__interrupt__":
+                continue
+            values = pending_write[2]
+            if not isinstance(values, list):
+                continue
+            for interrupt in values:
+                value = getattr(interrupt, "value", None)
+                interrupt_id = getattr(interrupt, "id", None)
+                if not isinstance(value, dict) or not isinstance(interrupt_id, str):
+                    continue
+                payload = dict(value)
+                payload["interrupt_id"] = interrupt_id
+                if payload.get("type") == "tool_approval":
+                    payload["approval_id"] = interrupt_id
+                    payload["id"] = interrupt_id
+                elif payload.get("type") == "ask_user":
+                    payload["action_id"] = interrupt_id
+                    payload["id"] = interrupt_id
+                interrupts.append(payload)
+    if not state_values and not is_running and not interrupts:
         raise NotFoundError(f"会话不存在: {session_id}")
     return AgentSessionStateResponse(
         session_id=session_id,
         state=state_values,
         is_running=is_running,
+        interrupts=interrupts,
     )
 
 

--- a/backend/app/api/routers/tasks.py
+++ b/backend/app/api/routers/tasks.py
@@ -11,7 +11,7 @@ from app.agent_runtime.modes import AgentMode
 from app.agent_runtime.attachments import delete_attachments_for_task
 from app.agent_runtime.persistence.child_runs import list_child_runs_for_parent
 from app.agent_runtime.persistence.task_projection import load_task_messages_for_agent_session
-from app.agent_runtime.runner.checkpointer import delete_checkpoints_for_thread
+from app.agent_runtime.runner.checkpointer import delete_checkpoints_for_thread, get_checkpointer
 
 from app.api.schemas.task import (
     TaskListItem,
@@ -52,6 +52,19 @@ async def _list_task_checkpoint_thread_ids(
     if not session_id:
         return []
     return [*await _list_descendant_child_thread_ids(session, session_id), session_id]
+
+
+async def _has_pending_interrupt(checkpointer, session_id: str | None) -> bool:
+    if not session_id:
+        return False
+    checkpoint = await checkpointer.aget_tuple({"configurable": {"thread_id": session_id}})
+    return any(
+        len(pending_write) >= 3
+        and pending_write[1] == "__interrupt__"
+        and isinstance(pending_write[2], list)
+        and pending_write[2]
+        for pending_write in checkpoint.pending_writes or []
+    ) if checkpoint is not None else False
 
 
 async def _delete_checkpoint_threads(
@@ -128,6 +141,11 @@ async def list_tasks(
             search_query=search,
             favorited_only=favorited,
         )
+        checkpointer = await get_checkpointer()
+        pending_interrupts = {
+            task.id: await _has_pending_interrupt(checkpointer, task.agent_session_id)
+            for task in result.items
+        }
 
         items = [
             TaskListItem(
@@ -139,7 +157,7 @@ async def list_tasks(
                 token_output=task.token_output,
                 token_cache=task.token_cache,
                 context_input_tokens=task.context_input_tokens,
-                is_running=task.is_running,
+                is_running=task.is_running or pending_interrupts[task.id],
                 is_favorited=task.is_favorited,
                 created_at=task.created_at,
                 updated_at=task.updated_at,

--- a/backend/app/api/schemas/agent.py
+++ b/backend/app/api/schemas/agent.py
@@ -185,6 +185,7 @@ class AgentSessionStateResponse(BaseModel):
     session_id: str = Field(..., description="会话ID")
     state: dict = Field(..., description="状态信息")
     is_running: bool = Field(default=False, description="会话是否仍有后台运行任务")
+    interrupts: list[dict] = Field(default_factory=list, description="待处理的可恢复中断")
 
 
 class ActiveSubagentStateResponse(BaseModel):

--- a/backend/tests/agent_runtime/persistence/test_persister.py
+++ b/backend/tests/agent_runtime/persistence/test_persister.py
@@ -184,6 +184,41 @@ async def test_persister_inserts_missing_batch_approval_preview_tool_messages(
 
 
 @pytest.mark.asyncio
+async def test_persister_persists_ask_user_interrupt_preview(
+    db_session: AsyncSession, db_session_factory, sample_task
+):
+    session_id = "session-ask-user-preview"
+    questions = [{"title": "剧情走向？", "description": "请选择下一段方向", "options": []}]
+    persister = MessagePersister(
+        session_id=session_id,
+        task_id=sample_task.id,
+        project_id=sample_task.project_id,
+        db_session_factory=db_session_factory,
+    )
+
+    await persister.apply_interrupt_preview(
+        {
+            "type": "ask_user",
+            "tool_call_id": "call-ask",
+            "tool_name": "ask_user",
+            "args": {"questions": questions},
+            "questions": questions,
+        }
+    )
+
+    messages = await repo.list_by_session(db_session, session_id)
+    assert len(messages) == 1
+    assert messages[0].tool_call_id == "call-ask"
+    assert messages[0].tool_name == "ask_user"
+    assert json.loads(messages[0].content) == {
+        "type": "preview",
+        "success": True,
+        "reason": "ask_user_pending",
+        "questions": questions,
+    }
+
+
+@pytest.mark.asyncio
 async def test_persister_replaces_approval_preview_with_rejected_result(
     db_session: AsyncSession, db_session_factory, sample_task
 ):

--- a/backend/tests/agent_runtime/persistence/test_task_projection.py
+++ b/backend/tests/agent_runtime/persistence/test_task_projection.py
@@ -522,6 +522,56 @@ async def test_projects_interrupted_ask_user_before_node_end(
 
 
 @pytest.mark.asyncio
+async def test_projects_pending_ask_user_preview_as_running_tool_message(
+    db_session: AsyncSession,
+    sample_task,
+) -> None:
+    sid = "session_pending_ask_user_projection"
+    questions = [{"title": "剧情走向？", "description": "请选择下一段方向", "options": []}]
+    await repo.insert_message(
+        db_session,
+        session_id=sid,
+        task_id=sample_task.id,
+        project_id=sample_task.project_id,
+        role="assistant",
+        status="complete",
+        tool_calls=[
+            {
+                "id": "call_ask",
+                "name": "ask_user",
+                "args": {"questions": questions},
+            }
+        ],
+    )
+    await repo.insert_message(
+        db_session,
+        session_id=sid,
+        task_id=sample_task.id,
+        project_id=sample_task.project_id,
+        role="tool",
+        status="aborted",
+        content=json.dumps(
+            {
+                "type": "preview",
+                "success": True,
+                "reason": "ask_user_pending",
+                "questions": questions,
+            },
+            ensure_ascii=False,
+        ),
+        tool_call_id="call_ask",
+        tool_name="ask_user",
+    )
+
+    messages = await load_task_messages_for_agent_session(db_session, sid)
+    tool_message = next(message for message in messages if message.message_type == "tool")
+    assert tool_message.message_status == "running"
+    assert tool_message.payload["tool_name"] == "ask_user"
+    assert tool_message.payload["tool_args"] == {"questions": questions}
+    assert tool_message.payload["tool_result"]["reason"] == "ask_user_pending"
+
+
+@pytest.mark.asyncio
 async def test_projects_resumed_tool_call_as_single_tool_message(
     db_session: AsyncSession,
     sample_task,

--- a/backend/tests/agent_runtime/test_react_agent.py
+++ b/backend/tests/agent_runtime/test_react_agent.py
@@ -20,6 +20,10 @@ from app.agent_runtime.graph.react_agent import (
 from app.settings import settings
 
 
+async def _proceed_hook(_ctx) -> HookResult:
+    return HookResult()
+
+
 def _submit_result(result: str) -> str:
     return f"submitted: {result}"
 
@@ -909,6 +913,75 @@ async def test_react_agent_passes_runtime_config_and_tool_call_id_to_agent_tools
 
 class ApprovalInput(BaseModel):
     value: str
+
+
+@pytest.mark.asyncio
+async def test_react_agent_attaches_tool_metadata_to_ask_user_interrupt() -> None:
+    from app.agent_runtime.tools.impls.interaction.ask_user import AskUserTool
+
+    graph = create_react_agent(
+        ReactAgentConfig(
+            name="test",
+            tools=[AskUserTool(_pre_hooks=[_proceed_hook])],
+            termination=TerminationCondition(mode="no_tool_call"),
+            max_iterations=1,
+        ),
+        checkpointer=InMemorySaver(),
+    )
+
+    async def invoke_model(*_args, **_kwargs):
+        return AIMessage(
+            content="",
+            tool_calls=[
+                {
+                    "id": "call_ask",
+                    "name": "ask_user",
+                    "args": {
+                        "questions": [
+                            {
+                                "title": "剧情走向？",
+                                "description": "请选择下一段的展开方向。",
+                                "options": [],
+                            }
+                        ]
+                    },
+                }
+            ],
+        )
+
+    config = {"configurable": {"thread_id": "ask-user-interrupt"}}
+    with patch(
+        "app.agent_runtime.graph.react_agent._invoke_model",
+        side_effect=invoke_model,
+    ):
+        await graph.ainvoke(
+            {
+                "messages": [HumanMessage(content="继续" )],
+                "iteration_count": 0,
+                "is_done": False,
+                "final_output": None,
+            },
+            config=config,
+        )
+
+    state = await graph.aget_state(config)
+    pending = [
+        pending_interrupt
+        for task in state.tasks
+        for pending_interrupt in getattr(task, "interrupts", ())
+    ]
+    assert len(pending) == 1
+    assert pending[0].value["tool_call_id"] == "call_ask"
+    assert pending[0].value["tool_name"] == "ask_user"
+    assert pending[0].value["args"] == {
+        "questions": [
+            {
+                "title": "剧情走向？",
+                "description": "请选择下一段的展开方向。",
+                "options": [],
+            }
+        ]
+    }
 
 
 async def _approval_hook(ctx) -> HookResult:

--- a/backend/tests/agent_runtime/test_session_runner.py
+++ b/backend/tests/agent_runtime/test_session_runner.py
@@ -12,7 +12,35 @@ from langgraph.types import interrupt
 from langgraph.types import Command
 
 from app.agent_runtime.context.types import ContextMessage
-from app.agent_runtime.runner.session_runner import SessionRunner
+from app.agent_runtime.runner.session_runner import SessionRunner, _interrupt_payloads
+
+
+def test_interrupt_payloads_preserve_pending_resume_data() -> None:
+    state = SimpleNamespace(
+        tasks=(
+            SimpleNamespace(
+                interrupts=(
+                    SimpleNamespace(
+                        id="interrupt-1",
+                        value={
+                            "type": "ask_user",
+                            "questions": [{"title": "继续吗？"}],
+                        },
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    assert _interrupt_payloads(state) == [
+        {
+            "type": "ask_user",
+            "questions": [{"title": "继续吗？"}],
+            "interrupt_id": "interrupt-1",
+            "action_id": "interrupt-1",
+            "id": "interrupt-1",
+        }
+    ]
 
 
 def test_session_runner_init():
@@ -250,6 +278,7 @@ async def test_run_emits_preview_for_each_parallel_tool_approval_interrupt():
         first_preview,
         second_preview,
     ]
+    assert all(payload["is_preview"] is True for payload in preview_result_payloads)
     interrupt_payloads = [
         call.args[1]
         for call in emit_mock.await_args_list

--- a/backend/tests/api/test_agent.py
+++ b/backend/tests/api/test_agent.py
@@ -1234,6 +1234,49 @@ class TestAgentAPI:
         assert data["is_running"] is True
         fake_registry.is_running.assert_awaited_once_with(session_id)
 
+    async def test_get_session_state_returns_pending_interrupts(
+        self,
+        client: AsyncClient,
+    ) -> None:
+        interrupt = SimpleNamespace(
+            id="interrupt-approval-1",
+            value={
+                "type": "tool_approval",
+                "tool_name": "edit_note",
+                "args": {"note_id": "note-1"},
+            },
+        )
+        fake_checkpointer = SimpleNamespace(
+            aget_tuple=AsyncMock(
+                return_value=SimpleNamespace(
+                    checkpoint={"channel_values": {"session_id": "session-interrupt"}},
+                    pending_writes=[("task-1", "__interrupt__", [interrupt])],
+                )
+            )
+        )
+        fake_registry = SimpleNamespace(is_running=AsyncMock(return_value=False))
+
+        with patch(
+            "app.api.routers.agent_runtime.get_checkpointer",
+            new=AsyncMock(return_value=fake_checkpointer),
+        ), patch(
+            "app.api.routers.agent_runtime.get_agent_run_registry",
+            return_value=fake_registry,
+        ):
+            response = await client.get("/api/v1/agent/sessions/session-interrupt")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["interrupts"] == [
+            {
+                "type": "tool_approval",
+                "tool_name": "edit_note",
+                "args": {"note_id": "note-1"},
+                "interrupt_id": "interrupt-approval-1",
+                "approval_id": "interrupt-approval-1",
+                "id": "interrupt-approval-1",
+            }
+        ]
+
     async def test_send_message_keeps_task_running_when_async_child_is_still_running(
         self,
         client: AsyncClient,

--- a/backend/tests/api/test_tasks.py
+++ b/backend/tests/api/test_tasks.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Task API contract tests for agent-runtime backed tasks."""
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -207,6 +208,39 @@ class TestTaskAPI:
         await session.commit()
 
         response = await client.get(f"/api/v1/projects/{project_id}/tasks")
+
+        assert response.status_code == status.HTTP_200_OK
+        items = {item["id"]: item for item in response.json()["items"]}
+        assert items[task.id]["is_running"] is True
+
+    async def test_list_tasks_treats_pending_interrupt_as_running(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+    ) -> None:
+        task, project_id, _chapter_id = await self.create_agent_task(
+            client,
+            session,
+            title="等待用户输入的任务",
+        )
+        task.is_running = False
+        await session.commit()
+
+        fake_checkpointer = AsyncMock()
+        fake_checkpointer.aget_tuple.return_value = SimpleNamespace(
+            pending_writes=[
+                (
+                    "task-write",
+                    "__interrupt__",
+                    [SimpleNamespace(value={"type": "ask_user"})],
+                )
+            ]
+        )
+        with patch(
+            "app.api.routers.tasks.get_checkpointer",
+            new=AsyncMock(return_value=fake_checkpointer),
+        ):
+            response = await client.get(f"/api/v1/projects/{project_id}/tasks")
 
         assert response.status_code == status.HTTP_200_OK
         items = {item["id"]: item for item in response.json()["items"]}

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -175,6 +175,19 @@ async def isolated_prompts_dir(monkeypatch, tmp_path: Path) -> AsyncGenerator[Pa
         shutil.rmtree(prompts_dir, ignore_errors=True)
 
 
+def pytest_sessionfinish(session, exitstatus):
+    """关闭全局 checkpoint 连接，避免 aiosqlite 非守护线程阻止进程退出。"""
+    import asyncio
+
+    from app.agent_runtime.runner import checkpointer
+
+    loop = asyncio.new_event_loop()
+    try:
+        loop.run_until_complete(checkpointer.close_checkpointer())
+    finally:
+        loop.close()
+
+
 @pytest_asyncio.fixture
 async def session(client: AsyncClient) -> AsyncGenerator[AsyncSession, None]:
     """向后兼容：从 app 覆盖中获取与 client 相同的数据库会话。"""

--- a/frontend/src/features/assistant/components/agent/agent-messages.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-messages.tsx
@@ -499,8 +499,8 @@ export function AgentMessages({
     [collapsedNodeIds, messageBlocks],
   );
   const toolbarTargets = useMemo(
-    () => getAgentRoundToolbarTargets(messageBlocks, visibleMessageBlocks, { isRunning, status }),
-    [isRunning, messageBlocks, status, visibleMessageBlocks],
+    () => getAgentRoundToolbarTargets(messageBlocks, visibleMessageBlocks),
+    [messageBlocks, visibleMessageBlocks],
   );
   const toolbarTargetByAnchorId = useMemo(
     () => new Map(toolbarTargets.map((target) => [target.anchorBlockId, target])),

--- a/frontend/src/features/assistant/components/agent/display/agent-message-blocks.ts
+++ b/frontend/src/features/assistant/components/agent/display/agent-message-blocks.ts
@@ -1,4 +1,4 @@
-import type { AgentMessage, AgentSessionStatus } from "@/lib/agent.types";
+import type { AgentMessage } from "@/lib/agent.types";
 
 import type { BlockDisplayMessage } from "./display-message-types";
 
@@ -24,11 +24,6 @@ export interface AgentRoundToolbarTarget {
   sourceRevisionId?: string;
   copyContent: string;
   timestamp?: number;
-}
-
-interface AgentRoundToolbarOptions {
-  isRunning?: boolean;
-  status?: AgentSessionStatus;
 }
 
 interface BuildAgentMessageBlocksOptions {
@@ -258,16 +253,7 @@ function getLatestAssistantToolbarTimestamp(blocks: AgentMessageBlock[]): number
 export function getAgentRoundToolbarTargets(
   blocks: AgentMessageBlock[],
   visibleBlocks: AgentMessageBlock[],
-  options: AgentRoundToolbarOptions = {},
 ): AgentRoundToolbarTarget[] {
-  if (
-    options.isRunning ||
-    options.status === "waiting_approval" ||
-    options.status === "waiting_answer"
-  ) {
-    return [];
-  }
-
   const roundOrder: string[] = [];
   const rounds = new Map<
     string,

--- a/frontend/src/features/assistant/components/agent/message-blocks/shared/message-shell.css
+++ b/frontend/src/features/assistant/components/agent/message-blocks/shared/message-shell.css
@@ -5,6 +5,7 @@
 
 .agent-message-user-shell-row {
   width: 100%;
+  margin-top: 4px;
 }
 
 .agent-message-block-shell--flush,

--- a/frontend/src/features/assistant/components/assistant-sidebar.tsx
+++ b/frontend/src/features/assistant/components/assistant-sidebar.tsx
@@ -888,6 +888,7 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
           agentSidebar.loadSession(sessionId, agentMessages, {
             reconnect: true,
             isRemoteRunning,
+            pendingInterrupts: bundle.sessionState?.interrupts,
             primaryAgentKey:
               typeof bundle.sessionState?.state.agent_key === "string"
                 ? bundle.sessionState.state.agent_key

--- a/frontend/src/features/assistant/hooks/use-agent-session-reconnect.ts
+++ b/frontend/src/features/assistant/hooks/use-agent-session-reconnect.ts
@@ -51,6 +51,29 @@ export function getLoadedAgentSessionState({
   isRemoteRunning?: boolean;
   primaryAgentKey?: string;
 }): LoadedAgentSessionState {
+  const pendingQuestion = messages.find(
+    (message) => message.type === "question" && message.status === "pending",
+  );
+  if (pendingQuestion) {
+    return {
+      status: "waiting_answer",
+      isRunning: false,
+      currentStage: i18n.t("assistant.waitingForAnswer"),
+    };
+  }
+  const pendingApproval = messages.find(
+    (message) =>
+      (message.type === "approval" || message.type === "tool_approval") &&
+      message.status === "pending",
+  );
+  if (pendingApproval) {
+    return {
+      status: "waiting_approval",
+      isRunning: false,
+      currentStage: i18n.t("assistant.waitingForApproval"),
+    };
+  }
+
   if (isRemoteRunning) {
     return {
       status: "running",

--- a/frontend/src/features/assistant/hooks/use-agent-session.ts
+++ b/frontend/src/features/assistant/hooks/use-agent-session.ts
@@ -20,6 +20,7 @@ import type {
   AgentSessionCreateResponse,
   AgentSessionStatus,
   AgentEvent,
+  ClarificationQuestion,
   ReasoningEffort,
 } from "@/lib/agent.types";
 import type { TokenUsageState } from "@/lib/agent.types";
@@ -146,6 +147,84 @@ function getAgentApiErrorMessage(error: unknown, fallback: string): string {
   }
   if (error instanceof Error && error.message) return error.message;
   return fallback;
+}
+
+function buildPendingInterruptMessages(interrupts: Record<string, unknown>[]): AgentMessage[] {
+  const restoredBatchId =
+    interrupts.length > 1 ? `restored-interrupt-batch-${Date.now()}` : undefined;
+  return interrupts.flatMap((interrupt, index): AgentMessage[] => {
+    const interruptId = getString(interrupt.interrupt_id) || getString(interrupt.id);
+    if (!interruptId) return [];
+    const timestamp = Date.now() + index;
+    const batchFields = {
+      interruptBatchId: getString(interrupt.batch_id) || restoredBatchId,
+      interruptBatchIndex:
+        typeof interrupt.batch_index === "number" ? interrupt.batch_index : index,
+      interruptBatchTotal:
+        typeof interrupt.batch_total === "number" ? interrupt.batch_total : interrupts.length,
+    };
+    if (interrupt.type === "ask_user") {
+      const questions = Array.isArray(interrupt.questions)
+        ? (interrupt.questions as ClarificationQuestion[])
+        : [];
+      return [
+        {
+          id: interruptId,
+          type: "question",
+          role: "system",
+          status: "pending",
+          display: "panel",
+          timestamp,
+          questions,
+          payload: { action_id: interruptId, questions, ...batchFields },
+          correlationId: interruptId,
+          ...batchFields,
+        },
+      ];
+    }
+    if (interrupt.type !== "tool_approval") return [];
+    const toolName = getString(interrupt.tool_name) || "";
+    const toolArgs = isRecord(interrupt.args)
+      ? interrupt.args
+      : isRecord(interrupt.tool_args)
+        ? interrupt.tool_args
+        : {};
+    const approvalId = getString(interrupt.approval_id) || interruptId;
+    const toolResultPreview = isRecord(interrupt.tool_result_preview)
+      ? interrupt.tool_result_preview
+      : undefined;
+    return [
+      {
+        id: interruptId,
+        type: "approval",
+        role: "system",
+        status: "pending",
+        display: "panel",
+        timestamp,
+        toolApproval: {
+          approval_id: approvalId,
+          tool_name: toolName,
+          tool_args: toolArgs,
+          tool_call_id: getString(interrupt.tool_call_id),
+          tool_result_preview: toolResultPreview,
+          message:
+            getString(interrupt.message) ||
+            i18n.t("assistant.tools.toolApprovalQuestion", { toolName }),
+          interrupt_behavior: interrupt.interrupt_behavior === "block" ? "block" : "cancel",
+        },
+        payload: {
+          approval_id: approvalId,
+          tool_name: toolName,
+          tool_args: toolArgs,
+          tool_call_id: getString(interrupt.tool_call_id),
+          tool_result_preview: toolResultPreview,
+          ...batchFields,
+        },
+        correlationId: interruptId,
+        ...batchFields,
+      },
+    ];
+  });
 }
 
 interface UseAgentSessionOptions {
@@ -1138,6 +1217,14 @@ export function useAgentSession({
 
   const abortSession = useCallback(async () => {
     const activeSessionId = sessionId;
+    if (
+      transcriptStateRef.current.status === "waiting_answer" ||
+      transcriptStateRef.current.status === "waiting_approval"
+    ) {
+      socketUnsubscribeRef.current?.();
+      socketUnsubscribeRef.current = null;
+      return;
+    }
     suppressSocketEventsAfterAbortRef.current = true;
     transportRetryAttemptRef.current = 0;
     suppressNextErrorAfterCompactionErrorRef.current = false;
@@ -1172,6 +1259,7 @@ export function useAgentSession({
         reconnect?: boolean;
         isRemoteRunning?: boolean;
         primaryAgentKey?: string;
+        pendingInterrupts?: Record<string, unknown>[];
       } = {},
     ) => {
       sessionIdRef.current = existingSessionId;
@@ -1185,13 +1273,38 @@ export function useAgentSession({
       socketUnsubscribeRef.current?.();
       socketUnsubscribeRef.current = null;
 
+      const pendingInterruptMessages = buildPendingInterruptMessages(
+        options.pendingInterrupts ?? [],
+      );
+      const loadedMessages = [
+        ...existingMessages,
+        ...pendingInterruptMessages.filter(
+          (interrupt) => !existingMessages.some((message) => message.id === interrupt.id),
+        ),
+      ];
+      const pendingBatch = pendingInterruptMessages.find(
+        (message) => message.interruptBatchId && message.interruptBatchTotal,
+      );
+      if (pendingBatch?.interruptBatchId && pendingBatch.interruptBatchTotal) {
+        interruptBatchRef.current = {
+          batchId: pendingBatch.interruptBatchId,
+          panels: pendingInterruptMessages
+            .filter((message) => message.interruptBatchId === pendingBatch.interruptBatchId)
+            .sort(
+              (left, right) => (left.interruptBatchIndex ?? 0) - (right.interruptBatchIndex ?? 0),
+            ),
+          decisions: {},
+        };
+      } else {
+        interruptBatchRef.current = null;
+      }
       const loadedState = getLoadedAgentSessionState({
-        messages: existingMessages,
+        messages: loadedMessages,
         isRemoteRunning: options.isRemoteRunning,
         primaryAgentKey: options.primaryAgentKey ?? agentKey,
       });
       commitTranscriptState({
-        messages: existingMessages,
+        messages: loadedMessages,
         status: loadedState.status,
         isRunning: loadedState.isRunning,
         currentStage: loadedState.currentStage,

--- a/frontend/src/features/assistant/lib/agent-socket-events.ts
+++ b/frontend/src/features/assistant/lib/agent-socket-events.ts
@@ -183,6 +183,8 @@ export function toAgentEvent(
         tool_args_text: typeof input === "string" ? input : JSON.stringify(input ?? {}),
         tool_result: result,
         success: toolSuccess,
+        is_preview: data.is_preview === true,
+        is_interrupt_preview: data.is_interrupt_preview === true,
       },
     };
   }

--- a/frontend/src/features/assistant/lib/agent-transcript-state.ts
+++ b/frontend/src/features/assistant/lib/agent-transcript-state.ts
@@ -711,6 +711,10 @@ export function applyAgentTranscriptEvent(
     }
 
     if (message.type === "tool") {
+      const isInterruptPreview = message.payload?.is_interrupt_preview === true;
+      const shouldKeepRunning =
+        !isInterruptPreview &&
+        (message.status === "running" || message.isStreaming || state.status === "running");
       const nextMessages = upsertTranscriptStreamingMessage(
         clearRetryMessages(
           stopStreamingReasoning(stopStreamingAssistantOutput(baseMessages)),
@@ -724,10 +728,12 @@ export function applyAgentTranscriptEvent(
           status:
             message.status === "error"
               ? "running"
-              : message.status === "running" || message.isStreaming
-                ? "running"
-                : state.status,
-          isRunning: message.status === "running" || message.isStreaming ? true : state.isRunning,
+              : isInterruptPreview
+                ? "waiting_approval"
+                : shouldKeepRunning
+                  ? "running"
+                  : state.status,
+          isRunning: shouldKeepRunning,
           currentStage: stageText || state.currentStage,
         },
         message,

--- a/frontend/src/lib/agent.types.ts
+++ b/frontend/src/lib/agent.types.ts
@@ -258,6 +258,7 @@ export interface AgentSessionStateResponse {
   sessionId: string;
   state: Record<string, unknown>;
   isRunning: boolean;
+  interrupts: Record<string, unknown>[];
 }
 
 export interface AgentSendMessageRequest {

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -2191,6 +2191,11 @@ export async function fetchAgentSessionState(
         ? (data.state as Record<string, unknown>)
         : {},
     isRunning: data.is_running === true,
+    interrupts: Array.isArray(data.interrupts)
+      ? data.interrupts.filter((item): item is Record<string, unknown> =>
+          Boolean(item && typeof item === "object" && !Array.isArray(item)),
+        )
+      : [],
   };
 }
 


### PR DESCRIPTION
## PR 标题

fix(agent): 修复中断暂停状态的会话无法恢复的问题

## 变更说明

- 问题: `ask_user` 和工具审批进入中断后，退出并重载会话时面板、工具消息和会话运行状态无法完整恢复。
- 重要性: 用户无法继续处理已暂停的 Agent 会话，任务列表也会将可恢复中断显示为非运行状态。
- 变化: 从 checkpoint 返回 pending interrupts，并在前端重建提问和审批面板。
- 变化: 中断预览与 `ask_user` 工具消息持久化为可恢复的等待状态。
- 变化: 任务列表识别 pending interrupt 为运行中，并按轮次保持已完成 Assistant toolbar 的显示。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [x] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

中断信息只存在于 LangGraph checkpoint，原会话状态接口和任务列表没有读取 pending interrupts；重载时前端只能从持久化任务消息恢复，无法还原完整的提问/审批状态。工具预览事件和会话运行状态的时序也会导致中断等待期间错误显示 toolbar 或取消状态。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证记录：

- `uv run ruff check .`
- `uv run ty check app`
- `uv run pytest tests/agent_runtime tests/api/test_agent.py tests/api/test_tasks.py -q`：`743 passed`
- `pnpm type-check`
- `pnpm format:check`
- `pnpm lint`
