### PR TITLE
test(desktop): 新增基于源码后端的本地开发模式

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -6,8 +6,10 @@
   "main": "dist/main/main.js",
   "packageManager": "pnpm@11.8.0",
   "scripts": {
-    "dev": "pnpm build:setup && pnpm build:main && electron .",
-    "build": "pnpm build:setup && pnpm build:main",
+    "dev": "pnpm build:frontend && pnpm build:setup && pnpm build:main && electron .",
+    "dev:local": "node scripts/dev-local.mjs",
+    "build": "pnpm build:frontend && pnpm build:setup && pnpm build:main",
+    "build:frontend": "pnpm --dir ../frontend build",
     "build:main": "tsc -p tsconfig.main.json",
     "build:setup": "vp build",
     "type-check": "tsc -p tsconfig.main.json --noEmit && tsc -p tsconfig.renderer.json --noEmit",

--- a/desktop/scripts/dev-local.mjs
+++ b/desktop/scripts/dev-local.mjs
@@ -1,0 +1,66 @@
+import { spawn } from "node:child_process";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const desktopDir = path.resolve(fileURLToPath(new URL("..", import.meta.url)));
+const frontendDir = path.resolve(desktopDir, "..", "frontend");
+const IS_WINDOWS = process.platform === "win32";
+
+function runPnpm(args, cwd) {
+  return new Promise((resolve, reject) => {
+    const child = spawn("pnpm", args, { cwd, stdio: "inherit", shell: IS_WINDOWS });
+    child.on("error", reject);
+    child.on("exit", (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+      reject(new Error(`pnpm ${args.join(" ")} exited with code ${code}`));
+    });
+  });
+}
+
+async function main() {
+  console.log("[dev:local] 构建前端 (frontend/dist)...");
+  await runPnpm(["build"], frontendDir);
+  console.log("[dev:local] 构建桌面端 setup UI 与主进程...");
+  await runPnpm(["build:setup"], desktopDir);
+  await runPnpm(["build:main"], desktopDir);
+
+  console.log("[dev:local] 启动 Electron（OPENFIC_DEV_MODE=1）...");
+  const electronEnv = { ...process.env, OPENFIC_DEV_MODE: "1" };
+  delete electronEnv.ELECTRON_RUN_AS_NODE;
+  const electronPath =
+    process.platform === "win32"
+      ? path.join(desktopDir, "node_modules", "electron", "dist", "electron.exe")
+      : process.platform === "darwin"
+        ? path.join(desktopDir, "node_modules", "electron", "dist", "Electron.app", "Contents", "MacOS", "Electron")
+        : path.join(desktopDir, "node_modules", "electron", "dist", "electron");
+  const electron = spawn(electronPath, ["."], {
+    cwd: desktopDir,
+    stdio: "inherit",
+    env: electronEnv,
+  });
+
+  const stopElectron = () => {
+    if (electron.exitCode !== null || electron.signalCode !== null) return;
+    if (IS_WINDOWS) {
+      spawn("taskkill", ["/F", "/T", "/PID", String(electron.pid)], { stdio: "ignore", windowsHide: true });
+      return;
+    }
+    electron.kill("SIGTERM");
+  };
+  process.on("SIGINT", stopElectron);
+  process.on("SIGTERM", stopElectron);
+
+  electron.on("exit", (code) => process.exit(code ?? 0));
+  electron.on("error", (error) => {
+    console.error(`[dev:local] 启动 Electron 失败：${error.message}`);
+    process.exit(1);
+  });
+}
+
+main().catch((error) => {
+  console.error(`[dev:local] ${error instanceof Error ? error.message : String(error)}`);
+  process.exit(1);
+});

--- a/desktop/src/main/config.ts
+++ b/desktop/src/main/config.ts
@@ -2,6 +2,14 @@ import { app } from "electron";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { defaultDesktopConfig, type DesktopConfig, type DesktopInstance } from "../shared/config.js";
+import {
+  DEV_INSTANCE_ID,
+  createDevInstance,
+  isDevInstance,
+  isDevMode,
+  persistDevInstanceDataDir,
+  readDevInstanceDataDir,
+} from "./runtime/dev-backend.js";
 
 function getConfigPath(): string {
   return path.join(app.getPath("userData"), "config.json");
@@ -70,20 +78,45 @@ function migrateLegacyConfig(config: Omit<DesktopInstance, "id" | "name">): Desk
 }
 
 export async function readDesktopConfig(): Promise<DesktopConfig | null> {
+  let config: DesktopConfig | null;
   try {
     const raw = await readFile(getConfigPath(), "utf-8");
     const parsed = JSON.parse(raw) as unknown;
-    if (isDesktopConfig(parsed)) return parsed;
-    if (!isLegacyDesktopConfig(parsed)) return null;
-    const migrated = migrateLegacyConfig(parsed);
-    await writeDesktopConfig(migrated);
-    return migrated;
+    if (isDesktopConfig(parsed)) {
+      config = parsed;
+    } else if (isLegacyDesktopConfig(parsed)) {
+      config = migrateLegacyConfig(parsed);
+      await writeDesktopConfig(config);
+    } else {
+      config = null;
+    }
   } catch {
-    return null;
+    config = null;
   }
+  if (isDevMode()) {
+    const devInstance = await createDevInstance();
+    config = {
+      ...(config ?? createDefaultConfig()),
+      activeInstanceId: DEV_INSTANCE_ID,
+      instances: [...(config?.instances ?? []).filter((instance) => !isDevInstance(instance)), devInstance],
+    };
+  }
+  return config;
 }
 
 export async function writeDesktopConfig(config: DesktopConfig): Promise<void> {
+  if (isDevMode()) {
+    const devInstance = config.instances.find(isDevInstance);
+    if (devInstance?.dataDir) {
+      const currentDataDir = await readDevInstanceDataDir();
+      if (devInstance.dataDir !== currentDataDir) await persistDevInstanceDataDir(devInstance.dataDir);
+    }
+    config = {
+      ...config,
+      activeInstanceId: config.activeInstanceId === DEV_INSTANCE_ID ? null : config.activeInstanceId,
+      instances: config.instances.filter((instance) => !isDevInstance(instance)),
+    };
+  }
   const configPath = getConfigPath();
   await mkdir(path.dirname(configPath), { recursive: true });
   await writeFile(configPath, `${JSON.stringify(config, null, 2)}\n`, "utf-8");

--- a/desktop/src/main/main.ts
+++ b/desktop/src/main/main.ts
@@ -1,5 +1,7 @@
 import { app, dialog, Menu, type BrowserWindow } from "electron";
+import { mkdir } from "node:fs/promises";
 import { registerAppScheme, handleAppProtocol, setRuntimeConfig } from "./protocol.js";
+import { getDevDataDir, isDevMode, DEV_INSTANCE_ID, startDevBackend } from "./runtime/dev-backend.js";
 import { createMainWindow } from "./windows.js";
 import { readDesktopConfig, writeDesktopConfig } from "./config.js";
 import { registerIpc } from "./ipc.js";
@@ -65,7 +67,7 @@ function setBackendBaseUrl(url: string): void {
 }
 
 function onConfigSaved(config: DesktopConfig): void {
-  activeInstanceId = config.activeInstanceId;
+  activeInstanceId = isDevMode() ? DEV_INSTANCE_ID : config.activeInstanceId;
 }
 
 function attachWindowLifecycle(window: BrowserWindow): void {
@@ -238,6 +240,46 @@ async function activateInstance(
 }
 
 async function switchInstance(instanceId: string): Promise<InitializeAppResult> {
+  if (isDevMode()) {
+    if (instanceId !== DEV_INSTANCE_ID) throw new Error("开发模式下仅支持源码后端实例");
+    const controller = beginStartupOperation();
+    const startupProgress = createStartupProgress();
+    startupProgress.begin({
+      step: "load-config",
+      title: "开发模式",
+      message: "正在重启本地开发后端",
+      progress: 0.1,
+    });
+    try {
+      await stopActiveBackend();
+      const devDataDir = getDevDataDir();
+      await mkdir(devDataDir, { recursive: true });
+      setLogsDir(devDataDir);
+      const { handle, baseUrl, maintenanceError } = await startDevBackend(startupProgress, controller.signal);
+      throwIfAborted(controller.signal);
+      setBackendBaseUrl(baseUrl);
+      if (handle) setBackend(handle);
+      activeInstanceId = DEV_INSTANCE_ID;
+      startupProgress.begin({
+        step: "ready",
+        title: "开发模式",
+        message: "OpenFic 开发后端已就绪",
+        progress: 1,
+      });
+      startupProgress.complete();
+      return {
+        status: "ready",
+        activeInstanceId: DEV_INSTANCE_ID,
+        maintenanceWarning: maintenanceError ?? undefined,
+      };
+    } catch (error) {
+      if (controller.signal.aborted) startupProgress.complete("已取消连接");
+      else startupProgress.fail(error);
+      throw error;
+    } finally {
+      finishStartupOperation(controller);
+    }
+  }
   const controller = beginStartupOperation();
   const startupProgress = createStartupProgress();
   startupProgress.begin({
@@ -300,7 +342,55 @@ function installMenu(): void {
   Menu.setApplicationMenu(null);
 }
 
+async function initializeDevApp(): Promise<InitializeAppResult> {
+  const controller = beginStartupOperation();
+  const startupProgress = createStartupProgress();
+  startupProgress.begin({
+    step: "load-config",
+    title: "开发模式",
+    message: "正在启动本地开发后端",
+    progress: 0.1,
+  });
+  try {
+    const devDataDir = getDevDataDir();
+    await mkdir(devDataDir, { recursive: true });
+    setLogsDir(devDataDir);
+    activeInstanceId = DEV_INSTANCE_ID;
+    const { handle, baseUrl, maintenanceError } = await startDevBackend(startupProgress, controller.signal);
+    throwIfAborted(controller.signal);
+    setBackendBaseUrl(baseUrl);
+    if (handle) setBackend(handle);
+    startupProgress.begin({
+      step: "ready",
+      title: "开发模式",
+      message: "OpenFic 开发后端已就绪",
+      progress: 1,
+    });
+    startupProgress.complete();
+    return {
+      status: "ready",
+      activeInstanceId: DEV_INSTANCE_ID,
+      maintenanceWarning: maintenanceError ?? undefined,
+    };
+  } catch (err) {
+    if (controller.signal.aborted) {
+      startupProgress.complete("已取消连接");
+      return { status: "needs-setup" };
+    }
+    writeStartupLog(`dev backend failed: ${err instanceof Error ? err.message : String(err)}`);
+    startupProgress.fail(err);
+    return {
+      status: "needs-setup",
+      activeInstanceId: null,
+      message: err instanceof Error ? err.message : String(err),
+    };
+  } finally {
+    finishStartupOperation(controller);
+  }
+}
+
 async function initializeApp(): Promise<InitializeAppResult> {
+  if (isDevMode()) return initializeDevApp();
   const controller = beginStartupOperation();
   const startupProgress = createStartupProgress();
   startupProgress.begin({
@@ -381,7 +471,7 @@ async function bootstrap(): Promise<void> {
 
   writeStartupLog("opening shell window");
   openMainWindow();
-  if (mainWindow) await initializeUpdater(mainWindow);
+  if (!isDevMode() && mainWindow) await initializeUpdater(mainWindow);
 }
 
 // Keep Chromium session data in Electron's default AppData location. Webviews

--- a/desktop/src/main/runtime/dev-backend.ts
+++ b/desktop/src/main/runtime/dev-backend.ts
@@ -1,0 +1,146 @@
+import { app } from "electron";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { DesktopInstance } from "../../shared/config.js";
+import { findFreePort } from "../ports.js";
+import { startBackendProcess, type BackendProcessHandle } from "../process.js";
+import { throwIfAborted, waitForBackend } from "../health.js";
+import type { StartupProgressTracker } from "../startup-progress.js";
+import { appendLog } from "../logging.js";
+
+const DEV_BACKEND_CONNECT_TIMEOUT_MS = 10_000;
+const DEV_BACKEND_SPAWN_TIMEOUT_MS = 120_000;
+
+export const DEV_INSTANCE_ID = "instance-dev-local";
+
+export function isDevMode(): boolean {
+  return !app.isPackaged && process.env.OPENFIC_DEV_MODE === "1";
+}
+
+export function getDevBackendUrl(): string | null {
+  const url = process.env.OPENFIC_DEV_BACKEND_URL;
+  return url ? url.replace(/\/+$/, "") : null;
+}
+
+export function getDevDataDir(): string {
+  const override = process.env.OPENFIC_DEV_DATA_DIR;
+  if (override) return path.resolve(override);
+  return path.join(app.getAppPath(), "..", "tmp", "dev-data");
+}
+
+function getDevStatePath(): string {
+  return path.join(app.getAppPath(), "..", "tmp", "dev-instance.json");
+}
+
+export async function readDevInstanceDataDir(): Promise<string> {
+  const override = process.env.OPENFIC_DEV_DATA_DIR;
+  if (override) return path.resolve(override);
+  try {
+    const raw = await readFile(getDevStatePath(), "utf-8");
+    const parsed = JSON.parse(raw) as { dataDir?: unknown };
+    if (typeof parsed.dataDir === "string" && parsed.dataDir) return parsed.dataDir;
+  } catch {
+    // 状态文件不存在或损坏时回退到默认目录
+  }
+  return getDevDataDir();
+}
+
+export function isDevInstance(instance: DesktopInstance): boolean {
+  return instance.id === DEV_INSTANCE_ID;
+}
+
+export async function createDevInstance(): Promise<DesktopInstance> {
+  return {
+    id: DEV_INSTANCE_ID,
+    name: "Dev",
+    mode: "local",
+    remoteUrl: null,
+    autoStartLocal: true,
+    installDir: path.join(app.getAppPath(), "..", "backend"),
+    dataDir: await readDevInstanceDataDir(),
+  };
+}
+
+export async function persistDevInstanceDataDir(dataDir: string): Promise<void> {
+  await mkdir(path.dirname(getDevStatePath()), { recursive: true });
+  await writeFile(getDevStatePath(), `${JSON.stringify({ dataDir }, null, 2)}\n`, "utf-8");
+}
+
+export interface DevBackendResult {
+  handle: BackendProcessHandle | null;
+  baseUrl: string;
+  maintenanceError: string | null;
+}
+
+async function fetchBackendMaintenanceError(baseUrl: string): Promise<string | null> {
+  try {
+    const response = await fetch(`${baseUrl}/api/v1/health/maintenance`);
+    if (!response.ok) return null;
+    const data = (await response.json()) as { status?: string; error?: string | null };
+    if (data.status !== "failed") return null;
+    return data.error || "本地数据库维护失败";
+  } catch {
+    return null;
+  }
+}
+
+export async function startDevBackend(
+  startupProgress: StartupProgressTracker,
+  signal: AbortSignal,
+): Promise<DevBackendResult> {
+  throwIfAborted(signal);
+  const externalUrl = getDevBackendUrl();
+  if (externalUrl) {
+    startupProgress.begin({
+      step: "connect-remote",
+      title: "连接开发后端",
+      message: `正在连接 ${externalUrl}`,
+      progress: 0.3,
+    });
+    await waitForBackend(externalUrl, { timeoutMs: DEV_BACKEND_CONNECT_TIMEOUT_MS, signal });
+    throwIfAborted(signal);
+    appendLog("backend", `开发模式已连接外部后端：${externalUrl}`);
+    const maintenanceError = await fetchBackendMaintenanceError(externalUrl);
+    return { handle: null, baseUrl: externalUrl, maintenanceError };
+  }
+
+  const devDataDir = getDevDataDir();
+  await mkdir(devDataDir, { recursive: true });
+  throwIfAborted(signal);
+  startupProgress.begin({
+    step: "start-backend",
+    title: "启动开发后端",
+    message: "正在从 backend 源码启动本地服务",
+    progress: 0.3,
+  });
+  const port = await findFreePort();
+  throwIfAborted(signal);
+  const backendDir = path.join(app.getAppPath(), "..", "backend");
+  const args = [
+    "run",
+    "--directory",
+    backendDir,
+    "uvicorn",
+    "app.main:app",
+    "--host",
+    "127.0.0.1",
+    "--port",
+    String(port),
+  ];
+  if (process.platform === "win32") args.push("--loop", "app.cli:_windows_selector_loop_factory");
+
+  const handle = startBackendProcess({ command: "uv", args, port, dataDir: devDataDir });
+  try {
+    await waitForBackend(handle.baseUrl, {
+      process: handle.process,
+      signal,
+      timeoutMs: DEV_BACKEND_SPAWN_TIMEOUT_MS,
+    });
+    throwIfAborted(signal);
+    const maintenanceError = await fetchBackendMaintenanceError(handle.baseUrl);
+    return { handle, baseUrl: handle.baseUrl, maintenanceError };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`${message}。日志路径：${handle.logPath}`);
+  }
+}


### PR DESCRIPTION
## 变更说明

- 问题: 桌面端开发测试不便——`pnpm dev` 加载过期前端产物（不触发前端构建），且没有连接本地 `backend/` 源码后端进行测试的路径
- 重要性: 每次改动前端/后端代码后需手动构建或依赖 PyPI 运行时，开发迭代效率低
- 变化:
  - `dev`/`build` 脚本链入前端构建（`build:frontend`），保证桌面端始终加载最新前端产物
  - 新增 `dev:local` 脚本：构建最新前端后以 `OPENFIC_DEV_MODE` 开发模式启动 Electron
  - 开发模式跳过实例配置与 PyPI 运行时管理，直接从 `backend/` 源码 spawn `uv run uvicorn`（Windows 自动附加事件循环参数）
  - 支持环境变量覆盖：`OPENFIC_DEV_BACKEND_URL` 连接已有后端、`OPENFIC_DEV_DATA_DIR` 指定数据目录
  - 开发会话合成本地实例且不写入正式 `config.json`，数据管理（备份/恢复/迁移）完整可用，迁移后的数据目录跨会话保留
  - 启动时检查后端维护状态（`/api/v1/health/maintenance`），在引导页呈现磁盘空间不足等维护失败提示
  - `dev:local` 直接启动 `electron.exe` 以精准管理进程树，避免残留实例占用单实例锁

## 关联 Issue / PR (如有)

无

## 变更类型

- [x] 测试相关 (test)

## 问题原因(如有)

- 不适用（test 类型）

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错（`pnpm lint`、`pnpm type-check`）
- [x] 已运行测试用例，全部通过（`node --test tests/main/data-manager.test.mjs` 8/8 通过；`archive.test.mjs` 3 个失败为 Windows 环境性（系统 tar/符号链接），与本次改动无关，改动未涉及 tar 相关模块）
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖（无新增依赖）
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理（无数据库变更）
- [x] 提交信息符合规范

## 补充信息

- 实测验证：`pnpm dev:local` 从源码启动后端并连接成功；VHDX 虚拟盘磁盘满场景下 VACUUM 中途失败 → 引导页呈现"磁盘空间不足"警告 → 确认后正常进入应用，checkpoints.db 数据完好
- 非调试路径不受影响：所有开发模式分支均由 `isDevMode()`（`!app.isPackaged && OPENFIC_DEV_MODE === "1"`）守卫，打包版与未设置环境变量的开发启动行为不变
