### PR TITLE
test(frontend): 新增 Agent 会话生命周期 E2E 测试

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -21,3 +21,7 @@ dist-ssr
 *.sw?
 tsconfig.tsbuildinfo
 stats.html
+
+# Playwright
+test-results
+playwright-report

--- a/frontend/e2e/approval-resume.spec.ts
+++ b/frontend/e2e/approval-resume.spec.ts
@@ -1,0 +1,104 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  APPROVAL_PANEL,
+  EMPTY_PROJECT_ID,
+  EMPTY_PROJECT_URL,
+  SEND_BUTTON,
+  approveUntilReply,
+  cancelSessionViaApi,
+  getLatestTask,
+  getLatestTaskDetail,
+  getSessionState,
+  getSettingsLock,
+  openProject,
+  sendMessage,
+  startNewTask,
+  waitForApprovalPanel,
+  waitForAssistantReply,
+  waitForRunningState,
+  waitForTaskRunning,
+} from "./helpers";
+
+test.describe("审批恢复与取消互斥", () => {
+  test("审批执行后会话继续直至完成", async ({ page }) => {
+    await openProject(page, EMPTY_PROJECT_URL);
+    await startNewTask(page);
+
+    const chapterName = `审批测试${Date.now().toString(36)}`;
+    await sendMessage(
+      page,
+      `请分两步执行：第一步，创建一个名为「${chapterName}」的章节。第二步，写入 50 字内容。完成后回复「审批完成」。`,
+    );
+    await waitForApprovalPanel(page);
+
+    await approveUntilReply(page, "审批完成");
+  });
+
+  test("取消后审批恢复被拒绝且锁与状态正确", async ({ page }) => {
+    await openProject(page, EMPTY_PROJECT_URL);
+    await startNewTask(page);
+
+    await sendMessage(
+      page,
+      `请分两步执行：第一步，创建一个名为「取消审批${Date.now().toString(36)}」的章节。第二步，写入 50 字内容。完成后回复「完成」。`,
+    );
+    await waitForApprovalPanel(page);
+
+    const task = await getLatestTaskDetail(page, EMPTY_PROJECT_ID);
+    expect(task.agent_session_id).toBeTruthy();
+    const sessionId = task.agent_session_id as string;
+
+    const runningTask = await getLatestTask(page, EMPTY_PROJECT_ID);
+    expect(runningTask.is_running).toBe(true);
+
+    const cancelStatus = await cancelSessionViaApi(page, sessionId);
+    expect(cancelStatus).toBe(200);
+
+    await expect(getSettingsLock(page)).resolves.toBe(false);
+
+    const state = await getSessionState(page, sessionId);
+    expect(state.interrupts ?? []).toHaveLength(0);
+
+    const cancelledTask = await getLatestTask(page, EMPTY_PROJECT_ID);
+    expect(cancelledTask.is_running).toBe(false);
+
+    await page.locator(APPROVAL_PANEL).getByRole("button", { name: "执行" }).click();
+
+    await expect(page.getByText("工具审批失败").first()).toBeVisible({ timeout: 30000 });
+  });
+
+  test("运行中取消后旧任务不被新消息复活", async ({ page }) => {
+    await openProject(page, EMPTY_PROJECT_URL);
+    await startNewTask(page);
+
+    await sendMessage(
+      page,
+      `请分两步执行：第一步，创建一个名为「复活测试${Date.now().toString(36)}」的章节。第二步，写入 50 字内容。完成后回复「完成」。`,
+    );
+    await waitForRunningState(page);
+    await waitForTaskRunning(page, EMPTY_PROJECT_ID);
+
+    const oldTask = await getLatestTaskDetail(page, EMPTY_PROJECT_ID);
+    expect(oldTask.agent_session_id).toBeTruthy();
+    const oldSessionId = oldTask.agent_session_id as string;
+    const oldRevisionId = oldTask.current_revision_id;
+
+    await page.locator(SEND_BUTTON).click();
+    await expect(page.getByText("正在考虑下一步").first()).toBeHidden({ timeout: 60000 });
+
+    const cancelledTask = await getLatestTask(page, EMPTY_PROJECT_ID);
+    expect(cancelledTask.is_running).toBe(false);
+    const cancelledState = await getSessionState(page, oldSessionId);
+    expect(cancelledState.interrupts ?? []).toHaveLength(0);
+
+    await sendMessage(page, "回复「新会话正常」五个字，不要执行任何工具。");
+    await waitForAssistantReply(page, "新会话正常");
+
+    const finalTask = await getLatestTaskDetail(page, EMPTY_PROJECT_ID);
+    expect(finalTask.agent_session_id).toBe(oldSessionId);
+    expect(finalTask.is_running).toBe(false);
+    expect(finalTask.current_revision_id).toBeTruthy();
+    expect(finalTask.current_revision_id).not.toBe(oldRevisionId);
+  });
+});

