### PR TITLE
fix(frontend): 收起下拉框时不误关闭设置面板

### DIFF
--- a/frontend/src/features/settings/components/settings-dialog.tsx
+++ b/frontend/src/features/settings/components/settings-dialog.tsx
@@ -1,4 +1,5 @@
 import { Dialog } from "@radix-ui/themes";
+import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
 
 import "./settings-dialog.css";
@@ -23,6 +24,17 @@ export function SettingsDialog({
 }: SettingsDialogProps) {
   const { t } = useTranslation();
   const routeKey = `${open ? "open" : "closed"}:${route?.category ?? "default"}:${route?.modelTab ?? ""}`;
+  const dropdownOpenAtPointerDownRef = useRef(false);
+
+  useEffect(() => {
+    const handlePointerDown = () => {
+      dropdownOpenAtPointerDownRef.current =
+        document.querySelector("[data-radix-select-viewport]") !== null ||
+        document.querySelector("[data-radix-popper-content-wrapper]") !== null;
+    };
+    document.addEventListener("pointerdown", handlePointerDown, true);
+    return () => document.removeEventListener("pointerdown", handlePointerDown, true);
+  }, []);
 
   return (
     <Dialog.Root
@@ -32,6 +44,12 @@ export function SettingsDialog({
       <Dialog.Content
         className="settings-dialog-surface"
         maxWidth="1180px"
+        onInteractOutside={(event) => {
+          if (dropdownOpenAtPointerDownRef.current) {
+            dropdownOpenAtPointerDownRef.current = false;
+            event.preventDefault();
+          }
+        }}
       >
         <Dialog.Title className="settings-dialog-visually-hidden">
           {t("topbar.settings")}


### PR DESCRIPTION
## 变更说明

- 问题: 设置面板内下拉框打开时，点按面板空白处将其收起，偶尔会连带把整个设置面板一并关闭。
- 重要性: 影响设置面板交互稳定性，属于高频误操作。
- 变化: 在按下时记录是否有嵌套下拉框打开，松开触发对话框延迟关闭判定时据此阻止误关闭。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

Radix Dialog 的 DismissableLayer 使用 `deferPointerDownOutside: true`，对话框关闭判定被延迟到松开（click 事件）时执行。而下拉框在按下时被收起并完全卸载，等到松开执行判定时下拉框已从 DOM 消失，导致本次"为了收起下拉框"的点按被误判为"点击对话框外部"，从而连带关闭了面板。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

无