### PR TITLE
chore(frontend): 支持提问面板折叠

### DIFF
--- a/frontend/e2e/question-panel-collapse.spec.ts
+++ b/frontend/e2e/question-panel-collapse.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+
+import { EMPTY_PROJECT_URL, openProject, sendMessage, startNewTask } from "./helpers";
+
+const QUESTION_PANEL = ".agent-special-panel-question";
+
+test.describe("提问面板收起", () => {
+  test("提问面板可以收起为摘要并重新展开", async ({ page }) => {
+    await openProject(page, EMPTY_PROJECT_URL);
+    await startNewTask(page);
+
+    await sendMessage(
+      page,
+      "请使用 ask_user 工具向我提出一个关于写作偏好的澄清问题，并在我回答前停止，不要执行其他工具。",
+    );
+
+    const panel = page.locator(QUESTION_PANEL);
+    await expect(panel).toBeVisible({ timeout: 180000 });
+    await expect(panel.getByRole("button", { name: "收起提问面板" })).toBeVisible();
+    await expect(panel.locator(".agent-special-panel-content")).toBeVisible();
+
+    await panel.getByRole("button", { name: "收起提问面板" }).click();
+
+    await expect(panel.locator(".agent-special-panel-content")).toBeHidden();
+    await expect(panel.getByRole("button", { name: "展开提问面板" })).toBeVisible();
+    await expect(panel).toContainText("需要补充信息");
+
+    await panel.getByRole("button", { name: "展开提问面板" }).click();
+
+    await expect(panel.locator(".agent-special-panel-content")).toBeVisible();
+    await expect(panel.getByRole("button", { name: "收起提问面板" })).toBeVisible();
+  });
+});

--- a/frontend/src/features/assistant/components/agent/message-blocks/panels/clarification-special-panel.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/panels/clarification-special-panel.tsx
@@ -1,5 +1,6 @@
-import { Box, Flex, Text } from "@radix-ui/themes";
-import { HelpCircle } from "lucide-react";
+import { Box, Flex, IconButton, Text, Tooltip } from "@radix-ui/themes";
+import { ChevronDown, ChevronUp, HelpCircle } from "lucide-react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { AgentQuestionSpecialPanel } from "../../agent-special-panels-state";
@@ -66,6 +67,7 @@ function ClarificationSpecialPanelContent({
   readOnly = false,
 }: ClarificationSpecialPanelContentProps) {
   const { t } = useTranslation();
+  const [isCollapsed, setIsCollapsed] = useState(false);
   const model = useClarificationQuestionFlow(prompt, {
     onSubmitQuestionAnswer: (actionId, answer) => {
       if (onBatchDecision) {
@@ -75,6 +77,9 @@ function ClarificationSpecialPanelContent({
       onSubmitQuestionAnswer?.(actionId, answer);
     },
   });
+  const collapseLabel = isCollapsed
+    ? t("assistant.specialPanels.expandQuestionPanel")
+    : t("assistant.specialPanels.collapseQuestionPanel");
   const content = readOnly ? (
     <Flex
       direction="column"
@@ -129,8 +134,24 @@ function ClarificationSpecialPanelContent({
       icon={<HelpCircle size={15} />}
       title={t("assistant.specialPanels.clarificationTitle")}
       summary={summary}
+      headingAction={
+        <Tooltip content={collapseLabel}>
+          <IconButton
+            variant="ghost"
+            color="gray"
+            size="1"
+            type="button"
+            aria-label={collapseLabel}
+            aria-expanded={!isCollapsed}
+            onClick={() => setIsCollapsed((current) => !current)}
+          >
+            {isCollapsed ? <ChevronDown size={16} /> : <ChevronUp size={16} />}
+          </IconButton>
+        </Tooltip>
+      }
+      isCollapsed={isCollapsed}
       progress={
-        panel.batchIndex !== undefined && panel.batchTotal !== undefined
+        panel.batchIndex !== undefined && panel.batchTotal !== undefined && panel.batchTotal > 1
           ? `${panel.batchIndex + 1}/${panel.batchTotal}`
           : undefined
       }

--- a/frontend/src/features/assistant/components/agent/message-blocks/panels/special-panel-shell.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/panels/special-panel-shell.tsx
@@ -5,7 +5,9 @@ interface SpecialPanelShellProps {
   actions?: ReactNode;
   className?: string;
   content?: ReactNode;
+  headingAction?: ReactNode;
   icon: ReactNode;
+  isCollapsed?: boolean;
   kind: "approval" | "question";
   summary?: ReactNode;
   title: string;
@@ -16,7 +18,9 @@ export function SpecialPanelShell({
   actions,
   className,
   content,
+  headingAction,
   icon,
+  isCollapsed = false,
   kind,
   summary,
   title,
@@ -29,6 +33,7 @@ export function SpecialPanelShell({
   return (
     <Box
       className={panelClassName}
+      data-collapsed={isCollapsed ? "true" : undefined}
       data-panel-kind={kind}
     >
       <Flex
@@ -57,6 +62,9 @@ export function SpecialPanelShell({
             </Text>
           ) : null}
         </Flex>
+        {headingAction ? (
+          <Box className="agent-special-panel-heading-action">{headingAction}</Box>
+        ) : null}
       </Flex>
       {summary ? (
         <Text
@@ -66,8 +74,10 @@ export function SpecialPanelShell({
           {summary}
         </Text>
       ) : null}
-      {content ? <Box className="agent-special-panel-content">{content}</Box> : null}
-      {actions ? (
+      {!isCollapsed && content ? (
+        <Box className="agent-special-panel-content">{content}</Box>
+      ) : null}
+      {!isCollapsed && actions ? (
         <Flex
           gap="2"
           justify="end"

--- a/frontend/src/features/assistant/components/assistant-sidebar.css
+++ b/frontend/src/features/assistant/components/assistant-sidebar.css
@@ -763,8 +763,22 @@
 }
 
 .agent-special-panel-heading {
+  justify-content: space-between;
   margin-bottom: 8px;
   color: var(--gray-12);
+}
+
+.agent-special-panel-heading-action {
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+
+.agent-special-panel[data-collapsed="true"] .agent-special-panel-heading {
+  margin-bottom: 4px;
+}
+
+.agent-special-panel[data-collapsed="true"] .agent-special-panel-summary {
+  margin-bottom: 0;
 }
 
 .agent-special-panel-title {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1750,6 +1750,8 @@
     },
     "specialPanels": {
       "clarificationTitle": "More information needed",
+      "collapseQuestionPanel": "Collapse question panel",
+      "expandQuestionPanel": "Expand question panel",
       "approvalTitle": "Approval required",
       "deny": "Deny",
       "approve": "Run"

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1813,6 +1813,8 @@
     },
     "specialPanels": {
       "clarificationTitle": "需要补充信息",
+      "collapseQuestionPanel": "收起提问面板",
+      "expandQuestionPanel": "展开提问面板",
       "approvalTitle": "需要审批",
       "deny": "拒绝",
       "approve": "执行"


### PR DESCRIPTION
## PR 标题

chore(frontend): 支持提问面板折叠

## 变更说明

- 问题: 小屏幕下提问面板内容较高，会遮挡 AI 回复。
- 重要性: 用户需要暂时收起提问内容查看上方回复，同时保留恢复入口。
- 变化: 为提问面板增加收起/展开按钮，收起时保留标题和问题数量摘要。
- 变化: 单次中断不再显示无意义的 `1/1` 批次进度。

## 关联 Issue / PR

Closes #296

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因

无

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

已运行 `pnpm type-check`、`pnpm lint` 和 `pnpm format:check`。
