### PR TITLE
fix(agent): 修复会话生命周期竞态导致取消和恢复异常的问题

### DIFF
--- a/backend/app/agent_runtime/revisions.py
+++ b/backend/app/agent_runtime/revisions.py
@@ -312,10 +312,12 @@ async def finalize_revision_status(
     session: AsyncSession,
     revision_id: str | None,
     status: str,
-) -> None:
+) -> bool:
     if not revision_id:
-        return
-    await revision_repo.update_status(session, revision_id, status)
+        return True
+    if status == "cancelled":
+        return await revision_repo.cancel_active_or_interrupted_revision(session, revision_id)
+    return await revision_repo.update_status_unless_cancelled(session, revision_id, status)
 
 
 async def record_chapter_diffs(

--- a/backend/app/agent_runtime/runner/run_registry.py
+++ b/backend/app/agent_runtime/runner/run_registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import weakref
 
 from loguru import logger
 
@@ -11,11 +12,29 @@ class AgentRunRegistry:
     def __init__(self) -> None:
         self._tasks: dict[str, dict[str, asyncio.Task[None]]] = {}
         self._cancelled_sessions: set[str] = set()
+        # Lifecycle locks are only needed while a caller holds a reference to
+        # them. A weak table prevents every historical session id from being
+        # retained for the lifetime of the worker.
+        self._session_locks: weakref.WeakValueDictionary[str, asyncio.Lock] = (
+            weakref.WeakValueDictionary()
+        )
         self._lock = asyncio.Lock()
 
-    async def register(self, session_id: str, task: asyncio.Task[None]) -> None:
+    def session_lock(self, session_id: str) -> asyncio.Lock:
+        """Serialize lifecycle transitions for one parent agent session."""
+
+        return self._session_locks.setdefault(session_id, asyncio.Lock())
+
+    async def register(
+        self,
+        session_id: str,
+        task: asyncio.Task[None],
+        *,
+        clear_cancelled: bool = True,
+    ) -> None:
         async with self._lock:
-            self._cancelled_sessions.discard(session_id)
+            if clear_cancelled:
+                self._cancelled_sessions.discard(session_id)
             session_tasks = self._tasks.setdefault(session_id, {})
             existing = session_tasks.get("__parent__")
             if existing is not None and not existing.done() and existing is not task:
@@ -42,9 +61,12 @@ class AgentRunRegistry:
         session_id: str,
         child_run_id: str,
         task: asyncio.Task[None],
+        *,
+        clear_cancelled: bool = True,
     ) -> None:
         async with self._lock:
-            self._cancelled_sessions.discard(session_id)
+            if clear_cancelled:
+                self._cancelled_sessions.discard(session_id)
             session_tasks = self._tasks.setdefault(session_id, {})
             existing = session_tasks.get(child_run_id)
             if existing is not None and not existing.done() and existing is not task:
@@ -60,13 +82,16 @@ class AgentRunRegistry:
         session_id: str,
         child_run_id: str,
         task: asyncio.Task[None],
+        *,
+        clear_cancelled: bool = True,
     ) -> bool:
         async with self._lock:
             session_tasks = self._tasks.setdefault(session_id, {})
             existing = session_tasks.get(child_run_id)
             if existing is not None and not existing.done() and existing is not task:
                 return False
-            self._cancelled_sessions.discard(session_id)
+            if clear_cancelled:
+                self._cancelled_sessions.discard(session_id)
             session_tasks[child_run_id] = task
             return True
 
@@ -83,10 +108,17 @@ class AgentRunRegistry:
                     return True
             return False
 
-    async def unregister_child(self, session_id: str, child_run_id: str) -> bool:
+    async def unregister_child(
+        self,
+        session_id: str,
+        child_run_id: str,
+        task: asyncio.Task[None] | None = None,
+    ) -> bool:
         async with self._lock:
             session_tasks = self._tasks.get(session_id)
             if not session_tasks or child_run_id not in session_tasks:
+                return False
+            if task is not None and session_tasks[child_run_id] is not task:
                 return False
             session_tasks.pop(child_run_id, None)
             if not session_tasks:
@@ -117,9 +149,27 @@ class AgentRunRegistry:
                 task.cancel()
             return True
 
-    async def mark_cancelled(self, session_id: str) -> None:
+    async def mark_cancelled(self, session_id: str) -> asyncio.Task[None] | None:
         async with self._lock:
             self._cancelled_sessions.add(session_id)
+            task = (self._tasks.get(session_id) or {}).get("__parent__")
+            if task is not None and not task.done():
+                return task
+            return None
+
+    async def cancel_task(self, session_id: str, task: asyncio.Task[None]) -> bool:
+        """Cancel only a task that is still the registered task for a session.
+
+        The identity check is important for cancellation requests that race a
+        newly registered run: a stale cancellation must not affect that run.
+        """
+
+        async with self._lock:
+            session_tasks = self._tasks.get(session_id) or {}
+            if task not in session_tasks.values() or task.done():
+                return False
+            task.cancel()
+            return True
 
     async def is_cancelled(self, session_id: str) -> bool:
         async with self._lock:

--- a/backend/app/agent_runtime/runner/session_runner.py
+++ b/backend/app/agent_runtime/runner/session_runner.py
@@ -34,12 +34,14 @@ from app.agent_runtime.persistence.model import AgentRunMessage
 from app.agent_runtime.revisions import begin_user_revision, finalize_revision_status
 from app.agent_runtime.runner.checkpointer import get_checkpointer, prune_thread_checkpoints
 from app.agent_runtime.runner.event_translator import EventTranslator
+from app.agent_runtime.runner.run_registry import get_agent_run_registry
 from app.agent_runtime.streaming.replay_buffer import get_agent_event_replay_buffer
 from app.agent_runtime.types import DEFAULT_AGENT_RECURSION_LIMIT
 from app.core.ids import generate_id
 from app.socket import emit
 from app.socket.handlers import agent_session_room
 from app.storage.database import _get_session_factory, create_session
