### PR TITLE
perf(backend): 优化检索索引状态与模型提供商列表接口性能

### DIFF
--- a/backend/app/api/routers/model_providers.py
+++ b/backend/app/api/routers/model_providers.py
@@ -59,8 +59,12 @@ async def _build_provider_response(
     service: ModelProviderService,
 ) -> ModelProviderResponse:
     catalog_match = await service.get_catalog_match(provider)
-    supported_task_types = await service.get_supported_task_types(provider)
-    icon_path = await service.get_effective_icon_path(provider)
+    supported_task_types = await service.get_supported_task_types(
+        provider, catalog_match=catalog_match
+    )
+    icon_path = await service.get_effective_icon_path(
+        provider, catalog_match=catalog_match
+    )
 
     return ModelProviderResponse(
         id=provider.id,

--- a/backend/app/api/routers/retrieval_index.py
+++ b/backend/app/api/routers/retrieval_index.py
@@ -21,6 +21,7 @@ from app.retrieval.chapter_index import (
     INDEX_MODE_ALL,
     INDEX_MODE_OFF,
     compute_project_index_status,
+    compute_projects_index_status,
     enqueue_project_index_update,
     get_index_settings,
     is_project_index_enabled,
@@ -127,7 +128,8 @@ async def get_overall_retrieval_index_status(
     session: Annotated[AsyncSession, Depends(get_session)],
 ) -> IndexOverallStatusResponse:
     config = await get_index_settings(session)
-    embedding_configured = await resolve_index_embedding_model(session, config) is not None
+    model = await resolve_index_embedding_model(session, config)
+    embedding_configured = model is not None
 
     projects: list[IndexProjectStatusResponse] = []
     total_chapters = 0
@@ -143,12 +145,12 @@ async def get_overall_retrieval_index_status(
             if config.mode == INDEX_MODE_ALL
             else set(config.enabled_projects)
         )
-        for project in all_projects:
-            if project.id not in enabled_ids:
-                continue
-            status_obj = await compute_project_index_status(
-                session, project_id=project.id, title=project.title
-            )
+        targets = [project for project in all_projects if project.id in enabled_ids]
+        # 批量查询各项目章节/索引/状态并内存聚合，避免按项目串行的 N+1 查询。
+        statuses = await compute_projects_index_status(
+            session, config=config, model=model, projects=targets
+        )
+        for status_obj in statuses:
             projects.append(_status_to_response(status_obj))
             total_chapters += status_obj.total_chapters
             indexed_count += status_obj.indexed_count

--- a/backend/app/models/catalog/service.py
+++ b/backend/app/models/catalog/service.py
@@ -78,6 +78,11 @@ _EMBEDDING_FAMILIES = {
     "bge",
 }
 
+# 进程级 catalog snapshot 缓存：key 为 (快照文件路径, mtime)，避免每次请求重复解析大 JSON。
+_SNAPSHOT_CACHE: dict[
+    tuple[Path, int], tuple[dict[str, Any], str, str | None]
+] = {}
+
 
 class ModelProviderCatalogService:
     """Catalog access with bundled fallback and refreshable local cache."""
@@ -247,9 +252,14 @@ class ModelProviderCatalogService:
         return url.strip().lower().rstrip("/")
 
     def _load_current_snapshot(self) -> tuple[dict[str, Any], str, str | None]:
-        if self.cache_snapshot_path.exists():
+        cache_path = self.cache_snapshot_path
+        if cache_path.exists():
+            cache_mtime = cache_path.stat().st_mtime_ns
+            cached = _SNAPSHOT_CACHE.get((cache_path, cache_mtime))
+            if cached is not None:
+                return cached
             try:
-                snapshot = self._read_json(self.cache_snapshot_path)
+                snapshot = self._read_json(cache_path)
                 if not self._is_current_snapshot(snapshot):
                     raise ValueError("Catalog cache schema is outdated")
                 metadata = (
@@ -257,14 +267,23 @@ class ModelProviderCatalogService:
                     if self.cache_metadata_path.exists()
                     else {}
                 )
-                return snapshot, "cache", metadata.get("last_refreshed_at")
+                result = snapshot, "cache", metadata.get("last_refreshed_at")
+                _SNAPSHOT_CACHE[(cache_path, cache_mtime)] = result
+                return result
             except Exception as exc:
                 logger.warning("Failed to load catalog cache, falling back to bundled: {}", exc)
 
-        snapshot = self._read_json(self.bundled_snapshot_path)
+        bundled_path = self.bundled_snapshot_path
+        bundled_mtime = bundled_path.stat().st_mtime_ns
+        cached = _SNAPSHOT_CACHE.get((bundled_path, bundled_mtime))
+        if cached is not None:
+            return cached
+        snapshot = self._read_json(bundled_path)
         if not self._is_current_snapshot(snapshot):
             raise ValueError("Bundled catalog snapshot schema is outdated")
-        return snapshot, "bundled", None
+        result = snapshot, "bundled", None
+        _SNAPSHOT_CACHE[(bundled_path, bundled_mtime)] = result
+        return result
 
     def _find_provider(
         self, snapshot: dict[str, Any], provider_type: str

--- a/backend/app/models/services/model_provider_service.py
+++ b/backend/app/models/services/model_provider_service.py
@@ -57,17 +57,27 @@ class ModelProviderService:
             provider.provider_type, provider.url
         )
 
-    async def get_supported_task_types(self, provider: ModelProvider) -> list[str]:
+    async def get_supported_task_types(
+        self,
+        provider: ModelProvider,
+        catalog_match: CatalogMatch | None = None,
+    ) -> list[str]:
         if provider.is_builtin:
             return ["embedding", "rerank"]
-        catalog_match = await self.get_catalog_match(provider)
+        if catalog_match is None:
+            catalog_match = await self.get_catalog_match(provider)
         return self.catalog_service.get_supported_task_types(
             provider.provider_type,
             catalog_match,
         )
 
-    async def get_effective_icon_path(self, provider: ModelProvider) -> str | None:
-        catalog_match = await self.get_catalog_match(provider)
+    async def get_effective_icon_path(
+        self,
+        provider: ModelProvider,
+        catalog_match: CatalogMatch | None = None,
+    ) -> str | None:
+        if catalog_match is None:
+            catalog_match = await self.get_catalog_match(provider)
         return catalog_match.icon_path if catalog_match else None
 
     async def get_provider_by_id(

--- a/backend/app/retrieval/chapter_index.py
+++ b/backend/app/retrieval/chapter_index.py
@@ -28,7 +28,9 @@ from app.retrieval.types import (
     RetrievalIndexContract,
 )
 from app.storage.models.chapter import Chapter
+from app.storage.models.project import Project
 from app.storage.models.retrieval_chapter_index_state import RetrievalChapterIndexState
+from app.storage.models.retrieval_index import RetrievalIndex
 from app.storage.repos import (
     chapter_repo,
     project_repo,
@@ -36,6 +38,7 @@ from app.storage.repos import (
     retrieval_index_repo,
     setting_repo,
 )
+from app.storage.repos.chapter_repo import ChapterIndexSource
 
 CHAPTER_INDEX_STATUS_NOT_INDEXED = "not_indexed"
 CHAPTER_INDEX_STATUS_QUEUED = "queued"
@@ -123,7 +126,9 @@ def chapter_document_id(chapter_id: str) -> str:
     return f"chapter:{chapter_id}"
 
 
-def _is_chapter_content_empty(chapter: Chapter) -> bool:
+def _is_chapter_content_empty(
+    chapter: ChapterIndexSource | Chapter,
+) -> bool:
     return not (chapter.content or "").strip()
 
 
@@ -286,7 +291,7 @@ class ProjectIndexStatus:
 
 
 def _effective_chapter_status(
-    chapter: Chapter,
+    chapter: ChapterIndexSource | Chapter,
     state: RetrievalChapterIndexState | None,
 ) -> str:
     """计算单章的有效索引状态（结合内容哈希实时判断是否过期）。"""
@@ -306,24 +311,19 @@ def _effective_chapter_status(
     return CHAPTER_INDEX_STATUS_NOT_INDEXED
 
 
-async def compute_project_index_status(
-    session: AsyncSession,
+def _summarize_project_status(
     *,
     project_id: str,
-    title: str | None = None,
+    title: str,
+    config: IndexSettingsConfig,
+    model: Model | None,
+    chapters: list[ChapterIndexSource],
+    project_index: RetrievalIndex | None,
+    states: dict[str, RetrievalChapterIndexState],
 ) -> ProjectIndexStatus:
-    """计算单个项目的索引状态汇总。
-
-    ``title`` 传入时直接使用；为 ``None`` 时按需查询项目标题。
-    """
-    config = await get_index_settings(session)
+    """将章节/索引/状态等数据聚合为单个项目的索引状态（纯内存计算，不访问 DB）。"""
     enabled = is_project_index_enabled(config, project_id)
-    chapters = await chapter_repo.list_by_project(session, project_id)
     total = len(chapters)
-
-    if title is None:
-        project = await project_repo.get_by_id(session, project_id)
-        title = project.title if project else ""
 
     if not enabled:
         return ProjectIndexStatus(
@@ -334,7 +334,6 @@ async def compute_project_index_status(
             total_chapters=total,
         )
 
-    model = await resolve_index_embedding_model(session, config)
     if model is None:
         return ProjectIndexStatus(
             project_id=project_id,
@@ -353,19 +352,11 @@ async def compute_project_index_status(
             total_chapters=0,
         )
 
-    index_key = chapter_index_key(project_id)
-    project_index = await retrieval_index_repo.get_by_index_key(session, index_key)
     # schema 升级：旧 schema_version 的索引整体需要重建，优先于其它状态判定。
     schema_outdated = (
         project_index is not None
         and project_index.schema_version < CURRENT_CHUNK_SCHEMA_VERSION
     )
-    states = {
-        state.chapter_id: state
-        for state in await retrieval_chapter_index_state_repo.list_by_project(
-            session, project_id=project_id, index_key=index_key
-        )
-    }
 
     indexed = 0
     pending = 0
@@ -426,6 +417,120 @@ async def compute_project_index_status(
         empty_content_count=empty_content,
         last_error=last_error,
     )
+
+
+async def compute_project_index_status(
+    session: AsyncSession,
+    *,
+    project_id: str,
+    title: str | None = None,
+    config: IndexSettingsConfig | None = None,
+    model: Model | None = None,
+) -> ProjectIndexStatus:
+    """计算单个项目的索引状态汇总。
+
+    ``title`` 传入时直接使用；为 ``None`` 时按需查询项目标题。
+    ``config`` / ``model`` 用于在批量计算时复用全局配置与 embedding 模型，缺省时自行读取。
+    """
+    if config is None:
+        config = await get_index_settings(session)
+    if title is None:
+        project = await project_repo.get_by_id(session, project_id)
+        title = project.title if project else ""
+    if model is None:
+        model = await resolve_index_embedding_model(session, config)
+
+    chapters = await chapter_repo.list_index_source_by_project(session, project_id)
+    if not is_project_index_enabled(config, project_id) or model is None or not chapters:
+        return _summarize_project_status(
+            project_id=project_id,
+            title=title,
+            config=config,
+            model=model,
+            chapters=chapters,
+            project_index=None,
+            states={},
+        )
+
+    index_key = chapter_index_key(project_id)
+    project_index = await retrieval_index_repo.get_by_index_key(session, index_key)
+    states = {
+        state.chapter_id: state
+        for state in await retrieval_chapter_index_state_repo.list_by_project(
+            session, project_id=project_id, index_key=index_key
+        )
+    }
+    return _summarize_project_status(
+        project_id=project_id,
+        title=title,
+        config=config,
+        model=model,
+        chapters=chapters,
+        project_index=project_index,
+        states=states,
+    )
+
+
+async def compute_projects_index_status(
+    session: AsyncSession,
+    *,
+    config: IndexSettingsConfig,
+    model: Model | None,
+    projects: list[Project],
+) -> list[ProjectIndexStatus]:
+    """批量计算多个项目的索引状态。
+
+    一次性批量查询所有项目的章节/索引/状态，再在内存中聚合，
+    避免整体状态接口按项目串行执行 N+1 次查询。
+    ``projects`` 中每个元素需提供 ``id`` 与 ``title`` 属性。
+    """
+    if not projects:
+        return []
+
+    if model is None:
+        return [
+            ProjectIndexStatus(
+                project_id=project.id,
+                enabled=True,
+                status=INDEX_STATUS_NOT_CONFIGURED,
+                title=project.title or "",
+                total_chapters=0,
+            )
+            for project in projects
+        ]
+
+    project_ids = [project.id for project in projects]
+    index_keys = {project_id: chapter_index_key(project_id) for project_id in project_ids}
+
+    chapters_by_project: dict[str, list[ChapterIndexSource]] = {}
+    for source in await chapter_repo.list_index_source_by_projects(session, project_ids):
+        chapters_by_project.setdefault(source.project_id, []).append(source)
+
+    indexes_by_key = {
+        index.index_key: index
+        for index in await retrieval_index_repo.get_by_index_keys(
+            session, list(index_keys.values())
+        )
+    }
+
+    states_by_index_key: dict[str, dict[str, RetrievalChapterIndexState]] = {}
+    for state in await retrieval_chapter_index_state_repo.list_by_index_keys(
+        session, list(index_keys.values())
+    ):
+        states_by_index_key.setdefault(state.index_key, {})[state.chapter_id] = state
+
+    return [
+        _summarize_project_status(
+            project_id=project.id,
+            title=project.title or "",
+            config=config,
+            model=model,
+            chapters=chapters_by_project.get(project.id, []),
+            project_index=indexes_by_key.get(index_keys[project.id]),
+            states=states_by_index_key.get(index_keys[project.id], {}),
+        )
+        for project in projects
+    ]
 
 
 @dataclass

--- a/backend/app/skills/loader.py
+++ b/backend/app/skills/loader.py
@@ -119,8 +119,26 @@ def _load_builtin_skill(yaml_path: Path) -> BuiltinSkill | None:
     )
 
 
+def _skills_fingerprint() -> tuple[tuple[str, int, int], ...]:
+    """基于技能文件名、修改时间与大小生成指纹，用于缓存失效判断。"""
+    if not SKILLS_DIR.exists():
+        return ()
+    return tuple(
+        (str(path), path.stat().st_mtime_ns, path.stat().st_size)
+        for path in sorted(SKILLS_DIR.glob("*.yaml"))
+    )
+
+
+_skills_cache: tuple[tuple[tuple[str, int, int], ...], tuple[BuiltinSkill, ...]] | None = None
+
+
 def load_builtin_skills() -> tuple[BuiltinSkill, ...]:
-    """加载全部有效的内置 Skill，单个错误文件不会影响其余 Skill。"""
+    """加载全部有效的内置 Skill，单个错误文件不会影响其余 Skill（带进程级缓存）。"""
+    global _skills_cache
+    fingerprint = _skills_fingerprint()
+    if _skills_cache is not None and _skills_cache[0] == fingerprint:
+        return _skills_cache[1]
+
     if not SKILLS_DIR.exists():
         return ()
 
@@ -135,15 +153,17 @@ def load_builtin_skills() -> tuple[BuiltinSkill, ...]:
             continue
         ids.add(skill.id)
         skills.append(skill)
-    return tuple(skills)
+
+    cached = tuple(skills)
+    _skills_cache = (fingerprint, cached)
+    return cached
 
 
 def load_builtin_skill(skill_id: str) -> BuiltinSkill | None:
-    """按固定 ID 读取单个内置 Skill。"""
+    """按固定 ID 读取单个内置 Skill（复用内置 Skill 缓存）。"""
     if not skill_id.startswith(BUILTIN_SKILL_ID_PREFIX):
         return None
-    filename = skill_id.removeprefix(BUILTIN_SKILL_ID_PREFIX)
-    if not filename or Path(filename).name != filename:
-        return None
-    skill = _load_builtin_skill(SKILLS_DIR / f"{filename}.yaml")
-    return skill if skill is not None and skill.id == skill_id else None
+    for skill in load_builtin_skills():
+        if skill.id == skill_id:
+            return skill
+    return None

--- a/backend/app/storage/repos/chapter_repo.py
+++ b/backend/app/storage/repos/chapter_repo.py
@@ -4,6 +4,7 @@ Chapter Repository - 章节数据访问层。
 """
 
 from datetime import UTC, datetime
+from typing import NamedTuple
 
 from sqlalchemy import case, delete as sql_delete
 from sqlalchemy import func, or_, select, update
@@ -12,6 +13,14 @@ from sqlmodel import col
 
 from app.storage.models.chapter import Chapter
 from app.storage.models.volume import Volume
+
+
+class ChapterIndexSource(NamedTuple):
+    """索引状态计算所需的轻量章节视图，仅含 id 与正文，避免加载整行。"""
+
+    project_id: str
+    id: str
+    content: str
 
 
 async def list_export_metadata_by_project(
@@ -99,6 +108,42 @@ async def list_by_project(
         .order_by(col(Volume.order).asc(), col(Chapter.order).asc())
     )
     return list(result.scalars().all())
+
+
+async def list_index_source_by_project(
+    session: AsyncSession,
+    project_id: str,
+) -> list[ChapterIndexSource]:
+    """仅读取章节 id 与正文，用于索引状态计算，避免加载整行。"""
+    result = await session.execute(
+        select(col(Chapter.id), col(Chapter.content))
+        .join(Volume, col(Chapter.volume_id) == col(Volume.id))
+        .where(col(Chapter.project_id) == project_id)
+        .order_by(col(Volume.order).asc(), col(Chapter.order).asc())
+    )
+    return [
+        ChapterIndexSource(project_id, chapter_id, content)
+        for chapter_id, content in result.all()
+    ]
+
+
+async def list_index_source_by_projects(
+    session: AsyncSession,
+    project_ids: list[str],
+) -> list[ChapterIndexSource]:
+    """批量读取多个项目下章节的 id 与正文，用于整体索引状态计算。"""
+    if not project_ids:
+        return []
+    result = await session.execute(
+        select(col(Chapter.project_id), col(Chapter.id), col(Chapter.content))
+        .join(Volume, col(Chapter.volume_id) == col(Volume.id))
+        .where(col(Chapter.project_id).in_(project_ids))
+        .order_by(col(Volume.order).asc(), col(Chapter.order).asc())
+    )
+    return [
+        ChapterIndexSource(project_id, chapter_id, content)
+        for project_id, chapter_id, content in result.all()
+    ]
 
 
 async def search_with_volume_by_project(

--- a/backend/app/storage/repos/retrieval_chapter_index_state_repo.py
+++ b/backend/app/storage/repos/retrieval_chapter_index_state_repo.py
@@ -42,6 +42,21 @@ async def list_by_project(
     return list(result.scalars().all())
 
 
+async def list_by_index_keys(
+    session: AsyncSession,
+    index_keys: list[str],
+) -> list[RetrievalChapterIndexState]:
+    """按多个 index_key 批量查询章节索引状态。"""
+    if not index_keys:
+        return []
+    result = await session.execute(
+        select(RetrievalChapterIndexState).where(
+            col(RetrievalChapterIndexState.index_key).in_(index_keys)
+        )
+    )
+    return list(result.scalars().all())
+
+
 async def queue_chapters_for_job(
     session: AsyncSession,
     *,

--- a/backend/app/storage/repos/retrieval_index_repo.py
+++ b/backend/app/storage/repos/retrieval_index_repo.py
@@ -63,6 +63,18 @@ async def get_by_index_key(
     return result.scalar_one_or_none()
 
 
+async def get_by_index_keys(
+    session: AsyncSession, index_keys: list[str]
+) -> list[RetrievalIndex]:
+    """按多个 index_key 批量查询索引记录。"""
+    if not index_keys:
+        return []
+    result = await session.execute(
+        select(RetrievalIndex).where(col(RetrievalIndex.index_key).in_(index_keys))
+    )
+    return list(result.scalars().all())
+
+
 async def get_by_embedding_model_ref_id(
     session: AsyncSession, model_id: str
 ) -> list[RetrievalIndex]:

--- a/backend/tests/agent_runtime/tools/test_skill_tools.py
+++ b/backend/tests/agent_runtime/tools/test_skill_tools.py
@@ -251,3 +251,54 @@ async def test_reference_skill_rejects_unknown_reference():
         )
 
     assert "参考文档不存在" in json.loads(result)["error"]
+
+
+def test_load_builtin_skills_caches_until_skill_files_change(tmp_path, monkeypatch):
+    import app.skills.loader as loader
+
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    (skills_dir / "skill-a.yaml").write_text("placeholder", encoding="utf-8")
+    (skills_dir / "skill-b.yaml").write_text("placeholder", encoding="utf-8")
+
+    loaded: list[str] = []
+
+    def fake_load(yaml_path):
+        loaded.append(yaml_path.name)
+        return SimpleNamespace(
+            id=f"builtin-skill--{yaml_path.stem}",
+            name=yaml_path.stem,
+            summary="s",
+            content="c",
+            is_enabled=True,
+            references=(),
+            created_at=None,
+            updated_at=None,
+            source="builtin",
+        )
+
+    monkeypatch.setattr(loader, "SKILLS_DIR", skills_dir)
+    monkeypatch.setattr(loader, "_load_builtin_skill", fake_load)
+    monkeypatch.setattr(loader, "_skills_cache", None)
+
+    first = loader.load_builtin_skills()
+    assert [skill.id for skill in first] == [
+        "builtin-skill--skill-a",
+        "builtin-skill--skill-b",
+    ]
+    assert loaded == ["skill-a.yaml", "skill-b.yaml"]
+
+    # 命中缓存，不再重新读取 YAML
+    second = loader.load_builtin_skills()
+    assert second == first
+    assert loaded == ["skill-a.yaml", "skill-b.yaml"]
+
+    # load_builtin_skill 复用缓存
+    skill = loader.load_builtin_skill("builtin-skill--skill-a")
+    assert skill is not None and skill.name == "skill-a"
+    assert len(loaded) == 2
+
+    # 修改文件内容使指纹变化，缓存失效后重新加载
+    (skills_dir / "skill-b.yaml").write_text("placeholder-longer", encoding="utf-8")
+    loader.load_builtin_skills()
+    assert len(loaded) == 4

--- a/backend/tests/models/test_model_provider_catalog_service.py
+++ b/backend/tests/models/test_model_provider_catalog_service.py
@@ -435,3 +435,32 @@ async def test_catalog_service_matches_openai_compatible_provider_by_exact_api(
         "solar-pro2",
         "solar-mini",
     ]
+
+
+@pytest.mark.asyncio
+async def test_catalog_service_caches_snapshot_until_refresh(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    service = _build_service(tmp_path)
+
+    reads: list[str] = []
+    original_read_json = service._read_json
+
+    def tracking_read_json(path: Path):
+        if path.suffix == ".json":
+            reads.append(f"{path.parent.name}/{path.name}")
+        return original_read_json(path)
+
+    monkeypatch.setattr(service, "_read_json", tracking_read_json)
+
+    await service.list_providers()
+    await service.list_providers()
+    # 命中缓存：第二次 list_providers 不再解析 bundled 快照文件
+    assert reads.count("bundled/snapshot.json") == 1
+
+    # refresh 写入新缓存文件，mtime 变化使缓存失效，之后只解析一次缓存快照
+    reads.clear()
+    await service.refresh()
+    await service.list_providers()
+    await service.list_providers()
+    assert reads.count("cache/snapshot.json") == 1


### PR DESCRIPTION
## 变更说明

- 问题: 整体检索索引状态接口按项目串行查询，项目较多时存在 N+1 查询；模型提供商列表每次请求重复解析 catalog 快照 JSON；内置 Skill 每次加载都重新解析 YAML
- 重要性: 上述接口在数据量上升后响应变慢，影响检索索引页与模型配置页的加载
- 变化:
  - 整体索引状态接口改为批量查询各项目章节、索引与状态记录，再在内存聚合，并只读取章节轻量字段
  - 模型提供商列表接口复用 catalog 匹配结果，catalog 快照增加进程级缓存
  - 内置 Skill 增加进程级缓存，按文件名、修改时间与大小做指纹失效判断

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [x] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

不适用（perf 类型）

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

相关测试：tests/api/test_retrieval_index.py、tests/retrieval/test_chapter_index_service.py、tests/models/test_model_provider_catalog_service.py、tests/agent_runtime/tools/test_skill_tools.py，共 45 项全部通过。