### PR TITLE
fix(frontend): 修复发送新消息后上一条 Assistant 轮次 toolbar 消失的问题

### DIFF
--- a/frontend/src/features/assistant/components/agent/agent-messages.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-messages.tsx
@@ -499,8 +499,8 @@ export function AgentMessages({
     [collapsedNodeIds, messageBlocks],
   );
   const toolbarTargets = useMemo(
-    () => getAgentRoundToolbarTargets(messageBlocks, visibleMessageBlocks),
-    [messageBlocks, visibleMessageBlocks],
+    () => getAgentRoundToolbarTargets(messageBlocks, visibleMessageBlocks, isRunning),
+    [messageBlocks, visibleMessageBlocks, isRunning],
   );
   const toolbarTargetByAnchorId = useMemo(
     () => new Map(toolbarTargets.map((target) => [target.anchorBlockId, target])),

--- a/frontend/src/features/assistant/components/agent/display/agent-message-blocks.ts
+++ b/frontend/src/features/assistant/components/agent/display/agent-message-blocks.ts
@@ -164,6 +164,7 @@ export function buildAgentMessageBlocks(
         type: "user",
         messages: [message],
         sourceRevisionId: message.revisionId,
+        agentRoundId: activeAgentRoundId,
       });
       continue;
     }
@@ -253,6 +254,7 @@ function getLatestAssistantToolbarTimestamp(blocks: AgentMessageBlock[]): number
 export function getAgentRoundToolbarTargets(
   blocks: AgentMessageBlock[],
   visibleBlocks: AgentMessageBlock[],
+  isSessionRunning: boolean,
 ): AgentRoundToolbarTarget[] {
   const roundOrder: string[] = [];
   const rounds = new Map<
@@ -265,7 +267,7 @@ export function getAgentRoundToolbarTargets(
   >();
 
   for (const block of blocks) {
-    if (!block.agentRoundId || (block.type !== "agent" && block.type !== "node")) continue;
+    if (!block.agentRoundId) continue;
     let round = rounds.get(block.agentRoundId);
     if (!round) {
       round = { blocks: [], visibleBlocks: [], sourceRevisionId: block.sourceRevisionId };
@@ -285,15 +287,17 @@ export function getAgentRoundToolbarTargets(
     if (round) round.visibleBlocks.push(block);
   }
 
-  return roundOrder.flatMap((roundId) => {
+  return roundOrder.flatMap((roundId, index) => {
     const round = rounds.get(roundId);
     if (!round) return [];
     const hasAgentWork = round.blocks.some((block) => block.type === "agent");
     const isRunning = round.blocks.some(
       (block) => block.type === "agent" && hasRunningMessage(block),
     );
+    const isLastRound = index === roundOrder.length - 1;
     const anchorBlock = round.visibleBlocks.at(-1);
     if (!hasAgentWork || isRunning || !anchorBlock) return [];
+    if (isSessionRunning && isLastRound) return [];
 
     let copyContent = "";
     for (let index = round.blocks.length - 1; index >= 0; index -= 1) {

--- a/frontend/src/features/assistant/hooks/use-agent-session.ts
+++ b/frontend/src/features/assistant/hooks/use-agent-session.ts
@@ -901,12 +901,17 @@ export function useAgentSession({
         return;
       }
 
+      const sessionWasRunning = transcriptStateRef.current.isRunning;
+      const optimisticMessage = sessionWasRunning ? null : createOptimisticUserMessage(message);
+
       try {
         suppressSocketEventsAfterAbortRef.current = false;
         transportRetryAttemptRef.current = 0;
         updateTranscriptState((current) => ({
           ...current,
-          messages: current.messages.filter((item) => item.type !== "error"),
+          messages: optimisticMessage
+            ? [...current.messages.filter((item) => item.type !== "error"), optimisticMessage]
+            : current.messages.filter((item) => item.type !== "error"),
           status: "running",
           isRunning: true,
           currentStage: getBestEffortContinueStage(current.messages, agentKey),
@@ -946,6 +951,9 @@ export function useAgentSession({
         console.error("Failed to send message:", error);
         updateTranscriptState((current) => ({
           ...current,
+          messages: optimisticMessage
+            ? current.messages.filter((item) => !(item.isDraft && item.content === message))
+            : current.messages,
           status: "error",
           isRunning: false,
           currentStage: "",


### PR DESCRIPTION
## PR 标题

fix(frontend): 修复发送新消息后上一条 Assistant 轮次 toolbar 消失的问题

## 变更说明

- 问题: 发送新消息后，上一条已完成的 Assistant 轮次 toolbar 会在收到 LLM 输出前整块消失；且一轮内多次 LLM Call 之间 toolbar 会闪现。
- 重要性: 影响 Agent 侧边栏消息块的工具栏可用性与视觉稳定性。
- 变化:
  - 构建消息块时为 user 块补充 `agentRoundId`，使新轮次可被工具栏计算追踪
  - `getAgentRoundToolbarTargets` 不再按块类型过滤，所有带 `agentRoundId` 的块均进入轮次顺序
  - `sendMessage` 在会话空闲时追加乐观用户消息，使上一条轮次在发送后立即不再是最后一个轮次；失败时清理乐观消息

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

`getAgentRoundToolbarTargets` 仅按 agent/node 块构建轮次顺序，用户块没有 `agentRoundId`，因此发送消息时新增的乐观用户消息对工具栏计算不可见。上一条轮次仍被判定为最后一个轮次，在会话运行中（`isSessionRunning && isLastRound`）被抑制，直到新的 user_request 注册（接近 LLM 返回）才恢复。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

行为验证（前端无测试框架，未新增单测）：
- 一轮内多次 LLM Call：由 `isSessionRunning && isLastRound` 抑制，整轮结束前不显示 toolbar，不再闪烁
- 发送新消息：乐观用户消息立即建立新轮次，上一条已完成轮次不再是最后一个，toolbar 立即保持显示
- 已通过 `pnpm type-check`、`pnpm lint`、`pnpm format:check`