### PR TITLE
fix(agent): 工具数量超限不再中断会话并返回错误结果

### DIFF
--- a/backend/app/agent_runtime/graph/react_agent.py
+++ b/backend/app/agent_runtime/graph/react_agent.py
@@ -137,7 +137,7 @@ async def _invoke_model(
 # 节点级重试已禁用：超时与重试统一由模型调用层（invoke_model_with_retry）处理，
 # 避免双层重试叠加。保留常量名以便测试禁用兜底重试。
 LLM_RETRY_POLICY = RetryPolicy(max_attempts=1)
-TOOL_BATCH_SIZE = 10
+TOOL_BATCH_SIZE = 20
 
 
 def _get_configurable(config: RunnableConfig | None) -> dict[str, Any]:
@@ -1112,8 +1112,65 @@ def create_react_agent(
     async def dispatch_tools(
         state: ReactState, config: Optional[RunnableConfig] = None
     ) -> dict:
-        del state, config
-        return {}
+        excess_outcomes: list[dict[str, Any]] = []
+        error_message = (
+            f"Agent 单轮最多调用 {TOOL_BATCH_SIZE} 个工具，"
+            "超出上限的工具调用未执行"
+        )
+        for message in reversed(state["messages"]):
+            if isinstance(message, AIMessage) and message.tool_calls:
+                for offset, tool_call in enumerate(
+                    message.tool_calls[TOOL_BATCH_SIZE:]
+                ):
+                    tool_name = str(tool_call.get("name") or "")
+                    tool_id = str(tool_call.get("id") or "")
+                    tool_args = tool_call.get("args")
+                    tool_args = tool_args if isinstance(tool_args, dict) else {}
+                    payload = {"error": error_message}
+                    result = json.dumps(payload, ensure_ascii=False)
+                    excess_outcomes.append(
+                        {
+                            "index": TOOL_BATCH_SIZE + offset,
+                            "tool_call_id": tool_id,
+                            "tool_name": tool_name,
+                            "tool_args": tool_args,
+                            "message": ToolMessage(
+                                content=result,
+                                tool_call_id=tool_id,
+                                name=tool_name,
+                            ),
+                            "payload": payload,
+                            "success": False,
+                            "latency_ms": 0,
+                        }
+                    )
+                break
+        if not excess_outcomes:
+            return {}
+        if state.get("tool_phase") == "execute":
+            tool_result_sink = _get_configurable(config).get("tool_result_sink")
+            if callable(tool_result_sink):
+                for outcome in excess_outcomes:
+                    output_payload = {
+                        "type": "fail",
+                        "success": False,
+                        "reason": "tool_error",
+                        "message": error_message,
+                        "tool_call_id": outcome["tool_call_id"],
+                        "tool_name": outcome["tool_name"],
+                    }
+                    result = tool_result_sink(
+                        {
+                            "session_id": _get_configurable(config).get("session_id"),
+                            "tool_call_id": outcome["tool_call_id"],
+                            "tool_name": outcome["tool_name"],
+                            "input": outcome["tool_args"],
+                            "output": output_payload,
+                        }
+                    )
+                    if inspect.isawaitable(result):
+                        await result
+        return {"tool_outcomes": excess_outcomes}
 
     def route_tool_batch(state: ReactState) -> list[Send]:
         last_message = next(
@@ -1126,12 +1183,6 @@ def create_react_agent(
         )
         if last_message is None:
             return []
-        if len(last_message.tool_calls) > TOOL_BATCH_SIZE:
-            raise RuntimeError(
-                f"Agent 单轮最多调用 {TOOL_BATCH_SIZE} 个工具，实际收到 "
-                f"{len(last_message.tool_calls)} 个"
-            )
-
         dispatch_count = 0
         sends: list[Send] = []
         for slot in range(TOOL_BATCH_SIZE):

--- a/backend/tests/agent_runtime/test_react_agent.py
+++ b/backend/tests/agent_runtime/test_react_agent.py
@@ -1084,8 +1084,9 @@ async def test_react_agent_does_not_execute_tool_after_approval_is_rejected() ->
 
 
 @pytest.mark.asyncio
-async def test_react_agent_rejects_more_than_ten_tool_calls_before_execution() -> None:
+async def test_react_agent_rejects_more_than_twenty_tool_calls_before_execution() -> None:
     executed: list[str] = []
+    tool_results: list[dict] = []
 
     class CountingTool(AgentTool):
         name: str = "counting_tool"
@@ -1106,28 +1107,44 @@ async def test_react_agent_rejects_more_than_ten_tool_calls_before_execution() -
     )
 
     async def invoke_model(*_args, **_kwargs):
-        return AIMessage(
-            content="",
-            tool_calls=[
-                {"id": f"call_{index}", "name": "counting_tool", "args": {"value": str(index)}}
-                for index in range(11)
-            ],
-        )
+        if getattr(invoke_model, "calls", 0) == 0:
+            invoke_model.calls = 1
+            return AIMessage(
+                content="",
+                tool_calls=[
+                    {"id": f"call_{index}", "name": "counting_tool", "args": {"value": str(index)}}
+                    for index in range(21)
+                ],
+            )
+        return AIMessage(content="done")
 
+    config = {"configurable": {"thread_id": "excess-tool-calls"}}
+    config["configurable"]["tool_result_sink"] = tool_results.append
     with patch(
         "app.agent_runtime.graph.react_agent._invoke_model",
         side_effect=invoke_model,
-    ), pytest.raises(RuntimeError, match="最多调用 10 个工具"):
-        await graph.ainvoke(
+    ):
+        result = await graph.ainvoke(
             {
                 "messages": [HumanMessage(content="run")],
                 "iteration_count": 0,
                 "is_done": False,
                 "final_output": None,
-            }
+            },
+            config=config,
         )
 
-    assert executed == []
+    assert executed == [str(index) for index in range(20)]
+    error_message = next(
+        message
+        for message in result["messages"]
+        if isinstance(message, ToolMessage) and "最多调用" in message.content
+    )
+    assert error_message.tool_call_id == "call_20"
+    assert len(tool_results) == 1
+    assert tool_results[0]["tool_call_id"] == "call_20"
+    assert tool_results[0]["output"]["success"] is False
+    assert tool_results[0]["output"]["reason"] == "tool_error"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## PR 标题

fix(agent): 工具数量超限不再中断会话并返回错误结果

## 变更说明

- 问题: 当 Agent 单轮的工具调用数超过并行上限时，`route_tool_batch` 直接抛出 `RuntimeError`，导致会话中止，且前端无法看到超限错误。
- 变化: 将并行工具数量上限从 10 调高到 20；超限的工具调用不再中断会话，而是以 error tool result 返回给 Agent，使其可继续收敛。
- 变化: 超限错误通过 `tool_result_sink` 发出 `agent:tool_result` 事件，前端可将其渲染为错误工具消息。

## 关联 Issue / PR (如有)

Closes #290

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

并行化工具调用改造（#266）将单轮工具执行拆成固定数量（10）的并行分支，因此单轮工具调用数被架构限制在 10。当模型一次性发出超过 10 个工具调用时，`route_tool_batch` 抛 `RuntimeError` 使会话中止。此前串行实现无此上限，故从未有人反馈。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

测试证据：`backend/tests/agent_runtime` 全部 678 个用例通过；`ruff check` 通过。