### PR TITLE
chore(config): 添加 Docker Compose 配置

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  openfic:
+    image: ghcr.io/syrizelink/openfic:latest
+    ports:
+      - "8000:8000"
+    volumes:
+      - openfic:/data
+    restart: unless-stopped
+
+volumes:
+  openfic:


### PR DESCRIPTION
## PR 标题

chore(config): 添加 Docker Compose 配置

## 变更说明

- 问题：项目缺少 Docker Compose 配置，部署时需要手动编写 `docker run` 命令。
- 重要性：为自托管部署提供统一的启动、端口映射和数据持久化配置。
- 变化：新增根目录 `docker-compose.yml`，使用发布镜像、暴露 `8000` 端口、挂载 `openfic` 命名卷，并配置 `unless-stopped` 重启策略。

## 关联 Issue / PR

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因

无

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

- 后端 lint/类型检查、前端 lint/类型检查和 Compose YAML 结构校验通过。
- 后端测试结果为 1472 个通过、6 个既有资源和数据断言失败，与本次 Compose 配置无关。
- 前端格式检查受仓库当前基线 434 个文件格式差异影响。
- 当前环境未安装 Docker CLI，未执行 `docker compose config --quiet`。
