### PR TITLE
fix(projects): 修复项目列表加载不完全导致分页、搜索和排序失效的问题

### DIFF
--- a/backend/app/api/routers/projects.py
+++ b/backend/app/api/routers/projects.py
@@ -3,7 +3,7 @@
 Projects Router - 项目 CRUD API。
 """
 
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, UploadFile, status
 from loguru import logger
@@ -98,6 +98,14 @@ async def list_projects(
     session: Annotated[AsyncSession, Depends(get_session)],
     page: Annotated[int, Query(ge=1, description="页码")] = 1,
     page_size: Annotated[int, Query(ge=1, le=100, description="每页数量")] = 20,
+    search: Annotated[str | None, Query(description="按项目标题或简介搜索")] = None,
+    sort_by: Annotated[
+        Literal["updated_at", "created_at", "title"],
+        Query(description="排序字段"),
+    ] = "updated_at",
+    sort_order: Annotated[
+        Literal["asc", "desc"], Query(description="排序方向")
+    ] = "desc",
 ) -> ProjectListResponse:
     """
     获取项目列表，支持分页。
@@ -106,11 +114,21 @@ async def list_projects(
         session: 数据库 session。
         page: 页码，从 1 开始。
         page_size: 每页数量，最大 100。
+        search: 项目标题或简介搜索词。
+        sort_by: 排序字段，可选 updated_at、created_at、title。
+        sort_order: 排序方向，可选 asc、desc。
 
     Returns:
         项目列表。
     """
-    result = await project_service.list_projects(session, page=page, page_size=page_size)
+    result = await project_service.list_projects(
+        session,
+        page=page,
+        page_size=page_size,
+        search=search,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    )
     return ProjectListResponse(
         items=[_project_to_response(p) for p in result.items],
         total=result.total,

--- a/backend/app/core/pinyin.py
+++ b/backend/app/core/pinyin.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+"""Utilities for Chinese pinyin search and ordering."""
+
+from functools import lru_cache
+
+from pypinyin import Style, lazy_pinyin
+
+
+@lru_cache(maxsize=4096)
+def _pinyin_parts(text: str) -> tuple[str, ...]:
+    """Convert text into lower-case, tone-free pinyin syllables."""
+    return tuple(
+        part.lower()
+        for part in lazy_pinyin(
+            text,
+            style=Style.NORMAL,
+            errors=lambda characters: list(characters),
+        )
+    )
+
+
+def to_pinyin(text: str | None) -> str:
+    """Return compact pinyin while preserving non-Chinese characters."""
+    if not text:
+        return ""
+    return "".join(_pinyin_parts(text))
+
+
+def to_pinyin_initials(text: str | None) -> str:
+    """Return the first character of each pinyin syllable."""
+    if not text:
+        return ""
+    return "".join(part[0] for part in _pinyin_parts(text) if part)

--- a/backend/app/core/pinyin.py
+++ b/backend/app/core/pinyin.py
@@ -14,7 +14,7 @@ def _pinyin_parts(text: str) -> tuple[str, ...]:
         for part in lazy_pinyin(
             text,
             style=Style.NORMAL,
-            errors=lambda characters: list(characters),
+            errors=lambda characters: characters,
         )
     )
 

--- a/backend/app/storage/database.py
+++ b/backend/app/storage/database.py
@@ -11,9 +11,11 @@ from alembic import command
 from alembic.config import Config
 from loguru import logger
 from sqlalchemy import event
+from sqlalchemy.engine import Engine
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
+from app.core.pinyin import to_pinyin, to_pinyin_initials
 from app.settings import settings
 
 _engine = None
@@ -31,6 +33,11 @@ def _set_sqlite_pragma(dbapi_connection, connection_record):
     cursor.execute("PRAGMA busy_timeout=30000")
     cursor.execute("PRAGMA synchronous=NORMAL")
     cursor.close()
+    dbapi_connection.create_function("pinyin_full", 1, to_pinyin, deterministic=True)
+    dbapi_connection.create_function("pinyin_initials", 1, to_pinyin_initials, deterministic=True)
+
+
+event.listen(Engine, "connect", _set_sqlite_pragma)
 
 
 def _get_engine():
@@ -46,7 +53,6 @@ def _get_engine():
             },
             pool_pre_ping=True,
         )
-        event.listen(_engine.sync_engine, "connect", _set_sqlite_pragma)
     return _engine
 
 

--- a/backend/app/storage/repos/project_repo.py
+++ b/backend/app/storage/repos/project_repo.py
@@ -3,11 +3,51 @@
 Project Repository - 项目数据访问层。
 """
 
-from sqlalchemy import func, select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
 from app.storage.models.project import Project
+
+SORT_COLUMNS = {
+    "updated_at": Project.updated_at,
+    "created_at": Project.created_at,
+    "title": Project.title,
+}
+
+
+def _escape_like_pattern(value: str) -> str:
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _pinyin_search_pattern(search: str) -> str | None:
+    compact_search = "".join(search.split())
+    if not compact_search.isascii() or not compact_search.isalpha():
+        return None
+    return f"%{_escape_like_pattern(compact_search.lower())}%"
+
+
+def _apply_search(stmt, search: str | None):
+    normalized_search = (search or "").strip()
+    if not normalized_search:
+        return stmt
+
+    pattern = f"%{_escape_like_pattern(normalized_search)}%"
+    predicates = [
+        col(Project.title).ilike(pattern, escape="\\"),
+        col(Project.description).ilike(pattern, escape="\\"),
+    ]
+    pinyin_pattern = _pinyin_search_pattern(normalized_search)
+    if pinyin_pattern:
+        predicates.extend(
+            (
+                func.pinyin_full(col(Project.title)).like(pinyin_pattern, escape="\\"),
+                func.pinyin_initials(col(Project.title)).like(pinyin_pattern, escape="\\"),
+                func.pinyin_full(col(Project.description)).like(pinyin_pattern, escape="\\"),
+                func.pinyin_initials(col(Project.description)).like(pinyin_pattern, escape="\\"),
+            )
+        )
+    return stmt.where(or_(*predicates))
 
 
 async def create(session: AsyncSession, project: Project) -> Project:
@@ -46,6 +86,10 @@ async def list_all(
     session: AsyncSession,
     offset: int = 0,
     limit: int = 20,
+    *,
+    search: str | None = None,
+    sort_by: str = "updated_at",
+    sort_order: str = "desc",
 ) -> list[Project]:
     """
     获取项目列表。
@@ -58,16 +102,22 @@ async def list_all(
     Returns:
         项目列表。
     """
-    result = await session.execute(
-        select(Project)
-        .order_by(col(Project.updated_at).desc())
+    sort_column = SORT_COLUMNS.get(sort_by, Project.updated_at)
+    sortable_expression = (
+        func.pinyin_full(col(Project.title)) if sort_by == "title" else col(sort_column)
+    )
+    order_expression = sortable_expression.asc() if sort_order == "asc" else sortable_expression.desc()
+    stmt = (
+        _apply_search(select(Project), search)
+        .order_by(order_expression, col(Project.id).asc())
         .offset(offset)
         .limit(limit)
     )
+    result = await session.execute(stmt)
     return list(result.scalars().all())
 
 
-async def count(session: AsyncSession) -> int:
+async def count(session: AsyncSession, *, search: str | None = None) -> int:
     """
     获取项目总数。
 
@@ -77,7 +127,9 @@ async def count(session: AsyncSession) -> int:
     Returns:
         项目总数。
     """
-    result = await session.execute(select(func.count(col(Project.id))))
+    result = await session.execute(
+        _apply_search(select(func.count(col(Project.id))), search)
+    )
     return result.scalar_one()
 
 

--- a/backend/app/storage/services/project_service.py
+++ b/backend/app/storage/services/project_service.py
@@ -81,6 +81,9 @@ async def list_projects(
     session: AsyncSession,
     page: int = 1,
     page_size: int = 20,
+    search: str | None = None,
+    sort_by: str = "updated_at",
+    sort_order: str = "desc",
 ) -> ProjectListResult:
     """
     获取项目列表。
@@ -89,13 +92,23 @@ async def list_projects(
         session: 数据库 session。
         page: 页码，从 1 开始。
         page_size: 每页数量。
+        search: 项目标题或简介搜索词。
+        sort_by: 排序字段。
+        sort_order: 排序方向。
 
     Returns:
         项目列表结果。
     """
     offset = (page - 1) * page_size
-    items = await project_repo.list_all(session, offset=offset, limit=page_size)
-    total = await project_repo.count(session)
+    items = await project_repo.list_all(
+        session,
+        offset=offset,
+        limit=page_size,
+        search=search,
+        sort_by=sort_by,
+        sort_order=sort_order,
+    )
+    total = await project_repo.count(session, search=search)
     return ProjectListResult(items=items, total=total, page=page, page_size=page_size)
 
 

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -69,6 +69,7 @@ dependencies = [
     "tzdata>=2025.2",
     "uvicorn[standard]>=0.40.0",
     "fastembed>=0.8.0",
+    "pypinyin>=0.55.0",
 ]
 
 [project.scripts]

--- a/backend/tests/api/test_projects.py
+++ b/backend/tests/api/test_projects.py
@@ -121,6 +121,63 @@ async def test_list_projects_pagination(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_list_projects_search_and_sort(client: AsyncClient) -> None:
+    """测试项目列表的服务端搜索和排序。"""
+    await client.post(
+        "/api/v1/projects",
+        data={"title": "Zeta 项目", "description": "包含目标词"},
+    )
+    await client.post(
+        "/api/v1/projects",
+        data={"title": "Alpha 项目", "description": "普通简介"},
+    )
+    await client.post(
+        "/api/v1/projects",
+        data={"title": "Beta 项目", "description": "另一个目标词"},
+    )
+
+    search_response = await client.get(
+        "/api/v1/projects?search=目标词&page=1&page_size=1",
+    )
+    assert search_response.status_code == 200
+    search_data = search_response.json()
+    assert search_data["total"] == 2
+    assert len(search_data["items"]) == 1
+
+    sort_response = await client.get(
+        "/api/v1/projects?sort_by=title&sort_order=asc&page_size=100",
+    )
+    assert sort_response.status_code == 200
+    assert [item["title"] for item in sort_response.json()["items"]] == [
+        "Alpha 项目",
+        "Beta 项目",
+        "Zeta 项目",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_list_projects_supports_pinyin_search_and_sort(client: AsyncClient) -> None:
+    """拼音搜索和标题排序应保持与旧客户端一致。"""
+    await client.post("/api/v1/projects", data={"title": "中篇项目"})
+    await client.post("/api/v1/projects", data={"title": "红星项目", "description": "银河故事"})
+    await client.post("/api/v1/projects", data={"title": "阿尔法项目"})
+
+    search_response = await client.get("/api/v1/projects?search=hxxm")
+    assert search_response.status_code == 200
+    assert [item["title"] for item in search_response.json()["items"]] == ["红星项目"]
+
+    sort_response = await client.get(
+        "/api/v1/projects?sort_by=title&sort_order=asc&page_size=100",
+    )
+    assert sort_response.status_code == 200
+    assert [item["title"] for item in sort_response.json()["items"]] == [
+        "阿尔法项目",
+        "红星项目",
+        "中篇项目",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_get_project(client: AsyncClient) -> None:
     """测试获取项目详情。"""
     # 创建项目

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1584,7 +1584,7 @@ name = "macholib"
 version = "1.16.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "altgraph" },
+    { name = "altgraph", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
 wheels = [
@@ -1923,6 +1923,7 @@ dependencies = [
     { name = "pillow" },
     { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
+    { name = "pypinyin" },
     { name = "python-multipart" },
     { name = "python-socketio" },
     { name = "pyyaml" },
@@ -1986,6 +1987,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=8.0,<12.0" },
     { name = "pydantic-settings", specifier = ">=2.12.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.10.1" },
+    { name = "pypinyin", specifier = ">=0.55.0" },
     { name = "python-multipart", specifier = ">=0.0.21" },
     { name = "python-socketio", extras = ["asgi"], specifier = ">=5.11.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
@@ -2557,6 +2559,15 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pypinyin"
+version = "0.55.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/a4/784cf98c09e0dc22776b0d7d8a4a5b761218bcae4608c2416ce1e167c8af/pypinyin-0.55.0.tar.gz", hash = "sha256:b5711b3a0c6f76e67408ec6b2e3c4987a3a806b7c528076e7c7b86fcf0eaa66b", size = 839836, upload-time = "2025-07-20T12:01:50.657Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/7b/4cabc76fcc21c3c7d5c671d8783984d30ac9d3bb387c4ba784fca3cdfa3a/pypinyin-0.55.0-py2.py3-none-any.whl", hash = "sha256:d53b1e8ad2cdb815fb2cb604ed3123372f5a28c6f447571244aca36fc62a286f", size = 840203, upload-time = "2025-07-20T12:01:48.535Z" },
 ]
 
 [[package]]

--- a/frontend/src/features/projects/hooks/use-projects.ts
+++ b/frontend/src/features/projects/hooks/use-projects.ts
@@ -4,7 +4,7 @@
  * 使用 TanStack Query 管理项目数据的异步状态。
  */
 
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { keepPreviousData, useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { fetchProjects, createProject, updateProject, deleteProject } from "@/lib/api-client";
 import { removeRecentProjectByProjectId } from "@/lib/local-db";
@@ -21,6 +21,7 @@ export function useProjects(params?: ProjectListParams) {
   return useQuery({
     queryKey: [...projectsQueryKey, params],
     queryFn: () => fetchProjects(params),
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/frontend/src/features/projects/pages/projects-page.tsx
+++ b/frontend/src/features/projects/pages/projects-page.tsx
@@ -4,17 +4,15 @@
  * 项目列表主页面，整合所有项目管理功能。
  */
 
-import { Box, Container, Flex, Text, Grid } from "@radix-ui/themes";
+import { Box, Button, Container, Flex, Text, Grid } from "@radix-ui/themes";
 import { useQueryClient } from "@tanstack/react-query";
-import Fuse from "fuse.js";
-import { BookOpen } from "lucide-react";
+import { BookOpen, ChevronLeft, ChevronRight } from "lucide-react";
 import { motion, AnimatePresence } from "motion/react";
-import { useState, useMemo } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { ConfirmDialog, Spinner, toast } from "@/components";
 import { MobileAppSidebarTrigger } from "@/features/app-shell";
-import { getPinyin, getInitials } from "@/lib/pinyin-search";
 import type { Project } from "@/lib/project.types";
 
 import { ImportDialog } from "../components/import-dialog";
@@ -32,19 +30,36 @@ import {
 import { useProjectsStore } from "../store/use-projects-store";
 
 const MotionBox = motion.create(Box);
+const PROJECTS_PAGE_SIZE = 40;
+
+function getVisiblePages(currentPage: number, totalPages: number): Array<number | "ellipsis"> {
+  if (totalPages <= 6) return Array.from({ length: totalPages }, (_, index) => index + 1);
+  if (currentPage <= 3) return [1, 2, 3, "ellipsis", totalPages - 1, totalPages];
+  if (currentPage >= totalPages - 2)
+    return [1, 2, "ellipsis", totalPages - 2, totalPages - 1, totalPages];
+  return [1, "ellipsis", currentPage - 1, currentPage, currentPage + 1, "ellipsis", totalPages];
+}
 
 export function ProjectsPage() {
   const { t } = useTranslation();
 
-  // 查询项目列表
-  const { data, isLoading, error } = useProjects();
+  // 本地 UI 状态
+  const { viewMode, searchQuery, sortBy, sortOrder } = useProjectsStore();
+  const [currentPage, setCurrentPage] = useState(1);
+  const hasMountedFilters = useRef(false);
+
+  // 服务端分页、搜索和排序
+  const { data, isLoading, isFetching, error } = useProjects({
+    page: currentPage,
+    pageSize: PROJECTS_PAGE_SIZE,
+    search: searchQuery.trim() || undefined,
+    sortBy,
+    sortOrder,
+  });
   const createMutation = useCreateProject();
   const updateMutation = useUpdateProject();
   const deleteMutation = useDeleteProject();
   const queryClient = useQueryClient();
-
-  // 本地 UI 状态
-  const { viewMode, searchQuery, sortBy, sortOrder } = useProjectsStore();
 
   // 对话框状态
   const [formDialogOpen, setFormDialogOpen] = useState(false);
@@ -65,85 +80,21 @@ export function ProjectsPage() {
     setImportDialogOpen(open);
   };
 
-  // 提取 items 引用，避免 React Compiler 依赖推断问题
-  const items = data?.items;
+  const items = data?.items ?? [];
+  const totalPages = Math.max(1, Math.ceil((data?.total ?? 0) / PROJECTS_PAGE_SIZE));
+  const activePage = Math.min(currentPage, totalPages);
 
-  // 为项目生成搜索索引
-  interface SearchableProject {
-    id: string;
-    title: string;
-    titlePinyin: string;
-    titleInitials: string;
-    description: string;
-    descriptionPinyin: string;
-    descriptionInitials: string;
-    original: Project;
-  }
-
-  const searchableProjects = useMemo((): SearchableProject[] => {
-    if (!items) return [];
-    return items.map((p) => ({
-      id: p.id,
-      title: p.title,
-      titlePinyin: getPinyin(p.title),
-      titleInitials: getInitials(p.title),
-      description: p.description ?? "",
-      descriptionPinyin: getPinyin(p.description ?? ""),
-      descriptionInitials: getInitials(p.description ?? ""),
-      original: p,
-    }));
-  }, [items]);
-
-  // 创建 Fuse 实例
-  const fuse = useMemo(() => {
-    return new Fuse(searchableProjects, {
-      keys: [
-        { name: "title", weight: 3 },
-        { name: "titlePinyin", weight: 2 },
-        { name: "titleInitials", weight: 2.5 },
-        { name: "description", weight: 1 },
-        { name: "descriptionPinyin", weight: 0.5 },
-        { name: "descriptionInitials", weight: 0.8 },
-      ],
-      threshold: 0.1,
-      ignoreLocation: true,
-      distance: 50,
-    });
-  }, [searchableProjects]);
-
-  // 过滤和排序项目
-  const filteredProjects = useMemo(() => {
-    if (!items) return [];
-
-    let filtered: Project[];
-
-    // 搜索过滤
-    if (searchQuery.trim()) {
-      const results = fuse.search(searchQuery);
-      filtered = results.map((r) => r.item.original);
-    } else {
-      filtered = [...items];
+  useEffect(() => {
+    if (!hasMountedFilters.current) {
+      hasMountedFilters.current = true;
+      return;
     }
+    setCurrentPage(1);
+  }, [searchQuery, sortBy, sortOrder]);
 
-    // 排序
-    filtered.sort((a, b) => {
-      let comparison = 0;
-      switch (sortBy) {
-        case "updated_at":
-          comparison = new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime();
-          break;
-        case "created_at":
-          comparison = new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
-          break;
-        case "title":
-          comparison = a.title.localeCompare(b.title, "zh-CN");
-          break;
-      }
-      return sortOrder === "asc" ? -comparison : comparison;
-    });
-
-    return filtered;
-  }, [items, searchQuery, sortBy, sortOrder, fuse]);
+  useEffect(() => {
+    setCurrentPage((page) => Math.min(page, totalPages));
+  }, [totalPages]);
 
   // 处理创建/编辑
   const handleOpenCreate = () => {
@@ -250,7 +201,7 @@ export function ProjectsPage() {
         )}
 
         {/* 空状态 */}
-        {!isLoading && !error && filteredProjects.length === 0 && (
+        {!isLoading && !error && items.length === 0 && (
           <MotionBox
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
@@ -293,7 +244,7 @@ export function ProjectsPage() {
         )}
 
         {/* 项目列表 */}
-        {!isLoading && !error && filteredProjects.length > 0 && (
+        {!isLoading && !error && items.length > 0 && (
           <Box mt="5">
             <AnimatePresence mode="wait">
               {viewMode === "grid" ? (
@@ -302,7 +253,7 @@ export function ProjectsPage() {
                   columns={{ initial: "2", sm: "3", md: "4", lg: "5" }}
                   gap="7"
                 >
-                  {filteredProjects.map((project) => (
+                  {items.map((project) => (
                     <ProjectCard
                       key={project.id}
                       project={project}
@@ -317,7 +268,7 @@ export function ProjectsPage() {
                   direction="column"
                   gap="3"
                 >
-                  {filteredProjects.map((project) => (
+                  {items.map((project) => (
                     <ProjectListItem
                       key={project.id}
                       project={project}
@@ -328,6 +279,85 @@ export function ProjectsPage() {
                 </Flex>
               )}
             </AnimatePresence>
+            {totalPages > 1 && (
+              <Flex
+                align="center"
+                justify="center"
+                gap="2"
+                mt="7"
+                pb="2"
+                wrap="wrap"
+                aria-label={t("projects.pageList")}
+              >
+                <Button
+                  type="button"
+                  variant="ghost"
+                  color="gray"
+                  size="2"
+                  style={{ margin: 0 }}
+                  disabled={activePage === 1 || isFetching}
+                  aria-label={t("projects.previousPage")}
+                  onClick={() => setCurrentPage(Math.max(1, activePage - 1))}
+                >
+                  <ChevronLeft
+                    size={16}
+                    aria-hidden="true"
+                  />
+                  {t("projects.previousPage")}
+                </Button>
+                {getVisiblePages(activePage, totalPages).map((page, index) =>
+                  page === "ellipsis" ? (
+                    <Flex
+                      key={`ellipsis-${index}`}
+                      align="center"
+                      justify="center"
+                      style={{ width: 32, height: 32, flexShrink: 0 }}
+                    >
+                      <Text
+                        size="2"
+                        color="gray"
+                        aria-hidden="true"
+                      >
+                        …
+                      </Text>
+                    </Flex>
+                  ) : (
+                    <Box
+                      key={page}
+                      style={{ width: 32, height: 32, flexShrink: 0 }}
+                    >
+                      <Button
+                        type="button"
+                        variant={page === activePage ? "soft" : "ghost"}
+                        size="2"
+                        style={{ width: "100%", height: "100%", margin: 0, padding: 0 }}
+                        disabled={page === activePage || isFetching}
+                        aria-label={t("projects.page", { page })}
+                        onClick={() => setCurrentPage(page)}
+                      >
+                        {page}
+                      </Button>
+                    </Box>
+                  ),
+                )}
+                <Button
+                  type="button"
+                  variant="ghost"
+                  color="gray"
+                  size="2"
+                  style={{ margin: 0 }}
+                  disabled={activePage === totalPages || isFetching}
+                  aria-label={t("projects.nextPage")}
+                  onClick={() => setCurrentPage(Math.min(totalPages, activePage + 1))}
+                >
+                  {t("projects.nextPage")}
+                  <ChevronRight
+                    size={16}
+                    aria-hidden="true"
+                  />
+                </Button>
+              </Flex>
+            )}
           </Box>
         )}
       </Container>

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -78,7 +78,11 @@
     "createFailed": "Creation failed. Please try again.",
     "projectDeleted": "Project deleted",
     "projectUnavailable": "This project has been deleted and cannot be opened.",
-    "deleteFailed": "Delete failed. Please try again."
+    "deleteFailed": "Delete failed. Please try again.",
+    "previousPage": "Previous page",
+    "nextPage": "Next page",
+    "pageList": "Project page list",
+    "page": "Page {{page}}"
   },
   "characters": {
     "title": "Characters",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -78,7 +78,11 @@
     "createFailed": "创建失败，请重试",
     "projectDeleted": "项目已删除",
     "projectUnavailable": "该项目已被删除，无法打开",
-    "deleteFailed": "删除失败，请重试"
+    "deleteFailed": "删除失败，请重试",
+    "previousPage": "上一页",
+    "nextPage": "下一页",
+    "pageList": "项目页码列表",
+    "page": "第 {{page}} 页"
   },
   "characters": {
     "title": "角色",

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -127,6 +127,9 @@ export async function fetchProjects(params?: ProjectListParams): Promise<Project
     params: {
       page: params?.page ?? 1,
       page_size: params?.pageSize ?? 20,
+      search: params?.search?.trim() || undefined,
+      sort_by: params?.sortBy ?? "updated_at",
+      sort_order: params?.sortOrder ?? "desc",
     },
   });
   const data = response.data;

--- a/frontend/src/lib/project.types.ts
+++ b/frontend/src/lib/project.types.ts
@@ -52,4 +52,7 @@ export interface ProjectListResponse {
 export interface ProjectListParams {
   page?: number;
   pageSize?: number;
+  search?: string;
+  sortBy?: "updated_at" | "created_at" | "title";
+  sortOrder?: "asc" | "desc";
 }


### PR DESCRIPTION
## PR 标题

fix(projects): 修复项目列表加载不完全导致分页、搜索和排序失效的问题

## 变更说明

- 问题: 项目列表只加载前 20 个项目；客户端搜索和排序无法覆盖其余项目。
- 重要性: 项目数量超过一页时，早期项目不可见且不可搜索，影响项目管理。
- 变化: 将搜索、排序和分页下沉到项目列表 API；新增拼音全拼/首字母搜索及按标题拼音排序；前端新增页码导航并在筛选条件变更时重置页码。
- 变化: 补充 API 测试，覆盖搜索、排序、分页和拼音查询。

## 关联 Issue / PR (如有)

Closes #276

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [x] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

主列表页仅请求默认的第一页 20 项；Fuse 搜索与排序均仅作用于已加载的这一页数据，导致其余项目不可见、不可搜索。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理（不涉及 schema 变更）
- [x] 提交信息符合规范

## 补充信息

验证命令：`uv run pytest tests/api/test_projects.py`、`pnpm lint`、`pnpm type-check`。