### PR TITLE
chore(vscode): 添加 VS Code 开发任务配置

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,131 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "前端开发服务器",
+      "type": "shell",
+      "command": "pnpm",
+      "args": ["dev"],
+      "options": {
+        "cwd": "${workspaceFolder}/frontend"
+      },
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "custom",
+        "pattern": {
+          "regexp": "^$"
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "VITE+",
+          "endsPattern": "Local"
+        }
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "dedicated",
+        "showReuseMessage": true,
+        "clear": false
+      }
+    },
+    {
+      "label": "后端开发服务器",
+      "type": "shell",
+      "command": "uv",
+      "args": [
+        "run", 
+        "uvicorn", 
+        "app.main:app",
+        "--port", "8000"
+      ],
+      "options": {
+        "cwd": "${workspaceFolder}/backend"
+      },
+      "windows": {
+        "args": [
+          "run",
+          "uvicorn",
+          "app.main:app",
+          "--port", "8000",
+          "--loop", "app.cli:_windows_selector_loop_factory"
+        ]
+      },
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "custom",
+        "pattern": {
+          "regexp": "^$"
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "Started server process",
+          "endsPattern": "Application startup complete\\."
+        }
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "dedicated",
+        "showReuseMessage": true,
+        "clear": false
+      }
+    },
+    {
+      "label": "桌面端开发服务器",
+      "type": "shell",
+      "command": "pnpm",
+      "args": ["dev:local"],
+      "options": {
+        "cwd": "${workspaceFolder}/desktop"
+      },
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "custom",
+        "pattern": {
+          "regexp": "^$"
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "\\[dev:local\\]",
+          "endsPattern": "启动 Electron"
+        }
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "dedicated",
+        "showReuseMessage": true,
+        "clear": false
+      }
+    },
+    {
+      "label": "全栈开发服务器",
+      "dependsOn": ["前端开发服务器", "后端开发服务器"],
+      "dependsOrder": "parallel",
+      "isBackground": true,
+      "problemMatcher": {
+        "owner": "custom",
+        "pattern": {
+          "regexp": "^$"
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": "VITE|Started",
+          "endsPattern": "ready in|Uvicorn running on"
+        }
+      },
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "new",
+        "showReuseMessage": true,
+        "clear": false
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## PR 标题

chore(vscode): 添加 VS Code 开发任务配置

## 变更说明

- 问题: 缺少 VS Code 任务配置，无法在编辑器内一键启动各开发服务器
- 重要性: 提升本地开发体验，补齐 Windows 下的后端开发兼容性
- 变化: 新增 `.vscode/tasks.json`，配置前端、后端、桌面端（`pnpm dev:local`）及全栈开发服务器任务，并为后端开发服务器添加 Windows 下的 uvicorn selector 循环参数

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因(如有)

无

## 自查清单

- [ ] 已添加/更新必要的测试
- [ ] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

无