--- a/frontend/e2e/cancel-flow.spec.ts
+++ b/frontend/e2e/cancel-flow.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  EMPTY_PROJECT_ID,
+  EMPTY_PROJECT_URL,
+  SEND_BUTTON,
+  openProject,
+  sendMessage,
+  startNewTask,
+  waitForAssistantReply,
+  waitForRunningState,
+  waitForTaskRunning,
+} from "./helpers";
+
+test.describe("会话取消流程", () => {
+  test("运行中取消后会话停止并可重新开始", async ({ page }) => {
+    await openProject(page, EMPTY_PROJECT_URL);
+    await startNewTask(page);
+
+    await sendMessage(
+      page,
+      `请分两步执行：第一步，创建一个名为「取消测试${Date.now().toString(36)}」的章节。第二步，在该章节中写入 60 字内容。完成后回复「完成」。`,
+    );
+    await waitForRunningState(page);
+    await waitForTaskRunning(page, EMPTY_PROJECT_ID);
+
+    const stopButton = page.locator(SEND_BUTTON);
+    await expect(stopButton).toBeEnabled();
+    await stopButton.click();
+
+    await expect(page.getByText("正在考虑下一步").first()).toBeHidden({ timeout: 60000 });
+
+    await expect(async () => {
+      const runningTexts = await page.getByText(/正在考虑下一步|正在等待审批|正在执行/).count();
+      expect(runningTexts).toBe(0);
+    }).toPass({ timeout: 30000 });
+
+    await sendMessage(page, "回复「会话正常」四个字，不要执行任何工具。");
+    await waitForRunningState(page);
+    await waitForAssistantReply(page, "会话正常");
+  });
+});

