### PR TITLE
fix(desktop): uv 安装 TLS 证书错误时自动重试

### DIFF
--- a/desktop/src/main/runtime/openfic.ts
+++ b/desktop/src/main/runtime/openfic.ts
@@ -27,6 +27,7 @@ const DEFAULT_PYPI_INDEX_URL = "https://pypi.org/simple/";
 const TSINGHUA_PYPI_INDEX_URL = "https://pypi.tuna.tsinghua.edu.cn/simple/";
 const PYPI_INDEX_PROBE_TIMEOUT_MS = 5_000;
 const PYPI_INDEX_PROBE_PACKAGE = "openfic";
+const UV_SYSTEM_CERTS_HINT = "Consider enabling use of system TLS certificates";
 const UTF8_PYTHON_ENVIRONMENT = {
   PYTHONIOENCODING: "utf-8",
   PYTHONUTF8: "1",
@@ -161,7 +162,7 @@ function run(
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     appendLog("runtime", `执行命令：${command} ${args.join(" ")}`);
-    let lastOutputLine = "";
+    const outputLines: string[] = [];
     const child = spawn(command, args, {
       cwd,
       env: { ...process.env, ...UTF8_PYTHON_ENVIRONMENT, ...environment },
@@ -171,7 +172,7 @@ function run(
     const handleOutput = (line: string) => {
       const text = stripAnsi(line).trim();
       if (!text) return;
-      lastOutputLine = text;
+      outputLines.push(text);
       onOutputLine?.(text);
     };
     forwardLines(child.stdout, createLogStream("runtime"), handleOutput);
@@ -186,7 +187,7 @@ function run(
         resolve();
         return;
       }
-      const outputDetail = lastOutputLine ? `：${lastOutputLine}` : "";
+      const outputDetail = outputLines.length ? `：${outputLines.join("\n")}` : "";
       const error = new Error(`${command} ${args.join(" ")} exited with code ${code}${outputDetail}`);
       appendLog("runtime", `命令执行失败：${error.message}`);
       reject(error);
@@ -247,6 +248,31 @@ function succeeds(command: string, args: string[], cwd: string): Promise<boolean
       resolve(code === 0);
     });
   });
+}
+
+async function runUvInstallWithSystemCertsRetry(
+  uvPath: string,
+  args: string[],
+  cwd: string,
+  onProgress: (step: OpenFicRuntimeStep, message: string) => void,
+  environment?: NodeJS.ProcessEnv,
+): Promise<void> {
+  try {
+    await run(uvPath, args, cwd, (line) => onProgress("install-openfic", line), environment);
+  } catch (error) {
+    if (error instanceof Error && error.message.includes(UV_SYSTEM_CERTS_HINT)) {
+      appendLog("runtime", "检测到 TLS 证书错误，使用 --system-certs 重试");
+      await run(
+        uvPath,
+        ["--system-certs", ...args],
+        cwd,
+        (line) => onProgress("install-openfic", line),
+        environment,
+      );
+      return;
+    }
+    throw error;
+  }
 }
 
 export async function inspectOpenFicRuntime(
@@ -342,11 +368,11 @@ export async function ensureOpenFicRuntime(
       expectedVersion,
       installedVersion === expectedVersion && !openFicCliIsUsable,
     );
-    await run(
+    await runUvInstallWithSystemCertsRetry(
       uvPath,
       installCommand.args,
       runtimeDir,
-      (message) => onProgress("install-openfic", message),
+      onProgress,
       packageIndexEnvironment,
     );
   }


### PR DESCRIPTION
## PR 标题

fix(desktop): uv 安装 TLS 证书错误时自动重试

## 变更说明

- 问题: 在部分设备上，setup 步骤运行至安装 OpenFic/uv 时，uv 无法找到系统 TLS 证书，报出 "Consider enabling use of system TLS certificates with the `--system-certs` command-line flag"，导致安装无法完成。
- 重要性: 阻塞了这部分设备上的桌面端首次安装。
- 变化:
  - `run` 命令执行现在累积完整输出，错误信息可携带准确的报错提示。
  - 新增 `runUvInstallWithSystemCertsRetry`：安装 OpenFic 后端时若检测到 TLS 证书提示，自动以 `uv --system-certs ...` 重试一次。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

uv 在部分设备上无法访问系统的 TLS 证书链，导致对其 HTTPS 包索引的请求失败。uv 提供了 `--system-certs` 全局参数以使用系统证书；检测到该错误时自动追加该参数重试即可完成安装。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

验证：`pnpm type-check` 与 `pnpm lint` 均通过。