### PR TITLE
fix(agent): 修复并行工具调用时唯一约束冲突的问题

### DIFF
--- a/backend/app/agent_runtime/tools/impls/_locks.py
+++ b/backend/app/agent_runtime/tools/impls/_locks.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Hashable
+
+_LOCKS: dict[Hashable, asyncio.Lock] = {}
+_GUARD = asyncio.Lock()
+
+
+async def keyed_lock(key: Hashable) -> asyncio.Lock:
+    async with _GUARD:
+        lock = _LOCKS.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            _LOCKS[key] = lock
+        return lock

--- a/backend/app/agent_runtime/tools/impls/chapter/create_volume.py
+++ b/backend/app/agent_runtime/tools/impls/chapter/create_volume.py
@@ -4,6 +4,7 @@ from typing import Any
 from pydantic import BaseModel, Field
 
 from app.agent_runtime.tools.base import AgentTool
+from app.agent_runtime.tools.impls._locks import keyed_lock
 from app.agent_runtime.tools.registry import ToolRegistry
 from app.storage.database import create_session
 from app.storage.models.volume import Volume
@@ -62,23 +63,24 @@ class CreateVolumeTool(AgentTool):
     async def _execute(self, title: str, description: str | None = None) -> str:
         session = await create_session()
         try:
-            max_order = await volume_repo.get_max_order(session, self.project_id)
-            volume = Volume(
-                project_id=self.project_id,
-                title=title,
-                description=description,
-                order=max_order + 1,
-                chapter_count=0,
-            )
-            volume = await volume_repo.create(session, volume)
-            await session.commit()
-            return json.dumps(
-                {
-                    "success": True,
-                    "metadata": {"volume": serialize_volume(volume)},
-                },
-                ensure_ascii=False,
-            )
+            async with await keyed_lock(self.project_id):
+                max_order = await volume_repo.get_max_order(session, self.project_id)
+                volume = Volume(
+                    project_id=self.project_id,
+                    title=title,
+                    description=description,
+                    order=max_order + 1,
+                    chapter_count=0,
+                )
+                volume = await volume_repo.create(session, volume)
+                await session.commit()
+                return json.dumps(
+                    {
+                        "success": True,
+                        "metadata": {"volume": serialize_volume(volume)},
+                    },
+                    ensure_ascii=False,
+                )
         except Exception:
             await session.rollback()
             raise

--- a/backend/app/agent_runtime/tools/impls/chapter/write_chapter.py
+++ b/backend/app/agent_runtime/tools/impls/chapter/write_chapter.py
@@ -24,6 +24,7 @@ from app.agent_runtime.tools.impls.chapter.refs import (
     resolve_chapter_from_list,
     resolve_volume_from_list,
 )
+from app.agent_runtime.tools.impls._locks import keyed_lock
 from app.agent_runtime.tools.registry import ToolRegistry
 from app.storage.database import create_session
 from app.storage.models.chapter import Chapter
@@ -105,66 +106,67 @@ class WriteChapterTool(AgentTool):
                 await volume_repo.list_by_project(session, self.project_id),
                 VolumeRef.model_validate(volume_ref),
             )