+from app.storage.repos import revision_repo
 from app.storage.services import task_service
 
 _HELD_EVENT_SESSION_IDS: ContextVar[frozenset[str]] = ContextVar(
@@ -912,19 +914,29 @@ class SessionRunner:
         if state.next:
             status_session = await create_session()
             try:
-                await finalize_revision_status(status_session, revision.id, "interrupted")
+                finalized = await finalize_revision_status(
+                    status_session, revision.id, "interrupted"
+                )
                 await status_session.commit()
             finally:
                 await status_session.close()
+            if not finalized:
+                await self._clear_replay_session()
+                return
             await self._emit_pending_interrupts(state)
             await self._clear_replay_session()
         else:
             status_session = await create_session()
             try:
-                await finalize_revision_status(status_session, revision.id, "completed")
+                finalized = await finalize_revision_status(
+                    status_session, revision.id, "completed"
+                )
                 await status_session.commit()
             finally:
                 await status_session.close()
+            if not finalized:
+                await self._clear_replay_session()
+                return
             await emit(
                 "agent:done",
                 {
@@ -1125,6 +1137,17 @@ class SessionRunner:
             audit_context=audit_context,
         )
         self._cancel_event.clear()
+        # The cancel endpoint commits this status before it signals in-memory
+        # runners. Together with the registry guard, this stops a queued resume
+        # task from clearing the cancellation signal and reviving the checkpoint.
+        if await get_agent_run_registry().is_cancelled(self.session_id):
+            await runtime_session.close()
+            return
+        if revision_id:
+            revision = await revision_repo.get_by_id(runtime_session, revision_id)
+            if revision is not None and revision.status == "cancelled":
+                await runtime_session.close()
+                return
 
         reason: Literal["done", "cancelled", "error"] = "done"
         try:
@@ -1253,19 +1276,29 @@ class SessionRunner:
         if state.next:
             status_session = await create_session()
             try:
-                await finalize_revision_status(status_session, revision_id, "interrupted")
+                finalized = await finalize_revision_status(
+                    status_session, revision_id, "interrupted"
+                )
                 await status_session.commit()
             finally:
                 await status_session.close()
+            if not finalized:
+                await self._clear_replay_session()
+                return
             await self._emit_pending_interrupts(state)
             await self._clear_replay_session()
         else:
             status_session = await create_session()
             try:
-                await finalize_revision_status(status_session, revision_id, "completed")
+                finalized = await finalize_revision_status(
+                    status_session, revision_id, "completed"
+                )
                 await status_session.commit()
             finally:
                 await status_session.close()
+            if not finalized:
+                await self._clear_replay_session()
+                return
             await emit(
                 "agent:done",
                 {

--- a/backend/app/agent_runtime/runner/subagent_runner.py
+++ b/backend/app/agent_runtime/runner/subagent_runner.py
@@ -1093,6 +1093,7 @@ class SubagentRunner:
                 parent_session_id=parent_session_id,
                 child_run_id=child_run_id,
                 runner=self,
+                clear_cancelled=False,
             )
             return
 

--- a/backend/app/agent_runtime/tools/impls/orchestration/common.py
+++ b/backend/app/agent_runtime/tools/impls/orchestration/common.py
@@ -254,17 +254,26 @@ async def ensure_child_processing(
     child_run_id: str,
     runner: Any,
     resume_payload: dict[str, Any] | None = None,
+    clear_cancelled: bool = True,
 ) -> bool:
     registry = get_agent_run_registry()
     if await registry.is_child_running(parent_session_id, child_run_id):
+        return False
+    if not clear_cancelled and await registry.is_cancelled(parent_session_id):
         return False
     await _clear_child_processing_failure(
         parent_session_id=parent_session_id,
         child_run_id=child_run_id,
     )
 
+    start_gate = asyncio.Event()
+    started = False
+
     async def _run() -> None:
+        nonlocal started
         try:
+            await start_gate.wait()
+            started = True
             if resume_payload is None:
                 await runner.run(child_run_id)
             else:
@@ -290,9 +299,15 @@ async def ensure_child_processing(
                 child_run_id=child_run_id,
             ).opt(exception=True).error("Child processing crashed")
         finally:
-            await registry.unregister_child(parent_session_id, child_run_id)
+            current_task = asyncio.current_task()
+            if current_task is not None:
+                await registry.unregister_child(
+                    parent_session_id,
+                    child_run_id,
+                    current_task,
+                )
             on_finished = getattr(runner, "on_child_processing_finished", None)
-            if callable(on_finished):
+            if started and callable(on_finished):
                 await maybe_await(
                     on_finished(
                         parent_session_id=parent_session_id,
@@ -302,9 +317,18 @@ async def ensure_child_processing(
 
     task = asyncio.create_task(_run())
     registered = await registry.try_register_child(
-        parent_session_id, child_run_id, task
+        parent_session_id,
+        child_run_id,
+        task,
+        clear_cancelled=clear_cancelled,
     )
     if registered:
+        if not clear_cancelled and await registry.is_cancelled(parent_session_id):
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+            await registry.unregister_child(parent_session_id, child_run_id)
+            return False
+        start_gate.set()
         return True
     task.cancel()
     await asyncio.gather(task, return_exceptions=True)

--- a/backend/app/agent_runtime/tools/impls/orchestration/dispatch_subagent.py
+++ b/backend/app/agent_runtime/tools/impls/orchestration/dispatch_subagent.py
@@ -230,6 +230,7 @@ class DispatchSubagentTool(AgentTool):
                 parent_session_id=self.session_id,
                 child_run_id=child_run_id,
                 runner=runner,
+                clear_cancelled=False,
             )
         while True:
             resolution = await wait_for_request_resolution(

--- a/backend/app/agent_runtime/tools/impls/orchestration/notify_subagent.py
+++ b/backend/app/agent_runtime/tools/impls/orchestration/notify_subagent.py
@@ -69,6 +69,7 @@ class NotifySubagentTool(AgentTool):
                 parent_session_id=self.session_id,
                 child_run_id=child_run_id,
                 runner=runner,
+                clear_cancelled=False,
             )
         while True:
             resolution = await wait_for_request_resolution(

--- a/backend/app/api/routers/agent_runtime.py
+++ b/backend/app/api/routers/agent_runtime.py
@@ -7,6 +7,7 @@ import asyncio
 import re
 import time
 from collections.abc import Callable
+from contextlib import asynccontextmanager, suppress
 from datetime import UTC, datetime
 from typing import TypeGuard, cast
 
@@ -322,6 +323,100 @@ async def _get_runner(
     return runner
 
 
+async def _is_agent_session_cancelled(
+    session: AsyncSession,
+    session_id: str,
+) -> bool:
+    """Whether the current revision was terminally cancelled.
+
+    LangGraph keeps an interrupt checkpoint after a cancellation so that a
+    normal paused session can be restored.  A cancelled revision, however,
+    must never be resumed from that checkpoint.
+    """
+
+    try:
+        task = await task_service.get_task_by_agent_session_id(session, session_id)
+    except NotFoundError:
+        return False
+    if not task.current_revision_id:
+        return False
+    revision = await revision_repo.get_by_id(session, task.current_revision_id)
+    return revision is not None and revision.status == "cancelled"
+
+
+async def _ensure_agent_session_resumable(
+    session: AsyncSession,
+    session_id: str,
+) -> None:
+    if await _is_agent_session_cancelled(session, session_id):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "session_cancelled",
+                "message": "会话已取消，无法恢复待处理的审批或问答",
+            },
+        )
+
+
+async def _claim_agent_session_resume(
+    session: AsyncSession,
+    session_id: str,
+    *,
+    allow_active: bool = False,
+) -> tuple[str | None, bool]:
+    """Reserve the interrupted revision and report whether this request claimed it.
+
+    This conditional transition serializes a competing cancel or duplicate
+    resume across application workers before a runner task is launched.
+    """
+
+    task = await task_service.get_task_by_agent_session_id(session, session_id)
+    revision_id = task.current_revision_id
+    if not revision_id:
+        return None, False
+    if await revision_repo.claim_interrupted_revision(session, revision_id):
+        await session.commit()
+        return revision_id, True
+
+    revision = await revision_repo.get_by_id(session, revision_id)
+    if revision is not None and revision.status == "cancelled":
+        await _ensure_agent_session_resumable(session, session_id)
+    if allow_active and revision is not None and revision.status == "active":
+        return revision_id, False
+    raise HTTPException(
+        status_code=status.HTTP_409_CONFLICT,
+        detail={
+            "code": "session_not_resumable",
+            "message": "会话当前不在可恢复的中断状态",
+        },
+    )
+
+
+@asynccontextmanager
+async def _agent_session_lifecycle_lock(registry, session_id: str):
+    """Serialize cancellation with starting or queuing a parent run."""
+
+    lock_factory = getattr(registry, "session_lock", None)
+    if callable(lock_factory):
+        async with lock_factory(session_id):
+            yield
+    else:
+        # Keep lightweight router tests with fake registries backwards-compatible.
+        yield
+
+
+async def _release_agent_session_resume_claim(
+    session: AsyncSession,
+    revision_id: str | None,
+) -> None:
+    """Make a claimed checkpoint resumable again when its launch fails."""
+
+    if not revision_id:
+        return
+    if await revision_repo.release_active_revision_claim(session, revision_id):
+        await session.commit()
+
+
 async def _build_model_config(
     model, provider, api_key: str, reasoning_effort: str | None = None
 ) -> dict:
@@ -480,46 +575,74 @@ async def _launch_task(
     task_id: str,
     project_id: str,
     coro,
+    clear_cancelled: bool = True,
+    lifecycle_lock_held: bool = False,
 ) -> None:
-    await _set_task_running_state(
-        db_session_factory=db_session_factory,
-        task_id=task_id,
-        session_id=session_id,
-        project_id=project_id,
-        is_running=True,
-    )
     registry = get_agent_run_registry()
 
+    start_gate = asyncio.Event()
+
     async def _run_and_cleanup() -> None:
+        started = False
         try:
+            await start_gate.wait()
+            started = True
             await coro
         except asyncio.CancelledError:
             logger.bind(session_id=session_id).info("Agent task cancelled")
         except Exception:
             logger.bind(session_id=session_id).opt(exception=True).error("Agent task failed")
         finally:
-            current_task = asyncio.current_task()
-            removed = False
-            if current_task is not None:
-                removed = await registry.unregister(session_id, current_task)
-            if removed:
-                try:
-                    if not await registry.is_running(session_id):
-                        await _set_task_running_state(
-                            db_session_factory=db_session_factory,
-                            task_id=task_id,
-                            session_id=session_id,
-                            project_id=project_id,
-                            is_running=False,
+            if not started:
+                close = getattr(coro, "close", None)
+                if callable(close):
+                    with suppress(Exception):
+                        close()
+            async with _agent_session_lifecycle_lock(registry, session_id):
+                current_task = asyncio.current_task()
+                removed = False
+                if current_task is not None:
+                    removed = await registry.unregister(session_id, current_task)
+                if removed:
+                    try:
+                        if not await registry.is_running(session_id):
+                            await _set_task_running_state(
+                                db_session_factory=db_session_factory,
+                                task_id=task_id,
+                                session_id=session_id,
+                                project_id=project_id,
+                                is_running=False,
+                            )
+                    except Exception:
+                        logger.bind(session_id=session_id).opt(exception=True).error(
+                            "Agent task running-state cleanup failed"
                         )
-                except Exception:
-                    logger.bind(session_id=session_id).opt(exception=True).error(
-                        "Agent task running-state cleanup failed"
-                    )
 
     task = asyncio.create_task(_run_and_cleanup())
+
+    async def _register_and_start() -> None:
+        if clear_cancelled:
+            await registry.register(session_id, task)
+        else:
+            await registry.register(session_id, task, clear_cancelled=False)
+        # Register before the task can enter SessionRunner.resume. A concurrent
+        # cancellation then either remains visible to the runner or cancels the
+        # registered task, instead of being erased by a late registration.
+        await _set_task_running_state(
+            db_session_factory=db_session_factory,
+            task_id=task_id,
+            session_id=session_id,
+            project_id=project_id,
+            is_running=True,
+        )
+        start_gate.set()
+
     try:
-        await registry.register(session_id, task)
+        if lifecycle_lock_held:
+            await _register_and_start()
+        else:
+            async with _agent_session_lifecycle_lock(registry, session_id):
+                await _register_and_start()
     except Exception:
         task.cancel()
         await _set_task_running_state(
@@ -576,24 +699,25 @@ async def _launch_continuation_task_replacing_current(
                 "Agent continuation task failed"
             )
         finally:
-            continuation_task = asyncio.current_task()
-            removed = False
-            if continuation_task is not None:
-                removed = await registry.unregister(session_id, continuation_task)
-            if removed:
-                try:
-                    if not await registry.is_running(session_id):
-                        await _set_task_running_state(
-                            db_session_factory=db_session_factory,
-                            task_id=task_id,
-                            session_id=session_id,
-                            project_id=project_id,
-                            is_running=False,
+            async with _agent_session_lifecycle_lock(registry, session_id):
+                continuation_task = asyncio.current_task()
+                removed = False
+                if continuation_task is not None:
+                    removed = await registry.unregister(session_id, continuation_task)
+                if removed:
+                    try:
+                        if not await registry.is_running(session_id):
+                            await _set_task_running_state(
+                                db_session_factory=db_session_factory,
+                                task_id=task_id,
+                                session_id=session_id,
+                                project_id=project_id,
+                                is_running=False,
+                            )
+                    except Exception:
+                        logger.bind(session_id=session_id).opt(exception=True).error(
+                            "Agent continuation running-state cleanup failed"
                         )
-                except Exception:
-                    logger.bind(session_id=session_id).opt(exception=True).error(
-                        "Agent continuation running-state cleanup failed"
-                    )
 
     task = asyncio.create_task(_run_and_cleanup())
     try:
@@ -773,17 +897,18 @@ async def send_agent_message(
     if _is_pending_agent_session_title(task.title):
         await enqueue_session_title_job(session, task, body.message)
         await background_service.commit_and_notify(session)
-    if await registry.is_running(session_id):
-        queue_kwargs = {"attachments": attachment_metadata} if attachment_metadata else {}
-        pending_message = await runner.queue_pending_user_message(body.message, **queue_kwargs)
-        return AgentSendMessageResponse(
-            success=True,
-            session_id=session_id,
-            message="Agent 消息已排队",
-            queued=True,
-            model_updated=False,
-            pending_message=AgentPendingMessageResponse(**pending_message),
-        )
+    async with _agent_session_lifecycle_lock(registry, session_id):
+        if await registry.is_running(session_id) and not await registry.is_cancelled(session_id):
+            queue_kwargs = {"attachments": attachment_metadata} if attachment_metadata else {}
+            pending_message = await runner.queue_pending_user_message(body.message, **queue_kwargs)
+            return AgentSendMessageResponse(
+                success=True,
+                session_id=session_id,
+                message="Agent 消息已排队",
+                queued=True,
+                model_updated=False,
+                pending_message=AgentPendingMessageResponse(**pending_message),
+            )
     model_updated = False
     if body.model_id:
         try:
@@ -863,15 +988,21 @@ async def compact_agent_session(
 ) -> AgentCompactionResponse:
     runner = await _get_runner(session_id, session)
     registry = get_agent_run_registry()
-    if await registry.is_running(session_id):
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail={
-                "code": "session_compacting",
-                "message": "会话运行中，不能手动压缩",
-            },
-        )
+    return await _run_agent_session_compaction(
+        session_id=session_id,
+        session=session,
+        runner=runner,
+        registry=registry,
+    )
 
+
+async def _run_agent_session_compaction(
+    *,
+    session_id: str,
+    session: AsyncSession,
+    runner: SessionRunner,
+    registry,
+) -> AgentCompactionResponse:
     current_task = asyncio.current_task()
     if current_task is None:
         raise HTTPException(
@@ -889,62 +1020,79 @@ async def compact_agent_session(
     status_session_factory = _make_status_session_factory(session)
 
     try:
-        registered = await registry.try_register_parent(session_id, current_task)
-        if not registered:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail={
-                    "code": "session_compacting",
-                    "message": "会话运行中，不能手动压缩",
-                },
+        # Only serialize the lifecycle transition. The compaction task remains
+        # registered in the run registry after this block, so other LLM calls
+        # still see the session as running while cancellation can acquire the
+        # lifecycle lock and cancel this task.
+        async with _agent_session_lifecycle_lock(registry, session_id):
+            await _ensure_agent_session_resumable(session, session_id)
+            if await registry.is_running(session_id):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail={
+                        "code": "session_compacting",
+                        "message": "会话运行中，不能手动压缩",
+                    },
+                )
+            registered = await registry.try_register_parent(session_id, current_task)
+            if not registered:
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail={
+                        "code": "session_compacting",
+                        "message": "会话运行中，不能手动压缩",
+                    },
+                )
+            await _set_task_running_state(
+                db_session_factory=status_session_factory,
+                task_id=runner.task_id,
+                session_id=session_id,
+                project_id=runner.project_id,
+                is_running=True,
             )
-        await _set_task_running_state(
-            db_session_factory=status_session_factory,
-            task_id=runner.task_id,
-            session_id=session_id,
-            project_id=runner.project_id,
-            is_running=True,
-        )
-        running_state_started = True
+            running_state_started = True
+
         try:
             result = await runner.compact()
-            pending_message = (
-                await runner.consume_next_pending_user_message_for_continuation()
-            )
-            if pending_message is not None:
-                message_id, content = pending_message
-                await _launch_continuation_task_replacing_current(
-                    db_session_factory=status_session_factory,
-                    session_id=session_id,
-                    task_id=runner.task_id,
-                    project_id=runner.project_id,
-                    registry=registry,
-                    current_task=current_task,
-                    coro=runner.run(
-                        user_request=content,
-                        user_message_id=message_id,
-                    ),
+            async with _agent_session_lifecycle_lock(registry, session_id):
+                pending_message = (
+                    await runner.consume_next_pending_user_message_for_continuation()
                 )
-                continuation_started = True
+                if pending_message is not None:
+                    message_id, content = pending_message
+                    await _launch_continuation_task_replacing_current(
+                        db_session_factory=status_session_factory,
+                        session_id=session_id,
+                        task_id=runner.task_id,
+                        project_id=runner.project_id,
+                        registry=registry,
+                        current_task=current_task,
+                        coro=runner.run(
+                            user_request=content,
+                            user_message_id=message_id,
+                        ),
+                    )
+                    continuation_started = True
         except CompactionError as exc:
             compaction_error = exc
     finally:
-        if registered:
-            removed = await registry.unregister(session_id, current_task)
-        if running_state_started and not continuation_started:
-            try:
-                if removed and not await registry.is_running(session_id):
-                    await _set_task_running_state(
-                        db_session_factory=status_session_factory,
-                        task_id=runner.task_id,
-                        session_id=session_id,
-                        project_id=runner.project_id,
-                        is_running=False,
+        async with _agent_session_lifecycle_lock(registry, session_id):
+            if registered:
+                removed = await registry.unregister(session_id, current_task)
+            if running_state_started and not continuation_started:
+                try:
+                    if removed and not await registry.is_running(session_id):
+                        await _set_task_running_state(
+                            db_session_factory=status_session_factory,
+                            task_id=runner.task_id,
+                            session_id=session_id,
+                            project_id=runner.project_id,
+                            is_running=False,
+                        )
+                except Exception:
+                    logger.bind(session_id=session_id).opt(exception=True).error(
+                        "Agent compaction running-state cleanup failed"
                     )
-            except Exception:
-                logger.bind(session_id=session_id).opt(exception=True).error(
-                    "Agent compaction running-state cleanup failed"
-                )
 
     if compaction_error is not None:
         error_status = (
@@ -988,6 +1136,7 @@ async def submit_agent_question_answer(
     body: AgentQuestionAnswerRequest,
     session: AsyncSession = Depends(get_session),
 ) -> dict:
+    await _ensure_agent_session_resumable(session, session_id)
     runner = await _get_runner(session_id, session)
     status_session_factory = _make_status_session_factory(session)
     payload = {
@@ -995,13 +1144,23 @@ async def submit_agent_question_answer(
         "action_id": body.action_id,
         "answer": [item.model_dump(mode="json") for item in body.answer],
     }
-    await _launch_task(
-        db_session_factory=status_session_factory,
-        session_id=session_id,
-        task_id=runner.task_id,
-        project_id=runner.project_id,
-        coro=runner.resume(payload),
-    )
+    registry = get_agent_run_registry()
+    async with _agent_session_lifecycle_lock(registry, session_id):
+        revision_id, claimed_revision = await _claim_agent_session_resume(session, session_id)
+        try:
+            await _launch_task(
+                db_session_factory=status_session_factory,
+                session_id=session_id,
+                task_id=runner.task_id,
+                project_id=runner.project_id,
+                coro=runner.resume(payload),
+                clear_cancelled=False,
+                lifecycle_lock_held=True,
+            )
+        except Exception:
+            if claimed_revision:
+                await _release_agent_session_resume_claim(session, revision_id)
+            raise
     return {"success": True, "session_id": session_id, "message": "已提交澄清回答"}
 
 
@@ -1011,16 +1170,27 @@ async def submit_agent_interrupt_resume(
     body: AgentInterruptResumeRequest,
     session: AsyncSession = Depends(get_session),
 ) -> dict:
+    await _ensure_agent_session_resumable(session, session_id)
     runner = await _get_runner(session_id, session)
     status_session_factory = _make_status_session_factory(session)
     responses = [item.model_dump(mode="json", exclude_none=True) for item in body.responses]
-    await _launch_task(
-        db_session_factory=status_session_factory,
-        session_id=session_id,
-        task_id=runner.task_id,
-        project_id=runner.project_id,
-        coro=runner.resume_interrupt_batch(body.batch_id, responses),
-    )
+    registry = get_agent_run_registry()
+    async with _agent_session_lifecycle_lock(registry, session_id):
+        revision_id, claimed_revision = await _claim_agent_session_resume(session, session_id)
+        try:
+            await _launch_task(
+                db_session_factory=status_session_factory,
+                session_id=session_id,
+                task_id=runner.task_id,
+                project_id=runner.project_id,
+                coro=runner.resume_interrupt_batch(body.batch_id, responses),
+                clear_cancelled=False,
+                lifecycle_lock_held=True,
+            )
+        except Exception:
+            if claimed_revision:
+                await _release_agent_session_resume_claim(session, revision_id)
+            raise
     return {"success": True, "session_id": session_id, "message": "已提交并行中断响应"}
 
 
@@ -1030,6 +1200,7 @@ async def submit_agent_tool_approval(
     body: AgentToolApprovalRequest,
     session: AsyncSession = Depends(get_session),
 ) -> dict:
+    await _ensure_agent_session_resumable(session, session_id)
     runner = await _get_runner(session_id, session)
     status_session_factory = _make_status_session_factory(session)
     payload = {
@@ -1042,40 +1213,86 @@ async def submit_agent_tool_approval(
         parent_session_id=session_id,
         approval_id=body.approval_id,
     )
+    registry = get_agent_run_registry()
     if child_run is not None:
-        subagent_runner = SubagentRunner(
-            session_factory=status_session_factory,
-            model_config=runner.model_config,
-            project_id=runner.project_id,
-        )
-        await _set_task_running_state(
-            db_session_factory=status_session_factory,
-            session_id=session_id,
-            task_id=runner.task_id,
-            project_id=runner.project_id,
-            is_running=True,
-        )
-        await ensure_child_processing(
-            parent_session_id=session_id,
-            child_run_id=child_run.id,
-            runner=subagent_runner,
-            resume_payload=payload,
-        )
+        async with _agent_session_lifecycle_lock(registry, session_id):
+            # The initial check above can race a cancellation. Recheck while holding
+            # the same lifecycle lock before marking the parent task as running.
+            await _ensure_agent_session_resumable(session, session_id)
+            revision_id, claimed_revision = await _claim_agent_session_resume(
+                session, session_id, allow_active=True
+            )
+            started = False
+            try:
+                subagent_runner = SubagentRunner(
+                    session_factory=status_session_factory,
+                    model_config=runner.model_config,
+                    project_id=runner.project_id,
+                )
+                await _set_task_running_state(
+                    db_session_factory=status_session_factory,
+                    session_id=session_id,
+                    task_id=runner.task_id,
+                    project_id=runner.project_id,
+                    is_running=True,
+                )
+                started = await ensure_child_processing(
+                    parent_session_id=session_id,
+                    child_run_id=child_run.id,
+                    runner=subagent_runner,
+                    resume_payload=payload,
+                    clear_cancelled=False,
+                )
+                if not started and await registry.is_cancelled(session_id):
+                    raise HTTPException(
+                        status_code=status.HTTP_409_CONFLICT,
+                        detail={
+                            "code": "session_cancelled",
+                            "message": "会话已取消，无法恢复待处理的审批或问答",
+                        },
+                    )
+            except Exception:
+                if not started:
+                    try:
+                        await _set_task_running_state(
+                            db_session_factory=status_session_factory,
+                            session_id=session_id,
+                            task_id=runner.task_id,
+                            project_id=runner.project_id,
+                            is_running=False,
+                        )
+                    except Exception:
+                        logger.bind(session_id=session_id).opt(exception=True).error(
+                            "Child agent launch running-state rollback failed"
+                        )
+                if claimed_revision:
+                    await _release_agent_session_resume_claim(session, revision_id)
+                raise
         return {"success": True, "session_id": session_id, "message": "已提交工具审批"}
 
-    await _launch_task(
-        db_session_factory=status_session_factory,
-        session_id=session_id,
-        task_id=runner.task_id,
-        project_id=runner.project_id,
-        coro=runner.resume(payload),
-    )
+    async with _agent_session_lifecycle_lock(registry, session_id):
+        revision_id, claimed_revision = await _claim_agent_session_resume(session, session_id)
+        try:
+            await _launch_task(
+                db_session_factory=status_session_factory,
+                session_id=session_id,
+                task_id=runner.task_id,
+                project_id=runner.project_id,
+                coro=runner.resume(payload),
+                clear_cancelled=False,
+                lifecycle_lock_held=True,
+            )
+        except Exception:
+            if claimed_revision:
+                await _release_agent_session_resume_claim(session, revision_id)
+            raise
     return {"success": True, "session_id": session_id, "message": "已提交工具审批"}
 
 
 @router.get("/sessions/{session_id}", response_model=AgentSessionStateResponse)
 async def get_agent_session_state(
     session_id: str,
+    session: AsyncSession = Depends(get_session),
 ) -> AgentSessionStateResponse:
     checkpointer = await get_checkpointer()
     checkpoint = await checkpointer.aget_tuple(
@@ -1083,9 +1300,21 @@ async def get_agent_session_state(
     )
     checkpoint_values = checkpoint.checkpoint.get("channel_values") if checkpoint else None
     state_values = dict(checkpoint_values) if isinstance(checkpoint_values, dict) else {}
+    is_cancelled = await _is_agent_session_cancelled(session, session_id)
+    # A new run can be registered before it commits its new revision.  Keep
+    # the live registry state authoritative for running status during that
+    # transition, while still suppressing interrupts from the cancelled
+    # checkpoint below.
     is_running = await get_agent_run_registry().is_running(session_id)
+    if is_cancelled:
+        try:
+            task = await task_service.get_task_by_agent_session_id(session, session_id)
+        except NotFoundError:
+            task = None
+        if task is not None and not task.is_running:
+            is_running = False
     interrupts: list[dict] = []
-    if checkpoint is not None:
+    if checkpoint is not None and not is_cancelled:
         for pending_write in checkpoint.pending_writes or []:
             if len(pending_write) < 3 or pending_write[1] != "__interrupt__":
                 continue
@@ -1430,32 +1659,114 @@ async def cancel_agent_session(
     session: AsyncSession = Depends(get_session),
 ) -> AgentCancelResponse:
     runner = await _get_runner(session_id, session)
+    registry = get_agent_run_registry()
     status_session_factory = _make_status_session_factory(session)
     status_publisher = SubagentRunner(
         session_factory=status_session_factory,
         model_config=runner.model_config,
         project_id=runner.project_id,
     )
-    runner.cancel()
-    await _cancel_subagent_session_tree(
-        session,
-        root_session_id=session_id,
-        status_publisher=status_publisher,
-    )
-    task = await task_service.get_task_by_agent_session_id(session, session_id)
-    revision = (
-        await revision_repo.get_by_id(session, task.current_revision_id)
-        if task.current_revision_id
+    session_lock_factory = getattr(registry, "session_lock", None)
+    session_lock = (
+        session_lock_factory(session_id)
+        if callable(session_lock_factory)
         else None
     )
-    if revision is not None and revision.status in {"active", "interrupted"}:
-        await finalize_revision_status(session, revision.id, "cancelled")
-    await task_service.update_task(session, task.id, is_running=False)
-    await session.commit()
-    await emit(
-        "agent:settings_lock_changed",
-        {"session_id": session_id, "is_running": False},
-    )
+    if session_lock is not None:
+        await session_lock.acquire()
+    parent_task: asyncio.Task[None] | None = None
+    try:
+        parent_task = await registry.mark_cancelled(session_id)
+        task = await task_service.get_task_by_agent_session_id(session, session_id)
+        revision = (
+            await revision_repo.get_by_id(session, task.current_revision_id)
+            if task.current_revision_id
+            else None
+        )
+        if revision is not None and revision.status in {"active", "interrupted"}:
+            await finalize_revision_status(session, revision.id, "cancelled")
+        await task_service.update_task(session, task.id, is_running=False)
+        await session.commit()
+    except Exception:
+        if session_lock is not None:
+            session_lock.release()
+        await registry.clear_cancelled(session_id)
+        raise
+
+    # Commit the terminal state before signalling the runner. A resume that
+    # races with cancellation will now either observe the cancelled revision
+    # before it starts, or receive this cancellation signal afterwards.
+    try:
+        if parent_task is not None:
+            try:
+                await registry.cancel_task(session_id, parent_task)
+            except Exception:
+                logger.bind(session_id=session_id).opt(exception=True).error(
+                    "Agent parent task cancellation failed after terminal commit"
+                )
+
+        try:
+            runner.cancel()
+        except Exception:
+            logger.bind(session_id=session_id).opt(exception=True).error(
+                "Agent runner cancellation signal failed after terminal commit"
+            )
+
+        try:
+            await _cancel_subagent_session_tree(
+                session,
+                root_session_id=session_id,
+                status_publisher=status_publisher,
+            )
+            await session.commit()
+        except Exception:
+            with suppress(Exception):
+                await session.rollback()
+            logger.bind(session_id=session_id).opt(exception=True).error(
+                "Agent subagent cancellation cleanup failed after terminal commit"
+            )
+
+        # Keep notifications inside the lifecycle lock. Otherwise a new run
+        # can publish is_running=True and then be overwritten by this
+        # cancellation's stale is_running=False notification. The terminal
+        # database state is already committed, so notification failures must
+        # not turn a successful cancellation into an error response.
+        if task.project_id:
+            try:
+                await emit(
+                    "background:event",
+                    {
+                        "type": "task_run_status_updated",
+                        "job_type": "agent_runtime",
+                        "subject_type": "project",
+                        "subject_id": task.project_id,
+                        "project_id": task.project_id,
+                        "task_id": task.id,
+                        "agent_session_id": session_id,
+                        "is_running": False,
+                        "payload": {"is_running": False},
+                        "created_at": datetime.now(UTC).isoformat(),
+                        "updated_at": task.updated_at.isoformat(),
+                        "project_revision": time.time_ns(),
+                    },
+                    room=background_project_room(task.project_id),
+                )
+            except Exception:
+                logger.bind(session_id=session_id).opt(exception=True).error(
+                    "Agent task status notification failed after cancellation"
+                )
+        try:
+            await emit(
+                "agent:settings_lock_changed",
+                {"session_id": session_id, "is_running": False},
+            )
+        except Exception:
+            logger.bind(session_id=session_id).opt(exception=True).error(
+                "Agent settings-lock notification failed after cancellation"
+            )
+    finally:
+        if session_lock is not None:
+            session_lock.release()
     return AgentCancelResponse(
         success=True,
         session_id=session_id,

--- a/backend/app/api/routers/tasks.py
+++ b/backend/app/api/routers/tasks.py
@@ -5,7 +5,9 @@ from typing import cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from loguru import logger
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
 
 from app.agent_runtime.modes import AgentMode
 from app.agent_runtime.attachments import delete_attachments_for_task
@@ -21,6 +23,7 @@ from app.api.schemas.task import (
 )
 from app.core.errors import NotFoundError
 from app.storage.database import get_session
+from app.storage.models.revision import Revision
 from app.storage.services import task_service
 
 router = APIRouter(tags=["Tasks"])
@@ -146,6 +149,20 @@ async def list_tasks(
             task.id: await _has_pending_interrupt(checkpointer, task.agent_session_id)
             for task in result.items
         }
+        current_revision_ids = {
+            task.current_revision_id
+            for task in result.items
+            if task.current_revision_id is not None
+        }
+        cancelled_revision_ids: set[str] = set()
+        if current_revision_ids:
+            cancelled_revision_result = await session.execute(
+                select(col(Revision.id)).where(
+                    col(Revision.id).in_(current_revision_ids),
+                    col(Revision.status) == "cancelled",
+                )
+            )
+            cancelled_revision_ids = set(cancelled_revision_result.scalars().all())
 
         items = [
             TaskListItem(
@@ -157,7 +174,11 @@ async def list_tasks(
                 token_output=task.token_output,
                 token_cache=task.token_cache,
                 context_input_tokens=task.context_input_tokens,
-                is_running=task.is_running or pending_interrupts[task.id],
+                is_running=task.is_running
+                or (
+                    pending_interrupts[task.id]
+                    and task.current_revision_id not in cancelled_revision_ids
+                ),
                 is_favorited=task.is_favorited,
                 created_at=task.created_at,
                 updated_at=task.updated_at,

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -91,7 +91,7 @@ from app.maintenance import maintenance_state
 from app.settings import settings as app_settings
 from app.socket import init_socketio
 from app.storage.database import close_db, create_session, init_db, vacuum_database_if_needed
-from app.storage.repos import setting_repo
+from app.storage.repos import revision_repo, setting_repo
 from app.storage.services import task_service
 from app.storage.services.revision_content_backfill import backfill_revision_content_blobs
 from app.storage.services.revision_service import cleanup_orphaned_revision_data
@@ -140,6 +140,16 @@ async def _reset_task_running_state() -> int:
         cleared = await task_service.clear_running_tasks(session)
         await session.commit()
         return cleared
+    finally:
+        await session.close()
+
+
+async def _reset_active_revision_state() -> int:
+    session = await create_session()
+    try:
+        recovered = await revision_repo.recover_active_revisions_for_stopped_tasks(session)
+        await session.commit()
+        return recovered
     finally:
         await session.close()
 
@@ -625,6 +635,9 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     cleared_tasks = await _reset_task_running_state()
     if cleared_tasks:
         logger.warning(f"已重置 {cleared_tasks} 个遗留的运行中任务状态")
+    recovered_revisions = await _reset_active_revision_state()
+    if recovered_revisions:
+        logger.warning(f"已恢复 {recovered_revisions} 个遗留的 Agent revision 状态")
     cancelled_child_runs = await _reset_interrupted_child_run_state()
     if cancelled_child_runs:
         logger.warning(f"已取消 {cancelled_child_runs} 个因服务重启中断的子 Agent 任务")

--- a/backend/app/storage/repos/revision_repo.py
+++ b/backend/app/storage/repos/revision_repo.py
@@ -214,6 +214,100 @@ async def update_status(
     return revision
 
 
+async def cancel_active_or_interrupted_revision(
+    session: AsyncSession,
+    revision_id: str,
+) -> bool:
+    """Atomically cancel a revision that is still resumable."""
+    from sqlalchemy import update as sql_update
+
+    now = datetime.now(UTC)
+    result = await session.execute(
+        sql_update(Revision)
+        .where(col(Revision.id) == revision_id)
+        .where(col(Revision.status).in_(("active", "interrupted")))
+        .values(status="cancelled", finished_at=now, updated_at=now)
+    )
+    await session.flush()
+    return cast("CursorResult[Any]", result).rowcount == 1
+
+
+async def update_status_unless_cancelled(
+    session: AsyncSession,
+    revision_id: str,
+    status: str,
+) -> bool:
+    """Update a revision without overwriting a committed cancellation."""
+    from sqlalchemy import update as sql_update
+
+    now = datetime.now(UTC)
+    values: dict[str, Any] = {
+        "status": status,
+        "updated_at": now,
+    }
+    if status in {"completed", "interrupted", "failed", "rollback", "rolled_back"}:
+        values["finished_at"] = now
+
+    result = await session.execute(
+        sql_update(Revision)
+        .where(col(Revision.id) == revision_id)
+        .where(col(Revision.status) != "cancelled")
+        .values(**values)
+    )
+    await session.flush()
+    return cast("CursorResult[Any]", result).rowcount == 1
+
+
+async def claim_interrupted_revision(session: AsyncSession, revision_id: str) -> bool:
+    """Atomically mark an interrupted revision active for a single resume."""
+    from sqlalchemy import update as sql_update
+
+    result = await session.execute(
+        sql_update(Revision)
+        .where(col(Revision.id) == revision_id)
+        .where(col(Revision.status) == "interrupted")
+        .values(status="active", finished_at=None, updated_at=datetime.now(UTC))
+    )
+    await session.flush()
+    return cast("CursorResult[Any]", result).rowcount == 1
+
+
+async def release_active_revision_claim(session: AsyncSession, revision_id: str) -> bool:
+    """Return a failed resume launch to its interrupted state without reviving a cancel."""
+    from sqlalchemy import update as sql_update
+
+    now = datetime.now(UTC)
+    result = await session.execute(
+        sql_update(Revision)
+        .where(col(Revision.id) == revision_id)
+        .where(col(Revision.status) == "active")
+        .values(status="interrupted", finished_at=now, updated_at=now)
+    )
+    await session.flush()
+    return cast("CursorResult[Any]", result).rowcount == 1
+
+
+async def recover_active_revisions_for_stopped_tasks(session: AsyncSession) -> int:
+    """Return orphaned active revisions to a resumable interrupted state."""
+    from sqlalchemy import update as sql_update
+
+    from app.storage.models.task import Task
+
+    now = datetime.now(UTC)
+    result = await session.execute(
+        sql_update(Revision)
+        .where(col(Revision.status) == "active")
+        .where(
+            col(Revision.task_id).in_(
+                select(col(Task.id)).where(col(Task.is_running).is_(False))
+            )
+        )
+        .values(status="interrupted", finished_at=now, updated_at=now)
+    )
+    await session.flush()
+    return cast("CursorResult[Any]", result).rowcount
+
+
 async def complete_active_revisions_by_session(
     session: AsyncSession,
     agent_session_id: str,

--- a/backend/tests/agent_runtime/runner/test_session_runner_config.py
+++ b/backend/tests/agent_runtime/runner/test_session_runner_config.py
@@ -1,7 +1,14 @@
+import asyncio
+import weakref
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
 import pytest
 
 from app.agent_runtime.context import ContextBuildError
+from app.agent_runtime.runner.run_registry import AgentRunRegistry
 from app.agent_runtime.runner.session_runner import SessionRunner
+from app.agent_runtime.tools.impls.orchestration.common import ensure_child_processing
 
 
 def test_missing_max_context_tokens_raises() -> None:
@@ -34,3 +41,172 @@ def test_valid_config_constructs_ok() -> None:
         project_id="p1",
     )
     assert runner.session_id == "s1"
+
+
+@pytest.mark.asyncio
+async def test_register_can_preserve_session_cancellation() -> None:
+    registry = AgentRunRegistry()
+    blocker = asyncio.Event()
+    task = asyncio.create_task(blocker.wait())
+    try:
+        await registry.mark_cancelled("session-cancelled")
+        await registry.register("session-cancelled", task, clear_cancelled=False)
+
+        assert await registry.is_cancelled("session-cancelled") is True
+    finally:
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_session_locks_are_not_retained_after_use() -> None:
+    registry = AgentRunRegistry()
+    lock = registry.session_lock("finished-session")
+    lock_ref = weakref.ref(lock)
+
+    del lock
+
+    assert lock_ref() is None
+    assert "finished-session" not in registry._session_locks
+
+
+@pytest.mark.asyncio
+async def test_child_resume_does_not_clear_session_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = AgentRunRegistry()
+    monkeypatch.setattr(
+        "app.agent_runtime.tools.impls.orchestration.common.get_agent_run_registry",
+        lambda: registry,
+    )
+    await registry.mark_cancelled("session-cancelled")
+
+    class Runner:
+        called = False
+
+        async def resume(self, child_run_id: str, payload: dict) -> None:
+            self.called = True
+
+    runner = Runner()
+    started = await ensure_child_processing(
+        parent_session_id="session-cancelled",
+        child_run_id="child-1",
+        runner=runner,
+        resume_payload={"approved": True},
+        clear_cancelled=False,
+    )
+
+    assert started is False
+    assert runner.called is False
+    assert await registry.is_cancelled("session-cancelled") is True
+    assert await registry.is_child_running("session-cancelled", "child-1") is False
+
+
+@pytest.mark.asyncio
+async def test_losing_child_start_does_not_unregister_winner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    registry = AgentRunRegistry()
+    monkeypatch.setattr(
+        "app.agent_runtime.tools.impls.orchestration.common.get_agent_run_registry",
+        lambda: registry,
+    )
+    monkeypatch.setattr(
+        "app.agent_runtime.tools.impls.orchestration.common._clear_child_processing_failure",
+        AsyncMock(),
+    )
+
+    registrations_ready = asyncio.Event()
+    registration_count = 0
+    original_try_register_child = registry.try_register_child
+
+    async def synchronized_try_register_child(
+        session_id: str,
+        child_run_id: str,
+        task: asyncio.Task[None],
+        *,
+        clear_cancelled: bool = True,
+    ) -> bool:
+        nonlocal registration_count
+        registration_count += 1
+        if registration_count == 2:
+            registrations_ready.set()
+        await registrations_ready.wait()
+        return await original_try_register_child(
+            session_id,
+            child_run_id,
+            task,
+            clear_cancelled=clear_cancelled,
+        )
+
+    monkeypatch.setattr(registry, "try_register_child", synchronized_try_register_child)
+
+    runner_started = asyncio.Event()
+    release_runner = asyncio.Event()
+
+    class Runner:
+        async def run(self, child_run_id: str) -> None:
+            runner_started.set()
+            await release_runner.wait()
+
+    runner = Runner()
+    results = await asyncio.gather(
+        ensure_child_processing(
+            parent_session_id="session-race",
+            child_run_id="child-race",
+            runner=runner,
+        ),
+        ensure_child_processing(
+            parent_session_id="session-race",
+            child_run_id="child-race",
+            runner=runner,
+        ),
+    )
+
+    await asyncio.wait_for(runner_started.wait(), timeout=1)
+    assert sorted(results) == [False, True]
+    assert await registry.is_child_running("session-race", "child-race") is True
+
+    release_runner.set()
+    for _ in range(10):
+        if not await registry.is_child_running("session-race", "child-race"):
+            break
+        await asyncio.sleep(0)
+    assert await registry.is_child_running("session-race", "child-race") is False
+
+
+@pytest.mark.asyncio
+async def test_child_completion_continuation_preserves_session_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from app.agent_runtime.runner.subagent_runner import SubagentRunner
+
+    ensure = AsyncMock()
+    monkeypatch.setattr(
+        "app.agent_runtime.tools.impls.orchestration.common.ensure_child_processing",
+        ensure,
+    )
+    runner = SubagentRunner(
+        session_factory=None,
+        model_config={},
+        project_id="p1",
+    )
+    monkeypatch.setattr(
+        runner,
+        "_load_child_run",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                is_active=True,
+                status="queued",
+            )
+        ),
+    )
+    monkeypatch.setattr(runner, "_count_pending_requests", AsyncMock(return_value=1))
+
+    await runner.on_child_processing_finished(
+        parent_session_id="session-cancelled",
+        child_run_id="child-1",
+    )
+
+    assert ensure.await_args is not None
+    assert ensure.await_args.kwargs["clear_cancelled"] is False

--- a/backend/tests/agent_runtime/test_agent_compaction_api.py
+++ b/backend/tests/agent_runtime/test_agent_compaction_api.py
@@ -8,6 +8,8 @@ from fastapi import status
 from httpx import AsyncClient
 
 from app.agent_runtime.context.compaction.service import CompactionError
+from app.agent_runtime.runner.run_registry import AgentRunRegistry
+from app.api.routers import agent_runtime
 from app.api.routers.agent_runtime import _SESSION_RUNNERS
 
 
@@ -59,6 +61,7 @@ def _registry(*, running: bool = False):
         register=AsyncMock(),
         unregister=AsyncMock(return_value=True),
         cancel=AsyncMock(),
+        is_cancelled=AsyncMock(return_value=False),
     )
 
 
@@ -115,6 +118,58 @@ async def test_manual_compaction_returns_structured_metrics(client: AsyncClient)
     runner.peek_next_pending_user_message.assert_not_called()
     launch_task.assert_not_awaited()
     assert set_running.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_manual_compaction_can_be_cancelled_while_model_call_is_waiting() -> None:
+    runner = _runner()
+    compact_started = asyncio.Event()
+    release_compact = asyncio.Event()
+
+    async def blocked_compact():
+        compact_started.set()
+        await release_compact.wait()
+        return {
+            "compaction_id": "cmp_api_1",
+            "start_seq": 2,
+            "end_seq": 7,
+        }
+
+    runner.compact = AsyncMock(side_effect=blocked_compact)
+    registry = AgentRunRegistry()
+    session = SimpleNamespace(bind=MagicMock())
+
+    with patch(
+        "app.api.routers.agent_runtime._ensure_agent_session_resumable",
+        AsyncMock(),
+    ), patch(
+        "app.api.routers.agent_runtime._set_task_running_state",
+        AsyncMock(),
+    ):
+        compaction_task = asyncio.create_task(
+            agent_runtime._run_agent_session_compaction(
+                session_id=runner.session_id,
+                session=session,
+                runner=runner,
+                registry=registry,
+            )
+        )
+        await asyncio.wait_for(compact_started.wait(), timeout=1)
+
+        lifecycle_lock = registry.session_lock(runner.session_id)
+        await asyncio.wait_for(lifecycle_lock.acquire(), timeout=1)
+        try:
+            parent_task = await registry.mark_cancelled(runner.session_id)
+            assert parent_task is compaction_task
+            assert await registry.cancel_task(runner.session_id, parent_task)
+        finally:
+            lifecycle_lock.release()
+
+        with pytest.raises(asyncio.CancelledError):
+            await compaction_task
+
+    runner.compact.assert_awaited_once_with()
+    assert not release_compact.is_set()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/test_session_runner.py
+++ b/backend/tests/agent_runtime/test_session_runner.py
@@ -233,6 +233,77 @@ async def test_prune_thread_checkpoints_failure_is_silent():
 
 
 @pytest.mark.asyncio
+async def test_run_suppresses_terminal_events_when_revision_finalization_is_rejected():
+    runner = SessionRunner(
+        session_id="sess_cancelled_finalization",
+        task_id="task_cancelled_finalization",
+        model_config={
+            "provider_type": "openai",
+            "model_id": "gpt",
+            "api_key": "k",
+            "base_url": "",
+            "max_context_tokens": 8000,
+        },
+    )
+    interrupt = SimpleNamespace(
+        id="cancelled-interrupt",
+        value={"type": "tool_approval", "tool_name": "write_note", "args": {}},
+    )
+
+    class _Graph:
+        async def astream_events(self, *_args, **_kwargs):
+            if False:
+                yield None
+
+        async def aget_state(self, *_args, **_kwargs):
+            return SimpleNamespace(
+                next=("tools",),
+                tasks=(SimpleNamespace(interrupts=(interrupt,)),),
+                values={},
+                config={"configurable": {}},
+            )
+
+    fake_session = MagicMock(close=AsyncMock(), commit=AsyncMock())
+    fake_persister = MagicMock(
+        handle=AsyncMock(),
+        mark_user_sent=AsyncMock(),
+        finalize=AsyncMock(),
+        apply_interrupt_preview=AsyncMock(),
+    )
+    persisted_message = SimpleNamespace(
+        id="msg_cancelled_finalization",
+        seq=0,
+        created_at=datetime.now(UTC),
+    )
+
+    with (
+        patch.object(runner, "_get_graph", AsyncMock(return_value=_Graph())),
+        patch.object(runner, "_prepare_run_persistence", AsyncMock(return_value=[])),
+        patch.object(runner, "_persist_user_message", AsyncMock(return_value=persisted_message)),
+        patch(
+            "app.agent_runtime.runner.session_runner.begin_user_revision",
+            AsyncMock(return_value=SimpleNamespace(id="rev_cancelled_finalization")),
+        ),
+        patch(
+            "app.agent_runtime.runner.session_runner.finalize_revision_status",
+            AsyncMock(return_value=False),
+        ),
+        patch("app.agent_runtime.runner.session_runner.emit", new=AsyncMock()) as emit_mock,
+        patch(
+            "app.agent_runtime.runner.session_runner.create_session",
+            AsyncMock(return_value=fake_session),
+        ),
+        patch.object(runner, "_make_persister", MagicMock(return_value=fake_persister)),
+        patch.object(runner, "_clear_replay_session", AsyncMock()),
+    ):
+        await runner.run(user_request="hi")
+
+    event_names = [call.args[0] for call in emit_mock.await_args_list if call.args]
+    assert "agent:interrupt" not in event_names
+    assert "agent:done" not in event_names
+
+
+@pytest.mark.asyncio
 async def test_run_emits_preview_for_each_parallel_tool_approval_interrupt():
     runner = SessionRunner(
         session_id="sess_parallel_approval",
@@ -529,6 +600,7 @@ async def test_resume_targets_the_approved_parallel_tool_interrupt():
     with patch.object(runner, "_get_graph", AsyncMock(return_value=_Graph())), \
          patch("app.agent_runtime.runner.session_runner.finalize_revision_status", AsyncMock()), \
          patch("app.agent_runtime.runner.session_runner.emit", new=AsyncMock()), \
+         patch("app.agent_runtime.runner.session_runner.revision_repo.get_by_id", AsyncMock(return_value=None)), \
          patch(
              "app.agent_runtime.runner.session_runner.create_session",
              AsyncMock(return_value=fake_session),
@@ -617,6 +689,7 @@ async def test_resume_restores_all_parallel_interrupts_in_one_command() -> None:
 
     with patch.object(runner, "_get_graph", AsyncMock(return_value=_Graph())), \
          patch("app.agent_runtime.runner.session_runner.finalize_revision_status", AsyncMock()), \
+         patch("app.agent_runtime.runner.session_runner.revision_repo.get_by_id", AsyncMock(return_value=None)), \
          patch("app.agent_runtime.runner.session_runner.create_session", AsyncMock(return_value=fake_session)), \
          patch.object(runner, "_make_persister", MagicMock(return_value=fake_persister)):
         await runner.resume_interrupt_batch("batch-1", responses)
@@ -1011,6 +1084,9 @@ async def test_resume_emits_error_and_marks_revision_failed_on_runtime_exception
         runner,
         "_make_persister",
         MagicMock(return_value=fake_persister),
+    ), patch(
+        "app.agent_runtime.runner.session_runner.revision_repo.get_by_id",
+        AsyncMock(return_value=None),
     ), patch.object(
         runner,
         "_clear_replay_session",

--- a/backend/tests/api/test_agent.py
+++ b/backend/tests/api/test_agent.py
@@ -2172,7 +2172,7 @@ class TestAgentAPI:
             assert request_row.status == "cancelled"
             assert request_row.error == "user cancelled subagent"
         finally:
-            get_agent_run_registry().unregister_child(parent_session_id, child.id)
+            await get_agent_run_registry().unregister_child(parent_session_id, child.id)
 
     async def test_cancel_subagent_session_returns_404_for_unknown_child(
         self,

--- a/backend/tests/api/test_agent.py
+++ b/backend/tests/api/test_agent.py
@@ -28,15 +28,21 @@ from app.agent_runtime.runner.checkpointer import get_checkpointer, reset_checkp
 from app.agent_runtime.runner.run_registry import get_agent_run_registry
 from app.agent_runtime.runner.session_runner import SessionRunner
 from app.agent_runtime.streaming.replay_buffer import get_agent_event_replay_buffer
-from app.api.routers.agent_runtime import _SESSION_RUNNERS, _build_model_config
+from app.api.routers.agent_runtime import (
+    _SESSION_RUNNERS,
+    _build_model_config,
+    _launch_task,
+)
 from app.settings import settings
 from app.socket.handlers import agent_session_room, agent_subagents_room
 from app.storage.models.chapter import Chapter
 from app.storage.models.commit import Commit
 from app.storage.models.project import Project
+from app.storage.models.revision import Revision
 from app.storage.models.revision_chapter_snapshot import RevisionChapterSnapshot
 from app.storage.models.task import Task
 from app.storage.models.volume import Volume
+from app.storage.repos import revision_repo
 from app.storage.services import task_service
 
 
@@ -840,6 +846,7 @@ class TestAgentAPI:
             "app.api.routers.agent_runtime.get_agent_run_registry"
         ) as get_registry:
             get_registry.return_value.is_running = AsyncMock(return_value=True)
+            get_registry.return_value.is_cancelled = AsyncMock(return_value=False)
             response = await client.post(
                 "/api/v1/agent/sessions/session-model-pending/message",
                 json={"message": "排队消息", "model_id": "next-model-record"},
@@ -1219,7 +1226,10 @@ class TestAgentAPI:
         )
         session_id = session_response.json()["session_id"]
 
-        fake_registry = SimpleNamespace(is_running=AsyncMock(return_value=True))
+        fake_registry = SimpleNamespace(
+            is_running=AsyncMock(return_value=True),
+            is_cancelled=AsyncMock(return_value=False),
+        )
 
         with patch(
             "app.api.routers.agent_runtime.get_agent_run_registry",
@@ -1276,6 +1286,434 @@ class TestAgentAPI:
                 "id": "interrupt-approval-1",
             }
         ]
+
+    async def test_get_session_state_hides_interrupts_after_session_cancelled(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={"project_id": target["project_id"], "model_id": target["model_id"]},
+        )
+        payload = session_response.json()
+        session_id = payload["session_id"]
+        task = await task_service.get_task(session, payload["task_id"])
+        revision = Revision(
+            project_id=task.project_id,
+            task_id=task.id,
+            message="cancelled approval",
+            agent_session_id=session_id,
+            revision_type="agent",
+            status="cancelled",
+            is_checkpoint=True,
+            project_snapshot_title="Cancelled approval",
+            project_snapshot_word_count=0,
+            project_snapshot_chapter_count=0,
+        )
+        session.add(revision)
+        await session.flush()
+        task.current_revision_id = revision.id
+        session.add(task)
+        await session.commit()
+
+        interrupt = SimpleNamespace(
+            id="interrupt-approval-cancelled",
+            value={"type": "tool_approval", "tool_name": "edit_note", "args": {}},
+        )
+        fake_checkpointer = SimpleNamespace(
+            aget_tuple=AsyncMock(
+                return_value=SimpleNamespace(
+                    checkpoint={"channel_values": {"session_id": session_id}},
+                    pending_writes=[("task-1", "__interrupt__", [interrupt])],
+                )
+            )
+        )
+        fake_registry = SimpleNamespace(is_running=AsyncMock(return_value=False))
+
+        with patch(
+            "app.api.routers.agent_runtime.get_checkpointer",
+            new=AsyncMock(return_value=fake_checkpointer),
+        ), patch(
+            "app.api.routers.agent_runtime.get_agent_run_registry",
+            return_value=fake_registry,
+        ):
+            response = await client.get(f"/api/v1/agent/sessions/{session_id}")
+
+            task.is_running = True
+            session.add(task)
+            await session.commit()
+            fake_registry.is_running.return_value = True
+            running_response = await client.get(f"/api/v1/agent/sessions/{session_id}")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["is_running"] is False
+        assert response.json()["interrupts"] == []
+
+        assert running_response.status_code == status.HTTP_200_OK
+        assert running_response.json()["is_running"] is True
+        assert running_response.json()["interrupts"] == []
+        assert fake_registry.is_running.await_count == 2
+
+    async def test_tool_approval_does_not_resume_cancelled_session(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={"project_id": target["project_id"], "model_id": target["model_id"]},
+        )
+        payload = session_response.json()
+        session_id = payload["session_id"]
+        task = await task_service.get_task(session, payload["task_id"])
+        revision = Revision(
+            project_id=task.project_id,
+            task_id=task.id,
+            message="cancelled approval",
+            agent_session_id=session_id,
+            revision_type="agent",
+            status="cancelled",
+            is_checkpoint=True,
+            project_snapshot_title="Cancelled approval",
+            project_snapshot_word_count=0,
+            project_snapshot_chapter_count=0,
+        )
+        session.add(revision)
+        await session.flush()
+        task.current_revision_id = revision.id
+        session.add(task)
+        await session.commit()
+
+        with patch("app.api.routers.agent_runtime._launch_task", new=AsyncMock()) as launch_task:
+            response = await client.post(
+                f"/api/v1/agent/sessions/{session_id}/tool-approval",
+                json={"approval_id": "interrupt-approval-cancelled", "approved": False},
+            )
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert response.json()["detail"]["code"] == "session_cancelled"
+        launch_task.assert_not_awaited()
+
+    async def test_manual_compaction_does_not_resume_cancelled_session(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={"project_id": target["project_id"], "model_id": target["model_id"]},
+        )
+        payload = session_response.json()
+        session_id = payload["session_id"]
+        task = await task_service.get_task(session, payload["task_id"])
+        revision = Revision(
+            project_id=task.project_id,
+            task_id=task.id,
+            message="cancelled compaction",
+            agent_session_id=session_id,
+            revision_type="agent",
+            status="cancelled",
+            is_checkpoint=True,
+            project_snapshot_title="Cancelled compaction",
+            project_snapshot_word_count=0,
+            project_snapshot_chapter_count=0,
+        )
+        session.add(revision)
+        await session.flush()
+        task.current_revision_id = revision.id
+        task.is_running = False
+        session.add(task)
+        await session.commit()
+
+        runner = _SESSION_RUNNERS[session_id]
+        with patch.object(runner, "compact", new=AsyncMock()) as compact:
+            response = await client.post(f"/api/v1/agent/sessions/{session_id}/compaction")
+
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert response.json()["detail"]["code"] == "session_cancelled"
+        compact.assert_not_awaited()
+
+    async def test_resume_claims_interrupted_revision_once(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={"project_id": target["project_id"], "model_id": target["model_id"]},
+        )
+        payload = session_response.json()
+        session_id = payload["session_id"]
+        task = await task_service.get_task(session, payload["task_id"])
+        revision = Revision(
+            project_id=task.project_id,
+            task_id=task.id,
+            message="waiting for approval",
+            agent_session_id=session_id,
+            revision_type="agent",
+            status="interrupted",
+            is_checkpoint=True,
+            project_snapshot_title="Waiting approval",
+            project_snapshot_word_count=0,
+            project_snapshot_chapter_count=0,
+        )
+        session.add(revision)
+        await session.flush()
+        task.current_revision_id = revision.id
+        session.add(task)
+        await session.commit()
+
+        with patch("app.api.routers.agent_runtime._launch_task", new=AsyncMock()) as launch_task:
+            response = await client.post(
+                f"/api/v1/agent/sessions/{session_id}/tool-approval",
+                json={"approval_id": "approval-claim", "approved": True},
+            )
+            duplicate_response = await client.post(
+                f"/api/v1/agent/sessions/{session_id}/tool-approval",
+                json={"approval_id": "approval-claim", "approved": True},
+            )
+
+        await session.refresh(revision)
+        assert response.status_code == status.HTTP_200_OK
+        assert duplicate_response.status_code == status.HTTP_409_CONFLICT
+        assert duplicate_response.json()["detail"]["code"] == "session_not_resumable"
+        assert revision.status == "active"
+        launch_task.assert_awaited_once()
+        launch_task.await_args.kwargs["coro"].close()
+
+    async def test_resume_claim_holds_session_lock_before_new_message_can_start(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={"project_id": target["project_id"], "model_id": target["model_id"]},
+        )
+        payload = session_response.json()
+        session_id = payload["session_id"]
+        task = await task_service.get_task(session, payload["task_id"])
+        revision = Revision(
+            project_id=task.project_id,
+            task_id=task.id,
+            message="waiting for approval",
+            agent_session_id=session_id,
+            revision_type="agent",
+            status="interrupted",
+            is_checkpoint=True,
+            project_snapshot_title="Waiting approval",
+            project_snapshot_word_count=0,
+            project_snapshot_chapter_count=0,
+        )
+        session.add(revision)
+        await session.flush()
+        task.current_revision_id = revision.id
+        session.add(task)
+        await session.commit()
+
+        claim_entered = asyncio.Event()
+        release_claim = asyncio.Event()
+
+        async def blocked_claim(*args: Any, **kwargs: Any) -> tuple[str, bool]:
+            claim_entered.set()
+            await release_claim.wait()
+            return revision.id, True
+
+        with patch(
+            "app.api.routers.agent_runtime._claim_agent_session_resume",
+            new=blocked_claim,
+        ), patch(
+            "app.api.routers.agent_runtime.SessionRunner.resume",
+            new=AsyncMock(return_value=None),
+        ), patch(
+            "app.api.routers.agent_runtime.SessionRunner.run",
+            new=AsyncMock(return_value=None),
+        ), patch(
+            "app.api.routers.agent_runtime.emit",
+            new=AsyncMock(),
+        ):
+            resume_task = asyncio.create_task(
+                client.post(
+                    f"/api/v1/agent/sessions/{session_id}/tool-approval",
+                    json={"approval_id": "approval-lock-race", "approved": True},
+                )
+            )
+            await asyncio.wait_for(claim_entered.wait(), timeout=1)
+
+            message_task = asyncio.create_task(
+                client.post(
+                    f"/api/v1/agent/sessions/{session_id}/message",
+                    json={"message": "new message during resume"},
+                )
+            )
+            await asyncio.sleep(0.05)
+            assert not message_task.done()
+
+            release_claim.set()
+            resume_response = await resume_task
+            message_response = await message_task
+
+        assert resume_response.status_code == status.HTTP_200_OK
+        assert message_response.status_code == status.HTTP_200_OK
+
+    async def test_resume_launch_failure_releases_interrupted_revision_claim(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={"project_id": target["project_id"], "model_id": target["model_id"]},
+        )
+        payload = session_response.json()
+        session_id = payload["session_id"]
+        task = await task_service.get_task(session, payload["task_id"])
+        revision = Revision(
+            project_id=task.project_id,
+            task_id=task.id,
+            message="waiting for approval",
+            agent_session_id=session_id,
+            revision_type="agent",
+            status="interrupted",
+            is_checkpoint=True,
+            project_snapshot_title="Waiting approval",
+            project_snapshot_word_count=0,
+            project_snapshot_chapter_count=0,
+        )
+        session.add(revision)
+        await session.flush()
+        task.current_revision_id = revision.id
+        session.add(task)
+        await session.commit()
+
+        async def fail_launch(**kwargs: Any) -> None:
+            kwargs["coro"].close()
+            raise RuntimeError("launch failed")
+
+        with patch("app.api.routers.agent_runtime._launch_task", new=fail_launch):
+            with pytest.raises(RuntimeError, match="launch failed"):
+                await client.post(
+                    f"/api/v1/agent/sessions/{session_id}/tool-approval",
+                    json={"approval_id": "approval-claim", "approved": True},
+                )
+
+        await session.refresh(revision)
+        assert revision.status == "interrupted"
+
+    async def test_runner_finalizer_does_not_overwrite_cancelled_revision(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={"project_id": target["project_id"], "model_id": target["model_id"]},
+        )
+        payload = session_response.json()
+        task = await task_service.get_task(session, payload["task_id"])
+        revision = Revision(
+            project_id=task.project_id,
+            task_id=task.id,
+            message="cancelled revision",
+            agent_session_id=payload["session_id"],
+            revision_type="agent",
+            status="cancelled",
+            is_checkpoint=True,
+            project_snapshot_title="Cancelled revision",
+            project_snapshot_word_count=0,
+            project_snapshot_chapter_count=0,
+        )
+        session.add(revision)
+        await session.flush()
+
+        finalized = await revision_repo.update_status_unless_cancelled(
+            session,
+            revision.id,
+            "completed",
+        )
+        await session.commit()
+        await session.refresh(revision)
+
+        assert finalized is False
+        assert revision.status == "cancelled"
+
+    async def test_cancellation_does_not_overwrite_terminal_revision(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={"project_id": target["project_id"], "model_id": target["model_id"]},
+        )
+        payload = session_response.json()
+        task = await task_service.get_task(session, payload["task_id"])
+        revision = Revision(
+            project_id=task.project_id,
+            task_id=task.id,
+            message="completed revision",
+            agent_session_id=payload["session_id"],
+            revision_type="agent",
+            status="completed",
+            is_checkpoint=True,
+            project_snapshot_title="Completed revision",
+            project_snapshot_word_count=0,
+            project_snapshot_chapter_count=0,
+        )
+        session.add(revision)
+        await session.flush()
+
+        cancelled = await revision_repo.cancel_active_or_interrupted_revision(
+            session, revision.id
+        )
+
+        await session.commit()
+        await session.refresh(revision)
+        assert cancelled is False
+        assert revision.status == "completed"
+
+    async def test_startup_recovery_returns_orphaned_active_revision_to_interrupt(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={"project_id": target["project_id"], "model_id": target["model_id"]},
+        )
+        payload = session_response.json()
+        task = await task_service.get_task(session, payload["task_id"])
+        revision = Revision(
+            project_id=task.project_id,
+            task_id=task.id,
+            message="orphaned active revision",
+            agent_session_id=payload["session_id"],
+            revision_type="agent",
+            status="active",
+            is_checkpoint=True,
+            project_snapshot_title="Orphaned revision",
+            project_snapshot_word_count=0,
+            project_snapshot_chapter_count=0,
+        )
+        session.add(revision)
+        await session.flush()
+
+        recovered = await revision_repo.recover_active_revisions_for_stopped_tasks(session)
+        await session.commit()
+        await session.refresh(revision)
+
+        assert recovered == 1
+        assert revision.status == "interrupted"
 
     async def test_send_message_keeps_task_running_when_async_child_is_still_running(
         self,
@@ -1401,6 +1839,9 @@ class TestAgentAPI:
 
         fake_registry = SimpleNamespace(
             cancel=AsyncMock(return_value=True),
+        mark_cancelled=AsyncMock(return_value=None),
+        cancel_task=AsyncMock(return_value=False),
+            clear_cancelled=AsyncMock(),
             register=AsyncMock(),
             unregister=AsyncMock(return_value=True),
             is_running=AsyncMock(return_value=False),
@@ -1502,6 +1943,9 @@ class TestAgentAPI:
 
         fake_registry = SimpleNamespace(
             cancel=AsyncMock(return_value=True),
+        mark_cancelled=AsyncMock(return_value=None),
+        cancel_task=AsyncMock(return_value=False),
+            clear_cancelled=AsyncMock(),
             register=AsyncMock(),
             unregister=AsyncMock(return_value=True),
             is_running=AsyncMock(return_value=False),
@@ -1588,6 +2032,9 @@ class TestAgentAPI:
 
             fake_registry = SimpleNamespace(
                 cancel=AsyncMock(return_value=True),
+        mark_cancelled=AsyncMock(return_value=None),
+        cancel_task=AsyncMock(return_value=False),
+                clear_cancelled=AsyncMock(),
                 register=AsyncMock(),
                 unregister=AsyncMock(return_value=True),
                 is_running=AsyncMock(return_value=False),
@@ -1824,6 +2271,9 @@ class TestAgentAPI:
 
         fake_registry = SimpleNamespace(
             cancel=AsyncMock(return_value=True),
+        mark_cancelled=AsyncMock(return_value=None),
+        cancel_task=AsyncMock(return_value=False),
+            clear_cancelled=AsyncMock(),
             register=AsyncMock(),
             unregister=AsyncMock(return_value=True),
             is_running=AsyncMock(return_value=False),
@@ -1850,6 +2300,312 @@ class TestAgentAPI:
         assert response.json()["success"] is True
         await asyncio.sleep(0.05)
         mock_run.assert_awaited_once_with(user_request="取消上一轮后重新开始")
+
+    async def test_cancel_does_not_cancel_run_waiting_to_start(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={
+                "project_id": target["project_id"],
+                "model_id": target["model_id"],
+                "max_iterations": 5,
+            },
+        )
+        payload = session_response.json()
+        session_id = payload["session_id"]
+        task = await task_service.get_task(session, payload["task_id"])
+        revision = Revision(
+            project_id=task.project_id,
+            task_id=task.id,
+            message="active revision",
+            agent_session_id=session_id,
+            revision_type="agent",
+            status="active",
+            is_checkpoint=True,
+            project_snapshot_title="Active revision",
+            project_snapshot_word_count=0,
+            project_snapshot_chapter_count=0,
+        )
+        session.add(revision)
+        await session.flush()
+        task.current_revision_id = revision.id
+        session.add(task)
+        await session.commit()
+
+        finalize_entered = asyncio.Event()
+        release_finalize = asyncio.Event()
+        emit_entered = asyncio.Event()
+        release_emit = asyncio.Event()
+        run_started = asyncio.Event()
+        release_run = asyncio.Event()
+        run_saw_cancel = False
+        runner = _SESSION_RUNNERS[session_id]
+
+        async def block_finalize(*args: Any, **kwargs: Any) -> None:
+            finalize_entered.set()
+            await release_finalize.wait()
+
+        async def fake_run(self: SessionRunner, *, user_request: str, **kwargs: Any) -> None:
+            nonlocal run_saw_cancel
+            self._cancel_event.clear()
+            run_started.set()
+            await release_run.wait()
+            run_saw_cancel = self._cancel_event.is_set()
+
+        async def block_cancel_notification(
+            event_name: str, payload: dict[str, Any], **kwargs: Any
+        ) -> None:
+            if payload.get("is_running") is False:
+                emit_entered.set()
+                await release_emit.wait()
+
+        with patch(
+            "app.api.routers.agent_runtime.finalize_revision_status",
+            new=block_finalize,
+        ), patch(
+            "app.api.routers.agent_runtime.SessionRunner.run",
+            new=fake_run,
+        ), patch(
+            "app.api.routers.agent_runtime.emit",
+            new=block_cancel_notification,
+        ):
+            cancel_task = asyncio.create_task(
+                client.post(f"/api/v1/agent/sessions/{session_id}/cancel")
+            )
+            await finalize_entered.wait()
+            send_task = asyncio.create_task(
+                client.post(
+                    f"/api/v1/agent/sessions/{session_id}/message",
+                    json={"message": "start after cancel"},
+                )
+            )
+            await asyncio.sleep(0.05)
+            assert not run_started.is_set()
+            assert not send_task.done()
+
+            release_finalize.set()
+            await emit_entered.wait()
+            await asyncio.sleep(0.05)
+            assert not run_started.is_set()
+
+            release_emit.set()
+            cancel_response = await cancel_task
+            send_response = await send_task
+            assert cancel_response.status_code == status.HTTP_200_OK
+            assert send_response.status_code == status.HTTP_200_OK
+            await run_started.wait()
+            release_run.set()
+            await asyncio.sleep(0.05)
+
+        assert run_saw_cancel is False
+        assert runner._cancel_event.is_set() is False
+
+    async def test_launch_task_returns_when_cancelled_before_start(self) -> None:
+        registry = get_agent_run_registry()
+        state_update_entered = asyncio.Event()
+        release_state_update = asyncio.Event()
+
+        async def block_state_update(**kwargs: Any) -> None:
+            state_update_entered.set()
+            await release_state_update.wait()
+
+        async def should_not_run() -> None:
+            raise AssertionError("cancelled task must not enter its coroutine")
+
+        launch_task = asyncio.create_task(
+            _launch_task(
+                db_session_factory=lambda: None,
+                session_id="launch-race",
+                task_id="task-id",
+                project_id="project-id",
+                coro=should_not_run(),
+            )
+        )
+        try:
+            with patch(
+                "app.api.routers.agent_runtime._set_task_running_state",
+                new=block_state_update,
+            ):
+                await asyncio.wait_for(state_update_entered.wait(), timeout=1)
+                assert await registry.cancel("launch-race") is True
+                release_state_update.set()
+                await asyncio.wait_for(launch_task, timeout=1)
+        finally:
+            release_state_update.set()
+            if not launch_task.done():
+                launch_task.cancel()
+            await asyncio.gather(launch_task, return_exceptions=True)
+
+        assert await registry.is_running("launch-race") is False
+
+    async def test_cancel_succeeds_when_post_commit_cleanup_fails(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={
+                "project_id": target["project_id"],
+                "model_id": target["model_id"],
+                "max_iterations": 5,
+            },
+        )
+        payload = session_response.json()
+        session_id = payload["session_id"]
+        task = await task_service.get_task(session, payload["task_id"])
+        revision = Revision(
+            project_id=task.project_id,
+            task_id=task.id,
+            message="active revision",
+            agent_session_id=session_id,
+            revision_type="agent",
+            status="active",
+            is_checkpoint=True,
+            project_snapshot_title="Active revision",
+            project_snapshot_word_count=0,
+            project_snapshot_chapter_count=0,
+        )
+        session.add(revision)
+        await session.flush()
+        task.current_revision_id = revision.id
+        session.add(task)
+        await session.commit()
+
+        registry = get_agent_run_registry()
+        parent_task = asyncio.create_task(asyncio.Event().wait())
+        await registry.register(session_id, parent_task)
+
+        with patch(
+            "app.api.routers.agent_runtime._cancel_subagent_session_tree",
+            new=AsyncMock(side_effect=RuntimeError("cleanup failed")),
+        ), patch(
+            "app.api.routers.agent_runtime.emit",
+            new=AsyncMock(side_effect=RuntimeError("notification failed")),
+        ):
+            response = await client.post(f"/api/v1/agent/sessions/{session_id}/cancel")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["success"] is True
+        await session.refresh(task)
+        await session.refresh(revision)
+        assert task.is_running is False
+        assert revision.status == "cancelled"
+        await asyncio.gather(parent_task, return_exceptions=True)
+        assert parent_task.cancelled()
+
+    async def test_send_does_not_queue_after_concurrent_cancellation(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={
+                "project_id": target["project_id"],
+                "model_id": target["model_id"],
+                "max_iterations": 5,
+            },
+        )
+        payload = session_response.json()
+        session_id = payload["session_id"]
+        task = await task_service.get_task(session, payload["task_id"])
+        revision = Revision(
+            project_id=task.project_id,
+            task_id=task.id,
+            message="active revision",
+            agent_session_id=session_id,
+            revision_type="agent",
+            status="active",
+            is_checkpoint=True,
+            project_snapshot_title="Active revision",
+            project_snapshot_word_count=0,
+            project_snapshot_chapter_count=0,
+        )
+        session.add(revision)
+        await session.flush()
+        task.current_revision_id = revision.id
+        session.add(task)
+        await session.commit()
+
+        registry = get_agent_run_registry()
+        parent_task = asyncio.create_task(asyncio.Event().wait())
+        await registry.register(session_id, parent_task)
+        runner = _SESSION_RUNNERS[session_id]
+        finalize_entered = asyncio.Event()
+        release_finalize = asyncio.Event()
+
+        async def block_finalize(*args: Any, **kwargs: Any) -> None:
+            finalize_entered.set()
+            await release_finalize.wait()
+
+        queue_message = AsyncMock(
+            return_value={
+                "message_id": "should-not-queue",
+                "content": "消息",
+                "created_at": "2026-06-12T00:00:00+00:00",
+            }
+        )
+        launch_task = AsyncMock(side_effect=lambda **kwargs: kwargs["coro"].close())
+        cancel_request = None
+        send_request = None
+        try:
+            with (
+                patch(
+                    "app.api.routers.agent_runtime.finalize_revision_status",
+                    new=block_finalize,
+                ),
+                patch.object(runner, "queue_pending_user_message", new=queue_message),
+                patch(
+                    "app.api.routers.agent_runtime.SessionRunner.run",
+                    new=AsyncMock(return_value=None),
+                ),
+                patch("app.api.routers.agent_runtime._launch_task", new=launch_task),
+                patch(
+                    "app.api.routers.agent_runtime._cancel_subagent_session_tree",
+                    new=AsyncMock(),
+                ),
+                patch("app.api.routers.agent_runtime.emit", new=AsyncMock()),
+            ):
+                cancel_request = asyncio.create_task(
+                    client.post(f"/api/v1/agent/sessions/{session_id}/cancel")
+                )
+                await asyncio.wait_for(finalize_entered.wait(), timeout=1)
+
+                send_request = asyncio.create_task(
+                    client.post(
+                        f"/api/v1/agent/sessions/{session_id}/message",
+                        json={"message": "并发消息"},
+                    )
+                )
+                await asyncio.sleep(0.05)
+                assert not send_request.done()
+                queue_message.assert_not_awaited()
+
+                release_finalize.set()
+                cancel_response = await cancel_request
+                send_response = await send_request
+
+            assert cancel_response.status_code == status.HTTP_200_OK
+            assert send_response.status_code == status.HTTP_200_OK
+            queue_message.assert_not_awaited()
+            launch_task.assert_awaited_once()
+        finally:
+            release_finalize.set()
+            pending_requests = [request for request in (cancel_request, send_request) if request]
+            for request in pending_requests:
+                if not request.done():
+                    request.cancel()
+            await asyncio.gather(*pending_requests, return_exceptions=True)
+            if not parent_task.done():
+                parent_task.cancel()
+            await asyncio.gather(parent_task, return_exceptions=True)
 
     async def test_get_session_state_reads_persisted_session_without_runner(
         self,
@@ -2312,7 +3068,10 @@ class TestAgentAPI:
         )
         session_id = session_response.json()["session_id"]
         runner = _SESSION_RUNNERS[session_id]
-        fake_registry = SimpleNamespace(is_running=AsyncMock(return_value=True))
+        fake_registry = SimpleNamespace(
+            is_running=AsyncMock(return_value=True),
+            is_cancelled=AsyncMock(return_value=False),
+        )
 
         with patch.object(
             runner,
@@ -2456,6 +3215,24 @@ class TestAgentAPI:
                 "child_run_id": row.id,
             },
         )
+        task = await task_service.get_task(session, task_id)
+        revision = Revision(
+            project_id=task.project_id,
+            task_id=task.id,
+            message="active parent revision",
+            agent_session_id=session_id,
+            revision_type="agent",
+            status="active",
+            is_checkpoint=True,
+            project_snapshot_title="Active parent revision",
+            project_snapshot_word_count=0,
+            project_snapshot_chapter_count=0,
+        )
+        session.add(revision)
+        await session.flush()
+        task.current_revision_id = revision.id
+        session.add(task)
+        await session.commit()
 
         with patch(
             "app.api.routers.agent_runtime.SessionRunner.resume",
@@ -2559,6 +3336,184 @@ class TestAgentAPI:
         assert type(ensure_kwargs["runner"]).__name__ == "SubagentRunner"
         mock_launch_task.assert_not_awaited()
         mock_parent_resume.assert_not_awaited()
+
+    async def test_submit_tool_approval_keeps_active_parent_revision_on_child_launch_failure(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={"project_id": target["project_id"], "model_id": target["model_id"]},
+        )
+        payload = session_response.json()
+        session_id = payload["session_id"]
+        task_id = payload["task_id"]
+        row = await create_child_run(
+            session,
+            parent_session_id=session_id,
+            parent_task_id=task_id,
+            parent_thread_id=session_id,
+            child_thread_id=f"{session_id}:child:launch-failure",
+            agent_key="writer",
+            dispatch_id="dispatch-child-launch-failure",
+            tool_call_id="tool-call-child-launch-failure",
+            request={"task": "write", "input": {}, "metadata": {}},
+            status="waiting_user",
+        )
+        await record_child_run_pending_approval(
+            session,
+            row.id,
+            approval_id="approval-child-launch-failure",
+            approval_request={
+                "type": "tool_approval",
+                "approval_id": "approval-child-launch-failure",
+                "child_run_id": row.id,
+            },
+        )
+        task = await task_service.get_task(session, task_id)
+        revision = Revision(
+            project_id=task.project_id,
+            task_id=task.id,
+            message="active parent revision",
+            agent_session_id=session_id,
+            revision_type="agent",
+            status="active",
+            is_checkpoint=True,
+            project_snapshot_title="Active parent revision",
+            project_snapshot_word_count=0,
+            project_snapshot_chapter_count=0,
+        )
+        session.add(revision)
+        await session.flush()
+        task.current_revision_id = revision.id
+        session.add(task)
+        await session.commit()
+
+        async def fail_child_processing(**kwargs: Any) -> bool:
+            raise RuntimeError("child launch failed")
+
+        with patch(
+            "app.api.routers.agent_runtime.ensure_child_processing",
+            new=fail_child_processing,
+        ):
+            with pytest.raises(RuntimeError, match="child launch failed"):
+                await client.post(
+                    f"/api/v1/agent/sessions/{session_id}/tool-approval",
+                    json={"approval_id": "approval-child-launch-failure", "approved": True},
+                )
+
+        await session.refresh(revision)
+        assert revision.status == "active"
+        await session.refresh(task)
+        assert task.is_running is False
+
+    async def test_cancel_blocks_child_approval_before_it_marks_task_running(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={"project_id": target["project_id"], "model_id": target["model_id"]},
+        )
+        payload = session_response.json()
+        session_id = payload["session_id"]
+        task_id = payload["task_id"]
+        row = await create_child_run(
+            session,
+            parent_session_id=session_id,
+            parent_task_id=task_id,
+            parent_thread_id=session_id,
+            child_thread_id=f"{session_id}:child:cancel-race",
+            agent_key="writer",
+            dispatch_id="dispatch-child-cancel-race",
+            tool_call_id="tool-call-child-cancel-race",
+            request={"task": "write", "input": {}, "metadata": {}},
+            status="waiting_user",
+        )
+        await record_child_run_pending_approval(
+            session,
+            row.id,
+            approval_id="approval-child-cancel-race",
+            approval_request={
+                "type": "tool_approval",
+                "approval_id": "approval-child-cancel-race",
+                "child_run_id": row.id,
+            },
+        )
+        task = await task_service.get_task(session, task_id)
+        revision = Revision(
+            project_id=task.project_id,
+            task_id=task.id,
+            message="active parent revision",
+            agent_session_id=session_id,
+            revision_type="agent",
+            status="active",
+            is_checkpoint=True,
+            project_snapshot_title="Active parent revision",
+            project_snapshot_word_count=0,
+            project_snapshot_chapter_count=0,
+        )
+        session.add(revision)
+        await session.flush()
+        task.current_revision_id = revision.id
+        session.add(task)
+        await session.commit()
+
+        finalize_entered = asyncio.Event()
+        release_finalize = asyncio.Event()
+
+        async def block_finalize(
+            finalize_session,
+            revision_id: str,
+            revision_status: str,
+        ) -> None:
+            assert revision_id == revision.id
+            assert revision_status == "cancelled"
+            finalize_entered.set()
+            await release_finalize.wait()
+            revision.status = revision_status
+            finalize_session.add(revision)
+
+        with patch(
+            "app.api.routers.agent_runtime.finalize_revision_status",
+            new=block_finalize,
+        ), patch(
+            "app.api.routers.agent_runtime.ensure_child_processing",
+            new=AsyncMock(return_value=True),
+        ) as mock_ensure_child_processing, patch(
+            "app.api.routers.agent_runtime.emit",
+            new=AsyncMock(),
+        ):
+            cancel_task = asyncio.create_task(
+                client.post(f"/api/v1/agent/sessions/{session_id}/cancel")
+            )
+            await finalize_entered.wait()
+            approval_task = asyncio.create_task(
+                client.post(
+                    f"/api/v1/agent/sessions/{session_id}/tool-approval",
+                    json={"approval_id": "approval-child-cancel-race", "approved": True},
+                )
+            )
+            await asyncio.sleep(0.05)
+            assert not approval_task.done()
+            mock_ensure_child_processing.assert_not_awaited()
+
+            release_finalize.set()
+            cancel_response = await cancel_task
+            approval_response = await approval_task
+
+        assert cancel_response.status_code == status.HTTP_200_OK
+        assert approval_response.status_code == status.HTTP_409_CONFLICT
+        assert approval_response.json()["detail"]["code"] == "session_cancelled"
+        mock_ensure_child_processing.assert_not_awaited()
+        await session.refresh(task)
+        await session.refresh(revision)
+        assert task.is_running is False
+        assert revision.status == "cancelled"
 
     async def test_submit_tool_approval_for_sync_child_does_not_cancel_parent_wait_task(
         self,

--- a/backend/tests/api/test_agent_settings_lock.py
+++ b/backend/tests/api/test_agent_settings_lock.py
@@ -223,9 +223,18 @@ async def test_cancelling_waiting_agent_session_releases_settings_lock(
 
     assert cancel_response.status_code == 200
     runner.cancel.assert_called_once_with()
-    emit_mock.assert_awaited_once_with(
-        "agent:settings_lock_changed",
-        {"session_id": task.agent_session_id, "is_running": False},
+    emitted_payloads = [call.args for call in emit_mock.await_args_list]
+    assert any(
+        event_name == "background:event"
+        and payload.get("type") == "task_run_status_updated"
+        and payload.get("task_id") == task.id
+        and payload.get("is_running") is False
+        for event_name, payload, *_ in emitted_payloads
+    )
+    assert any(
+        event_name == "agent:settings_lock_changed"
+        and payload == {"session_id": task.agent_session_id, "is_running": False}
+        for event_name, payload, *_ in emitted_payloads
     )
     assert lock_response.json() == {"is_locked": False}
     await session.refresh(task)

--- a/backend/tests/api/test_tasks.py
+++ b/backend/tests/api/test_tasks.py
@@ -22,6 +22,7 @@ from app.agent_runtime.persistence.model import (
     PlanTodoRecord,
 )
 from app.storage.models.llm_audit_log import LLMAuditLog
+from app.storage.models.revision import Revision
 from app.storage.services import task_service
 
 
@@ -245,6 +246,55 @@ class TestTaskAPI:
         assert response.status_code == status.HTTP_200_OK
         items = {item["id"]: item for item in response.json()["items"]}
         assert items[task.id]["is_running"] is True
+
+    async def test_list_tasks_ignores_pending_interrupt_for_cancelled_revision(
+        self,
+        client: AsyncClient,
+        session: AsyncSession,
+    ) -> None:
+        task, project_id, _chapter_id = await self.create_agent_task(
+            client,
+            session,
+            title="宸插彇娑堢殑浠诲姟",
+        )
+        revision = Revision(
+            project_id=task.project_id,
+            task_id=task.id,
+            message="cancelled approval",
+            agent_session_id=task.agent_session_id,
+            revision_type="agent",
+            status="cancelled",
+            is_checkpoint=True,
+            project_snapshot_title="Cancelled approval",
+            project_snapshot_word_count=0,
+            project_snapshot_chapter_count=0,
+        )
+        session.add(revision)
+        await session.flush()
+        task.current_revision_id = revision.id
+        task.is_running = False
+        session.add(task)
+        await session.commit()
+
+        fake_checkpointer = AsyncMock()
+        fake_checkpointer.aget_tuple.return_value = SimpleNamespace(
+            pending_writes=[
+                (
+                    "task-write",
+                    "__interrupt__",
+                    [SimpleNamespace(value={"type": "tool_approval"})],
+                )
+            ]
+        )
+        with patch(
+            "app.api.routers.tasks.get_checkpointer",
+            new=AsyncMock(return_value=fake_checkpointer),
+        ):
+            response = await client.get(f"/api/v1/projects/{project_id}/tasks")
+
+        assert response.status_code == status.HTTP_200_OK
+        items = {item["id"]: item for item in response.json()["items"]}
+        assert items[task.id]["is_running"] is False
 
     async def test_list_tasks_rejects_removed_mode_query(
         self,

--- a/backend/tests/test_main.py
+++ b/backend/tests/test_main.py
@@ -57,6 +57,7 @@ async def test_lifespan_refreshes_catalog_in_background_and_cancels_on_shutdown(
     monkeypatch.setattr(main, "init_db", do_nothing)
     monkeypatch.setattr(main, "_reset_task_running_state", reset_task_state)
     monkeypatch.setattr(main, "_reset_interrupted_child_run_state", reset_task_state)
+    monkeypatch.setattr(main, "_reset_active_revision_state", reset_task_state)
     monkeypatch.setattr(main, "_load_telemetry_enabled", do_nothing)
     monkeypatch.setattr(main, "_seed_builtin_models", do_nothing)
     monkeypatch.setattr(main, "init_checkpointer", do_nothing)

--- a/frontend/src/features/assistant/hooks/use-agent-session.ts
+++ b/frontend/src/features/assistant/hooks/use-agent-session.ts
@@ -120,6 +120,22 @@ function removeApprovalMessageById(messages: AgentMessage[], approvalId: string)
   });
 }
 
+function clearPendingInterruptMessages(messages: AgentMessage[]): AgentMessage[] {
+  return messages.filter((message) => {
+    if (
+      message.type !== "approval" &&
+      message.type !== "tool_approval" &&
+      message.type !== "question" &&
+      message.type !== "clarification"
+    ) {
+      return true;
+    }
+    return (
+      message.status !== undefined && message.status !== "pending" && message.status !== "running"
+    );
+  });
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
@@ -1209,6 +1225,7 @@ export function useAgentSession({
     transportRetryAttemptRef.current = 0;
     suppressNextErrorAfterCompactionErrorRef.current = false;
     ignoredApprovalIdsRef.current.clear();
+    interruptBatchRef.current = null;
     manualCompactionPreviousStateRef.current = null;
     syncPendingMessageState(null);
     syncCompactingState(false);
@@ -1225,17 +1242,19 @@ export function useAgentSession({
 
   const abortSession = useCallback(async () => {
     const activeSessionId = sessionId;
-    if (
-      transcriptStateRef.current.status === "waiting_answer" ||
-      transcriptStateRef.current.status === "waiting_approval"
-    ) {
-      socketUnsubscribeRef.current?.();
-      socketUnsubscribeRef.current = null;
-      return;
-    }
+    const previousTranscriptState = {
+      ...transcriptStateRef.current,
+      messages: [...transcriptStateRef.current.messages],
+    };
+    const previousInterruptBatch = interruptBatchRef.current;
+    const previousPendingMessage = pendingMessageRef.current;
+    const previousIsCompacting = isCompactingRef.current;
+    const previousManualCompactionState = manualCompactionPreviousStateRef.current;
     suppressSocketEventsAfterAbortRef.current = true;
     transportRetryAttemptRef.current = 0;
     suppressNextErrorAfterCompactionErrorRef.current = false;
+    interruptBatchRef.current = null;
+    manualCompactionPreviousStateRef.current = null;
     socketUnsubscribeRef.current?.();
     socketUnsubscribeRef.current = null;
     syncPendingMessageState(null);
@@ -1244,7 +1263,9 @@ export function useAgentSession({
       abortCompactionTranscriptState(
         {
           ...current,
-          messages: clearRetryMessages(cancelStreamingAgentMessages(current.messages)),
+          messages: clearPendingInterruptMessages(
+            clearRetryMessages(cancelStreamingAgentMessages(current.messages)),
+          ),
         },
         activeSessionId ?? undefined,
       ),
@@ -1255,9 +1276,26 @@ export function useAgentSession({
         await cancelAgentSession(activeSessionId);
       } catch (error) {
         console.error("Failed to cancel agent session:", error);
+        interruptBatchRef.current = previousInterruptBatch;
+        manualCompactionPreviousStateRef.current = previousManualCompactionState;
+        suppressSocketEventsAfterAbortRef.current = false;
+        syncPendingMessageState(previousPendingMessage);
+        syncCompactingState(previousIsCompacting);
+        commitTranscriptState(previousTranscriptState);
+        attachAgentSocket(activeSessionId);
+        await joinAgentSession(activeSessionId).catch((joinError) => {
+          console.error("Failed to restore agent session connection:", joinError);
+        });
       }
     }
-  }, [sessionId, syncCompactingState, syncPendingMessageState, updateTranscriptState]);
+  }, [
+    attachAgentSocket,
+    commitTranscriptState,
+    sessionId,
+    syncCompactingState,
+    syncPendingMessageState,
+    updateTranscriptState,
+  ]);
 
   const loadSession = useCallback(
     (


### PR DESCRIPTION
## PR 标题

fix(agent): 修复会话生命周期竞态导致取消和恢复异常的问题

## 变更说明

- 问题: Agent 会话的取消与恢复之间存在多处竞态，导致点击【终止】后会话仍显示活跃、待处理的审批/问答被错误复活，且手动压缩无法在模型调用期间被取消（#278）。
- 重要性: 长时间运行的并行创作场景（如多个子 Agent 并行写章节）中，用户无法可靠地终止会话，取消操作形同虚设。
- 变化:
  - 为每个父会话引入生命周期锁，串行化取消、启动、排队、压缩与恢复声明，消除内存竞态。
  - 注册表新增任务身份校验：恢复路径保留取消标记，注销只作用于自身任务，陈旧取消不会误伤新运行。
  - 新增数据库原子条件更新：取消/终态更新/恢复声明/孤儿恢复互不覆盖，被取消的 revision 永不复活。
  - 重排取消流程：先提交数据库终态再发送内存信号，取消后的清理失败不影响取消成功。
  - 手动压缩注册后允许通过生命周期锁取消；取消后抑制前端残留的 pending 中断消息与任务列表的运行状态。

## 关联 Issue / PR (如有)

Closes #278

## 变更类型

- [x] 错误修复 (fix)

## 问题原因

1. 恢复任务的迟到注册会无条件清除取消标记，导致被取消的会话从 LangGraph interrupt checkpoint 复活。
2. 恢复任务启动时无条件清除取消事件，未检查取消终态。
3. revision 状态更新无原子条件约束，运行中任务退出时可能将已取消的 revision 覆盖回 completed/interrupted。
4. 取消与恢复、并发子 Agent 注册之间无互斥机制。
5. 服务重启后孤儿 active revision 无法恢复也无法取消。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

### 测试证据

后端相关测试全部通过（约 300 项）：

```
uv run pytest tests/api/test_agent.py tests/api/test_tasks.py \
  tests/api/test_agent_settings_lock.py \
  tests/agent_runtime/test_agent_compaction_api.py \
  tests/agent_runtime/test_session_runner.py \
  tests/agent_runtime/runner/test_session_runner_config.py -q
```

新增 20 个测试函数覆盖以下竞态场景：取消后隐藏 interrupts、取消会话不可恢复、恢复声明唯一、声明持锁期间阻止新消息、启动失败释放声明、finalizer 不覆盖取消终态、启动恢复孤儿 revision、取消不影响未启动的运行、压缩期间可取消、post-commit 清理失败取消仍成功、并发取消后消息不排队、子 Agent 启动失败保留父 revision、取消拦截子审批、竞争注册失败者不注销赢家等。
