### PR TITLE
fix(agent): 限制智能体列表高度并支持滚动

### DIFF
--- a/frontend/src/features/assistant/components/agent/active-subagent-list.css
+++ b/frontend/src/features/assistant/components/agent/active-subagent-list.css
@@ -69,9 +69,10 @@
 
 .active-subagent-panel-list {
   margin: 0;
+  max-height: calc(5 * 30px + 4px);
   padding: 0;
   list-style: none;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 .active-subagent-panel-list-item + .active-subagent-panel-list-item {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -348,7 +348,7 @@
       "unfavorite": "取消收藏",
       "taskRunning": "会话运行中",
       "activeSubagents": "活跃子代理",
-      "activeSubagentsCount": "{{count}}个活跃的智能体",
+      "activeSubagentsCount": "{{count}} 个活跃的智能体",
       "returnToPrimary": "返回主会话",
       "subagentReadOnly": "子智能体会话是只读的，如需继续交互请",
       "subagentInactive": "已结束",


### PR DESCRIPTION
## PR 标题

fix(agent): 限制智能体列表高度并支持滚动

## 变更说明

- 问题: subagent 数量较多时，列表没有最大高度限制，会持续向下延展。
- 重要性: 避免列表占用过多界面空间，保证后续 subagent 仍可查看和管理。
- 变化: 将列表可视高度限制为 5 个 subagent，超出部分支持纵向滚动；调整对应中文数量文案的排版空格。

## 关联 Issue / PR (如有)

Closes #265

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

列表容器原本只有 `overflow: hidden`，没有最大高度；subagent 数量增加时，容器会随列表内容无限增长。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [ ] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证命令：
- `pnpm format:check`
- `pnpm type-check`
- `pnpm lint`
- `git diff --check`
