### PR TITLE
chore(agent): 记住输入历史和未发送草稿

### DIFF
--- a/frontend/src/features/assistant/components/agent/agent-composer-editor.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-composer-editor.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/features/assistant/lib/mention-text";
 import { searchMentionCandidates } from "@/lib/api-client";
 
+import type { AgentInputHistoryDirection } from "../../lib/agent-input-history-state";
 import { MentionNode } from "./extensions/mention-node";
 import type { AssistantMentionNodeAttributes } from "./extensions/mention-node";
 
@@ -52,6 +53,7 @@ interface AgentComposerEditorProps {
   onDropFiles?: (dataTransfer: DataTransfer) => void;
   onChange: (value: string) => void;
   onSubmit: () => void;
+  onHistoryNavigate?: (direction: AgentInputHistoryDirection) => boolean;
 }
 
 interface MentionQueryState {
@@ -156,6 +158,7 @@ export function AgentComposerEditor({
   onDropFiles,
   onChange,
   onSubmit,
+  onHistoryNavigate,
 }: AgentComposerEditorProps) {
   const isApplyingExternalValueRef = useRef(false);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -339,6 +342,31 @@ export function AgentComposerEditor({
 
   const handleEditorKeyDownCapture = useCallback(
     (event: ReactKeyboardEvent<HTMLDivElement>) => {
+      if (
+        !disabled &&
+        !mentionQuery.visible &&
+        editor &&
+        !event.shiftKey &&
+        !event.ctrlKey &&
+        !event.altKey &&
+        !event.metaKey &&
+        (event.key === "ArrowUp" || event.key === "ArrowDown")
+      ) {
+        const { selection } = editor.state;
+        const isAtBoundary =
+          selection.empty &&
+          (event.key === "ArrowUp"
+            ? selection.from <= 1
+            : selection.to >= editor.state.doc.content.size - 1);
+        if (isAtBoundary) {
+          const direction = event.key === "ArrowUp" ? "older" : "newer";
+          if (onHistoryNavigate?.(direction)) {
+            event.preventDefault();
+            return;
+          }
+        }
+      }
+
       if (event.key !== "Enter") return;
       if (event.shiftKey) {
         if (!editor) return;
@@ -350,7 +378,15 @@ export function AgentComposerEditor({
       event.preventDefault();
       onSubmit();
     },
-    [editor, onSubmit, suggestionItems.length, suggestionStatus],
+    [
+      disabled,
+      editor,
+      mentionQuery.visible,
+      onHistoryNavigate,
+      onSubmit,
+      suggestionItems.length,
+      suggestionStatus,
+    ],
   );
 
   const handlePasteCapture = (event: ReactClipboardEvent<HTMLDivElement>) => {

--- a/frontend/src/features/assistant/components/agent/agent-input.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-input.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, IconButton, Text, Tooltip } from "@radix-ui/themes";
 import { ArrowUp, CloudUpload, ExternalLink, ShieldCheck, Square, X } from "lucide-react";
 import { AnimatePresence, motion } from "motion/react";
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { PhotoProvider, PhotoView } from "react-photo-view";
@@ -14,6 +14,7 @@ import { SimpleSelect, type SelectOption } from "@/components/select";
 import { ProviderIcon } from "@/features/settings/lib/provider-icons";
 import type { AgentPendingMessage, AgentSessionStatus, ReasoningEffort } from "@/lib/agent.types";
 
+import { useAgentInputHistory } from "../../hooks/use-agent-input-history";
 import {
   getAgentImageFiles,
   hasLeftAgentImageDropZone,
@@ -21,6 +22,7 @@ import {
   type PendingAgentImageAttachment,
   validateAgentImageFiles,
 } from "../../lib/agent-image-attachments";
+import type { AgentInputHistoryDirection } from "../../lib/agent-input-history-state";
 import { AgentComposerEditor, type AgentComposerSuggestionState } from "./agent-composer-editor";
 import { AgentIndexStatusIndicator } from "./agent-index-status-indicator";
 import { canSendAgentInput, getAgentInputBodyMode, isAgentInputLocked } from "./agent-input-state";
@@ -121,6 +123,15 @@ export function AgentInput({
   const [mentionSuggestions, setMentionSuggestions] = useState<AgentComposerSuggestionState | null>(
     null,
   );
+  const {
+    draft: persistedDraft,
+    handleInputChange: handleHistoryInputChange,
+    isDraftLoaded,
+    navigate: navigateInputHistory,
+    record: recordInputHistory,
+  } = useAgentInputHistory(projectId);
+  const historyValueRef = useRef<string | null>(null);
+  const previousProjectIdRef = useRef(projectId);
   const selectedModel = useMemo(
     () => models.find((model) => model.value === modelId || model.id === modelId),
     [modelId, models],
@@ -145,6 +156,54 @@ export function AgentInput({
     { value: "xhigh", label: "Xhigh" },
     { value: "max", label: "Max" },
   ];
+
+  useEffect(() => {
+    if (previousProjectIdRef.current === projectId) return;
+    previousProjectIdRef.current = projectId;
+    historyValueRef.current = "";
+    onChange("");
+  }, [onChange, projectId]);
+
+  useEffect(() => {
+    if (!isDraftLoaded || !persistedDraft || value !== "") return;
+    historyValueRef.current = persistedDraft;
+    onChange(persistedDraft);
+  }, [isDraftLoaded, onChange, persistedDraft, value]);
+
+  useEffect(() => {
+    if (!isDraftLoaded) return;
+    if (historyValueRef.current === value) {
+      historyValueRef.current = null;
+      return;
+    }
+    historyValueRef.current = null;
+    handleHistoryInputChange(value);
+  }, [handleHistoryInputChange, isDraftLoaded, value]);
+
+  const handleComposerChange = useCallback(
+    (nextValue: string) => {
+      historyValueRef.current = null;
+      handleHistoryInputChange(nextValue);
+      onChange(nextValue);
+    },
+    [handleHistoryInputChange, onChange],
+  );
+
+  const handleHistoryNavigate = useCallback(
+    (direction: AgentInputHistoryDirection): boolean => {
+      const nextValue = navigateInputHistory(direction, value);
+      if (nextValue === null) return false;
+      historyValueRef.current = nextValue;
+      onChange(nextValue);
+      return true;
+    },
+    [navigateInputHistory, onChange, value],
+  );
+
+  const handleSubmit = useCallback(() => {
+    recordInputHistory(value);
+    onSend();
+  }, [onSend, recordInputHistory, value]);
 
   useLayoutEffect(() => {
     const container = inputContainerRef.current;
@@ -403,8 +462,9 @@ export function AgentInput({
                   onMentionSuggestionsChange={setMentionSuggestions}
                   onPasteFiles={handlePastedFiles}
                   onDropFiles={handleDroppedFiles}
-                  onChange={onChange}
-                  onSubmit={onSend}
+                  onChange={handleComposerChange}
+                  onHistoryNavigate={handleHistoryNavigate}
+                  onSubmit={handleSubmit}
                 />
               </motion.div>
             )}
@@ -594,7 +654,7 @@ export function AgentInput({
                 variant="solid"
                 size="1"
                 className="ai-sidebar-send-button"
-                onClick={shouldAbort ? onAbort : onSend}
+                onClick={shouldAbort ? onAbort : handleSubmit}
                 disabled={shouldAbort ? false : !canSend}
                 aria-disabled={!buttonActive || undefined}
                 style={{

--- a/frontend/src/features/assistant/hooks/use-agent-input-history.ts
+++ b/frontend/src/features/assistant/hooks/use-agent-input-history.ts
@@ -1,0 +1,175 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { getAgentInputHistory, setAgentInputHistory } from "@/lib/local-db";
+
+import {
+  appendAgentInputHistory,
+  applyAgentInputChange,
+  createAgentInputHistoryState,
+  navigateAgentInputHistory,
+  normalizeAgentInputDraft,
+  type AgentInputHistoryDirection,
+  type AgentInputHistoryState,
+} from "../lib/agent-input-history-state";
+
+const AGENT_INPUT_DRAFT_SAVE_DELAY = 300;
+
+export function useAgentInputHistory(projectId: string) {
+  const [historyState, setHistoryState] = useState<AgentInputHistoryState>(() =>
+    createAgentInputHistoryState([]),
+  );
+  const [draft, setDraft] = useState("");
+  const [isDraftLoaded, setIsDraftLoaded] = useState(false);
+  const historyStateRef = useRef(historyState);
+  const draftRef = useRef("");
+  const draftChangedRef = useRef(false);
+  const draftSaveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const writeQueueRef = useRef(Promise.resolve());
+
+  const commitState = useCallback((nextState: AgentInputHistoryState) => {
+    historyStateRef.current = nextState;
+    setHistoryState(nextState);
+  }, []);
+
+  const persistState = useCallback(
+    (targetProjectId: string, entries: string[], targetDraft: string) => {
+      if (!targetProjectId) return;
+      const nextWrite = writeQueueRef.current.then(() =>
+        setAgentInputHistory(targetProjectId, entries, targetDraft),
+      );
+      writeQueueRef.current = nextWrite.then(
+        () => undefined,
+        () => undefined,
+      );
+    },
+    [],
+  );
+
+  const clearDraftSaveTimer = useCallback(() => {
+    if (draftSaveTimerRef.current === null) return;
+    clearTimeout(draftSaveTimerRef.current);
+    draftSaveTimerRef.current = null;
+  }, []);
+
+  const flushDraftForProject = useCallback(
+    (targetProjectId: string) => {
+      clearDraftSaveTimer();
+      if (!targetProjectId || !draftChangedRef.current) return;
+      draftChangedRef.current = false;
+      persistState(targetProjectId, historyStateRef.current.entries, draftRef.current);
+    },
+    [clearDraftSaveTimer, persistState],
+  );
+
+  const scheduleDraftSave = useCallback(
+    (value: string) => {
+      draftRef.current = normalizeAgentInputDraft(value);
+      draftChangedRef.current = true;
+      setDraft(draftRef.current);
+      clearDraftSaveTimer();
+      if (!projectId) return;
+
+      draftSaveTimerRef.current = setTimeout(() => {
+        draftSaveTimerRef.current = null;
+        if (!draftChangedRef.current) return;
+        draftChangedRef.current = false;
+        persistState(projectId, historyStateRef.current.entries, draftRef.current);
+      }, AGENT_INPUT_DRAFT_SAVE_DELAY);
+    },
+    [clearDraftSaveTimer, persistState, projectId],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    commitState(createAgentInputHistoryState([]));
+    draftRef.current = "";
+    draftChangedRef.current = false;
+    setDraft("");
+    setIsDraftLoaded(false);
+
+    if (!projectId) {
+      setIsDraftLoaded(true);
+      return () => undefined;
+    }
+
+    void getAgentInputHistory(projectId).then((storedState) => {
+      if (cancelled) return;
+
+      let mergedEntries = storedState.entries;
+      for (const entry of historyStateRef.current.entries) {
+        mergedEntries = appendAgentInputHistory(mergedEntries, entry);
+      }
+      const hasPendingDraft = draftChangedRef.current;
+      const nextDraft = hasPendingDraft ? draftRef.current : storedState.draft;
+      commitState(createAgentInputHistoryState(mergedEntries));
+      draftRef.current = nextDraft;
+      draftChangedRef.current = false;
+      setDraft(nextDraft);
+      setIsDraftLoaded(true);
+
+      if (hasPendingDraft || mergedEntries.length !== storedState.entries.length) {
+        persistState(projectId, mergedEntries, nextDraft);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      flushDraftForProject(projectId);
+    };
+  }, [commitState, flushDraftForProject, persistState, projectId]);
+
+  useEffect(() => {
+    const handlePageHide = () => flushDraftForProject(projectId);
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "hidden") handlePageHide();
+    };
+
+    window.addEventListener("pagehide", handlePageHide);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    return () => {
+      window.removeEventListener("pagehide", handlePageHide);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [flushDraftForProject, projectId]);
+
+  const handleInputChange = useCallback(
+    (value: string) => {
+      commitState(applyAgentInputChange(historyStateRef.current, value));
+      scheduleDraftSave(value);
+    },
+    [commitState, scheduleDraftSave],
+  );
+
+  const navigate = useCallback(
+    (direction: AgentInputHistoryDirection, currentValue: string): string | null => {
+      const result = navigateAgentInputHistory(historyStateRef.current, direction, currentValue);
+      if (!result.handled) return null;
+      commitState(result.state);
+      return result.value;
+    },
+    [commitState],
+  );
+
+  const record = useCallback(
+    (value: string) => {
+      const currentState = historyStateRef.current;
+      const nextEntries = appendAgentInputHistory(currentState.entries, value);
+      clearDraftSaveTimer();
+      draftRef.current = "";
+      draftChangedRef.current = false;
+      setDraft("");
+      commitState(createAgentInputHistoryState(nextEntries));
+      if (projectId) persistState(projectId, nextEntries, "");
+    },
+    [clearDraftSaveTimer, commitState, persistState, projectId],
+  );
+
+  return {
+    draft,
+    handleInputChange,
+    isDraftLoaded,
+    navigate,
+    record,
+    historyState,
+  };
+}

--- a/frontend/src/features/assistant/lib/agent-input-history-state.ts
+++ b/frontend/src/features/assistant/lib/agent-input-history-state.ts
@@ -1,0 +1,85 @@
+export const AGENT_INPUT_HISTORY_LIMIT = 50;
+
+export type AgentInputHistoryDirection = "older" | "newer";
+
+export function normalizeAgentInputDraft(value: string): string {
+  return value.trim() ? value : "";
+}
+
+export interface AgentInputHistoryState {
+  entries: string[];
+  index: number | null;
+  draft: string;
+}
+
+export interface AgentInputHistoryNavigationResult {
+  state: AgentInputHistoryState;
+  value: string;
+  handled: boolean;
+}
+
+export function appendAgentInputHistory(entries: string[], value: string): string[] {
+  if (!value.trim() || entries.at(-1) === value) return entries;
+  return [...entries, value].slice(-AGENT_INPUT_HISTORY_LIMIT);
+}
+
+export function createAgentInputHistoryState(entries: string[]): AgentInputHistoryState {
+  return {
+    entries: entries.slice(-AGENT_INPUT_HISTORY_LIMIT),
+    index: null,
+    draft: "",
+  };
+}
+
+export function applyAgentInputChange(
+  state: AgentInputHistoryState,
+  value: string,
+): AgentInputHistoryState {
+  return {
+    ...state,
+    index: null,
+    draft: value,
+  };
+}
+
+export function navigateAgentInputHistory(
+  state: AgentInputHistoryState,
+  direction: AgentInputHistoryDirection,
+  currentValue: string,
+): AgentInputHistoryNavigationResult {
+  if (direction === "older") {
+    const nextIndex = state.index === null ? state.entries.length - 1 : state.index - 1;
+    if (nextIndex < 0) {
+      return { state, value: currentValue, handled: false };
+    }
+
+    return {
+      state: {
+        ...state,
+        index: nextIndex,
+        draft: state.index === null ? currentValue : state.draft,
+      },
+      value: state.entries[nextIndex],
+      handled: true,
+    };
+  }
+
+  if (state.index === null) {
+    return { state, value: currentValue, handled: false };
+  }
+
+  const nextIndex = state.index + 1;
+  if (nextIndex < state.entries.length) {
+    return {
+      state: { ...state, index: nextIndex },
+      value: state.entries[nextIndex],
+      handled: true,
+    };
+  }
+
+  return {
+    state: { ...state, index: null },
+    value: state.draft,
+    handled: true,
+  };
+}

--- a/frontend/src/features/projects/hooks/use-projects.ts
+++ b/frontend/src/features/projects/hooks/use-projects.ts
@@ -7,7 +7,7 @@
 import { keepPreviousData, useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 
 import { fetchProjects, createProject, updateProject, deleteProject } from "@/lib/api-client";
-import { removeRecentProjectByProjectId } from "@/lib/local-db";
+import { deleteAgentInputHistory, removeRecentProjectByProjectId } from "@/lib/local-db";
 import type { ProjectCreate, ProjectUpdate, ProjectListParams } from "@/lib/project.types";
 import type { RecentProject } from "@/lib/recent-projects";
 
@@ -64,7 +64,10 @@ export function useDeleteProject() {
     mutationFn: (projectId: string) => deleteProject(projectId),
     onSuccess: async (_data, projectId) => {
       await queryClient.cancelQueries({ queryKey: ["recent-projects"] });
-      await removeRecentProjectByProjectId(projectId);
+      await Promise.all([
+        removeRecentProjectByProjectId(projectId),
+        deleteAgentInputHistory(projectId),
+      ]);
       queryClient.setQueryData<RecentProject[]>(["recent-projects"], (recentProjects) =>
         recentProjects?.filter((project) => project.projectId !== projectId),
       );

--- a/frontend/src/lib/local-db.ts
+++ b/frontend/src/lib/local-db.ts
@@ -87,6 +87,13 @@ export interface WritingWorkingCopy {
   updatedAt: Date;
 }
 
+interface AgentInputHistory {
+  projectId: string;
+  entries: string[];
+  draft: string;
+  updatedAt: Date;
+}
+
 /**
  * OpenFic 本地数据库
  */
@@ -96,6 +103,7 @@ class OpenFicDB extends Dexie {
   userPreferences!: EntityTable<UserPreference, "key">;
   promptChainWorkingCopies!: EntityTable<PromptChainWorkingCopy, "chainId">;
   writingWorkingCopies!: EntityTable<WritingWorkingCopy, "id">;
+  agentInputHistories!: EntityTable<AgentInputHistory, "projectId">;
   recentProjects!: EntityTable<RecentProject, "slot">;
 
   constructor() {
@@ -146,6 +154,16 @@ class OpenFicDB extends Dexie {
       userPreferences: "key, updatedAt",
       promptChainWorkingCopies: "chainId, updatedAt",
       writingWorkingCopies: "id, entityId, type, updatedAt",
+      recentProjects: "slot, projectId, openedAt",
+    });
+
+    this.version(8).stores({
+      projectLastChapters: "projectId, updatedAt",
+      projectTabs: "projectId, updatedAt",
+      userPreferences: "key, updatedAt",
+      promptChainWorkingCopies: "chainId, updatedAt",
+      writingWorkingCopies: "id, entityId, type, updatedAt",
+      agentInputHistories: "projectId, updatedAt",
       recentProjects: "slot, projectId, openedAt",
     });
   }
@@ -262,6 +280,57 @@ export async function deleteProjectTabs(projectId: string): Promise<void> {
     await db.projectTabs.delete(projectId);
   } catch {
     console.error("删除项目标签页记录失败");
+  }
+}
+
+// ==================== Agent 输入历史 ====================
+
+/**
+ * 获取项目的 Agent 输入历史。
+ */
+export async function getAgentInputHistory(
+  projectId: string,
+): Promise<{ entries: string[]; draft: string }> {
+  try {
+    const record = await db.agentInputHistories.get(projectId);
+    return {
+      entries: record?.entries ?? [],
+      draft: record?.draft ?? "",
+    };
+  } catch {
+    console.error("获取 Agent 输入历史失败");
+    return { entries: [], draft: "" };
+  }
+}
+
+/**
+ * 保存项目的 Agent 输入历史和未发送草稿。
+ */
+export async function setAgentInputHistory(
+  projectId: string,
+  entries: string[],
+  draft = "",
+): Promise<void> {
+  try {
+    await db.agentInputHistories.put({
+      projectId,
+      entries,
+      draft,
+      updatedAt: new Date(),
+    });
+  } catch {
+    console.error("保存 Agent 输入历史失败");
+  }
+}
+
+/**
+ * 删除项目的 Agent 输入历史。
+ */
+export async function deleteAgentInputHistory(projectId: string): Promise<void> {
+  try {
+    await db.agentInputHistories.delete(projectId);
+  } catch {
+    console.error("删除 Agent 输入历史失败");
   }
 }
 


### PR DESCRIPTION
## PR 标题

chore(agent): 记住输入历史和未发送草稿

## 变更说明

- 问题: Agent 输入框原本只保留当前内存内容，切换页面或关闭页面后无法恢复未发送草稿，也无法按项目切换已发送输入历史。
- 重要性: 减少重复输入，避免页面切换或意外关闭导致工作内容丢失。
- 变化: 使用 Dexie 按 `projectId` 保存最多 50 条输入历史和未发送草稿；支持上下键切换历史、300ms 防抖保存及页面隐藏时补写。

## 关联 Issue / PR (如有)

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因(如有)

原输入框状态只存在 React 内存中，没有项目级本地持久化，也没有历史导航状态。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理
- [x] 提交信息符合规范

## 补充信息

已通过 `pnpm type-check`、`pnpm lint`、`pnpm exec oxfmt . --check` 和 `pnpm build`；草稿状态临时 Node 测试全部通过。持久化使用前端 Dexie version 8，不涉及后端数据库或 Alembic。
