### PR TITLE
fix(backend): 修复 LLM 长响应被超时中断的问题

### DIFF
--- a/backend/app/agent_runtime/graph/llm_invoke.py
+++ b/backend/app/agent_runtime/graph/llm_invoke.py
@@ -2,13 +2,12 @@
 
 单一入口 ``invoke_model_with_retry`` 负责：错误分类、退避计算、
 重试事件发布与空响应重放；超时通过 ``_TimedStream`` 包装流式
-迭代器实现 chunk 空闲超时与总时长超时。
+迭代器实现 chunk 空闲超时。
 """
 
 from __future__ import annotations
 
 import asyncio
-import time
 from collections.abc import Awaitable, Callable, Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -52,13 +51,12 @@ class EmptyResponseError(RuntimeError):
 
 
 class LLMStreamTimeoutError(TimeoutError):
-    """流式调用在 chunk 空闲或总时长上超时。"""
+    """流式调用在 chunk 空闲时超时。"""
 
 
 @dataclass(frozen=True)
 class LLMInvokeSettings:
     connect_timeout: float = 10.0
-    total_timeout: float = 300.0
     chunk_timeout: float = 120.0
     max_attempts: int = 5
     retry_base_interval: float = 2.0
@@ -71,7 +69,6 @@ def load_llm_invoke_settings() -> LLMInvokeSettings:
 
     return LLMInvokeSettings(
         connect_timeout=settings.llm_connect_timeout,
-        total_timeout=settings.llm_total_timeout,
         chunk_timeout=settings.llm_chunk_timeout,
         max_attempts=settings.llm_retry_max_attempts,
         retry_base_interval=settings.llm_retry_base_interval,
@@ -233,37 +230,20 @@ class _TimedStream:
         astream: Any,
         *,
         chunk_timeout: float | None,
-        total_timeout: float | None,
     ) -> None:
         self._iterator = astream.__aiter__()
         self._chunk_timeout = chunk_timeout
-        self._total_timeout = total_timeout
-        self._started = time.perf_counter()
 
     def __aiter__(self) -> _TimedStream:
         return self
 
     async def __anext__(self) -> Any:
         timeout = self._chunk_timeout
-        timed_out_by = "chunk"
-        if self._total_timeout is not None:
-            remaining = self._total_timeout - (time.perf_counter() - self._started)
-            if remaining <= 0:
-                raise LLMStreamTimeoutError(
-                    f"LLM stream exceeded total timeout of {self._total_timeout}s"
-                )
-            if timeout is None or remaining < timeout:
-                timeout = remaining
-                timed_out_by = "total"
         if timeout is None:
             return await self._iterator.__anext__()
         try:
             return await asyncio.wait_for(self._iterator.__anext__(), timeout=timeout)
         except TimeoutError as exc:
-            if timed_out_by == "total":
-                raise LLMStreamTimeoutError(
-                    f"LLM stream exceeded total timeout of {self._total_timeout}s"
-                ) from exc
             raise LLMStreamTimeoutError(
                 f"LLM stream chunk idle timeout after {timeout}s"
             ) from exc
@@ -320,7 +300,6 @@ async def invoke_model_with_retry(
                 model,
                 messages,
                 chunk_timeout=settings.chunk_timeout,
-                total_timeout=settings.total_timeout,
             )
         except asyncio.CancelledError:
             raise

--- a/backend/app/agent_runtime/graph/react_agent.py
+++ b/backend/app/agent_runtime/graph/react_agent.py
@@ -103,7 +103,6 @@ async def _invoke_model(
     messages: list[BaseMessage],
     *,
     chunk_timeout: float | None = None,
-    total_timeout: float | None = None,
 ) -> AIMessage:
     """Stream the LLM response and normalize it for checkpoint persistence."""
     start_time = time.perf_counter()
@@ -113,7 +112,6 @@ async def _invoke_model(
     stream = _TimedStream(
         model.astream(messages),
         chunk_timeout=chunk_timeout,
-        total_timeout=total_timeout,
     )
     async for chunk in stream:
         if first_token_ms is None:

--- a/backend/app/background/jobs/base.py
+++ b/backend/app/background/jobs/base.py
@@ -35,7 +35,7 @@ class JobDefinition:
     on_timeout: JobLifecycleHook | None = None
     on_cancelled: JobLifecycleHook | None = None
     default_queue: str = "default"
-    default_timeout_seconds: int = 300
+    default_timeout_seconds: int | None = 300
     default_max_attempts: int = 1
     supports_cancel: bool = False
     supports_batch: bool = False

--- a/backend/app/background/jobs/definitions/chapter_summary.py
+++ b/backend/app/background/jobs/definitions/chapter_summary.py
@@ -369,7 +369,7 @@ CHAPTER_SUMMARY_JOB = JobDefinition(
     on_timeout=mark_chapter_summary_failed,
     on_cancelled=mark_chapter_summary_failed,
     default_queue=JOB_QUEUE_LLM,
-    default_timeout_seconds=180,
+    default_timeout_seconds=720,
     default_max_attempts=1,
     supports_cancel=True,
 )
@@ -385,7 +385,7 @@ LONG_TERM_SUMMARY_JOB = JobDefinition(
     on_timeout=mark_long_term_summary_failed,
     on_cancelled=mark_long_term_summary_failed,
     default_queue=JOB_QUEUE_LLM,
-    default_timeout_seconds=240,
+    default_timeout_seconds=720,
     default_max_attempts=1,
     supports_cancel=True,
 )

--- a/backend/app/background/jobs/definitions/summary_batch.py
+++ b/backend/app/background/jobs/definitions/summary_batch.py
@@ -595,7 +595,7 @@ SUMMARY_BATCH_JOB = JobDefinition(
     on_timeout=_handle_summary_batch_timeout,
     on_cancelled=_handle_summary_batch_cancelled,
     default_queue=JOB_QUEUE_LLM,
-    default_timeout_seconds=900,
+    default_timeout_seconds=None,
     default_max_attempts=1,
     supports_cancel=True,
 )

--- a/backend/app/background/llm/resolver.py
+++ b/backend/app/background/llm/resolver.py
@@ -69,7 +69,7 @@ async def resolve_background_llm(
                 frequency_penalty=model.frequency_penalty,
                 presence_penalty=model.presence_penalty,
                 repetition_penalty=model.repetition_penalty,
-                request_timeout=60,
+                request_timeout=int(settings.llm_request_timeout),
             )
         ),
         model=model,

--- a/backend/app/memory/chapter/summary_generator.py
+++ b/backend/app/memory/chapter/summary_generator.py
@@ -209,7 +209,7 @@ async def generate_chapter_summary_from_prompt(
         model_name=model_name,
         request_messages=messages,
     ) as audit:
-        response = await llm_client.generate_with_tools(messages, timeout=120)
+        response = await llm_client.generate_with_tools(messages)
         audit.record_response(
             content=response.content,
             tool_calls=response.tool_calls,
@@ -294,7 +294,7 @@ async def generate_long_term_summary_from_prompt(
         model_name=model_name,
         request_messages=messages,
     ) as audit:
-        response = await llm_client.generate_with_tools(messages, timeout=120)
+        response = await llm_client.generate_with_tools(messages)
         audit.record_response(
             content=response.content,
             tool_calls=response.tool_calls,

--- a/backend/app/models/clients/llm_client.py
+++ b/backend/app/models/clients/llm_client.py
@@ -28,7 +28,7 @@ from app.models.clients.deepseek_payload import patch_deepseek_reasoning_payload
 from app.models.clients.model_factory import ModelConfig, ReasoningEffort, create_chat_model
 
 
-DEFAULT_LLM_TIMEOUT = 120
+DEFAULT_LLM_TIMEOUT = 600
 _patch_deepseek_reasoning_payload = patch_deepseek_reasoning_payload
 
 

--- a/backend/app/models/clients/model_factory.py
+++ b/backend/app/models/clients/model_factory.py
@@ -80,7 +80,13 @@ def _three_level_reasoning_effort(
 def _request_timeout() -> tuple[float, float]:
     from app.settings import settings
 
-    return (settings.llm_connect_timeout, settings.llm_total_timeout)
+    return (settings.llm_connect_timeout, settings.llm_request_timeout)
+
+
+def _stream_chunk_timeout() -> float | None:
+    from app.settings import settings
+
+    return settings.llm_chunk_timeout
 
 
 def _openai_compatible_kwargs(config: ModelConfig) -> dict[str, Any]:
@@ -98,6 +104,7 @@ def _openai_compatible_kwargs(config: ModelConfig) -> dict[str, Any]:
         reasoning_effort=_enabled_reasoning_effort(config),
         max_retries=0,
         stream_usage=True,
+        stream_chunk_timeout=_stream_chunk_timeout(),
         timeout=_request_timeout(),
     )
     extra_body = {
@@ -177,6 +184,7 @@ def create_chat_model(config: ModelConfig) -> Runnable[LanguageModelInput, BaseM
             reasoning_effort=reasoning_effort,
             max_retries=0,
             stream_usage=True,
+            stream_chunk_timeout=_stream_chunk_timeout(),
             timeout=_request_timeout(),
         ))
 

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -107,8 +107,8 @@ class Settings(BaseSettings):
 
     # LLM invocation timeouts & retries
     llm_connect_timeout: float = 10.0
-    llm_total_timeout: float = 300.0
     llm_chunk_timeout: float = 120.0
+    llm_request_timeout: float = 600.0
     llm_retry_max_attempts: int = 5
     llm_retry_base_interval: float = 2.0
     llm_retry_max_interval: float = 30.0

--- a/backend/tests/agent_runtime/graph/test_llm_invoke.py
+++ b/backend/tests/agent_runtime/graph/test_llm_invoke.py
@@ -231,7 +231,14 @@ class TestTimedStream:
         stream = _TimedStream(
             _SlowStream(["a", "b"], delay=0),
             chunk_timeout=1.0,
-            total_timeout=5.0,
+        )
+        assert [chunk async for chunk in stream] == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_allows_stream_to_exceed_previous_total_timeout(self) -> None:
+        stream = _TimedStream(
+            _SlowStream(["a", "b"], delay=0.1),
+            chunk_timeout=1.0,
         )
         assert [chunk async for chunk in stream] == ["a", "b"]
 
@@ -240,20 +247,8 @@ class TestTimedStream:
         stream = _TimedStream(
             _SlowStream(["a"], delay=0.2),
             chunk_timeout=0.05,
-            total_timeout=None,
         )
         with pytest.raises(LLMStreamTimeoutError, match="chunk idle"):
-            await stream.__anext__()
-
-    @pytest.mark.asyncio
-    async def test_total_timeout(self) -> None:
-        stream = _TimedStream(
-            _SlowStream(["a", "b"], delay=0.1),
-            chunk_timeout=1.0,
-            total_timeout=0.15,
-        )
-        assert await stream.__anext__() == "a"
-        with pytest.raises(LLMStreamTimeoutError, match="total timeout"):
             await stream.__anext__()
 
 
@@ -285,7 +280,7 @@ class TestInvokeModelWithRetry:
         assert result.content == "ok"
         assert len(calls) == 2
         assert calls[0]["chunk_timeout"] == _ZERO_BACKOFF.chunk_timeout
-        assert calls[0]["total_timeout"] == _ZERO_BACKOFF.total_timeout
+        assert "total_timeout" not in calls[0]
         assert events == [
             {
                 "session_id": "sess_001",

--- a/backend/tests/agent_runtime/test_model_factory.py
+++ b/backend/tests/agent_runtime/test_model_factory.py
@@ -35,6 +35,8 @@ def test_create_chat_model_openai_returns_chat_openai():
 
     assert isinstance(model, ChatOpenAI)
     assert model.model_name == "gpt-4o"
+    assert model.stream_chunk_timeout == 120.0
+    assert model.request_timeout == (10.0, 600.0)
 
 
 def test_create_chat_model_anthropic_uses_native_client():
@@ -379,7 +381,10 @@ def test_create_chat_model_uses_native_client_for_configured_provider():
     assert model.anthropic_api_url == "https://api.anthropic.com"
 
 
-def test_create_chat_model_deepseek_uses_native_client():
+def test_create_chat_model_deepseek_uses_native_client(monkeypatch):
+    from app.settings import settings
+
+    monkeypatch.setattr(settings, "llm_chunk_timeout", 77.0)
     config = ModelConfig(
         provider_type="deepseek",
         base_url="https://api.deepseek.com",
@@ -390,6 +395,7 @@ def test_create_chat_model_deepseek_uses_native_client():
     from langchain_deepseek import ChatDeepSeek
 
     assert isinstance(model, ChatDeepSeek)
+    assert model.stream_chunk_timeout == 77.0
 
 
 def test_create_chat_model_openrouter_uses_native_client():

--- a/backend/tests/background/test_background_jobs.py
+++ b/backend/tests/background/test_background_jobs.py
@@ -1695,6 +1695,10 @@ async def test_summary_batch_persists_running_status_before_generation(tmp_path,
         await engine.dispose()
 
 
+def test_summary_batch_has_no_fixed_outer_timeout():
+    assert summary_batch_definition.SUMMARY_BATCH_JOB.default_timeout_seconds is None
+
+
 @pytest.mark.asyncio
 async def test_summary_batch_progress_event_contains_aggregated_batch_progress(tmp_path, monkeypatch):
     engine, factory = await _configure_file_database(tmp_path)

--- a/backend/tests/providers/test_llm_client.py
+++ b/backend/tests/providers/test_llm_client.py
@@ -1,8 +1,11 @@
 from typing import Any
+from unittest.mock import AsyncMock
 
 from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage
+import pytest
 
-from app.models.clients.llm_client import LLMClient, _patch_deepseek_reasoning_payload
+from app.core.errors import LLMTimeoutError
+from app.models.clients.llm_client import LLMClient, LLMConfig, _patch_deepseek_reasoning_payload
 
 
 def test_patch_deepseek_reasoning_payload_adds_reasoning_content() -> None:
@@ -67,3 +70,21 @@ def test_extract_usage_reads_response_metadata() -> None:
         "completion_tokens": 2,
         "total_tokens": 12,
     }
+
+
+@pytest.mark.asyncio
+async def test_generate_with_tools_uses_configured_request_timeout() -> None:
+    client = LLMClient(
+        LLMConfig(
+            provider_type="openai",
+            base_url="",
+            api_key="test",
+            model_id="test-model",
+            request_timeout=600,
+        )
+    )
+    client._llm_with_tools = AsyncMock()
+    client._llm_with_tools.ainvoke.side_effect = TimeoutError()
+
+    with pytest.raises(LLMTimeoutError, match="600s"):
+        await client.generate_with_tools([])


### PR DESCRIPTION
## PR 标题

fix(backend): 修复 LLM 长响应被超时中断的问题

## 变更说明

- 问题: Agent 流式调用即使持续返回 chunk，也会在累计 300 秒后被 OpenFic 主动中断；章节摘要仍硬编码 120 秒超时；批量摘要会受固定整体超时影响。
- 重要性: 高思考强度模型和大批量摘要可能在提供商已完成计费后，被客户端误判为超时并重复请求。
- 变化: 移除 Agent 流式调用总时长限制，只保留 chunk 空闲超时；非流式 LLM 请求统一改为 600 秒；章节摘要任务外层调整为 720 秒；批量摘要取消整体固定超时，仅保留单项请求超时。
- 变化: OpenAI Compatible 与 DeepSeek 显式同步 `stream_chunk_timeout`，并补充流式、摘要和批量任务的回归测试。

## 关联 Issue / PR (如有)

Closes #274

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

v0.9.2 的 Agent 超时保护同时设置了 120 秒 chunk 空闲超时和 300 秒总时长超时。后者不关心流是否持续返回内容，会直接取消长响应。章节摘要的调用点还保留了独立的 120 秒硬编码限制，批量摘要则使用无法适配 item 数量的 900 秒整体超时。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

- `just lint`、`just type-check` 通过。
- `uv run pytest -q`：1419 passed。测试输出保留两个既有 warning：NVIDIA 模型弃用提示，以及子代理取消测试中的未 await 协程 warning。