-            before = images_by_id(await chapter_repo.list_by_project(session, self.project_id))
-            max_order = await chapter_repo.get_max_order(session, volume.id)
-            if chapter_ref is not None:
-                ref = ChapterRef.model_validate(chapter_ref)
-                chapters = await chapter_repo.list_by_volume(session, volume.id)
-                match = resolve_chapter_from_list(chapters, ref)
-                insert_order = match.order
-                await chapter_repo.shift_orders(
-                    session, volume.id, insert_order, max_order, 1
+            async with await keyed_lock(volume.id):
+                before = images_by_id(await chapter_repo.list_by_project(session, self.project_id))
+                max_order = await chapter_repo.get_max_order(session, volume.id)
+                if chapter_ref is not None:
+                    ref = ChapterRef.model_validate(chapter_ref)
+                    chapters = await chapter_repo.list_by_volume(session, volume.id)
+                    match = resolve_chapter_from_list(chapters, ref)
+                    insert_order = match.order
+                    await chapter_repo.shift_orders(
+                        session, volume.id, insert_order, max_order, 1
+                    )
+                    order = insert_order
+                else:
+                    order = max_order + 1
+                chapter = Chapter(
+                    project_id=self.project_id,
+                    volume_id=volume.id,
+                    title=title,
+                    content=content,
+                    word_count=count_words(content),
+                    order=order,
                 )
-                order = insert_order
-            else:
-                order = max_order + 1
-            chapter = Chapter(
-                project_id=self.project_id,
-                volume_id=volume.id,
-                title=title,
-                content=content,
-                word_count=count_words(content),
-                order=order,
-            )
-            chapter = await chapter_repo.create(session, chapter)
-            after = images_by_id(await chapter_repo.list_by_project(session, self.project_id))
-            affected = await record_chapter_diffs(
-                session,
-                revision_id=revision_id,
-                project_id=self.project_id,
-                before=before,
-                after=after,
-            )
-            for chapter_id in affected:
-                await record_agent_activity_for_change(
+                chapter = await chapter_repo.create(session, chapter)
+                after = images_by_id(await chapter_repo.list_by_project(session, self.project_id))
+                affected = await record_chapter_diffs(
                     session,
                     revision_id=revision_id,
-                    task_id=str(self._state.get("task_id") or ""),
-                    agent_session_id=self.session_id,
-                    before=before.get(chapter_id),
-                    after=after.get(chapter_id),
+                    project_id=self.project_id,
+                    before=before,
+                    after=after,
                 )
-            await refresh_volume_chapter_count(session, volume.id)
-            await refresh_project_stats(session, self.project_id)
-            from app.background.jobs import service as background_service
-            from app.retrieval.chapter_index import safe_maybe_enqueue_auto_index
-            from app.retrieval.index_status import schedule_emit_index_status
+                for chapter_id in affected:
+                    await record_agent_activity_for_change(
+                        session,
+                        revision_id=revision_id,
+                        task_id=str(self._state.get("task_id") or ""),
+                        agent_session_id=self.session_id,
+                        before=before.get(chapter_id),
+                        after=after.get(chapter_id),
+                    )
+                await refresh_volume_chapter_count(session, volume.id)
+                await refresh_project_stats(session, self.project_id)
+                from app.background.jobs import service as background_service
+                from app.retrieval.chapter_index import safe_maybe_enqueue_auto_index
+                from app.retrieval.index_status import schedule_emit_index_status
 
-            await safe_maybe_enqueue_auto_index(session, project_id=self.project_id)
-            schedule_emit_index_status(session, self.project_id)
-            await background_service.commit_and_notify(session)
-            chapter_diff = build_chapter_diff_preview(
-                None,
-                chapter_preview_from_object(chapter),
-            )
-            return json.dumps(
-                {
-                    "success": True,
-                    "word_count": chapter.word_count,
-                    "metadata": {"chapter_diff": chapter_diff},
-                },
-                ensure_ascii=False,
-            )
+                await safe_maybe_enqueue_auto_index(session, project_id=self.project_id)
+                schedule_emit_index_status(session, self.project_id)
+                await background_service.commit_and_notify(session)
+                chapter_diff = build_chapter_diff_preview(
+                    None,
+                    chapter_preview_from_object(chapter),
+                )
+                return json.dumps(
+                    {
+                        "success": True,
+                        "word_count": chapter.word_count,
+                        "metadata": {"chapter_diff": chapter_diff},
+                    },
+                    ensure_ascii=False,
+                )
         except Exception:
             await session.rollback()
             raise

--- a/backend/app/agent_runtime/tools/impls/context/character.py
+++ b/backend/app/agent_runtime/tools/impls/context/character.py
@@ -12,6 +12,7 @@ from app.agent_runtime.revisions import (
 from app.agent_runtime.tools.base import AgentTool
 from app.core.editor_content_limits import EditorContentLimitError, validate_editor_content
 from app.agent_runtime.tools.errors import ToolExecutionError
+from app.agent_runtime.tools.impls._locks import keyed_lock
 from app.agent_runtime.tools.registry import ToolRegistry
 from app.agent_runtime.tools.text_match import fuzzy_replace
 from app.storage.database import create_session
@@ -260,31 +261,32 @@ class CreateCharacterTool(AgentTool):
             raise ToolExecutionError(str(exc)) from exc
         session = await create_session()
         try:
-            normalized_name = await _ensure_name_available(session, self.project_id, name)
-            character = await character_service.create_character(
-                session,
-                self.project_id,
-                name=normalized_name,
-                description=description,
-            )
-            await record_character_diffs(
-                session,
-                revision_id=revision_id,
-                project_id=self.project_id,
-                before={},
-                after=character_images_by_id([character]),
-            )
-            await session.commit()
-            character_preview = _preview_from_character(character)
-            return json.dumps(
-                {
-                    "success": True,
-                    "metadata": {
-                        "character_diff": _build_character_diff(None, character_preview),
+            async with await keyed_lock(self.project_id):
+                normalized_name = await _ensure_name_available(session, self.project_id, name)
+                character = await character_service.create_character(
+                    session,
+                    self.project_id,
+                    name=normalized_name,
+                    description=description,
+                )
+                await record_character_diffs(
+                    session,
+                    revision_id=revision_id,
+                    project_id=self.project_id,
+                    before={},
+                    after=character_images_by_id([character]),
+                )
+                await session.commit()
+                character_preview = _preview_from_character(character)
+                return json.dumps(
+                    {
+                        "success": True,
+                        "metadata": {
+                            "character_diff": _build_character_diff(None, character_preview),
+                        },
                     },
-                },
-                ensure_ascii=False,
-            )
+                    ensure_ascii=False,
+                )
         except ToolExecutionError:
             raise
         except Exception:
@@ -364,54 +366,55 @@ class EditCharacterTool(AgentTool):
         revision_id = _require_revision_id(self._state)
         session = await create_session()
         try:
-            character = await _resolve_character_by_name(session, self.project_id, name)
-            before = _preview_from_character(character)
-            description = character.description
-            if old_description is not None and new_description is not None:
-                replace_result = fuzzy_replace(
-                    description, old_description, new_description,
-                    replace_all=replace_all,
-                )
-                if replace_result is None:
-                    raise ToolExecutionError("未在角色描述中找到要替换的文本")
-                description = replace_result.new_content
-                try:
-                    validate_editor_content(description)
-                except EditorContentLimitError as exc:
-                    raise ToolExecutionError(str(exc)) from exc
-            normalized_new_name = None
-            if new_name is not None:
-                normalized_new_name = await _ensure_name_available(
+            async with await keyed_lock(self.project_id):
+                character = await _resolve_character_by_name(session, self.project_id, name)
+                before = _preview_from_character(character)
+                description = character.description
+                if old_description is not None and new_description is not None:
+                    replace_result = fuzzy_replace(
+                        description, old_description, new_description,
+                        replace_all=replace_all,
+                    )
+                    if replace_result is None:
+                        raise ToolExecutionError("未在角色描述中找到要替换的文本")
+                    description = replace_result.new_content
+                    try:
+                        validate_editor_content(description)
+                    except EditorContentLimitError as exc:
+                        raise ToolExecutionError(str(exc)) from exc
+                normalized_new_name = None
+                if new_name is not None:
+                    normalized_new_name = await _ensure_name_available(
+                        session,
+                        self.project_id,
+                        new_name,
+                        exclude_character_id=character.id,
+                    )
+                before_images = character_images_by_id([character])
+                updated = await character_service.update_character(
                     session,
-                    self.project_id,
-                    new_name,
-                    exclude_character_id=character.id,
+                    character.id,
+                    name=normalized_new_name,
+                    description=description if description != before.description else None,
                 )
-            before_images = character_images_by_id([character])
-            updated = await character_service.update_character(
-                session,
-                character.id,
-                name=normalized_new_name,
-                description=description if description != before.description else None,
-            )
-            await record_character_diffs(
-                session,
-                revision_id=revision_id,
-                project_id=self.project_id,
-                before=before_images,
-                after=character_images_by_id([updated]),
-            )
-            await session.commit()
-            after = _preview_from_character(updated)
-            return json.dumps(
-                {
-                    "success": True,
-                    "metadata": {
-                        "character_diff": _build_character_diff(before, after),
+                await record_character_diffs(
+                    session,
+                    revision_id=revision_id,
+                    project_id=self.project_id,
+                    before=before_images,
+                    after=character_images_by_id([updated]),
+                )
+                await session.commit()
+                after = _preview_from_character(updated)
+                return json.dumps(
+                    {
+                        "success": True,
+                        "metadata": {
+                            "character_diff": _build_character_diff(before, after),
+                        },
                     },
-                },
-                ensure_ascii=False,
-            )
+                    ensure_ascii=False,
+                )
         except ToolExecutionError:
             raise
         except Exception:

--- a/backend/app/agent_runtime/tools/impls/context/world_entry.py
+++ b/backend/app/agent_runtime/tools/impls/context/world_entry.py
@@ -12,6 +12,7 @@ from app.agent_runtime.revisions import (
 from app.agent_runtime.tools.base import AgentTool
 from app.core.editor_content_limits import EditorContentLimitError, validate_editor_content
 from app.agent_runtime.tools.errors import ToolExecutionError
+from app.agent_runtime.tools.impls._locks import keyed_lock
 from app.agent_runtime.tools.registry import ToolRegistry
 from app.agent_runtime.tools.text_match import fuzzy_replace
 from app.storage.database import create_session
@@ -286,33 +287,34 @@ class CreateWorldEntryTool(AgentTool):
         session = await create_session()
         try:
             world_info = await _get_project_world_info(session, self.project_id)
-            normalized_title = await _ensure_title_available(session, world_info.id, title)
-            entry = await world_info_entry_service.create_entry(
-                session,
-                world_info.id,
-                name=normalized_title,
-                content=content,
-                is_enabled=True,
-            )
-            await record_world_entry_diffs(
-                session,
-                revision_id=revision_id,
-                project_id=self.project_id,
-                before={},
-                after=world_entry_images_by_id([entry], project_id=self.project_id),
-            )
-            await session.commit()
-            entry_preview = _preview_from_entry(entry)
-            return json.dumps(
-                {
-                    "success": True,
-                    "metadata": {
-                        "world_info_id": world_info.id,
-                        "world_entry_diff": _build_world_entry_diff(None, entry_preview),
+            async with await keyed_lock(world_info.id):
+                normalized_title = await _ensure_title_available(session, world_info.id, title)
+                entry = await world_info_entry_service.create_entry(
+                    session,
+                    world_info.id,
+                    name=normalized_title,
+                    content=content,
+                    is_enabled=True,
+                )
+                await record_world_entry_diffs(
+                    session,
+                    revision_id=revision_id,
+                    project_id=self.project_id,
+                    before={},
+                    after=world_entry_images_by_id([entry], project_id=self.project_id),
+                )
+                await session.commit()
+                entry_preview = _preview_from_entry(entry)
+                return json.dumps(
+                    {
+                        "success": True,
+                        "metadata": {
+                            "world_info_id": world_info.id,
+                            "world_entry_diff": _build_world_entry_diff(None, entry_preview),
+                        },
                     },
-                },
-                ensure_ascii=False,
-            )
+                    ensure_ascii=False,
+                )
         except ToolExecutionError:
             raise
         except Exception:

--- a/backend/app/agent_runtime/tools/impls/note/create_note_category.py
+++ b/backend/app/agent_runtime/tools/impls/note/create_note_category.py
@@ -20,6 +20,7 @@ from app.agent_runtime.tools.impls.note.refs import (
     generate_unique_title,
     resolve_category_from_list,
 )
+from app.agent_runtime.tools.impls._locks import keyed_lock
 from app.agent_runtime.tools.registry import ToolRegistry
 from app.storage.database import create_session
 from app.storage.models.note import NoteCategory
@@ -102,47 +103,48 @@ class CreateNoteCategoryTool(AgentTool):
                     raise ToolExecutionError("父分类不属于当前项目")
                 parent_id = parent.id
 
-            before = note_category_images_by_id(
-                await note_category_repo.list_by_project(session, self.project_id)
-            )
-            sibling_titles = {
-                c.title for c in before.values() if c.parent_id == parent_id
-            }
-            unique_title = generate_unique_title(title, sibling_titles)
+            async with await keyed_lock((self.project_id, parent_id)):
+                before = note_category_images_by_id(
+                    await note_category_repo.list_by_project(session, self.project_id)
+                )
+                sibling_titles = {
+                    c.title for c in before.values() if c.parent_id == parent_id
+                }
+                unique_title = generate_unique_title(title, sibling_titles)
 
-            category = NoteCategory(
-                project_id=self.project_id,
-                parent_id=parent_id,
-                title=unique_title,
-            )
-            category = await note_category_repo.create(session, category)
-            after = note_category_images_by_id(
-                await note_category_repo.list_by_project(session, self.project_id)
-            )
-            await record_note_category_diffs(
-                session,
-                revision_id=revision_id,
-                project_id=self.project_id,
-                before=before,
-                after=after,
-            )
+                category = NoteCategory(
+                    project_id=self.project_id,
+                    parent_id=parent_id,
+                    title=unique_title,
+                )
+                category = await note_category_repo.create(session, category)
+                after = note_category_images_by_id(
+                    await note_category_repo.list_by_project(session, self.project_id)
+                )
+                await record_note_category_diffs(
+                    session,
+                    revision_id=revision_id,
+                    project_id=self.project_id,
+                    before=before,
+                    after=after,
+                )
 
-            from app.background.jobs import service as background_service
+                from app.background.jobs import service as background_service
 
-            await background_service.commit_and_notify(session)
-            return json.dumps(
-                {
-                    "success": True,
-                    "metadata": {
-                        "category": {
-                            "id": category.id,
-                            "title": category.title,
-                            "parent_id": category.parent_id,
-                        }
+                await background_service.commit_and_notify(session)
+                return json.dumps(
+                    {
+                        "success": True,
+                        "metadata": {
+                            "category": {
+                                "id": category.id,
+                                "title": category.title,
+                                "parent_id": category.parent_id,
+                            }
+                        },
                     },
-                },
-                ensure_ascii=False,
-            )
+                    ensure_ascii=False,
+                )
         except ToolExecutionError:
             raise
         except Exception:

--- a/backend/app/agent_runtime/tools/impls/note/edit_note_category.py
+++ b/backend/app/agent_runtime/tools/impls/note/edit_note_category.py
@@ -20,6 +20,7 @@ from app.agent_runtime.tools.impls.note.refs import (
     CategoryRef,
     resolve_category_from_list,
 )
+from app.agent_runtime.tools.impls._locks import keyed_lock
 from app.agent_runtime.tools.registry import ToolRegistry
 from app.storage.database import create_session
 from app.storage.repos import note_category_repo
@@ -97,48 +98,49 @@ class EditNoteCategoryTool(AgentTool):
             if category.project_id != self.project_id:
                 raise ToolExecutionError("分类不属于当前项目")
 
-            before = note_category_images_by_id(
-                await note_category_repo.list_by_project(session, self.project_id)
-            )
-            if any(
-                item.title == new_title
-                and item.parent_id == category.parent_id
-                and item.id != category.id
-                for item in before.values()
-            ):
-                raise ToolExecutionError(f"同级分类已存在同名标题: {new_title}")
-            previous_title = category.title
-            category.title = new_title
-            category.updated_at = datetime.now(UTC)
-            category = await note_category_repo.update_category(session, category)
-            after = note_category_images_by_id(
-                await note_category_repo.list_by_project(session, self.project_id)
-            )
-            await record_note_category_diffs(
-                session,
-                revision_id=revision_id,
-                project_id=self.project_id,
-                before=before,
-                after=after,
-            )
+            async with await keyed_lock((self.project_id, category.parent_id)):
+                before = note_category_images_by_id(
+                    await note_category_repo.list_by_project(session, self.project_id)
+                )
+                if any(
+                    item.title == new_title
+                    and item.parent_id == category.parent_id
+                    and item.id != category.id
+                    for item in before.values()
+                ):
+                    raise ToolExecutionError(f"同级分类已存在同名标题: {new_title}")
+                previous_title = category.title
+                category.title = new_title
+                category.updated_at = datetime.now(UTC)
+                category = await note_category_repo.update_category(session, category)
+                after = note_category_images_by_id(
+                    await note_category_repo.list_by_project(session, self.project_id)
+                )
+                await record_note_category_diffs(
+                    session,
+                    revision_id=revision_id,
+                    project_id=self.project_id,
+                    before=before,
+                    after=after,
+                )
 
-            from app.background.jobs import service as background_service
+                from app.background.jobs import service as background_service
 
-            await background_service.commit_and_notify(session)
-            return json.dumps(
-                {
-                    "success": True,
-                    "metadata": {
-                        "category": {
-                            "id": category.id,
-                            "title": category.title,
-                            "previous_title": previous_title,
-                            "parent_id": category.parent_id,
-                        }
+                await background_service.commit_and_notify(session)
+                return json.dumps(
+                    {
+                        "success": True,
+                        "metadata": {
+                            "category": {
+                                "id": category.id,
+                                "title": category.title,
+                                "previous_title": previous_title,
+                                "parent_id": category.parent_id,
+                            }
+                        },
                     },
-                },
-                ensure_ascii=False,
-            )
+                    ensure_ascii=False,
+                )
         except ToolExecutionError:
             raise
         except Exception:

--- a/backend/app/agent_runtime/tools/impls/note/write_note.py
+++ b/backend/app/agent_runtime/tools/impls/note/write_note.py
@@ -21,6 +21,7 @@ from app.agent_runtime.tools.impls.note.refs import (
     generate_unique_title,
     resolve_category_from_list,
 )
+from app.agent_runtime.tools.impls._locks import keyed_lock
 from app.agent_runtime.tools.registry import ToolRegistry
 from app.storage.database import create_session
 from app.storage.models.note import Note
@@ -129,69 +130,70 @@ class WriteNoteTool(AgentTool):
                     raise ToolExecutionError("目标分类不属于当前项目")
                 category_id = cat.id
 
-            notes = await note_repo.list_by_project(
-                session, self.project_id, include_hidden=False
-            )
-            sibling_titles = {
-                n.title for n in notes if n.category_id == category_id
-            }
-            unique_title = generate_unique_title(title, sibling_titles)
-
-            before = note_images_by_id(
-                await note_repo.list_by_project(
-                    session, self.project_id, include_hidden=True
+            async with await keyed_lock((self.project_id, category_id)):
+                notes = await note_repo.list_by_project(
+                    session, self.project_id, include_hidden=False
                 )
-            )
-            note = Note(
-                project_id=self.project_id,
-                category_id=category_id,
-                title=unique_title,
-                content=content,
-                is_locked=False,
-                is_hidden=False,
-            )
-            note = await note_repo.create(session, note)
-            after = note_images_by_id(
-                await note_repo.list_by_project(
-                    session, self.project_id, include_hidden=True
-                )
-            )
-            await record_note_diffs(
-                session,
-                revision_id=revision_id,
-                project_id=self.project_id,
-                before=before,
-                after=after,
-            )
-
-            content_lines = content.splitlines()
-            diff_lines = [
-                {
-                    "type": "added",
-                    "before_line_number": None,
-                    "after_line_number": i + 1,
-                    "text": line,
+                sibling_titles = {
+                    n.title for n in notes if n.category_id == category_id
                 }
-                for i, line in enumerate(content_lines)
-            ]
-            note_diff = {
-                "operation": "create",
-                "sections": [{"type": "content", "lines": diff_lines}],
-                "note_id": note.id,
-                "note_title": note.title,
-                "category_id": note.category_id,
-            }
+                unique_title = generate_unique_title(title, sibling_titles)
 
-            from app.background.jobs import service as background_service
+                before = note_images_by_id(
+                    await note_repo.list_by_project(
+                        session, self.project_id, include_hidden=True
+                    )
+                )
+                note = Note(
+                    project_id=self.project_id,
+                    category_id=category_id,
+                    title=unique_title,
+                    content=content,
+                    is_locked=False,
+                    is_hidden=False,
+                )
+                note = await note_repo.create(session, note)
+                after = note_images_by_id(
+                    await note_repo.list_by_project(
+                        session, self.project_id, include_hidden=True
+                    )
+                )
+                await record_note_diffs(
+                    session,
+                    revision_id=revision_id,
+                    project_id=self.project_id,
+                    before=before,
+                    after=after,
+                )
 
-            await background_service.commit_and_notify(session)
-            return json.dumps(
-                {
-                    "success": True,
-                    "metadata": {"note_diff": note_diff},
-                },
-                ensure_ascii=False,
-            )
+                content_lines = content.splitlines()
+                diff_lines = [
+                    {
+                        "type": "added",
+                        "before_line_number": None,
+                        "after_line_number": i + 1,
+                        "text": line,
+                    }
+                    for i, line in enumerate(content_lines)
+                ]
+                note_diff = {
+                    "operation": "create",
+                    "sections": [{"type": "content", "lines": diff_lines}],
+                    "note_id": note.id,
+                    "note_title": note.title,
+                    "category_id": note.category_id,
+                }
+
+                from app.background.jobs import service as background_service
+
+                await background_service.commit_and_notify(session)
+                return json.dumps(
+                    {
+                        "success": True,
+                        "metadata": {"note_diff": note_diff},
+                    },
+                    ensure_ascii=False,
+                )
         except ToolExecutionError:
             raise
         except Exception:

--- a/backend/tests/agent_runtime/tools/test_chapter_tools.py
+++ b/backend/tests/agent_runtime/tools/test_chapter_tools.py
@@ -1,5 +1,6 @@
 """Tests for Agent chapter and volume tools."""
 
+import asyncio
 import json
 from datetime import UTC, datetime
 from types import SimpleNamespace
@@ -238,6 +239,90 @@ async def test_write_chapter_appends_to_volume_and_returns_volume_id() -> None:
     assert created_chapter.volume_id == "vol-1"
     assert created_chapter.order == 4
     refresh_volume_count.assert_awaited_once_with(mock_session, "vol-1")
+
+
+async def test_write_chapter_serializes_parallel_writes_per_volume() -> None:
+    from app.agent_runtime.tools.impls import _locks
+    from app.agent_runtime.tools.impls.chapter import write_chapter as wc
+
+    _locks._LOCKS.clear()
+    volume = _make_volume(chapter_count=3)
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    call_count = 0
+
+    async def get_max_order(_session, _volume_id):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            entered.set()
+            await release.wait()
+        return 0
+
+    async def create_chapter(_session, chapter):
+        chapter.id = "chap-new"
+        return chapter
+
+    _locks._LOCKS.clear()
+
+    def make_tool():
+        return wc.WriteChapterTool(_state=_make_state())
+
+    with patch("app.agent_runtime.tools.impls.chapter.write_chapter.create_session") as mock_cs:
+        mock_cs.return_value = AsyncMock()
+        with patch(
+            "app.agent_runtime.tools.impls.chapter.write_chapter.volume_repo.list_by_project",
+            AsyncMock(return_value=[volume]),
+        ), patch(
+            "app.agent_runtime.tools.impls.chapter.write_chapter.chapter_repo"
+        ) as mock_repo, patch(
+            "app.agent_runtime.tools.impls.chapter.write_chapter.record_chapter_diffs",
+            AsyncMock(return_value=["chap-new"]),
+        ), patch(
+            "app.agent_runtime.tools.impls.chapter.write_chapter.record_agent_activity_for_change",
+            AsyncMock(),
+        ), patch(
+            "app.agent_runtime.tools.impls.chapter.write_chapter.refresh_volume_chapter_count",
+            AsyncMock(),
+        ), patch(
+            "app.agent_runtime.tools.impls.chapter.write_chapter.refresh_project_stats",
+            AsyncMock(),
+        ), patch(
+            "app.retrieval.chapter_index.safe_maybe_enqueue_auto_index", AsyncMock()
+        ), patch(
+            "app.retrieval.index_status.schedule_emit_index_status", lambda *_a, **_k: None
+        ), patch(
+            "app.background.jobs.service.commit_and_notify", AsyncMock()
+        ):
+            mock_repo.list_by_project = AsyncMock(return_value=[])
+            mock_repo.get_max_order = AsyncMock(side_effect=get_max_order)
+            mock_repo.create = AsyncMock(side_effect=create_chapter)
+
+            task1 = asyncio.create_task(
+                make_tool().ainvoke(
+                    {
+                        "volume_ref": {"type": "order", "value": 1},
+                        "title": "A",
+                        "content": "A",
+                    }
+                )
+            )
+            await entered.wait()
+            task2 = asyncio.create_task(
+                make_tool().ainvoke(
+                    {
+                        "volume_ref": {"type": "order", "value": 1},
+                        "title": "B",
+                        "content": "B",
+                    }
+                )
+            )
+            await asyncio.sleep(0.05)
+            assert not task2.done()
+            assert mock_repo.get_max_order.call_count == 1
+            release.set()
+            await asyncio.gather(task1, task2)
+            assert mock_repo.get_max_order.call_count == 2
 
 
 async def test_write_chapter_rejects_over_limit_content_without_creating() -> None:
@@ -532,6 +617,52 @@ async def test_create_volume_appends_to_project() -> None:
     assert volume_arg.project_id == "proj-1"
     assert volume_arg.order == 3
     mock_session.commit.assert_called_once()
+
+
+async def test_create_volume_serializes_parallel_writes_per_project() -> None:
+    from app.agent_runtime.tools.impls import _locks
+    from app.agent_runtime.tools.impls.chapter import create_volume as cv
+
+    _locks._LOCKS.clear()
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    call_count = 0
+
+    async def get_max_order(_session, _project_id):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            entered.set()
+            await release.wait()
+        return 0
+
+    async def create_volume(_session, volume):
+        volume.id = "vol-new"
+        return volume
+
+    def make_tool():
+        return cv.CreateVolumeTool(_state=_make_state())
+
+    with patch("app.agent_runtime.tools.impls.chapter.create_volume.create_session") as mock_cs:
+        mock_cs.return_value = AsyncMock()
+        with patch(
+            "app.agent_runtime.tools.impls.chapter.create_volume.volume_repo.get_max_order",
+            AsyncMock(side_effect=get_max_order),
+        ), patch(
+            "app.agent_runtime.tools.impls.chapter.create_volume.volume_repo.create",
+            AsyncMock(side_effect=create_volume),
+        ):
+            task1 = asyncio.create_task(
+                make_tool().ainvoke({"title": "第一卷", "description": "A"})
+            )
+            await entered.wait()
+            task2 = asyncio.create_task(
+                make_tool().ainvoke({"title": "第二卷", "description": "B"})
+            )
+            await asyncio.sleep(0.05)
+            assert not task2.done()
+            release.set()
+            await asyncio.gather(task1, task2)
 
 
 async def test_create_volume_builds_approval_preview() -> None:

--- a/backend/tests/agent_runtime/tools/test_context_tools.py
+++ b/backend/tests/agent_runtime/tools/test_context_tools.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -280,6 +281,54 @@ async def test_create_character_returns_diff() -> None:
             }
         ],
     }
+
+
+async def test_create_character_serializes_parallel_creates_per_project() -> None:
+    from app.agent_runtime.tools.impls import _locks
+    from app.agent_runtime.tools.impls.context import character as ch
+
+    _locks._LOCKS.clear()
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    call_count = 0
+
+    async def list_characters(*_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            entered.set()
+            await release.wait()
+        return []
+
+    created = SimpleNamespace(id="char-1", project_id="proj-1", name="林舟", description="主角")
+    ch_name = "app.agent_runtime.tools.impls.context.character"
+    with patch(f"{ch_name}.create_session") as mock_cs, patch(
+        f"{ch_name}.character_repo"
+    ) as mock_repo, patch(
+        f"{ch_name}.character_service"
+    ) as mock_service, patch(
+        f"{ch_name}.record_character_diffs", AsyncMock()
+    ):
+        mock_cs.return_value = AsyncMock()
+        mock_repo.list_all_by_project = AsyncMock(side_effect=list_characters)
+        mock_service.create_character = AsyncMock(return_value=created)
+
+        def make_tool():
+            return ch.CreateCharacterTool(
+                _state={**_make_state(), "current_revision_id": "rev-1"}
+            )
+
+        task1 = asyncio.create_task(
+            make_tool().ainvoke({"name": "林舟", "description": "主角"})
+        )
+        await entered.wait()
+        task2 = asyncio.create_task(
+            make_tool().ainvoke({"name": "林舟", "description": "主角"})
+        )
+        await asyncio.sleep(0.05)
+        assert not task2.done()
+        release.set()
+        await asyncio.gather(task1, task2)
 
 
 @pytest.mark.asyncio
@@ -599,6 +648,66 @@ async def test_create_world_entry_returns_diff() -> None:
             }
         ],
     }
+
+
+async def test_create_world_entry_serializes_parallel_creates_per_world() -> None:
+    from app.agent_runtime.tools.impls import _locks
+    from app.agent_runtime.tools.impls.context import world_entry as we
+
+    _locks._LOCKS.clear()
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    call_count = 0
+
+    async def list_entries(*_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            entered.set()
+            await release.wait()
+        return []
+
+    created = SimpleNamespace(
+        id="e1",
+        world_info_id="world-1",
+        uid=1,
+        name="主角",
+        order=1,
+        content="林舟",
+        token_count=2,
+        is_enabled=True,
+    )
+    we_name = "app.agent_runtime.tools.impls.context.world_entry"
+    with patch(f"{we_name}.create_session") as mock_cs, patch(
+        f"{we_name}.world_info_repo"
+    ) as mock_world_repo, patch(
+        f"{we_name}.world_info_entry_repo"
+    ) as mock_entry_repo, patch(
+        f"{we_name}.world_info_entry_service"
+    ) as mock_entry_service, patch(
+        f"{we_name}.record_world_entry_diffs", AsyncMock(return_value=["e1"])
+    ):
+        mock_cs.return_value = AsyncMock()
+        mock_world_repo.get_by_project_id = AsyncMock(return_value=SimpleNamespace(id="world-1"))
+        mock_entry_repo.list_all_by_world_info = AsyncMock(side_effect=list_entries)
+        mock_entry_service.create_entry = AsyncMock(return_value=created)
+
+        def make_tool():
+            return we.CreateWorldEntryTool(
+                _state={**_make_state(), "current_revision_id": "rev-1"}
+            )
+
+        task1 = asyncio.create_task(
+            make_tool().ainvoke({"title": "主角", "content": "林舟"})
+        )
+        await entered.wait()
+        task2 = asyncio.create_task(
+            make_tool().ainvoke({"title": "配角", "content": "林舟"})
+        )
+        await asyncio.sleep(0.05)
+        assert not task2.done()
+        release.set()
+        await asyncio.gather(task1, task2)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/tools/test_note_tools.py
+++ b/backend/tests/agent_runtime/tools/test_note_tools.py
@@ -1,5 +1,6 @@
 """Tests for Agent note tools."""
 
+import asyncio
 import json
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -410,6 +411,52 @@ async def test_write_note_creates_note_and_returns_success() -> None:
     assert data["metadata"]["note_diff"]["sections"][0]["type"] == "content"
 
 
+async def test_write_note_serializes_parallel_creates_per_category() -> None:
+    from app.agent_runtime.tools.impls import _locks
+    from app.agent_runtime.tools.impls.note import write_note as wn
+
+    _locks._LOCKS.clear()
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    call_count = 0
+
+    async def list_notes(*_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            entered.set()
+            await release.wait()
+        return []
+
+    async def _fake_create(session, note):
+        note.id = "note-new"
+        return note
+
+    wn_name = "app.agent_runtime.tools.impls.note.write_note"
+    with patch(f"{wn_name}.create_session") as mock_cs:
+        mock_cs.return_value = AsyncMock()
+        with (
+            patch(f"{wn_name}.note_repo.list_by_project", AsyncMock(side_effect=list_notes)),
+            patch(f"{wn_name}.note_repo.create", AsyncMock(side_effect=_fake_create)),
+            patch(f"{wn_name}.record_note_diffs", AsyncMock(return_value=[])),
+            patch("app.background.jobs.service.commit_and_notify", AsyncMock()),
+        ):
+            def make_tool():
+                return wn.WriteNoteTool(_state=_make_state())
+
+            task1 = asyncio.create_task(
+                make_tool().ainvoke({"title": "新笔记", "content": "正文"})
+            )
+            await entered.wait()
+            task2 = asyncio.create_task(
+                make_tool().ainvoke({"title": "新笔记", "content": "正文"})
+            )
+            await asyncio.sleep(0.05)
+            assert not task2.done()
+            release.set()
+            await asyncio.gather(task1, task2)
+
+
 async def test_write_note_rejects_over_limit_content_without_creating() -> None:
     from app.agent_runtime.tools.impls.note.write_note import WriteNoteTool
 
@@ -641,6 +688,51 @@ async def test_create_note_category_returns_success_and_metadata() -> None:
             "category": {"id": "cat-new", "title": "新分类", "parent_id": "cat-1"}
         },
     }
+
+
+async def test_create_note_category_serializes_parallel_creates_per_parent() -> None:
+    from app.agent_runtime.tools.impls import _locks
+    from app.agent_runtime.tools.impls.note import create_note_category as cnc
+
+    _locks._LOCKS.clear()
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    call_count = 0
+
+    async def list_categories(*_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            entered.set()
+            await release.wait()
+        return []
+
+    cnc_name = "app.agent_runtime.tools.impls.note.create_note_category"
+    with patch(f"{cnc_name}.create_session") as mock_cs:
+        mock_cs.return_value = AsyncMock()
+        with patch(
+            f"{cnc_name}.note_category_repo.list_by_project",
+            AsyncMock(side_effect=list_categories),
+        ), patch(
+            f"{cnc_name}.note_category_repo.create",
+            AsyncMock(side_effect=lambda _s, cat: cat),
+        ), patch(
+            f"{cnc_name}.record_note_category_diffs", AsyncMock(return_value=[])
+        ), patch("app.background.jobs.service.commit_and_notify", AsyncMock()):
+            def make_tool():
+                return cnc.CreateNoteCategoryTool(_state=_make_state())
+
+            task1 = asyncio.create_task(
+                make_tool().ainvoke({"title": "新分类"})
+            )
+            await entered.wait()
+            task2 = asyncio.create_task(
+                make_tool().ainvoke({"title": "新分类"})
+            )
+            await asyncio.sleep(0.05)
+            assert not task2.done()
+            release.set()
+            await asyncio.gather(task1, task2)
 
 
 async def test_create_note_category_builds_approval_preview() -> None:


### PR DESCRIPTION
## PR 标题

fix(agent): 修复并行工具调用时唯一约束冲突的问题

## 变更说明

- 问题: Agent 并行调用多个创建/写入工具（如 `write_chapter`、`create_volume`、`create_character`、`create_world_entry`、`write_note`、`create_note_category`）时，各调用独立读取同一最大序号并计算下一个 `order`，导致唯一约束冲突（如 `chapters.volume_id, chapters.order`），报错 `UNIQUE constraint failed`。
- 重要性: 并行工具调用是号主 Agent 的常见行为，唯一约束冲突会导致章节/卷/角色等创建失败，需要修复。
- 变化: 新增共享的按域 asyncio 锁（`impls/_locks.py` 的 `keyed_lock`），为上述工具的同域写入路径加锁串行化，保证并行调用下 `order`/`uid`/标题唯一性；并新增对应串行化测试。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

各工具在独立 DB session 中通过 `get_max_order` 计算 `order = max_order + 1`。并行调用时多个调用读到相同的 `max_order`，算出相同的 `order`，撞上数据库唯一约束。类似地，角色/笔记依赖读后查重来保证名字唯一，并行时也会产生重名。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

新增按域共享的 `asyncio.Lock`（以 `volume_id`/`project_id`/`world_info_id`/分类等为 key），同域写入在进程内串行化，不同域仍可并行。`chapters`、`volumes` 的唯一约束仍作为多进程部署下的兜底。

测试证据: `tests/agent_runtime/tools/test_chapter_tools.py`、`test_context_tools.py`、`test_note_tools.py` 共 71 项通过；`ruff check` 通过。