--- a/frontend/e2e/compaction.spec.ts
+++ b/frontend/e2e/compaction.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  COMPACT_BUTTON,
+  LARGE_PROJECT_ID,
+  LARGE_PROJECT_URL,
+  approveUntilReply,
+  cancelSessionViaApi,
+  getLatestTaskDetail,
+  openProject,
+  sendMessage,
+  startNewTask,
+  waitForAssistantReply,
+} from "./helpers";
+
+const READ_TASK =
+  "请连续使用读章节工具，读取第一卷的前 15 章内容，不要概括内容。全部读完后回复「阅读完成」。不要修改任何章节。";
+
+const SECOND_TURN =
+  "请用一句话总结你刚才读到的五章内容的整体基调，回复以「总结完成」结尾。不要执行任何工具。";
+
+test.describe("上下文压缩", () => {
+  test("大项目多轮会话后手动压缩成功", async ({ page }) => {
+    await openProject(page, LARGE_PROJECT_URL);
+    await startNewTask(page);
+
+    await sendMessage(page, READ_TASK);
+    await approveUntilReply(page, "阅读完成", 600000);
+
+    await sendMessage(page, SECOND_TURN);
+    await waitForAssistantReply(page, "总结完成", 300000);
+
+    await expect(page.getByRole("button", { name: COMPACT_BUTTON })).toBeEnabled({
+      timeout: 60000,
+    });
+
+    await page.getByRole("button", { name: COMPACT_BUTTON }).click();
+
+    await expect(page.getByText("上下文已压缩").first()).toBeVisible({ timeout: 600000 });
+    await expect(page.getByRole("button", { name: COMPACT_BUTTON })).toBeEnabled({
+      timeout: 60000,
+    });
+  });
+
+  test("压缩期间取消会话", async ({ page }) => {
+    await openProject(page, LARGE_PROJECT_URL);
+    await startNewTask(page);
+
+    await sendMessage(page, READ_TASK);
+    await approveUntilReply(page, "阅读完成", 600000);
+
+    await sendMessage(page, SECOND_TURN);
+    await waitForAssistantReply(page, "总结完成", 300000);
+
+    await expect(page.getByRole("button", { name: COMPACT_BUTTON })).toBeEnabled({
+      timeout: 60000,
+    });
+
+    const task = await getLatestTaskDetail(page, LARGE_PROJECT_ID);
+    expect(task.agent_session_id).toBeTruthy();
+
+    await page.getByRole("button", { name: COMPACT_BUTTON }).click();
+    await expect(page.getByText("正在压缩上下文").first()).toBeVisible({ timeout: 60000 });
+
+    await page.waitForTimeout(3000);
+
+    const cancelStatus = await cancelSessionViaApi(page, task.agent_session_id as string);
+    expect(cancelStatus).toBe(200);
+
+    await expect(page.getByRole("button", { name: COMPACT_BUTTON })).toBeEnabled({
+      timeout: 120000,
+    });
+
+    await sendMessage(page, "回复「压缩后会话正常」六个字，不要执行任何工具。");
+    await waitForAssistantReply(page, "压缩后会话正常");
+  });
+});

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -1,0 +1,199 @@
+import { expect, type Page } from "@playwright/test";
+
+export const EMPTY_PROJECT_ID = "EDzAi3teTeKimQH_VXoxB";
+export const LARGE_PROJECT_ID = "sEhu5CzLC-GfoDjsM01yg";
+
+export const EMPTY_PROJECT_URL = `/projects/${EMPTY_PROJECT_ID}`;
+export const LARGE_PROJECT_URL = `/projects/${LARGE_PROJECT_ID}`;
+
+export const COMPOSER = ".ai-sidebar-input-body[data-mode='composer']";
+export const SEND_BUTTON = ".ai-sidebar-send-button";
+export const APPROVAL_PANEL = ".agent-special-panel-approval";
+export const COMPACT_BUTTON = "压缩上下文";
+export const NEW_TASK_BUTTON = "新建任务";
+
+export interface TaskInfo {
+  id: string;
+  is_running: boolean;
+  title: string;
+}
+
+export interface TaskDetail extends TaskInfo {
+  agent_session_id: string | null;
+  current_revision_id: string | null;
+}
+
+export async function apiRequest<T>(
+  page: Page,
+  method: "GET" | "POST",
+  url: string,
+  body?: unknown,
+): Promise<{ status: number; data: T | null }> {
+  const response = await page.request.fetch(url, {
+    method,
+    data: body,
+    headers: body !== undefined ? { "Content-Type": "application/json" } : undefined,
+  });
+  let data: T | null = null;
+  try {
+    data = (await response.json()) as T;
+  } catch {
+    data = null;
+  }
+  return { status: response.status(), data };
+}
+
+export async function listTasks(page: Page, projectId: string): Promise<TaskInfo[]> {
+  const { status, data } = await apiRequest<{ items: TaskInfo[] }>(
+    page,
+    "GET",
+    `/api/v1/projects/${projectId}/tasks`,
+  );
+  expect(status).toBe(200);
+  return data?.items ?? [];
+}
+
+export async function getLatestTask(page: Page, projectId: string): Promise<TaskInfo> {
+  const tasks = await listTasks(page, projectId);
+  const task = tasks[0];
+  expect(task).toBeTruthy();
+  return task;
+}
+
+export async function getLatestTaskDetail(page: Page, projectId: string): Promise<TaskDetail> {
+  const task = await getLatestTask(page, projectId);
+  const { status, data } = await apiRequest<TaskDetail>(page, "GET", `/api/v1/tasks/${task.id}`);
+  expect(status).toBe(200);
+  expect(data).toBeTruthy();
+  return data as TaskDetail;
+}
+
+export async function getSettingsLock(page: Page): Promise<boolean> {
+  const { status, data } = await apiRequest<{ is_locked: boolean }>(
+    page,
+    "GET",
+    "/api/v1/settings/agent-session-lock",
+  );
+  expect(status).toBe(200);
+  return data?.is_locked === true;
+}
+
+export async function cancelSessionViaApi(page: Page, sessionId: string): Promise<number> {
+  const { status } = await apiRequest(
+    page,
+    "POST",
+    `/api/v1/agent/sessions/${sessionId}/cancel`,
+    {},
+  );
+  return status;
+}
+
+export async function getSessionState(
+  page: Page,
+  sessionId: string,
+): Promise<{
+  status: number;
+  is_running?: boolean;
+  interrupts?: unknown[];
+}> {
+  const { status, data } = await apiRequest<{
+    is_running?: boolean;
+    interrupts?: unknown[];
+  }>(page, "GET", `/api/v1/agent/sessions/${sessionId}`);
+  return { status, ...(data ?? {}) };
+}
+
+export async function openProject(page: Page, projectUrl: string): Promise<void> {
+  await page.goto(projectUrl);
+  await expect(page.locator(".ai-sidebar-input-area")).toBeVisible({ timeout: 30000 });
+}
+
+export async function startNewTask(page: Page): Promise<void> {
+  const newTaskButton = page.getByRole("button", { name: NEW_TASK_BUTTON });
+  if (await newTaskButton.isVisible().catch(() => false)) {
+    await newTaskButton.click();
+  }
+  await expect(page.locator(".ai-sidebar-input-area")).toBeVisible();
+}
+
+export const MESSAGES_AREA = ".agent-message-scroll-content";
+
+export async function typeMessage(page: Page, text: string): Promise<void> {
+  const editor = page.locator(`${COMPOSER} p`).first();
+  await editor.click();
+  await editor.fill(text);
+}
+
+export async function sendMessage(page: Page, text: string): Promise<void> {
+  await typeMessage(page, text);
+  const sendButton = page.locator(SEND_BUTTON);
+  await expect(sendButton).toBeEnabled({ timeout: 10000 });
+  await sendButton.click();
+  const confirmButton = page.getByRole("button", { name: "继续发送" });
+  if (await confirmButton.isVisible({ timeout: 5000 }).catch(() => false)) {
+    await confirmButton.click();
+  }
+  const editor = page.locator(`${COMPOSER} p`).first();
+  await expect(editor).toBeEmpty({ timeout: 10000 });
+}
+
+export async function waitForRunningState(page: Page, timeout = 120000): Promise<void> {
+  await expect(page.getByText("正在考虑下一步").first()).toBeVisible({ timeout });
+}
+
+export async function waitForTaskRunning(
+  page: Page,
+  projectId: string,
+  timeout = 60000,
+): Promise<void> {
+  await expect(async () => {
+    const tasks = await listTasks(page, projectId);
+    expect(tasks[0]?.is_running).toBe(true);
+  }).toPass({ timeout });
+}
+
+export async function waitForAssistantReply(
+  page: Page,
+  text: string,
+  timeout = 240000,
+): Promise<void> {
+  await expect(
+    page.locator(`${MESSAGES_AREA} [data-block-type="agent"]`).getByText(text).first(),
+  ).toBeVisible({ timeout });
+}
+
+export async function waitForApprovalPanel(page: Page, timeout = 180000): Promise<void> {
+  await expect(page.locator(APPROVAL_PANEL)).toBeVisible({ timeout });
+}
+
+export async function approveUntilReply(
+  page: Page,
+  text: string,
+  timeoutMs = 420000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const approval = page.locator(APPROVAL_PANEL);
+    if (await approval.isVisible().catch(() => false)) {
+      await approval.getByRole("button", { name: "执行" }).click();
+      await expect(approval)
+        .toBeHidden({ timeout: 120000 })
+        .catch(() => undefined);
+    }
+    const reply = page
+      .locator(`${MESSAGES_AREA} [data-block-type="agent"]`)
+      .getByText(text)
+      .first();
+    if (await reply.isVisible().catch(() => false)) return;
+    await page.waitForTimeout(2000);
+  }
+  throw new Error(`未在 ${timeoutMs}ms 内收到回复: ${text}`);
+}
+
+export async function waitForIdle(page: Page, timeout = 180000): Promise<void> {
+  await expect(page.locator(SEND_BUTTON)).toHaveClass(/ai-sidebar-send-button/, { timeout });
+  await expect(async () => {
+    const running = await page.getByText(/正在考虑下一步|正在等待审批|正在执行/).count();
+    expect(running).toBe(0);
+  }).toPass({ timeout });
+}

