### PR TITLE
fix(openrouter): 修复 OpenRouter SDK 超时单位混淆导致请求卡住的问题

### DIFF
--- a/backend/app/models/clients/model_factory.py
+++ b/backend/app/models/clients/model_factory.py
@@ -223,7 +223,7 @@ def create_chat_model(config: ModelConfig) -> Runnable[LanguageModelInput, BaseM
             ),
             reasoning={"effort": reasoning_effort} if reasoning_effort else None,
             max_retries=0,
-            timeout=int(_request_timeout()[1]),
+            timeout=int(_request_timeout()[1] * 1000),
         ))
 
     if provider == "groq":

--- a/backend/tests/agent_runtime/test_model_factory.py
+++ b/backend/tests/agent_runtime/test_model_factory.py
@@ -398,7 +398,10 @@ def test_create_chat_model_deepseek_uses_native_client(monkeypatch):
     assert model.stream_chunk_timeout == 77.0
 
 
-def test_create_chat_model_openrouter_uses_native_client():
+def test_create_chat_model_openrouter_uses_native_client(monkeypatch):
+    from app.settings import settings
+
+    monkeypatch.setattr(settings, "llm_request_timeout", 600.0)
     config = ModelConfig(
         provider_type="openrouter",
         base_url="https://openrouter.ai/api/v1",
@@ -411,6 +414,7 @@ def test_create_chat_model_openrouter_uses_native_client():
     from langchain_openrouter import ChatOpenRouter
 
     assert isinstance(model, ChatOpenRouter)
+    assert model.request_timeout == 600000
 
 
 def test_create_chat_model_groq_uses_native_client():


### PR DESCRIPTION
## PR 标题

fix(openrouter): 修复 OpenRouter SDK 超时单位混淆导致请求卡住的问题

## 变更说明

- 问题: OpenRouter 提供商使用 Auto Router 模型时，请求会因首字节响应超时而持续重试，前端表现为无限卡住。
- 重要性: 修复后可以正常使用 OpenRouter 的 Auto Router 模型，避免错误的短超时和无效重试。
- 变化: 将 OpenRouter SDK 所需的请求超时时间从秒转换为毫秒，并新增超时单位回归测试。
- 验证: 完整复现请求从 100 秒无响应恢复为约 3 秒完成。

## 关联 Issue / PR (如有)

Closes #318

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

`ChatOpenRouter.timeout` 的单位是毫秒，但项目将 `llm_request_timeout` 的秒值直接传入。配置值 `600` 因此被 SDK 解析为 600 毫秒，Auto Router 的路由和首字节响应通常超过该时间，触发超时和持续重试。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和类型检查，无报错
- [x] 已运行受影响的测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 本次无数据库变更，无需 Alembic 迁移
- [x] 提交信息符合规范

## 补充信息

已通过 `tests/agent_runtime/test_model_factory.py` 的 33 个测试、Ruff 和 ty 类型检查。