### PR TITLE
fix(desktop): 限制 setup 错误内容高度

### DIFF
--- a/desktop/src/ui/pages/setup/setup.css
+++ b/desktop/src/ui/pages/setup/setup.css
@@ -418,9 +418,17 @@
 }
 
 .setup-alert-error {
+  max-height: min(180px, 30vh);
+  overflow-y: auto;
+  align-items: flex-start;
   background: var(--red-a3);
   color: var(--red-11, #b91c1c);
   border: 1px solid var(--red-a5);
+}
+
+.setup-alert-error > span {
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
 .setup-alert-success {


### PR DESCRIPTION
## PR 标题

fix(desktop): 限制 setup 错误内容高度

## 变更说明

- 问题: setup 页面错误信息过长时会无限撑开错误区域，导致页面整体布局被顶乱。
- 重要性: 保持 setup 页面在长错误信息下的布局稳定和可读性。
- 变化: 限制错误区域最大高度并启用内部滚动，同时允许超长路径和无空格文本换行。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

`.setup-alert-error` 原先没有最大高度和内部滚动约束，长错误文本会直接增加 setup 卡片高度并挤压页面布局。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

已通过 `pnpm type-check`、`pnpm lint` 和 `pnpm build:setup`。