--- a/frontend/e2e/queueing.spec.ts
+++ b/frontend/e2e/queueing.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  EMPTY_PROJECT_URL,
+  SEND_BUTTON,
+  approveUntilReply,
+  openProject,
+  sendMessage,
+  startNewTask,
+  typeMessage,
+  waitForRunningState,
+} from "./helpers";
+
+test.describe("消息排队", () => {
+  test("运行中发送新消息进入排队并在首条完成后继续", async ({ page }) => {
+    await openProject(page, EMPTY_PROJECT_URL);
+    await startNewTask(page);
+
+    await sendMessage(
+      page,
+      `请分三步执行：第一步，创建一个名为「排队测试${Date.now().toString(36)}」的章节。第二步，写入 50 字内容。第三步，完成前不要提前回复总结。`,
+    );
+    await waitForRunningState(page);
+
+    await typeMessage(page, "第一条完成后请回复「第二条已处理」，不要执行其他工具。");
+
+    const messageResponse = page.waitForResponse(
+      (response) =>
+        response.request().method() === "POST" &&
+        response.url().includes("/agent/sessions/") &&
+        response.url().endsWith("/message"),
+      { timeout: 30000 },
+    );
+    await page.locator(SEND_BUTTON).click();
+    const response = await messageResponse;
+    expect(response.status()).toBe(200);
+    const body = (await response.json()) as { queued?: boolean };
+    expect(body.queued).toBe(true);
+
+    await approveUntilReply(page, "第二条已处理", 480000);
+  });
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "format:check": "oxfmt . --check",
     "lint": "oxlint .",
     "preview": "vp preview",
+    "test:e2e": "playwright test",
     "type-check": "oxlint . --type-aware --type-check"
   },
   "dependencies": {
@@ -104,6 +105,7 @@
     "zustand": "^5.0.13"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.1",
     "@types/diff-match-patch": "^1.0.36",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  workers: 1,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  timeout: 10 * 60 * 1000,
+  expect: {
+    timeout: 30 * 1000,
+  },
+  reporter: [["list"]],
+  use: {
+    baseURL: "http://127.0.0.1:9000",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+    actionTimeout: 30 * 1000,
+    ...devices["Desktop Chrome"],
+    viewport: { width: 1600, height: 1000 },
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -279,6 +279,9 @@ importers:
         specifier: ^5.0.13
         version: 5.0.13(@types/react@19.2.14)(immer@11.1.7)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       '@types/diff-match-patch':
         specifier: ^1.0.36
         version: 1.0.36
@@ -905,6 +908,11 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -2974,6 +2982,11 @@ packages:
       react-dom:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3691,6 +3704,16 @@ packages:
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   pngjs@7.0.0:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
@@ -5065,6 +5088,10 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -7161,6 +7188,9 @@ snapshots:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -8173,6 +8203,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.5: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pngjs@7.0.0: {}
 

--- a/frontend/tsconfig.e2e.json
+++ b/frontend/tsconfig.e2e.json
@@ -1,15 +1,14 @@
 {
   "compilerOptions": {
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.e2e.tsbuildinfo",
     "target": "ES2023",
-    "lib": ["ES2023"],
+    "lib": ["ES2023", "DOM"],
     "module": "ESNext",
     "types": ["node"],
     "skipLibCheck": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
@@ -20,10 +19,9 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true,
     "paths": {
       "@/*": ["./src/*"]
     }
   },
-  "include": ["vite.config.ts", "playwright.config.ts"]
+  "include": ["e2e/**/*.ts"]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "files": [],
-  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" },
+    { "path": "./tsconfig.e2e.json" }
+  ],
   "compilerOptions": {
     "forceConsistentCasingInFileNames": true,
     "strict": true,


### PR DESCRIPTION
# test(frontend): 新增 Agent 会话生命周期 E2E 测试

## 变更说明

- 问题: Agent 会话取消/恢复/压缩等生命周期逻辑仅有后端单元测试，缺少端到端回归保护
- 重要性: 生命周期竞态类缺陷只有通过真实 UI 与后端联调才能复现，需要 E2E 兜底
- 变化:
  - 引入 Playwright 测试框架（@playwright/test），新增独立 tsconfig 与 test:e2e 脚本
  - 新增 7 个 E2E 用例，覆盖运行中取消、审批恢复、取消后恢复被拒、压缩成功、压缩期间取消、消息排队等核心交互
  - 更新 .gitignore 忽略测试产物

## 关联 Issue / PR

无

## 变更类型

- [x] 测试相关 (test)

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错（pnpm type-check / pnpm lint）
- [x] 已运行测试用例，全部通过（7/7，pnpm test:e2e）
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖（@playwright/test 为测试依赖，需评审确认）
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 测试证据

```
pnpm exec playwright test --reporter=list

Running 7 tests using 1 worker

  ok 1 approval-resume.spec.ts:24:3 › 审批恢复与取消互斥 › 审批执行后会话继续直至完成 (28.4s)
  ok 2 approval-resume.spec.ts:38:3 › 审批恢复与取消互斥 › 取消后审批恢复被拒绝且锁与状态正确 (11.1s)
  ok 3 approval-resume.spec.ts:71:3 › 审批恢复与取消互斥 › 运行中取消后旧任务不被新消息复活 (7.7s)
  ok 4 cancel-flow.spec.ts:16:3 › 会话取消流程 › 运行中取消后会话停止并可重新开始 (8.4s)
  ok 5 compaction.spec.ts:21:3 › 上下文压缩 › 大项目多轮会话后手动压缩成功 (45.3s)
  ok 6 compaction.spec.ts:43:3 › 上下文压缩 › 压缩期间取消会话 (42.3s)
  ok 7 queueing.spec.ts:15:3 › 消息排队 › 运行中发送新消息进入排队并在首条完成后继续 (16.9s)

  7 passed (2.7m)
```

## 补充信息

- E2E 依赖本地 dev 环境（http://127.0.0.1:9000）与已配置的模型，运行前需确保后端与前端 dev server 就绪
- 测试使用真实模型调用，运行耗时约 3 分钟
