### PR TITLE
fix(desktop): 修复 PyPI 镜像 wheel 文件 403 导致桌面更新失败的问题

### DIFF
--- a/desktop/src/main/runtime/openfic.ts
+++ b/desktop/src/main/runtime/openfic.ts
@@ -132,18 +132,7 @@ async function probePypiIndex(indexUrl: string, expectedVersion: string): Promis
   }
 }
 
-async function getFastestPypiEnvironment(expectedVersion: string): Promise<NodeJS.ProcessEnv> {
-  await configureDefaultSystemProxy();
-  const probes = await Promise.all(
-    [DEFAULT_PYPI_INDEX_URL, TSINGHUA_PYPI_INDEX_URL].map((indexUrl) => probePypiIndex(indexUrl, expectedVersion)),
-  );
-  let fastestProbe: PypiIndexProbe | null = null;
-  for (const probe of probes) {
-    if (probe && (!fastestProbe || probe.elapsedMs < fastestProbe.elapsedMs)) fastestProbe = probe;
-  }
-
-  const indexUrl = fastestProbe?.indexUrl ?? DEFAULT_PYPI_INDEX_URL;
-  appendLog("runtime", `使用 Python 包索引：${indexUrl}`);
+async function buildPypiEnvironment(indexUrl: string): Promise<NodeJS.ProcessEnv> {
   const proxyEnvironment = await getSystemProxyEnvironment(indexUrl);
   return {
     ...proxyEnvironment,
@@ -152,6 +141,21 @@ async function getFastestPypiEnvironment(expectedVersion: string): Promise<NodeJ
     pip_index_url: indexUrl,
     uv_index_url: indexUrl,
   };
+}
+
+async function getPypiEnvironmentsBySpeed(expectedVersion: string): Promise<NodeJS.ProcessEnv[]> {
+  await configureDefaultSystemProxy();
+  const probes = await Promise.all(
+    [DEFAULT_PYPI_INDEX_URL, TSINGHUA_PYPI_INDEX_URL].map((indexUrl) => probePypiIndex(indexUrl, expectedVersion)),
+  );
+  const orderedUrls = probes
+    .filter((probe): probe is PypiIndexProbe => probe !== null)
+    .sort((a, b) => a.elapsedMs - b.elapsedMs)
+    .map((probe) => probe.indexUrl);
+  if (orderedUrls.length === 0) orderedUrls.push(DEFAULT_PYPI_INDEX_URL);
+
+  appendLog("runtime", `Python 包索引回退顺序：${orderedUrls.join(", ")}`);
+  return Promise.all(orderedUrls.map((indexUrl) => buildPypiEnvironment(indexUrl)));
 }
 
 function run(
@@ -276,6 +280,26 @@ async function runUvInstallWithSystemCertsRetry(
   }
 }
 
+async function runInstallWithIndexFallback(
+  environments: NodeJS.ProcessEnv[],
+  runInstall: (environment: NodeJS.ProcessEnv) => Promise<void>,
+): Promise<void> {
+  let lastError: unknown = null;
+  for (let index = 0; index < environments.length; index += 1) {
+    const environment = environments[index];
+    const indexUrl = environment.UV_INDEX_URL ?? environment.PIP_INDEX_URL ?? `第 ${index + 1} 个`;
+    appendLog("runtime", `尝试使用 Python 包索引安装：${indexUrl}`);
+    try {
+      await runInstall(environment);
+      return;
+    } catch (error) {
+      lastError = error;
+      appendLog("runtime", `使用 ${indexUrl} 安装失败，尝试回退：${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+  throw lastError;
+}
+
 export async function inspectOpenFicRuntime(
   runtimeDir: string,
   expectedVersion: string,
@@ -318,8 +342,8 @@ export async function ensureOpenFicRuntime(
   const venvDir = getVenvDir(runtimeDir);
   const venvPythonPath = getVenvPythonPath(runtimeDir);
   const uvPath = getUvPath(runtimeDir);
-  let pypiEnvironment: Promise<NodeJS.ProcessEnv> | null = null;
-  const getPypiEnvironment = () => (pypiEnvironment ??= getFastestPypiEnvironment(expectedVersion));
+  let pypiEnvironments: Promise<NodeJS.ProcessEnv[]> | null = null;
+  const getPypiEnvironments = () => (pypiEnvironments ??= getPypiEnvironmentsBySpeed(expectedVersion));
 
   appendLog("runtime", `开始检查 OpenFic 运行环境：${runtimeDir}`);
   await mkdir(runtimeDir, { recursive: true });
@@ -342,13 +366,15 @@ export async function ensureOpenFicRuntime(
   if (!uvIsUsable) {
     appendLog("runtime", "uv 不存在或不可用，开始安装");
     onProgress("install-uv", "安装 uv");
-    const packageIndexEnvironment = await getPypiEnvironment();
-    await run(
-      venvPythonPath,
-      ["-m", "pip", "install", "--force-reinstall", "uv"],
-      runtimeDir,
-      (message) => onProgress("install-uv", message),
-      packageIndexEnvironment,
+    const packageIndexEnvironments = await getPypiEnvironments();
+    await runInstallWithIndexFallback(packageIndexEnvironments, (environment) =>
+      run(
+        venvPythonPath,
+        ["-m", "pip", "install", "--force-reinstall", "uv"],
+        runtimeDir,
+        (message) => onProgress("install-uv", message),
+        environment,
+      ),
     );
   }
 
@@ -363,18 +389,14 @@ export async function ensureOpenFicRuntime(
       installedVersion ? `OpenFic 后端需要更新：${installedVersion} -> ${expectedVersion}` : "OpenFic 后端尚未安装",
     );
     onProgress("install-openfic", installedVersion ? "更新 OpenFic 后端" : "安装 OpenFic 后端");
-    const packageIndexEnvironment = await getPypiEnvironment();
+    const packageIndexEnvironments = await getPypiEnvironments();
     const installCommand = createOpenFicInstallCommand(
       venvPythonPath,
       expectedVersion,
       installedVersion === expectedVersion && !openFicCliIsUsable,
     );
-    await runUvInstallWithSystemCertsRetry(
-      uvPath,
-      installCommand.args,
-      runtimeDir,
-      onProgress,
-      packageIndexEnvironment,
+    await runInstallWithIndexFallback(packageIndexEnvironments, (environment) =>
+      runUvInstallWithSystemCertsRetry(uvPath, installCommand.args, runtimeDir, onProgress, environment),
     );
   }
 


### PR DESCRIPTION
## PR 标题

fix(desktop): 修复 PyPI 镜像 wheel 文件 403 导致桌面更新失败的问题

## 变更说明

- 问题: PyPI 镜像索引可能已经列出目标版本，但对应 wheel 尚未同步，安装时返回 403 并导致桌面更新失败。
- 重要性: 避免单个镜像的 wheel 同步延迟阻断桌面端运行环境安装和更新。
- 变化: 按探测耗时排序候选源；uv 和 OpenFic 安装失败时依次回退到其他源；保留每个源内部的 system-certs 重试。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

原实现只根据 PyPI 索引页判断版本可用，并且只使用探测最快的一个源；索引已同步但 wheel 返回 403 时，安装流程没有后备源可用。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

已通过 `pnpm type-check`、`pnpm lint` 和 `pnpm build:main`。当前没有覆盖该回退流程的专用自动化测试。
