### PR TITLE
chore(agent): 支持 Skill Command 引用

### DIFF
--- a/backend/app/agent_runtime/context/build_context.py
+++ b/backend/app/agent_runtime/context/build_context.py
@@ -45,7 +45,7 @@ async def build_context_parts(
         parts.extend(prompt_messages)
     if (m := await build_rules(db_session, state.get("project_id"))) is not None:
         parts.append(m)
-    if (m := await build_skills(state, agent_name, db_session)) is not None:
+    if (m := await build_skills(state, agent_name, db_session, node_messages)) is not None:
         parts.append(m)
     parts.extend(await build_history(node_messages, db_session))
 

--- a/backend/app/agent_runtime/context/helpers/__init__.py
+++ b/backend/app/agent_runtime/context/helpers/__init__.py
@@ -6,7 +6,7 @@ from app.agent_runtime.context.helpers.canonical_mentions import (
 from app.agent_runtime.context.helpers.canonical_commands import (
     CanonicalSkillCommand,
     compile_canonical_commands,
-    extract_referenced_skill_names,
+    extract_referenced_skill_ids,
     parse_canonical_skill_commands,
 )
 
@@ -15,7 +15,7 @@ __all__ = [
     "CanonicalMention",
     "compile_canonical_commands",
     "compile_canonical_mentions",
-    "extract_referenced_skill_names",
+    "extract_referenced_skill_ids",
     "parse_canonical_skill_commands",
     "parse_canonical_mentions",
 ]

--- a/backend/app/agent_runtime/context/helpers/__init__.py
+++ b/backend/app/agent_runtime/context/helpers/__init__.py
@@ -3,9 +3,19 @@ from app.agent_runtime.context.helpers.canonical_mentions import (
     compile_canonical_mentions,
     parse_canonical_mentions,
 )
+from app.agent_runtime.context.helpers.canonical_commands import (
+    CanonicalSkillCommand,
+    compile_canonical_commands,
+    extract_referenced_skill_names,
+    parse_canonical_skill_commands,
+)
 
 __all__ = [
+    "CanonicalSkillCommand",
     "CanonicalMention",
+    "compile_canonical_commands",
     "compile_canonical_mentions",
+    "extract_referenced_skill_names",
+    "parse_canonical_skill_commands",
     "parse_canonical_mentions",
 ]

--- a/backend/app/agent_runtime/context/helpers/canonical_commands.py
+++ b/backend/app/agent_runtime/context/helpers/canonical_commands.py
@@ -16,6 +16,7 @@ _ATTR_RE = re.compile(r'([A-Za-z_][A-Za-z0-9_]*)="([^"]*)"')
 @dataclass(frozen=True)
 class CanonicalSkillCommand:
     raw: str
+    skill_id: str
     name: str
 
 
@@ -29,9 +30,15 @@ def parse_canonical_skill_commands(text: str) -> list[str | CanonicalSkillComman
         if match.start() > cursor:
             parts.append(text[cursor : match.start()])
         attrs = _parse_attrs(match.group("attrs_self") or "")
+        skill_id = attrs.get("id", "").strip()
+        if not skill_id:
+            parts.append(match.group(0))
+            cursor = match.end()
+            continue
         parts.append(
             CanonicalSkillCommand(
                 raw=match.group(0),
+                skill_id=skill_id,
                 name=attrs.get("name", "").strip(),
             )
         )
@@ -54,35 +61,26 @@ def compile_canonical_commands(text: str) -> str:
         elif part.name:
             compiled.append(f"@skill:{part.name}")
         else:
-            compiled.append(part.raw)
+            compiled.append(f"@skill:{part.skill_id}")
     return "".join(compiled)
 
 
-def extract_referenced_skill_names(
+def extract_referenced_skill_ids(
     texts: Iterable[str],
-    available_names: Iterable[str],
 ) -> tuple[str, ...]:
-    names = tuple(dict.fromkeys(name.strip() for name in available_names if name.strip()))
-    if not names:
-        return ()
-
+    """提取 Skill 的稳定 ID；带 ID 的规范命令不依赖名称边界。"""
     referenced: list[str] = []
     for text in texts:
-        compiled = compile_canonical_commands(text)
-        cursor = 0
-        while (marker_start := compiled.find("@skill:", cursor)) >= 0:
-            suffix = compiled[marker_start + len("@skill:") :]
-            matches = [name for name in names if suffix.startswith(name)]
-            if matches:
-                name = max(matches, key=len)
-                if name not in referenced:
-                    referenced.append(name)
-                cursor = marker_start + len("@skill:") + len(name)
-            else:
-                cursor = marker_start + len("@skill:")
+        for part in parse_canonical_skill_commands(text):
+            if isinstance(part, CanonicalSkillCommand):
+                _append_unique(referenced, part.skill_id)
     return tuple(referenced)
+
+
+def _append_unique(values: list[str], value: str) -> None:
+    if value and value not in values:
+        values.append(value)
 
 
 def _parse_attrs(raw_attrs: str) -> dict[str, str]:
     return {key: html.unescape(value) for key, value in _ATTR_RE.findall(raw_attrs)}
-

--- a/backend/app/agent_runtime/context/helpers/canonical_commands.py
+++ b/backend/app/agent_runtime/context/helpers/canonical_commands.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+import html
+import re
+from collections.abc import Iterable
+
+
+_SKILL_COMMAND_RE = re.compile(
+    r"<of-skill\b(?P<attrs_self>[^<>]*?)\s*/>",
+    re.DOTALL,
+)
+_ATTR_RE = re.compile(r'([A-Za-z_][A-Za-z0-9_]*)="([^"]*)"')
+
+
+@dataclass(frozen=True)
+class CanonicalSkillCommand:
+    raw: str
+    name: str
+
+
+def parse_canonical_skill_commands(text: str) -> list[str | CanonicalSkillCommand]:
+    if not text or "<of-skill" not in text:
+        return [text]
+
+    parts: list[str | CanonicalSkillCommand] = []
+    cursor = 0
+    for match in _SKILL_COMMAND_RE.finditer(text):
+        if match.start() > cursor:
+            parts.append(text[cursor : match.start()])
+        attrs = _parse_attrs(match.group("attrs_self") or "")
+        parts.append(
+            CanonicalSkillCommand(
+                raw=match.group(0),
+                name=attrs.get("name", "").strip(),
+            )
+        )
+        cursor = match.end()
+
+    if cursor < len(text):
+        parts.append(text[cursor:])
+    return parts
+
+
+def compile_canonical_commands(text: str) -> str:
+    parts = parse_canonical_skill_commands(text)
+    if len(parts) == 1 and parts[0] == text:
+        return text
+
+    compiled: list[str] = []
+    for part in parts:
+        if isinstance(part, str):
+            compiled.append(part)
+        elif part.name:
+            compiled.append(f"@skill:{part.name}")
+        else:
+            compiled.append(part.raw)
+    return "".join(compiled)
+
+
+def extract_referenced_skill_names(
+    texts: Iterable[str],
+    available_names: Iterable[str],
+) -> tuple[str, ...]:
+    names = tuple(dict.fromkeys(name.strip() for name in available_names if name.strip()))
+    if not names:
+        return ()
+
+    referenced: list[str] = []
+    for text in texts:
+        compiled = compile_canonical_commands(text)
+        cursor = 0
+        while (marker_start := compiled.find("@skill:", cursor)) >= 0:
+            suffix = compiled[marker_start + len("@skill:") :]
+            matches = [name for name in names if suffix.startswith(name)]
+            if matches:
+                name = max(matches, key=len)
+                if name not in referenced:
+                    referenced.append(name)
+                cursor = marker_start + len("@skill:") + len(name)
+            else:
+                cursor = marker_start + len("@skill:")
+    return tuple(referenced)
+
+
+def _parse_attrs(raw_attrs: str) -> dict[str, str]:
+    return {key: html.unescape(value) for key, value in _ATTR_RE.findall(raw_attrs)}
+

--- a/backend/app/agent_runtime/context/helpers/canonical_mentions.py
+++ b/backend/app/agent_runtime/context/helpers/canonical_mentions.py
@@ -6,6 +6,7 @@ import re
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.agent_runtime.context.helpers.canonical_commands import compile_canonical_commands
 from app.storage.repos.character_repo import get_by_id as get_character_by_id
 from app.storage.repos.chapter_repo import get_by_id as get_chapter_by_id
 from app.storage.repos.note_category_repo import (
@@ -211,7 +212,7 @@ async def compile_canonical_mentions(
 ) -> str:
     parts = parse_canonical_mentions(text)
     if len(parts) == 1 and parts[0] == text:
-        return text
+        return compile_canonical_commands(text)
 
     resolver = _MentionResolver(session)
     compiled: list[str] = []
@@ -231,7 +232,7 @@ async def compile_canonical_mentions(
 
         compiled.append(await _compile_compact_mention(part, resolver))
 
-    return "".join(compiled)
+    return compile_canonical_commands("".join(compiled))
 
 
 def _fallback_label(mention: CanonicalMention) -> str:

--- a/backend/app/agent_runtime/context/parts/history.py
+++ b/backend/app/agent_runtime/context/parts/history.py
@@ -61,7 +61,12 @@ async def build_history(
         name = name or metadata_tool_name
         metadata = _history_metadata(raw, tool_name=name if role == "tool" else None)
         content = raw.get("content", "")
-        if role == "user" and db_session is not None and isinstance(content, str) and "<of-mention" in content:
+        if (
+            role == "user"
+            and db_session is not None
+            and isinstance(content, str)
+            and ("<of-mention" in content or "<of-skill" in content)
+        ):
             content = await compile_canonical_mentions(content, db_session)
         additional_kwargs = (
             raw.get("additional_kwargs") if isinstance(raw.get("additional_kwargs"), dict) else None

--- a/backend/app/agent_runtime/context/parts/skills.py
+++ b/backend/app/agent_runtime/context/parts/skills.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.agents.definitions import load_agent_definition
 from app.agent_runtime.context.errors import ContextBuildError
-from app.agent_runtime.context.helpers import extract_referenced_skill_names
+from app.agent_runtime.context.helpers import extract_referenced_skill_ids
 from app.agent_runtime.context.types import ContextMessage
 from app.agent_runtime.graph.state import AgentRuntimeState
 from app.storage.services import skill_service
@@ -32,10 +32,17 @@ async def build_skills(
     """构建 Skills 上下文片段：列出 agent 可用技能的名称与简介。"""
 
     enabled_skill_ids = await _get_enabled_skill_ids_for_agent(db_session, agent_name)
-    user_message_texts = tuple(_user_message_texts(state, node_messages))
-    has_skill_references = any(
-        "<of-skill" in text or "@skill:" in text for text in user_message_texts
+    existing_referenced_ids = _state_skill_ids(state)
+    node_message_texts = tuple(_node_user_message_texts(node_messages))
+    current_request = state.get("user_request")
+    user_message_texts = (
+        tuple(text for text in node_message_texts if text != current_request)
+        if existing_referenced_ids
+        else tuple(_user_message_texts(state, node_messages))
     )
+    has_skill_references = any(
+        "<of-skill" in text for text in user_message_texts
+    ) or bool(existing_referenced_ids)
 
     try:
         agent_skills = await skill_service.list_enabled_skills_by_ids(
@@ -48,18 +55,18 @@ async def build_skills(
     except Exception as e:
         raise ContextBuildError("skills", "failed to load enabled skills", cause=e) from e
 
-    referenced_names = extract_referenced_skill_names(
-        user_message_texts,
-        (skill.name for skill in globally_enabled),
+    referenced_ids = _merge_unique(
+        existing_referenced_ids,
+        extract_referenced_skill_ids(user_message_texts),
     )
     if isinstance(state, dict):
-        state["referenced_skill_names"] = list(referenced_names)
+        state["referenced_skill_ids"] = list(referenced_ids)
 
     agent_skill_ids = {skill.id for skill in agent_skills}
     referenced_skills = [
         skill
         for skill in globally_enabled
-        if skill.name.strip() in referenced_names and skill.id not in agent_skill_ids
+        if skill.id in referenced_ids and skill.id not in agent_skill_ids
     ]
     available = [*agent_skills, *referenced_skills]
 
@@ -86,6 +93,32 @@ async def build_skills(
     )
 
 
+def _state_skill_ids(state: AgentRuntimeState) -> tuple[str, ...]:
+    values = state.get("referenced_skill_ids")
+    if not isinstance(values, (list, tuple, set)):
+        return ()
+    return _merge_unique(value for value in values if isinstance(value, str))
+
+
+def _merge_unique(*groups: Iterable[str]) -> tuple[str, ...]:
+    values: list[str] = []
+    for group in groups:
+        for value in group:
+            normalized = value.strip()
+            if normalized and normalized not in values:
+                values.append(normalized)
+    return tuple(values)
+
+
+def _node_user_message_texts(node_messages: list[dict] | None) -> Iterable[str]:
+    for raw in node_messages or []:
+        if not isinstance(raw, dict) or raw.get("role") != "user":
+            continue
+        content: Any = raw.get("content")
+        if isinstance(content, str) and content:
+            yield content
+
+
 def _user_message_texts(
     state: AgentRuntimeState,
     node_messages: list[dict] | None,
@@ -93,10 +126,4 @@ def _user_message_texts(
     user_request = state.get("user_request")
     if isinstance(user_request, str) and user_request:
         yield user_request
-
-    for raw in node_messages or []:
-        if not isinstance(raw, dict) or raw.get("role") != "user":
-            continue
-        content: Any = raw.get("content")
-        if isinstance(content, str) and content:
-            yield content
+    yield from _node_user_message_texts(node_messages)

--- a/backend/app/agent_runtime/context/parts/skills.py
+++ b/backend/app/agent_runtime/context/parts/skills.py
@@ -1,7 +1,12 @@
+from collections.abc import Iterable
+import html
+from typing import Any
+
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.agents.definitions import load_agent_definition
 from app.agent_runtime.context.errors import ContextBuildError
+from app.agent_runtime.context.helpers import extract_referenced_skill_names
 from app.agent_runtime.context.types import ContextMessage
 from app.agent_runtime.graph.state import AgentRuntimeState
 from app.storage.services import skill_service
@@ -22,24 +27,48 @@ async def build_skills(
     state: AgentRuntimeState,
     agent_name: str,
     db_session: AsyncSession,
+    node_messages: list[dict] | None = None,
 ) -> ContextMessage | None:
     """构建 Skills 上下文片段：列出 agent 可用技能的名称与简介。"""
 
     enabled_skill_ids = await _get_enabled_skill_ids_for_agent(db_session, agent_name)
+    user_message_texts = tuple(_user_message_texts(state, node_messages))
+    has_skill_references = any(
+        "<of-skill" in text or "@skill:" in text for text in user_message_texts
+    )
 
     try:
-        available = await skill_service.list_enabled_skills_by_ids(
+        agent_skills = await skill_service.list_enabled_skills_by_ids(
             db_session,
             enabled_skill_ids,
         )
+        globally_enabled = (
+            await skill_service.list_enabled_skills(db_session) if has_skill_references else []
+        )
     except Exception as e:
         raise ContextBuildError("skills", "failed to load enabled skills", cause=e) from e
+
+    referenced_names = extract_referenced_skill_names(
+        user_message_texts,
+        (skill.name for skill in globally_enabled),
+    )
+    if isinstance(state, dict):
+        state["referenced_skill_names"] = list(referenced_names)
+
+    agent_skill_ids = {skill.id for skill in agent_skills}
+    referenced_skills = [
+        skill
+        for skill in globally_enabled
+        if skill.name.strip() in referenced_names and skill.id not in agent_skill_ids
+    ]
+    available = [*agent_skills, *referenced_skills]
 
     if not available:
         return None
 
     skill_blocks = "\n".join(
-        f"<skill>\n  <name>{skill.name}</name>\n  <description>{skill.summary}</description>\n</skill>"
+        f"<skill>\n  <name>{html.escape(skill.name.strip())}</name>\n"
+        f"  <description>{html.escape(skill.summary)}</description>\n</skill>"
         for skill in available
     )
     content = (
@@ -55,3 +84,19 @@ async def build_skills(
         content=content,
         metadata={"part": "skills"},
     )
+
+
+def _user_message_texts(
+    state: AgentRuntimeState,
+    node_messages: list[dict] | None,
+) -> Iterable[str]:
+    user_request = state.get("user_request")
+    if isinstance(user_request, str) and user_request:
+        yield user_request
+
+    for raw in node_messages or []:
+        if not isinstance(raw, dict) or raw.get("role") != "user":
+            continue
+        content: Any = raw.get("content")
+        if isinstance(content, str) and content:
+            yield content

--- a/backend/app/agent_runtime/graph/orchestrator/graph.py
+++ b/backend/app/agent_runtime/graph/orchestrator/graph.py
@@ -15,14 +15,17 @@ from app.agent_runtime.agents.definitions import (
     load_all_agent_definitions,
 )
 from app.agent_runtime.agents.tool_categories import get_tool_names_for_categories
-from app.agent_runtime.context.helpers import extract_referenced_skill_names
+from app.agent_runtime.context.helpers import extract_referenced_skill_ids
 from app.agent_runtime.graph.config import build_child_config, get_inject_queue
 from app.agent_runtime.graph.node_events import with_node_events
 from app.agent_runtime.graph.orchestrator.state import OrchestratorState
 from app.agent_runtime.graph.react_agent import create_react_agent
 from app.agent_runtime.model_config import to_client_model_config
 from app.agent_runtime.tools import ToolRegistry
-from app.agent_runtime.tools.impls.skill.skill import skill_tool_names_for_definition
+from app.agent_runtime.tools.impls.skill.skill import (
+    SKILL_TOOL_NAMES,
+    skill_tool_names_for_definition,
+)
 from app.agent_runtime.tools.hooks.auth import auth_hook
 from app.agent_runtime.tools.hooks.character_refresh import character_refresh_post_hook
 from app.agent_runtime.tools.hooks.chapter_refresh import chapter_refresh_post_hook
@@ -33,7 +36,6 @@ from app.agent_runtime.tools.hooks.note_refresh import note_refresh_post_hook
 from app.agent_runtime.tools.hooks.world_entry_refresh import world_entry_refresh_post_hook
 from app.agent_runtime.types import ReactAgentConfig, TerminationCondition
 from app.models.clients.model_factory import ModelConfig, create_chat_model
-from app.storage.services import skill_service
 
 DEFAULT_PRIMARY_TOOL_CATEGORIES = (
     "orchestration",
@@ -49,48 +51,59 @@ async def _primary_tool_names(
     config: RunnableConfig | None,
     agent_key: str = "build",
     *,
-    referenced_skill_names: tuple[str, ...] = (),
+    referenced_skill_ids: tuple[str, ...] = (),
+    allow_runtime_skill_references: bool = False,
 ) -> list[str]:
     configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
     db_session = configurable.get("db_session") if isinstance(configurable, dict) else None
     if db_session is None:
-        return list(get_tool_names_for_categories(DEFAULT_PRIMARY_TOOL_CATEGORIES))
+        names = list(get_tool_names_for_categories(DEFAULT_PRIMARY_TOOL_CATEGORIES))
+        return [*names, *SKILL_TOOL_NAMES] if allow_runtime_skill_references else names
     definition = await load_agent_definition(db_session, agent_key)
     return list(get_tool_names_for_categories(definition.enabled_tool_categories)) + list(
         await skill_tool_names_for_definition(
             definition,
             db_session,
-            referenced_skill_names=referenced_skill_names,
+            referenced_skill_ids=referenced_skill_ids,
+            allow_runtime_skill_references=allow_runtime_skill_references,
         )
     )
 
 
-async def _primary_referenced_skill_names(
-    state: OrchestratorState,
-    config: RunnableConfig | None,
-) -> tuple[str, ...]:
-    configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
-    db_session = configurable.get("db_session") if isinstance(configurable, dict) else None
-    if db_session is None:
-        return ()
-
+def _primary_referenced_skill_ids(state: OrchestratorState) -> tuple[str, ...]:
+    existing_ids = _state_skill_ids(state)
     texts: list[str] = []
     user_request = state.get("user_request") or ""
-    if isinstance(user_request, str) and user_request:
+    if not existing_ids and isinstance(user_request, str) and user_request:
         texts.append(user_request)
     for message in state.get("messages") or []:
         if not isinstance(message, HumanMessage):
             continue
         if isinstance(message.content, str) and message.content:
             texts.append(message.content)
-    if not any("<of-skill" in text or "@skill:" in text for text in texts):
-        return ()
-
-    globally_enabled = await skill_service.list_enabled_skills(db_session)
-    return extract_referenced_skill_names(
-        texts,
-        (skill.name for skill in globally_enabled),
+    if existing_ids and isinstance(user_request, str):
+        texts = [text for text in texts if text != user_request]
+    return _merge_unique(
+        existing_ids,
+        extract_referenced_skill_ids(texts),
     )
+
+
+def _state_skill_ids(state: OrchestratorState) -> tuple[str, ...]:
+    values = state.get("referenced_skill_ids")
+    if not isinstance(values, (list, tuple, set)):
+        return ()
+    return _merge_unique(value for value in values if isinstance(value, str))
+
+
+def _merge_unique(*groups) -> tuple[str, ...]:
+    values: list[str] = []
+    for group in groups:
+        for value in group:
+            normalized = value.strip()
+            if normalized and normalized not in values:
+                values.append(normalized)
+    return tuple(values)
 
 
 async def _primary_build_hooks(
@@ -139,11 +152,12 @@ async def primary_node(
     model_config = ModelConfig(**to_client_model_config(runtime_model_config))
     model = create_chat_model(model_config)
     agent_key = state.get("agent_key", "build")
-    referenced_skill_names = await _primary_referenced_skill_names(state, config)
+    referenced_skill_ids = _primary_referenced_skill_ids(state)
+    inject_queue = get_inject_queue(config)
     tool_state = dict(state)
     tool_state["model_config"] = dict(runtime_model_config)
     tool_state["active_agent"] = agent_key
-    tool_state["referenced_skill_names"] = list(referenced_skill_names)
+    tool_state["referenced_skill_ids"] = list(referenced_skill_ids)
 
     agent_config = ReactAgentConfig(
         name=agent_key,
@@ -153,7 +167,8 @@ async def primary_node(
                 names=await _primary_tool_names(
                     config,
                     agent_key=agent_key,
-                    referenced_skill_names=referenced_skill_names,
+                    referenced_skill_ids=referenced_skill_ids,
+                    allow_runtime_skill_references=inject_queue is not None,
                 ),
                 state=tool_state,
                 build_hooks=await _primary_build_hooks(config, agent_key=agent_key),
@@ -171,12 +186,13 @@ async def primary_node(
     react_graph = create_react_agent(
         agent_config,
         model=model,
-        inject_queue=get_inject_queue(config),
+        inject_queue=inject_queue,
     )
 
     effective_state = dict(state)
     effective_state["model_config"] = dict(runtime_model_config)
     effective_state["active_agent"] = agent_key
+    effective_state["referenced_skill_ids"] = list(referenced_skill_ids)
     await react_graph.ainvoke(
         {
             "messages": await _primary_messages(state),

--- a/backend/app/agent_runtime/graph/orchestrator/graph.py
+++ b/backend/app/agent_runtime/graph/orchestrator/graph.py
@@ -15,6 +15,7 @@ from app.agent_runtime.agents.definitions import (
     load_all_agent_definitions,
 )
 from app.agent_runtime.agents.tool_categories import get_tool_names_for_categories
+from app.agent_runtime.context.helpers import extract_referenced_skill_names
 from app.agent_runtime.graph.config import build_child_config, get_inject_queue
 from app.agent_runtime.graph.node_events import with_node_events
 from app.agent_runtime.graph.orchestrator.state import OrchestratorState
@@ -32,6 +33,7 @@ from app.agent_runtime.tools.hooks.note_refresh import note_refresh_post_hook
 from app.agent_runtime.tools.hooks.world_entry_refresh import world_entry_refresh_post_hook
 from app.agent_runtime.types import ReactAgentConfig, TerminationCondition
 from app.models.clients.model_factory import ModelConfig, create_chat_model
+from app.storage.services import skill_service
 
 DEFAULT_PRIMARY_TOOL_CATEGORIES = (
     "orchestration",
@@ -43,14 +45,51 @@ DEFAULT_PRIMARY_TOOL_CATEGORIES = (
 )
 
 
-async def _primary_tool_names(config: RunnableConfig | None, agent_key: str = "build") -> list[str]:
+async def _primary_tool_names(
+    config: RunnableConfig | None,
+    agent_key: str = "build",
+    *,
+    referenced_skill_names: tuple[str, ...] = (),
+) -> list[str]:
     configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
     db_session = configurable.get("db_session") if isinstance(configurable, dict) else None
     if db_session is None:
         return list(get_tool_names_for_categories(DEFAULT_PRIMARY_TOOL_CATEGORIES))
     definition = await load_agent_definition(db_session, agent_key)
     return list(get_tool_names_for_categories(definition.enabled_tool_categories)) + list(
-        await skill_tool_names_for_definition(definition, db_session)
+        await skill_tool_names_for_definition(
+            definition,
+            db_session,
+            referenced_skill_names=referenced_skill_names,
+        )
+    )
+
+
+async def _primary_referenced_skill_names(
+    state: OrchestratorState,
+    config: RunnableConfig | None,
+) -> tuple[str, ...]:
+    configurable = config.get("configurable", {}) if isinstance(config, dict) else {}
+    db_session = configurable.get("db_session") if isinstance(configurable, dict) else None
+    if db_session is None:
+        return ()
+
+    texts: list[str] = []
+    user_request = state.get("user_request") or ""
+    if isinstance(user_request, str) and user_request:
+        texts.append(user_request)
+    for message in state.get("messages") or []:
+        if not isinstance(message, HumanMessage):
+            continue
+        if isinstance(message.content, str) and message.content:
+            texts.append(message.content)
+    if not any("<of-skill" in text or "@skill:" in text for text in texts):
+        return ()
+
+    globally_enabled = await skill_service.list_enabled_skills(db_session)
+    return extract_referenced_skill_names(
+        texts,
+        (skill.name for skill in globally_enabled),
     )
 
 
@@ -100,16 +139,22 @@ async def primary_node(
     model_config = ModelConfig(**to_client_model_config(runtime_model_config))
     model = create_chat_model(model_config)
     agent_key = state.get("agent_key", "build")
+    referenced_skill_names = await _primary_referenced_skill_names(state, config)
     tool_state = dict(state)
     tool_state["model_config"] = dict(runtime_model_config)
     tool_state["active_agent"] = agent_key
+    tool_state["referenced_skill_names"] = list(referenced_skill_names)
 
     agent_config = ReactAgentConfig(
         name=agent_key,
         tools=cast(
             list[BaseTool],
             ToolRegistry.get_tools(
-                names=await _primary_tool_names(config, agent_key=agent_key),
+                names=await _primary_tool_names(
+                    config,
+                    agent_key=agent_key,
+                    referenced_skill_names=referenced_skill_names,
+                ),
                 state=tool_state,
                 build_hooks=await _primary_build_hooks(config, agent_key=agent_key),
                 pre_hooks=[auth_hook],

--- a/backend/app/agent_runtime/graph/react_agent.py
+++ b/backend/app/agent_runtime/graph/react_agent.py
@@ -689,7 +689,7 @@ def create_react_agent(
                         if (
                             db_session is not None
                             and isinstance(content, str)
-                            and "<of-mention" in content
+                            and ("<of-mention" in content or "<of-skill" in content)
                         ):
                             compiled_content = await compile_canonical_mentions(
                                 content, db_session

--- a/backend/app/agent_runtime/graph/react_agent.py
+++ b/backend/app/agent_runtime/graph/react_agent.py
@@ -12,7 +12,7 @@ import copy
 import inspect
 import json
 import time
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable, Iterable, Mapping
 from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional, TypedDict, cast
 
 from langchain_core.messages import (
@@ -38,7 +38,10 @@ from app.agent_runtime.context import build_context, build_context_parts
 from app.agent_runtime.context.processors.filter import (
     filter_tool_result_metadata_content,
 )
-from app.agent_runtime.context.helpers import compile_canonical_mentions
+from app.agent_runtime.context.helpers import (
+    compile_canonical_mentions,
+    extract_referenced_skill_ids,
+)
 from app.agent_runtime.context.compaction.config import AUTO_TRIGGER_RATIO
 from app.agent_runtime.context.compaction.service import CompactionError, compact_window
 from app.agent_runtime.context.compaction.tokens import count_context_tokens
@@ -505,6 +508,24 @@ def _to_history_dict(m: BaseMessage) -> dict:
 # ---------------------------------------------------------------------------
 
 
+def _runtime_skill_ids(runtime_state: Mapping[str, Any]) -> tuple[str, ...]:
+    values = runtime_state.get("referenced_skill_ids")
+    return _merge_skill_ids(values)
+
+
+def _merge_skill_ids(*groups: object) -> tuple[str, ...]:
+    merged: list[str] = []
+    for group in groups:
+        values = group if isinstance(group, (list, tuple, set)) else (group,)
+        for value in values:
+            if not isinstance(value, str):
+                continue
+            normalized = value.strip()
+            if normalized and normalized not in merged:
+                merged.append(normalized)
+    return tuple(merged)
+
+
 def create_react_agent(
     config: ReactAgentConfig,
     model: Any | None = None,
@@ -537,6 +558,13 @@ def create_react_agent(
     # Bind tools to model if provided
     bound_model = model.bind_tools(tools) if model else None
     active_audit: LLMCallAudit | None = None
+
+    def update_skill_tool_references(referenced_skill_ids: Iterable[str]) -> None:
+        values = list(referenced_skill_ids)
+        for tool in tools:
+            runtime_state = getattr(tool, "runtime_state", None)
+            if isinstance(runtime_state, dict):
+                runtime_state["referenced_skill_ids"] = values
 
     async def _finish_active_audit(status: str = "success") -> None:
         nonlocal active_audit
@@ -603,17 +631,15 @@ def create_react_agent(
             runtime_model_config = None
         drained_injected_user_message = False
         context_parts: list[ContextMessage] | None = None
-        effective_runtime_state: Mapping[str, Any] | None = None
+        effective_runtime_state: dict[str, Any] | None = None
+        injected_user_contents: list[str] = []
 
         if isinstance(runtime_state, Mapping) and db_session is not None:
             node_messages = [_to_history_dict(m) for m in state["messages"]]
             runtime_context = configurable.get("runtime_context")
-            effective_runtime_state = cast(
-                Mapping[str, Any],
-                {**runtime_state, **runtime_context}
-                if isinstance(runtime_context, Mapping)
-                else runtime_state,
-            )
+            effective_runtime_state = dict(runtime_state)
+            if isinstance(runtime_context, Mapping):
+                effective_runtime_state.update(runtime_context)
             model_config = effective_runtime_state.get("model_config")
             if (
                 isinstance(model_config, Mapping)
@@ -685,6 +711,11 @@ def create_react_agent(
                             consumed = await consumed
                         should_inject = consumed is not False
                     if should_inject:
+                        if (
+                            isinstance(content, str)
+                            and "<of-skill" in content
+                        ):
+                            injected_user_contents.append(content)
                         compiled_content = content
                         if (
                             db_session is not None
@@ -720,6 +751,28 @@ def create_react_agent(
                                 ]
                             )
                         )
+
+        if injected_user_contents and effective_runtime_state is not None:
+            injected_skill_ids = extract_referenced_skill_ids(injected_user_contents)
+            current_skill_ids = _runtime_skill_ids(effective_runtime_state)
+            merged_skill_ids = _merge_skill_ids(current_skill_ids, injected_skill_ids)
+            if merged_skill_ids != current_skill_ids:
+                effective_runtime_state["referenced_skill_ids"] = list(merged_skill_ids)
+                update_skill_tool_references(merged_skill_ids)
+                if context_parts is not None:
+                    context_parts = await build_context_parts(
+                        state=cast("AgentRuntimeState", effective_runtime_state),
+                        agent_name=react_config.name,
+                        node_messages=node_messages,
+                        db_session=cast("AsyncSession", db_session),
+                    )
+                else:
+                    messages = await build_context(
+                        state=cast("AgentRuntimeState", effective_runtime_state),
+                        agent_name=react_config.name,
+                        node_messages=node_messages,
+                        db_session=cast("AsyncSession", db_session),
+                    )
 
         if (
             termination.mode == "tool_success"

--- a/backend/app/agent_runtime/graph/state.py
+++ b/backend/app/agent_runtime/graph/state.py
@@ -1,4 +1,4 @@
-from typing import Any, TypedDict
+from typing import Any, NotRequired, TypedDict
 
 
 class AgentRuntimeState(TypedDict):
@@ -14,3 +14,4 @@ class AgentRuntimeState(TypedDict):
     user_request: str
     user_attachments: list[dict[str, Any]]
     current_revision_id: str | None
+    referenced_skill_names: NotRequired[list[str]]

--- a/backend/app/agent_runtime/graph/state.py
+++ b/backend/app/agent_runtime/graph/state.py
@@ -14,4 +14,4 @@ class AgentRuntimeState(TypedDict):
     user_request: str
     user_attachments: list[dict[str, Any]]
     current_revision_id: str | None
-    referenced_skill_names: NotRequired[list[str]]
+    referenced_skill_ids: NotRequired[list[str]]

--- a/backend/app/agent_runtime/runner/session_runner.py
+++ b/backend/app/agent_runtime/runner/session_runner.py
@@ -620,7 +620,7 @@ class SessionRunner:
         *,
         db_session: AsyncSession | None = None,
     ) -> str:
-        if not content or "<of-mention" not in content:
+        if not content or ("<of-mention" not in content and "<of-skill" not in content):
             return content
         if db_session is not None:
             return await compile_canonical_mentions(content, db_session)

--- a/backend/app/agent_runtime/runner/session_runner.py
+++ b/backend/app/agent_runtime/runner/session_runner.py
@@ -17,7 +17,10 @@ from app.agent_runtime.context.compaction.window import (
     CompactionNoWindowError,
     select_compaction_window,
 )
-from app.agent_runtime.context.helpers import compile_canonical_mentions
+from app.agent_runtime.context.helpers import (
+    compile_canonical_mentions,
+    extract_referenced_skill_ids,
+)
 from app.audit import AuditContext
 from app.agent_runtime.graph.orchestrator.graph import build_orchestrator_graph
 from app.agent_runtime.graph.react_agent import _to_history_dict
@@ -803,6 +806,7 @@ class SessionRunner:
         try:
             history_messages = await self._prepare_run_persistence()
             graph = await self._get_graph()
+            referenced_skill_ids = extract_referenced_skill_ids([user_request])
             if user_message_id is None:
                 compiled_user_request = await self._compile_user_message_content(
                     user_request,
@@ -837,6 +841,7 @@ class SessionRunner:
                 "user_request": state_user_request,
                 "user_attachments": attachments or [],
                 "current_revision_id": revision.id,
+                "referenced_skill_ids": list(referenced_skill_ids),
                 "messages": history_messages,
             }
             async for event in graph.astream_events(

--- a/backend/app/agent_runtime/runner/subagent_runner.py
+++ b/backend/app/agent_runtime/runner/subagent_runner.py
@@ -16,6 +16,7 @@ from app.agent_runtime.agents.definitions import (
 )
 from app.audit import AuditContext
 from app.agent_runtime.agents.tool_categories import get_tool_names_for_categories
+from app.agent_runtime.context.helpers import extract_referenced_skill_ids
 from app.agent_runtime.graph.react_agent import create_react_agent
 from app.agent_runtime.model_config import to_client_model_config
 from app.agent_runtime.persistence import MessagePersister
@@ -74,6 +75,29 @@ _SUBAGENT_RESTRICTED_TOOL_NAMES = frozenset(
 
 def build_child_messages(history: list[BaseMessage], *, content: str) -> list[BaseMessage]:
     return [*history, HumanMessage(content=content)]
+
+
+def _get_referenced_skill_ids(runtime_state: dict[str, Any]) -> tuple[str, ...]:
+    existing = runtime_state.get("referenced_skill_ids")
+    existing_ids = _merge_skill_ids(existing)
+    content = runtime_state.get("user_request")
+    if not isinstance(content, str) or not content:
+        return existing_ids
+    extracted = extract_referenced_skill_ids([content])
+    return _merge_skill_ids(existing_ids, extracted)
+
+
+def _merge_skill_ids(*groups: object) -> tuple[str, ...]:
+    merged: list[str] = []
+    for group in groups:
+        values = group if isinstance(group, (list, tuple, set)) else (group,)
+        for value in values:
+            if not isinstance(value, str):
+                continue
+            normalized = value.strip()
+            if normalized and normalized not in merged:
+                merged.append(normalized)
+    return tuple(merged)
 
 
 async def _maybe_await(value: Any) -> Any:
@@ -298,7 +322,15 @@ class SubagentRunner:
         ]
         session = await _open_session(self.session_factory)
         try:
-            names.extend(await skill_tool_names_for_definition(definition, session))
+            referenced_skill_ids = _get_referenced_skill_ids(runtime_state)
+            runtime_state["referenced_skill_ids"] = list(referenced_skill_ids)
+            names.extend(
+                await skill_tool_names_for_definition(
+                    definition,
+                    session,
+                    referenced_skill_ids=referenced_skill_ids,
+                )
+            )
         finally:
             await _close_session(session)
         return ToolRegistry.get_tools(

--- a/backend/app/agent_runtime/tools/impls/skill/skill.py
+++ b/backend/app/agent_runtime/tools/impls/skill/skill.py
@@ -19,14 +19,24 @@ async def skill_tool_names_for_definition(
     definition: AgentDefinition,
     db_session: AsyncSession,
     *,
-    referenced_skill_names: Iterable[str] = (),
+    referenced_skill_ids: Iterable[str] = (),
+    allow_runtime_skill_references: bool = False,
 ) -> tuple[str, ...]:
     """当 agent 存在实际可用技能时，才返回 skill 工具名；否则返回空。"""
     normalized_references = {
-        name.strip() for name in referenced_skill_names if isinstance(name, str) and name.strip()
+        skill_id.strip()
+        for skill_id in referenced_skill_ids
+        if isinstance(skill_id, str) and skill_id.strip()
     }
-    if not definition.enabled_skills and not normalized_references:
+    if (
+        not definition.enabled_skills
+        and not normalized_references
+        and not allow_runtime_skill_references
+    ):
         return ()
+
+    if allow_runtime_skill_references and not definition.enabled_skills and not normalized_references:
+        return SKILL_TOOL_NAMES
 
     available = []
     if definition.enabled_skills:
@@ -39,9 +49,9 @@ async def skill_tool_names_for_definition(
     if normalized_references:
         global_skills = await skill_service.list_enabled_skills(db_session)
         available.extend(
-            skill for skill in global_skills if skill.name.strip() in normalized_references
+            skill for skill in global_skills if skill.id.strip() in normalized_references
         )
-    return SKILL_TOOL_NAMES if available else ()
+    return SKILL_TOOL_NAMES if available or allow_runtime_skill_references else ()
 
 
 class ActivateSkillInput(BaseModel):
@@ -68,12 +78,25 @@ async def _resolve_authorized_skill(session: AsyncSession, state: dict, skill_na
         session,
         [skill_id for skill_id in definition.enabled_skills if skill_id],
     )
-    skill = next((s for s in available if s.name.strip() == normalized), None)
+    skill = next(
+        (s for s in available if s.name.strip() == normalized or s.id.strip() == normalized),
+        None,
+    )
     if skill is None:
-        referenced_names = state.get("referenced_skill_names")
-        if isinstance(referenced_names, (list, tuple, set)) and normalized in referenced_names:
+        referenced_ids = state.get("referenced_skill_ids")
+        if isinstance(referenced_ids, (list, tuple, set)) and normalized in referenced_ids:
             globally_enabled = await skill_service.list_enabled_skills(session)
-            skill = next((s for s in globally_enabled if s.name.strip() == normalized), None)
+            skill = next((s for s in globally_enabled if s.id.strip() == normalized), None)
+        elif isinstance(referenced_ids, (list, tuple, set)):
+            globally_enabled = await skill_service.list_enabled_skills(session)
+            skill = next(
+                (
+                    s
+                    for s in globally_enabled
+                    if s.id.strip() in referenced_ids and s.name.strip() == normalized
+                ),
+                None,
+            )
     if skill is None:
         raise ToolExecutionError(f"技能不在该智能体的可用列表中: {normalized}")
 

--- a/backend/app/agent_runtime/tools/impls/skill/skill.py
+++ b/backend/app/agent_runtime/tools/impls/skill/skill.py
@@ -1,5 +1,7 @@
 """Skill 工具：按需激活技能与读取参考文档。"""
 
+from collections.abc import Iterable
+
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -16,14 +18,29 @@ SKILL_TOOL_NAMES: tuple[str, ...] = ("activate_skill", "reference_skill")
 async def skill_tool_names_for_definition(
     definition: AgentDefinition,
     db_session: AsyncSession,
+    *,
+    referenced_skill_names: Iterable[str] = (),
 ) -> tuple[str, ...]:
     """当 agent 存在实际可用技能时，才返回 skill 工具名；否则返回空。"""
-    if not definition.enabled_skills:
+    normalized_references = {
+        name.strip() for name in referenced_skill_names if isinstance(name, str) and name.strip()
+    }
+    if not definition.enabled_skills and not normalized_references:
         return ()
-    available = await skill_service.list_enabled_skills_by_ids(
-        db_session,
-        [skill_id for skill_id in definition.enabled_skills if skill_id],
-    )
+
+    available = []
+    if definition.enabled_skills:
+        available.extend(
+            await skill_service.list_enabled_skills_by_ids(
+                db_session,
+                [skill_id for skill_id in definition.enabled_skills if skill_id],
+            )
+        )
+    if normalized_references:
+        global_skills = await skill_service.list_enabled_skills(db_session)
+        available.extend(
+            skill for skill in global_skills if skill.name.strip() in normalized_references
+        )
     return SKILL_TOOL_NAMES if available else ()
 
 
@@ -51,7 +68,12 @@ async def _resolve_authorized_skill(session: AsyncSession, state: dict, skill_na
         session,
         [skill_id for skill_id in definition.enabled_skills if skill_id],
     )
-    skill = next((s for s in available if s.name == normalized), None)
+    skill = next((s for s in available if s.name.strip() == normalized), None)
+    if skill is None:
+        referenced_names = state.get("referenced_skill_names")
+        if isinstance(referenced_names, (list, tuple, set)) and normalized in referenced_names:
+            globally_enabled = await skill_service.list_enabled_skills(session)
+            skill = next((s for s in globally_enabled if s.name.strip() == normalized), None)
     if skill is None:
         raise ToolExecutionError(f"技能不在该智能体的可用列表中: {normalized}")
 

--- a/backend/app/api/routers/commands.py
+++ b/backend/app/api/routers/commands.py
@@ -1,0 +1,47 @@
+from typing import Annotated, Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.schemas.command import CommandCandidateItem, CommandSearchResponse
+from app.core.errors import NotFoundError
+from app.storage.database import get_session
+from app.storage.services import command_service
+
+
+router = APIRouter(tags=["commands"])
+
+
+@router.get(
+    "/projects/{project_id}/commands",
+    response_model=CommandSearchResponse,
+    summary="检索 Agent Command 候选项",
+)
+async def search_commands(
+    project_id: str,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    query: Annotated[str, Query(description="Command 检索词")] = "",
+    limit: Annotated[int, Query(ge=1, le=50, description="返回的最大候选数")] = 20,
+    kind: Annotated[Literal["skill"], Query(description="Command 类型")] = "skill",
+) -> CommandSearchResponse:
+    try:
+        items = await command_service.search_commands(
+            session,
+            project_id,
+            query,
+            kind=kind,
+            limit=limit,
+        )
+        return CommandSearchResponse(
+            items=[
+                CommandCandidateItem(
+                    kind=item.kind,
+                    id=item.id,
+                    name=item.name,
+                    description=item.description,
+                )
+                for item in items
+            ]
+        )
+    except NotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc))

--- a/backend/app/api/schemas/command.py
+++ b/backend/app/api/schemas/command.py
@@ -1,0 +1,14 @@
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class CommandCandidateItem(BaseModel):
+    kind: Literal["skill"] = Field(description="命令类型")
+    id: str = Field(description="命令关联对象 ID")
+    name: str = Field(description="命令名称")
+    description: str = Field(description="命令说明")
+
+
+class CommandSearchResponse(BaseModel):
+    items: list[CommandCandidateItem] = Field(description="命令候选项")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,6 +33,7 @@ from app.api.routers import (
     chapter_context,
     chapter_exports,
     chapters,
+    commands,
     dashboard,
     health,
     import_router,
@@ -703,6 +704,7 @@ def create_app() -> FastAPI:
     app.include_router(volumes.router, prefix=app_settings.api_v1_prefix)
     app.include_router(chapters.router, prefix=app_settings.api_v1_prefix)
     app.include_router(notes.router, prefix=app_settings.api_v1_prefix)
+    app.include_router(commands.router, prefix=app_settings.api_v1_prefix)
     app.include_router(characters.router, prefix=app_settings.api_v1_prefix)
     app.include_router(world_info.router, prefix=app_settings.api_v1_prefix)
     app.include_router(world_info_entries.router, prefix=app_settings.api_v1_prefix)

--- a/backend/app/storage/repos/skill_repo.py
+++ b/backend/app/storage/repos/skill_repo.py
@@ -72,6 +72,15 @@ async def list_page(
     return list(result.scalars().all())
 
 
+async def list_enabled(session: AsyncSession) -> list[Skill]:
+    result = await session.execute(
+        select(Skill)
+        .where(_custom_skill_filter(), col(Skill.is_enabled) == True)  # noqa: E712
+        .order_by(col(Skill.created_at).asc(), col(Skill.id).asc())
+    )
+    return list(result.scalars().all())
+
+
 async def list_by_names(session: AsyncSession, names: list[str]) -> list[Skill]:
     if not names:
         return []

--- a/backend/app/storage/repos/skill_repo.py
+++ b/backend/app/storage/repos/skill_repo.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Skill Repository - Skill 数据访问层。"""
 
-from sqlalchemy import func, select
+from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
 
@@ -78,6 +78,45 @@ async def list_enabled(session: AsyncSession) -> list[Skill]:
         .where(_custom_skill_filter(), col(Skill.is_enabled) == True)  # noqa: E712
         .order_by(col(Skill.created_at).asc(), col(Skill.id).asc())
     )
+    return list(result.scalars().all())
+
+
+async def search_enabled(
+    session: AsyncSession,
+    query: str,
+    *,
+    limit: int,
+) -> list[Skill]:
+    normalized_query = query.strip().lower()
+    name_expr = func.lower(func.coalesce(col(Skill.name), ""))
+    complete_filter = (
+        func.trim(col(Skill.name)) != "",
+        func.trim(col(Skill.summary)) != "",
+        func.trim(col(Skill.content)) != "",
+    )
+    stmt = select(Skill).where(
+        _custom_skill_filter(),
+        col(Skill.is_enabled) == True,  # noqa: E712
+        *complete_filter,
+    )
+    if normalized_query:
+        match_rank = case(
+            (name_expr == normalized_query, 0),
+            (name_expr.like(f"{normalized_query}%"), 1),
+            else_=2,
+        )
+        stmt = stmt.where(name_expr.contains(normalized_query)).order_by(
+            match_rank.asc(),
+            name_expr.asc(),
+            col(Skill.id).asc(),
+        )
+    else:
+        stmt = stmt.order_by(
+            col(Skill.updated_at).desc(),
+            name_expr.asc(),
+            col(Skill.id).asc(),
+        )
+    result = await session.execute(stmt.limit(limit))
     return list(result.scalars().all())
 
 

--- a/backend/app/storage/services/command_service.py
+++ b/backend/app/storage/services/command_service.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.errors import NotFoundError
+from app.storage.repos import project_repo
+from app.storage.services import skill_service
+
+
+@dataclass(frozen=True)
+class CommandCandidate:
+    kind: Literal["skill"]
+    id: str
+    name: str
+    description: str
+
+
+async def search_commands(
+    session: AsyncSession,
+    project_id: str,
+    query: str,
+    *,
+    kind: Literal["skill"] = "skill",
+    limit: int = 20,
+) -> list[CommandCandidate]:
+    if await project_repo.get_by_id(session, project_id) is None:
+        raise NotFoundError(f"项目不存在: {project_id}")
+    if kind != "skill":
+        return []
+
+    skills = await skill_service.search_enabled_skills(session, query, limit=limit)
+    return [
+        CommandCandidate(
+            kind="skill",
+            id=skill.id,
+            name=skill.name.strip(),
+            description=skill.summary,
+        )
+        for skill in skills
+    ]

--- a/backend/app/storage/services/skill_service.py
+++ b/backend/app/storage/services/skill_service.py
@@ -137,7 +137,7 @@ async def create_skill(
     content: str = "",
     is_enabled: bool = False,
 ) -> Skill:
-    unique_name = await _ensure_unique_name(session, name)
+    unique_name = await _ensure_unique_name(session, name.strip())
     skill = Skill(
         name=unique_name,
         summary=summary,
@@ -232,6 +232,56 @@ async def list_enabled_skills_by_ids(
     return [skill_by_id[skill_id] for skill_id in ids if skill_id in skill_by_id]
 
 
+async def list_enabled_skills(session: AsyncSession) -> list[SkillData]:
+    builtin_skills = await _load_builtin_skills_with_settings(session)
+    custom_skills = await skill_repo.list_enabled(session)
+    return [
+        skill
+        for skill in [*builtin_skills, *custom_skills]
+        if skill.is_enabled and is_skill_complete(skill)
+    ]
+
+
+async def search_enabled_skills(
+    session: AsyncSession,
+    query: str,
+    *,
+    limit: int,
+) -> list[SkillData]:
+    normalized_query = query.strip().lower()
+    candidates = await list_enabled_skills(session)
+    if not normalized_query:
+        candidates.sort(
+            key=lambda skill: (_as_utc_datetime(skill.updated_at), skill.name.lower()),
+            reverse=True,
+        )
+        return candidates[: min(limit, 10)]
+
+    candidates = [skill for skill in candidates if normalized_query in skill.name.strip().lower()]
+    candidates.sort(
+        key=lambda skill: (
+            _skill_match_rank(skill.name, normalized_query),
+            skill.name.lower(),
+        )
+    )
+    return candidates[: max(1, min(limit, 50))]
+
+
+def _skill_match_rank(name: str, normalized_query: str) -> int:
+    normalized_name = name.strip().lower()
+    if normalized_name == normalized_query:
+        return 0
+    if normalized_name.startswith(normalized_query):
+        return 1
+    return 2
+
+
+def _as_utc_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
 async def update_skill(
     session: AsyncSession,
     skill_db_id: str,
@@ -247,13 +297,14 @@ async def update_skill(
 
     assert isinstance(skill, Skill)
 
-    if name is not None and name != skill.name:
-        if name in {builtin_skill.name for builtin_skill in load_builtin_skills()}:
-            raise ConflictError(f"技能名称已存在: {name}")
-        matches = await skill_repo.list_by_names(session, [name])
+    normalized_name = name.strip() if name is not None else None
+    if normalized_name is not None and normalized_name != skill.name:
+        if normalized_name in {builtin_skill.name for builtin_skill in load_builtin_skills()}:
+            raise ConflictError(f"技能名称已存在: {normalized_name}")
+        matches = await skill_repo.list_by_names(session, [normalized_name])
         if any(other.id != skill.id for other in matches):
-            raise ConflictError(f"技能名称已存在: {name}")
-        skill.name = name
+            raise ConflictError(f"技能名称已存在: {normalized_name}")
+        skill.name = normalized_name
     if summary is not None:
         skill.summary = summary
     if content is not None:

--- a/backend/app/storage/services/skill_service.py
+++ b/backend/app/storage/services/skill_service.py
@@ -249,13 +249,24 @@ async def search_enabled_skills(
     limit: int,
 ) -> list[SkillData]:
     normalized_query = query.strip().lower()
-    candidates = await list_enabled_skills(session)
+    result_limit = max(1, min(limit, 50))
+    custom_limit = min(result_limit, 10) if not normalized_query else result_limit
+    builtin_skills = await _load_builtin_skills_with_settings(session)
+    custom_skills = await skill_repo.search_enabled(
+        session,
+        normalized_query,
+        limit=custom_limit,
+    )
+    all_candidates: list[SkillData] = [*builtin_skills, *custom_skills]
+    candidates = [
+        skill for skill in all_candidates if skill.is_enabled and is_skill_complete(skill)
+    ]
     if not normalized_query:
         candidates.sort(
             key=lambda skill: (_as_utc_datetime(skill.updated_at), skill.name.lower()),
             reverse=True,
         )
-        return candidates[: min(limit, 10)]
+        return candidates[: min(result_limit, 10)]
 
     candidates = [skill for skill in candidates if normalized_query in skill.name.strip().lower()]
     candidates.sort(
@@ -264,7 +275,7 @@ async def search_enabled_skills(
             skill.name.lower(),
         )
     )
-    return candidates[: max(1, min(limit, 50))]
+    return candidates[:result_limit]
 
 
 def _skill_match_rank(name: str, normalized_query: str) -> int:

--- a/backend/tests/agent_runtime/context/helpers/test_canonical_commands.py
+++ b/backend/tests/agent_runtime/context/helpers/test_canonical_commands.py
@@ -1,0 +1,40 @@
+import pytest
+
+from app.agent_runtime.context.helpers.canonical_mentions import compile_canonical_mentions
+from app.agent_runtime.context.helpers.canonical_commands import extract_referenced_skill_names
+
+
+@pytest.mark.asyncio
+async def test_compile_canonical_mentions_compiles_skill_command() -> None:
+    compiled = await compile_canonical_mentions(
+        '请使用<of-skill name="小说人物设计" />',
+    )
+
+    assert compiled == "请使用@skill:小说人物设计"
+
+
+@pytest.mark.asyncio
+async def test_compile_canonical_mentions_keeps_skill_command_name_without_lookup() -> None:
+    compiled = await compile_canonical_mentions(
+        '<of-skill name="已禁用技能" />',
+    )
+
+    assert compiled == "@skill:已禁用技能"
+
+
+def test_extract_referenced_skill_names_prefers_the_longest_matching_name() -> None:
+    names = extract_referenced_skill_names(
+        ["@skill:foo bar"],
+        ["foo", "foo bar"],
+    )
+
+    assert names == ("foo bar",)
+
+
+def test_extract_referenced_skill_names_allows_cjk_text_after_ascii_name() -> None:
+    names = extract_referenced_skill_names(
+        ["@skill:foo请继续"],
+        ["foo"],
+    )
+
+    assert names == ("foo",)

--- a/backend/tests/agent_runtime/context/helpers/test_canonical_commands.py
+++ b/backend/tests/agent_runtime/context/helpers/test_canonical_commands.py
@@ -1,13 +1,16 @@
 import pytest
 
 from app.agent_runtime.context.helpers.canonical_mentions import compile_canonical_mentions
-from app.agent_runtime.context.helpers.canonical_commands import extract_referenced_skill_names
+from app.agent_runtime.context.helpers.canonical_commands import (
+    extract_referenced_skill_ids,
+    parse_canonical_skill_commands,
+)
 
 
 @pytest.mark.asyncio
 async def test_compile_canonical_mentions_compiles_skill_command() -> None:
     compiled = await compile_canonical_mentions(
-        '请使用<of-skill name="小说人物设计" />',
+        '请使用<of-skill id="skill-1" name="小说人物设计" />',
     )
 
     assert compiled == "请使用@skill:小说人物设计"
@@ -16,25 +19,38 @@ async def test_compile_canonical_mentions_compiles_skill_command() -> None:
 @pytest.mark.asyncio
 async def test_compile_canonical_mentions_keeps_skill_command_name_without_lookup() -> None:
     compiled = await compile_canonical_mentions(
-        '<of-skill name="已禁用技能" />',
+        '<of-skill id="disabled-skill" name="已禁用技能" />',
     )
 
     assert compiled == "@skill:已禁用技能"
 
 
-def test_extract_referenced_skill_names_prefers_the_longest_matching_name() -> None:
-    names = extract_referenced_skill_names(
-        ["@skill:foo bar"],
-        ["foo", "foo bar"],
+def test_canonical_skill_command_preserves_id() -> None:
+    parsed = parse_canonical_skill_commands(
+        '<of-skill id="skill-foo" name="foo" />',
     )
 
-    assert names == ("foo bar",)
+    assert parsed[0].skill_id == "skill-foo"
 
 
-def test_extract_referenced_skill_names_allows_cjk_text_after_ascii_name() -> None:
-    names = extract_referenced_skill_names(
-        ["@skill:foo请继续"],
-        ["foo"],
+def test_extract_referenced_skill_ids_ignores_text_after_command() -> None:
+    skill_ids = extract_referenced_skill_ids(
+        ['<of-skill id="skill-foo" name="foo" /> bar'],
     )
 
-    assert names == ("foo",)
+    assert skill_ids == ("skill-foo",)
+
+
+@pytest.mark.asyncio
+async def test_pure_name_skill_command_is_not_compiled() -> None:
+    raw = '<of-skill name="foo" />'
+    compiled = await compile_canonical_mentions(raw)
+
+    assert compiled == raw
+    assert extract_referenced_skill_ids([raw]) == ()
+
+
+def test_extract_referenced_skill_ids_ignores_pure_name_marker() -> None:
+    skill_ids = extract_referenced_skill_ids(["@skill:foo"])
+
+    assert skill_ids == ()

--- a/backend/tests/agent_runtime/context/parts/test_history.py
+++ b/backend/tests/agent_runtime/context/parts/test_history.py
@@ -159,7 +159,7 @@ async def test_history_preserves_user_xml_when_session_unavailable():
 async def test_history_compiles_skill_commands_for_llm_context_when_session_available():
     raw = [{
         "role": "user",
-        "content": '<of-skill name="小说人物设计" />',
+        "content": '<of-skill id="skill-1" name="小说人物设计" />',
     }]
 
     fake_session = object()

--- a/backend/tests/agent_runtime/context/parts/test_history.py
+++ b/backend/tests/agent_runtime/context/parts/test_history.py
@@ -154,3 +154,20 @@ async def test_history_preserves_user_xml_when_session_unavailable():
     result = await build_history(raw)
 
     assert result[0].content == raw[0]["content"]
+
+
+async def test_history_compiles_skill_commands_for_llm_context_when_session_available():
+    raw = [{
+        "role": "user",
+        "content": '<of-skill name="小说人物设计" />',
+    }]
+
+    fake_session = object()
+    with patch(
+        "app.agent_runtime.context.parts.history.compile_canonical_mentions",
+        AsyncMock(return_value="@skill:小说人物设计"),
+    ) as compile_mock:
+        result = await build_history(raw, fake_session)
+
+    compile_mock.assert_awaited_once_with(raw[0]["content"], fake_session)
+    assert result[0].content == "@skill:小说人物设计"

--- a/backend/tests/agent_runtime/context/parts/test_skills.py
+++ b/backend/tests/agent_runtime/context/parts/test_skills.py
@@ -63,7 +63,7 @@ async def test_skills_renders_available_xml(make_state, mock_session):
 
 @pytest.mark.asyncio
 async def test_skills_appends_referenced_global_skill_after_agent_skills(make_state, mock_session):
-    state = make_state(user_request="请使用@skill:global-skill")
+    state = make_state(user_request="请继续")
     agent_skill = SimpleNamespace(
         id="agent-skill",
         name="agent-skill",
@@ -95,7 +95,12 @@ async def test_skills_appends_referenced_global_skill_after_agent_skills(make_st
             state,
             "writer",
             mock_session,
-            [{"role": "user", "content": '<of-skill name="global-skill" />'}],
+            [
+                {
+                    "role": "user",
+                    "content": '<of-skill id="global-skill-id" name="global-skill" />',
+                }
+            ],
         )
 
     assert msg is not None
@@ -106,7 +111,7 @@ async def test_skills_appends_referenced_global_skill_after_agent_skills(make_st
 
 @pytest.mark.asyncio
 async def test_skills_does_not_append_disabled_referenced_skill(make_state, mock_session):
-    state = make_state(user_request="请使用@skill:disabled-skill")
+    state = make_state(user_request="请继续")
     agent_skill = _skill("agent-skill", "默认技能", "内容")
 
     with patch(
@@ -124,7 +129,12 @@ async def test_skills_does_not_append_disabled_referenced_skill(make_state, mock
             state,
             "writer",
             mock_session,
-            [{"role": "user", "content": '<of-skill name="disabled-skill" />'}],
+            [
+                {
+                    "role": "user",
+                    "content": '<of-skill id="disabled-skill-id" name="disabled-skill" />',
+                }
+            ],
         )
 
     assert msg is not None

--- a/backend/tests/agent_runtime/context/parts/test_skills.py
+++ b/backend/tests/agent_runtime/context/parts/test_skills.py
@@ -5,7 +5,7 @@ from app.agent_runtime.context.parts.skills import build_skills
 
 
 def _skill(name: str, summary: str, content: str = ""):
-    return SimpleNamespace(name=name, summary=summary, content=content)
+    return SimpleNamespace(id=name, name=name, summary=summary, content=content)
 
 
 @pytest.mark.asyncio
@@ -59,3 +59,92 @@ async def test_skills_renders_available_xml(make_state, mock_session):
     assert "<description>Extract PDF text, fill forms, merge files.</description>" in msg.content
     assert "<name>data-analysis</name>" in msg.content
     assert "<skill>" in msg.content
+
+
+@pytest.mark.asyncio
+async def test_skills_appends_referenced_global_skill_after_agent_skills(make_state, mock_session):
+    state = make_state(user_request="请使用@skill:global-skill")
+    agent_skill = SimpleNamespace(
+        id="agent-skill",
+        name="agent-skill",
+        summary="默认技能",
+        content="内容",
+    )
+    referenced_skill = SimpleNamespace(
+        id="global-skill-id",
+        name="global-skill",
+        summary="显式引用技能",
+        content="内容",
+    )
+
+    async def list_by_ids(_session, ids):
+        return [agent_skill] if ids == ["agent-skill"] else []
+
+    with patch(
+        "app.agent_runtime.context.parts.skills._get_enabled_skill_ids_for_agent",
+        AsyncMock(return_value=["agent-skill"]),
+    ), patch(
+        "app.agent_runtime.context.parts.skills.skill_service.list_enabled_skills_by_ids",
+        AsyncMock(side_effect=list_by_ids),
+    ), patch(
+        "app.agent_runtime.context.parts.skills.skill_service.list_enabled_skills",
+        AsyncMock(return_value=[agent_skill, referenced_skill]),
+        create=True,
+    ):
+        msg = await build_skills(
+            state,
+            "writer",
+            mock_session,
+            [{"role": "user", "content": '<of-skill name="global-skill" />'}],
+        )
+
+    assert msg is not None
+    assert msg.content.index("<name>agent-skill</name>") < msg.content.index(
+        "<name>global-skill</name>"
+    )
+
+
+@pytest.mark.asyncio
+async def test_skills_does_not_append_disabled_referenced_skill(make_state, mock_session):
+    state = make_state(user_request="请使用@skill:disabled-skill")
+    agent_skill = _skill("agent-skill", "默认技能", "内容")
+
+    with patch(
+        "app.agent_runtime.context.parts.skills._get_enabled_skill_ids_for_agent",
+        AsyncMock(return_value=["agent-skill"]),
+    ), patch(
+        "app.agent_runtime.context.parts.skills.skill_service.list_enabled_skills_by_ids",
+        AsyncMock(return_value=[agent_skill]),
+    ), patch(
+        "app.agent_runtime.context.parts.skills.skill_service.list_enabled_skills",
+        AsyncMock(return_value=[agent_skill]),
+        create=True,
+    ):
+        msg = await build_skills(
+            state,
+            "writer",
+            mock_session,
+            [{"role": "user", "content": '<of-skill name="disabled-skill" />'}],
+        )
+
+    assert msg is not None
+    assert "<name>disabled-skill</name>" not in msg.content
+
+
+@pytest.mark.asyncio
+async def test_skills_escapes_xml_fields(make_state, mock_session):
+    state = make_state()
+    unsafe_skill = _skill("skill & <name>", '描述 & <指令> "quoted"', "内容")
+
+    with patch(
+        "app.agent_runtime.context.parts.skills._get_enabled_skill_ids_for_agent",
+        AsyncMock(return_value=[unsafe_skill.id]),
+    ), patch(
+        "app.agent_runtime.context.parts.skills.skill_service.list_enabled_skills_by_ids",
+        AsyncMock(return_value=[unsafe_skill]),
+    ):
+        msg = await build_skills(state, "writer", mock_session)
+
+    assert msg is not None
+    assert "skill &amp; &lt;name&gt;" in msg.content
+    assert "描述 &amp; &lt;指令&gt; &quot;quoted&quot;" in msg.content

--- a/backend/tests/agent_runtime/graph/test_react_agent_context.py
+++ b/backend/tests/agent_runtime/graph/test_react_agent_context.py
@@ -728,6 +728,81 @@ def test_llm_call_marks_consumed_injected_user_messages_sent() -> None:
     )
 
 
+def test_llm_call_updates_skill_references_for_injected_command() -> None:
+    from app.agent_runtime.tools.impls.skill.skill import ActivateSkillTool
+
+    runtime_state: dict[str, object] = {
+        "session_id": "s1",
+        "task_id": "t1",
+        "project_id": "p1",
+        "model_config": {"max_context_tokens": 8000},
+        "active_agent": "writer",
+        "is_completed": False,
+        "error": None,
+        "retry_count": 0,
+        "user_request": "hi",
+    }
+    skill_tool = ActivateSkillTool(_state=runtime_state)
+    config = ReactAgentConfig(
+        name="writer",
+        tools=[skill_tool],
+        termination=TerminationCondition(mode="no_tool_call"),
+        max_iterations=1,
+    )
+    injected_queue: asyncio.Queue[tuple[str | None, str, str]] = asyncio.Queue()
+    injected_queue.put_nowait(
+        (
+            "msg_pending_1",
+            "user",
+            '<of-skill id="skill-explicit" name="显式引用技能" />',
+        )
+    )
+
+    async def _mock_invoke(_model, _messages, **_kwargs):
+        return AIMessage(content="done")
+
+    with (
+        patch(
+            "app.agent_runtime.graph.react_agent._invoke_model",
+            side_effect=_mock_invoke,
+        ),
+        patch(
+            "app.storage.services.skill_service.list_enabled_skills",
+            new=AsyncMock(
+                return_value=[SimpleNamespace(id="skill-explicit", name="显式引用技能")]
+            ),
+        ),
+        patch(
+            "app.agent_runtime.graph.react_agent.build_context_parts",
+            new=AsyncMock(return_value=[]),
+            create=True,
+        ),
+    ):
+        model = Mock()
+        model.bind_tools.return_value = model
+        graph = create_react_agent(config, model=model, inject_queue=injected_queue)
+        asyncio.run(
+            graph.ainvoke(
+                {
+                    "messages": [HumanMessage(content="hi")],
+                    "iteration_count": 0,
+                    "is_done": False,
+                    "final_output": None,
+                },
+                config={
+                    "configurable": {
+                        "runtime_state": runtime_state,
+                        "db_session": AsyncMock(),
+                        "thread_id": "s1",
+                        "inject_message_consumed_sink": AsyncMock(return_value=True),
+                    }
+                },
+            )
+        )
+
+    assert skill_tool.runtime_state["referenced_skill_ids"] == ["skill-explicit"]
+
+
 def test_to_history_dict_preserves_reasoning_content() -> None:
     from app.agent_runtime.graph.react_agent import _to_history_dict
 

--- a/backend/tests/agent_runtime/runner/test_subagent_runner.py
+++ b/backend/tests/agent_runtime/runner/test_subagent_runner.py
@@ -1,4 +1,5 @@
 from collections.abc import AsyncGenerator
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock
 
@@ -218,6 +219,58 @@ async def test_subagent_runner_excludes_restricted_tools_from_definition(
     assert "recycle_subagent" not in captured["names"]
     assert "ask_user" not in captured["names"]
     assert "read_chapter" in captured["names"]
+
+
+@pytest.mark.asyncio
+async def test_subagent_runner_forwards_explicit_skill_ids_to_tool_registration(
+    db_session_factory,
+    monkeypatch,
+):
+    from app.agent_runtime.runner.subagent_runner import SubagentRunner
+
+    captured: dict[str, object] = {}
+
+    def fake_get_tools(*, names, **_kwargs):
+        captured["names"] = names
+        return []
+
+    async def fake_skill_tool_names(*_args, **kwargs):
+        captured["referenced_skill_ids"] = kwargs.get("referenced_skill_ids")
+        return ("activate_skill", "reference_skill")
+
+    monkeypatch.setattr(
+        "app.agent_runtime.runner.subagent_runner.ToolRegistry.get_tools",
+        fake_get_tools,
+    )
+    monkeypatch.setattr(
+        "app.agent_runtime.runner.subagent_runner.skill_tool_names_for_definition",
+        fake_skill_tool_names,
+    )
+    monkeypatch.setattr(
+        "app.storage.services.skill_service.list_enabled_skills",
+        AsyncMock(return_value=[SimpleNamespace(id="skill-explicit", name="显式引用技能")]),
+    )
+
+    runner = SubagentRunner(
+        session_factory=db_session_factory,
+        model_config={},
+        project_id="project-1",
+    )
+    definition = SimpleNamespace(
+        key="writer",
+        enabled=True,
+        kind="subagent",
+        enabled_tool_categories=(),
+        enabled_skills=(),
+    )
+    runtime_state = {
+        "user_request": '<of-skill id="skill-explicit" name="显式引用技能" />',
+    }
+
+    await runner._build_tools(definition, runtime_state)
+
+    assert captured["referenced_skill_ids"] == ("skill-explicit",)
+    assert runtime_state["referenced_skill_ids"] == ["skill-explicit"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/test_orchestrator_graph.py
+++ b/backend/tests/agent_runtime/test_orchestrator_graph.py
@@ -1,4 +1,5 @@
 import json
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -62,6 +63,38 @@ async def test_primary_messages_preserves_attachment_metadata_without_embedding_
     assert isinstance(messages[0], HumanMessage)
     assert messages[0].content == "请描述图片"
     assert messages[0].additional_kwargs == {"openfic_attachments": [attachment]}
+
+
+@pytest.mark.asyncio
+async def test_primary_tool_names_forward_explicit_skill_references() -> None:
+    from app.agent_runtime.graph.orchestrator.graph import _primary_tool_names
+
+    with patch(
+        "app.agent_runtime.graph.orchestrator.graph.load_agent_definition",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                enabled_tool_categories=(),
+                enabled_skills=[],
+            )
+        ),
+    ), patch(
+        "app.agent_runtime.graph.orchestrator.graph.get_tool_names_for_categories",
+        return_value=(),
+    ), patch(
+        "app.agent_runtime.graph.orchestrator.graph.skill_tool_names_for_definition",
+        AsyncMock(return_value=("activate_skill", "reference_skill")),
+    ) as skill_tools:
+        result = await _primary_tool_names(
+            {"configurable": {"db_session": object()}},
+            referenced_skill_names=("显式引用技能",),
+        )
+
+    assert result == ["activate_skill", "reference_skill"]
+    skill_tools.assert_awaited_once_with(
+        skill_tools.call_args.args[0],
+        skill_tools.call_args.args[1],
+        referenced_skill_names=("显式引用技能",),
+    )
 
 
 def test_session_runner_constructor_no_longer_accepts_mode():

--- a/backend/tests/agent_runtime/test_orchestrator_graph.py
+++ b/backend/tests/agent_runtime/test_orchestrator_graph.py
@@ -86,14 +86,15 @@ async def test_primary_tool_names_forward_explicit_skill_references() -> None:
     ) as skill_tools:
         result = await _primary_tool_names(
             {"configurable": {"db_session": object()}},
-            referenced_skill_names=("显式引用技能",),
+            referenced_skill_ids=("skill-explicit",),
         )
 
     assert result == ["activate_skill", "reference_skill"]
     skill_tools.assert_awaited_once_with(
         skill_tools.call_args.args[0],
         skill_tools.call_args.args[1],
-        referenced_skill_names=("显式引用技能",),
+        referenced_skill_ids=("skill-explicit",),
+        allow_runtime_skill_references=False,
     )
 
 

--- a/backend/tests/agent_runtime/tools/test_skill_tools.py
+++ b/backend/tests/agent_runtime/tools/test_skill_tools.py
@@ -71,6 +71,30 @@ async def test_skill_tool_names_for_definition_with_skills():
     )
 
 
+@pytest.mark.asyncio
+async def test_skill_tool_names_for_definition_with_explicit_reference():
+    from app.agent_runtime.tools.impls.skill.skill import skill_tool_names_for_definition
+
+    with patch(
+        "app.agent_runtime.tools.impls.skill.skill.skill_service.list_enabled_skills_by_ids",
+        AsyncMock(return_value=[]),
+    ), patch(
+        "app.agent_runtime.tools.impls.skill.skill.skill_service.list_enabled_skills",
+        AsyncMock(return_value=[_skill(name="显式引用技能")]),
+        create=True,
+    ):
+        result = await skill_tool_names_for_definition(
+            _definition([]),
+            AsyncMock(),
+            referenced_skill_names=["显式引用技能"],
+        )
+
+    assert result == (
+        "activate_skill",
+        "reference_skill",
+    )
+
+
 def _patch_env(definition, skill, docs):
     def _list_by_ids(_session, _ids):
         return [skill]
@@ -190,6 +214,31 @@ async def test_activate_skill_rejects_unauthorized_skill():
         result = await tool.ainvoke({"skill_name": "pdf-processing"})
 
     assert "技能不在该智能体的可用列表中" in json.loads(result)["error"]
+
+
+@pytest.mark.asyncio
+async def test_activate_skill_accepts_explicitly_referenced_global_skill():
+    from app.agent_runtime.tools.impls.skill.skill import _resolve_authorized_skill
+
+    skill = _skill(name="显式引用技能")
+    state = _make_state()
+    state["referenced_skill_names"] = [skill.name]
+    session = AsyncMock()
+
+    with patch(
+        "app.agent_runtime.tools.impls.skill.skill.load_agent_definition",
+        AsyncMock(return_value=_definition([])),
+    ), patch(
+        "app.agent_runtime.tools.impls.skill.skill.skill_service.list_enabled_skills_by_ids",
+        AsyncMock(return_value=[]),
+    ), patch(
+        "app.agent_runtime.tools.impls.skill.skill.skill_service.list_enabled_skills",
+        AsyncMock(return_value=[skill]),
+        create=True,
+    ):
+        resolved = await _resolve_authorized_skill(session, state, skill.name)
+
+    assert resolved is skill
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/tools/test_skill_tools.py
+++ b/backend/tests/agent_runtime/tools/test_skill_tools.py
@@ -80,13 +80,13 @@ async def test_skill_tool_names_for_definition_with_explicit_reference():
         AsyncMock(return_value=[]),
     ), patch(
         "app.agent_runtime.tools.impls.skill.skill.skill_service.list_enabled_skills",
-        AsyncMock(return_value=[_skill(name="显式引用技能")]),
+        AsyncMock(return_value=[_skill(id="skill-explicit", name="显式引用技能")]),
         create=True,
     ):
         result = await skill_tool_names_for_definition(
             _definition([]),
             AsyncMock(),
-            referenced_skill_names=["显式引用技能"],
+            referenced_skill_ids=["skill-explicit"],
         )
 
     assert result == (
@@ -220,9 +220,9 @@ async def test_activate_skill_rejects_unauthorized_skill():
 async def test_activate_skill_accepts_explicitly_referenced_global_skill():
     from app.agent_runtime.tools.impls.skill.skill import _resolve_authorized_skill
 
-    skill = _skill(name="显式引用技能")
+    skill = _skill(id="skill-explicit", name="显式引用技能")
     state = _make_state()
-    state["referenced_skill_names"] = [skill.name]
+    state["referenced_skill_ids"] = [skill.id]
     session = AsyncMock()
 
     with patch(

--- a/backend/tests/api/test_commands.py
+++ b/backend/tests/api/test_commands.py
@@ -1,0 +1,48 @@
+import pytest
+from httpx import AsyncClient
+
+
+async def _create_project(client: AsyncClient) -> str:
+    response = await client.post("/api/v1/projects", data={"title": "Command 测试项目"})
+    assert response.status_code == 201
+    return response.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_skill_commands_search_all_enabled_skills(client: AsyncClient) -> None:
+    project_id = await _create_project(client)
+    enabled = await client.post(
+        "/api/v1/skills",
+        json={
+            "name": "小说人物设计",
+            "summary": "设计人物",
+            "content": "完整技能内容",
+            "is_enabled": True,
+        },
+    )
+    disabled = await client.post(
+        "/api/v1/skills",
+        json={
+            "name": "小说人物禁用",
+            "summary": "不应出现",
+            "content": "完整技能内容",
+            "is_enabled": False,
+        },
+    )
+    assert enabled.status_code == 201
+    assert disabled.status_code == 201
+
+    response = await client.get(
+        f"/api/v1/projects/{project_id}/commands",
+        params={"kind": "skill", "query": "人物"},
+    )
+
+    assert response.status_code == 200
+    items = response.json()["items"]
+    assert any(
+        item["id"] == enabled.json()["id"]
+        and item["name"] == enabled.json()["name"]
+        and item["description"] == "设计人物"
+        for item in items
+    )
+    assert all(item["name"] != "小说人物禁用" for item in items)

--- a/backend/tests/api/test_skills.py
+++ b/backend/tests/api/test_skills.py
@@ -95,6 +95,21 @@ async def test_create_skill_with_empty_name(client: AsyncClient) -> None:
 
 
 @pytest.mark.asyncio
+async def test_create_skill_strips_name_whitespace(client: AsyncClient) -> None:
+    response = await client.post(
+        "/api/v1/skills",
+        json={
+            "name": "  可引用技能  ",
+            "summary": "简述",
+            "content": "技能内容",
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.json()["name"] == "可引用技能"
+
+
+@pytest.mark.asyncio
 async def test_incomplete_skill_cannot_be_enabled(client: AsyncClient) -> None:
     response = await client.post(
         "/api/v1/skills",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -29,6 +29,7 @@ from app.api.routers import (
     chapter_context,
     chapter_exports,
     chapters,
+    commands,
     dashboard,
     health,
     import_router,
@@ -80,6 +81,7 @@ def _create_test_app() -> FastAPI:
     test_app.include_router(volumes.router, prefix="/api/v1")
     test_app.include_router(chapters.router, prefix="/api/v1")
     test_app.include_router(notes.router, prefix="/api/v1")
+    test_app.include_router(commands.router, prefix="/api/v1")
     test_app.include_router(characters.router, prefix="/api/v1")
     test_app.include_router(world_info.router, prefix="/api/v1")
     test_app.include_router(world_info_entries.router, prefix="/api/v1")

--- a/backend/tests/storage/test_command_service.py
+++ b/backend/tests/storage/test_command_service.py
@@ -1,0 +1,29 @@
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.storage.services.skill_service import search_enabled_skills
+
+
+@pytest.mark.asyncio
+async def test_empty_skill_command_query_returns_ten_most_recent_skills() -> None:
+    now = datetime(2026, 8, 21, tzinfo=UTC)
+    skills = [
+        SimpleNamespace(
+            id=f"skill-{index}",
+            name=f"技能 {index}",
+            updated_at=now - timedelta(minutes=index),
+        )
+        for index in range(12)
+    ]
+    skills[0].updated_at = now.replace(tzinfo=None)
+
+    with patch(
+        "app.storage.services.skill_service.list_enabled_skills",
+        AsyncMock(return_value=skills),
+    ):
+        result = await search_enabled_skills(AsyncMock(), "", limit=20)
+
+    assert [skill.id for skill in result] == [f"skill-{index}" for index in range(10)]

--- a/backend/tests/storage/test_command_service.py
+++ b/backend/tests/storage/test_command_service.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import ANY, AsyncMock, patch
 
 import pytest
 
@@ -13,17 +13,27 @@ async def test_empty_skill_command_query_returns_ten_most_recent_skills() -> Non
     skills = [
         SimpleNamespace(
             id=f"skill-{index}",
-            name=f"技能 {index}",
-            updated_at=now - timedelta(minutes=index),
+                name=f"技能 {index}",
+                summary="简述",
+                content="内容",
+                is_enabled=True,
+                updated_at=now - timedelta(minutes=index),
         )
         for index in range(12)
     ]
     skills[0].updated_at = now.replace(tzinfo=None)
 
-    with patch(
-        "app.storage.services.skill_service.list_enabled_skills",
-        AsyncMock(return_value=skills),
+    with (
+        patch(
+            "app.storage.services.skill_service._load_builtin_skills_with_settings",
+            AsyncMock(return_value=[]),
+        ),
+        patch(
+            "app.storage.services.skill_service.skill_repo.search_enabled",
+            AsyncMock(return_value=skills[:10]),
+        ) as search_enabled,
     ):
         result = await search_enabled_skills(AsyncMock(), "", limit=20)
 
+    search_enabled.assert_awaited_once_with(ANY, "", limit=10)
     assert [skill.id for skill in result] == [f"skill-{index}" for index in range(10)]

--- a/frontend/src/features/assistant/components/agent/agent-composer-editor.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-composer-editor.tsx
@@ -11,6 +11,10 @@ import type {
   KeyboardEvent as ReactKeyboardEvent,
 } from "react";
 
+import {
+  buildSkillCommandTag,
+  findActiveCommandQuery,
+} from "@/features/assistant/lib/command-text";
 import type { AssistantMentionCandidate } from "@/features/assistant/lib/mention-text";
 import {
   buildCharacterMentionTag,
@@ -21,24 +25,30 @@ import {
   buildWorldInfoEntryMentionTag,
   findActiveMentionQuery,
   mentionTextToHtml,
-  parseMentionText,
+  parseAssistantMarkup,
 } from "@/features/assistant/lib/mention-text";
-import { searchMentionCandidates } from "@/lib/api-client";
+import { searchCommands, searchMentionCandidates } from "@/lib/api-client";
+import type { AssistantCommandCandidate } from "@/lib/command.types";
 
 import type { AgentInputHistoryDirection } from "../../lib/agent-input-history-state";
+import { CommandNode } from "./extensions/command-node";
+import type { AssistantCommandNodeAttributes } from "./extensions/command-node";
 import { MentionNode } from "./extensions/mention-node";
 import type { AssistantMentionNodeAttributes } from "./extensions/mention-node";
 
 export type AgentComposerSuggestionStatus = "idle" | "loading" | "empty" | "ready";
+export type AgentComposerSuggestionMode = "mention" | "command";
+export type AgentComposerSuggestionItem = AssistantMentionCandidate | AssistantCommandCandidate;
 
-const EMPTY_MENTION_CANDIDATES: AssistantMentionCandidate[] = [];
+const EMPTY_SUGGESTION_ITEMS: AgentComposerSuggestionItem[] = [];
 
 export interface AgentComposerSuggestionState {
-  items: AssistantMentionCandidate[];
+  mode: AgentComposerSuggestionMode;
+  items: AgentComposerSuggestionItem[];
   selectedIndex: number;
   status: AgentComposerSuggestionStatus;
   onClose: () => void;
-  onSelect: (item: AssistantMentionCandidate, index: number) => void;
+  onSelect: (item: AgentComposerSuggestionItem, index: number) => void;
   onSelectedIndexChange: (index: number) => void;
 }
 
@@ -57,6 +67,7 @@ interface AgentComposerEditorProps {
 }
 
 interface MentionQueryState {
+  mode: AgentComposerSuggestionMode;
   query: string;
   replaceFrom: number;
   visible: boolean;
@@ -64,6 +75,7 @@ interface MentionQueryState {
 
 function createClosedMentionQueryState(): MentionQueryState {
   return {
+    mode: "mention",
     query: "",
     replaceFrom: -1,
     visible: false,
@@ -89,6 +101,10 @@ function docToCanonicalText(doc: ProseMirrorNode): string {
       }
       if (child.type.name === "assistantMention") {
         current += String(child.attrs.mentionRaw ?? "");
+        return;
+      }
+      if (child.type.name === "assistantCommand") {
+        current += String(child.attrs.commandRaw ?? "");
       }
     });
     paragraphs.push(current);
@@ -147,6 +163,18 @@ function createMentionNodeAttrs(
   };
 }
 
+function createCommandNodeAttrs(
+  candidate: AssistantCommandCandidate,
+): AssistantCommandNodeAttributes {
+  const commandRaw = buildSkillCommandTag(candidate.name);
+  return {
+    commandKind: candidate.kind,
+    commandLabel: candidate.name,
+    commandRaw,
+    commandName: candidate.name,
+  };
+}
+
 export function AgentComposerEditor({
   projectId,
   value,
@@ -166,27 +194,33 @@ export function AgentComposerEditor({
     createClosedMentionQueryState,
   );
 
-  const normalizedMentionQuery = mentionQuery.query.trim();
-  const shouldSearchMentionCandidates =
-    mentionQuery.visible && normalizedMentionQuery.length > 0 && projectId.trim().length > 0;
-  const { data: remoteMentionCandidates, isFetching: isSearchingMentionCandidates } = useQuery({
-    queryKey: ["assistant-mention-candidates", projectId, normalizedMentionQuery],
-    queryFn: ({ signal }) =>
-      searchMentionCandidates(projectId, normalizedMentionQuery, 20, undefined, signal),
-    enabled: shouldSearchMentionCandidates,
+  const normalizedQuery = mentionQuery.query.trim();
+  const shouldSearchSuggestionItems =
+    mentionQuery.visible &&
+    projectId.trim().length > 0 &&
+    (mentionQuery.mode === "command" || normalizedQuery.length > 0);
+  const { data: remoteSuggestionItems, isFetching: isSearchingSuggestionItems } = useQuery<
+    AgentComposerSuggestionItem[]
+  >({
+    queryKey: ["assistant-composer-candidates", projectId, mentionQuery.mode, normalizedQuery],
+    queryFn: ({ signal }): Promise<AgentComposerSuggestionItem[]> =>
+      mentionQuery.mode === "command"
+        ? searchCommands(projectId, normalizedQuery, 20, "skill", signal)
+        : searchMentionCandidates(projectId, normalizedQuery, 20, undefined, signal),
+    enabled: shouldSearchSuggestionItems,
     staleTime: 30 * 1000,
   });
-  const suggestionItems = shouldSearchMentionCandidates
-    ? (remoteMentionCandidates ?? EMPTY_MENTION_CANDIDATES)
-    : EMPTY_MENTION_CANDIDATES;
+  const suggestionItems = shouldSearchSuggestionItems
+    ? (remoteSuggestionItems ?? EMPTY_SUGGESTION_ITEMS)
+    : EMPTY_SUGGESTION_ITEMS;
   const suggestionStatus: AgentComposerSuggestionStatus | null = !mentionQuery.visible
     ? null
-    : normalizedMentionQuery.length === 0
-      ? "idle"
-      : isSearchingMentionCandidates
-        ? "loading"
-        : suggestionItems.length > 0
-          ? "ready"
+    : isSearchingSuggestionItems
+      ? "loading"
+      : suggestionItems.length > 0
+        ? "ready"
+        : normalizedQuery.length === 0 && mentionQuery.mode === "mention"
+          ? "idle"
           : "empty";
   const effectiveSelectedIndex =
     suggestionStatus === "ready" && suggestionItems.length > 0
@@ -215,6 +249,7 @@ export function AgentComposerEditor({
       MentionNode.configure({
         onOpenMentionChapter,
       }),
+      CommandNode,
     ],
     [onOpenMentionChapter, placeholder],
   );
@@ -276,13 +311,16 @@ export function AgentComposerEditor({
 
       const { from, $from } = selection;
       const textBefore = $from.parent.textBetween(0, $from.parentOffset, undefined, "\ufffc");
-      const activeQuery = findActiveMentionQuery(textBefore);
+      const activeCommandQuery = findActiveCommandQuery(textBefore);
+      const activeMentionQuery = findActiveMentionQuery(textBefore);
+      const activeQuery = activeCommandQuery ?? activeMentionQuery;
       if (!activeQuery) {
         setMentionQuery((current) => (current.visible ? createClosedMentionQueryState() : current));
         return;
       }
 
       setMentionQuery({
+        mode: activeCommandQuery ? "command" : "mention",
         query: activeQuery.query,
         replaceFrom: from - activeQuery.replaceLength,
         visible: true,
@@ -308,7 +346,7 @@ export function AgentComposerEditor({
 
   useEffect(() => {
     if (!editor) return;
-    const parsedSegments = parseMentionText(value);
+    const parsedSegments = parseAssistantMarkup(value);
     const hasOnlyMentions =
       parsedSegments.length > 0 &&
       parsedSegments.every((segment) => typeof segment !== "string" || !segment.trim());
@@ -323,18 +361,20 @@ export function AgentComposerEditor({
   }, []);
 
   const handleSelectSuggestion = useCallback(
-    (candidate: AssistantMentionCandidate, index: number) => {
+    (candidate: AgentComposerSuggestionItem, index: number) => {
       if (!editor || mentionQuery.replaceFrom < 0) return;
-      const attrs = createMentionNodeAttrs(candidate);
       const currentSelectionTo = editor.state.selection.from;
       setSelectedIndex(index);
-      editor
+      const chain = editor
         .chain()
         .focus()
-        .deleteRange({ from: mentionQuery.replaceFrom, to: currentSelectionTo })
-        .insertAssistantMention(attrs)
-        .insertContent(" ")
-        .run();
+        .deleteRange({ from: mentionQuery.replaceFrom, to: currentSelectionTo });
+      if (candidate.kind === "skill") {
+        chain.insertAssistantCommand(createCommandNodeAttrs(candidate));
+      } else {
+        chain.insertAssistantMention(createMentionNodeAttrs(candidate));
+      }
+      chain.insertContent(" ").run();
       closeSuggestions();
     },
     [closeSuggestions, editor, mentionQuery.replaceFrom],
@@ -423,6 +463,7 @@ export function AgentComposerEditor({
     }
 
     onMentionSuggestionsChange({
+      mode: mentionQuery.mode,
       items: suggestionItems,
       selectedIndex: effectiveSelectedIndex,
       status: suggestionStatus,
@@ -434,6 +475,7 @@ export function AgentComposerEditor({
     closeSuggestions,
     effectiveSelectedIndex,
     handleSelectSuggestion,
+    mentionQuery.mode,
     mentionQuery.visible,
     onMentionSuggestionsChange,
     suggestionItems,

--- a/frontend/src/features/assistant/components/agent/agent-composer-editor.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-composer-editor.tsx
@@ -166,11 +166,12 @@ function createMentionNodeAttrs(
 function createCommandNodeAttrs(
   candidate: AssistantCommandCandidate,
 ): AssistantCommandNodeAttributes {
-  const commandRaw = buildSkillCommandTag(candidate.name);
+  const commandRaw = buildSkillCommandTag(candidate.id, candidate.name);
   return {
     commandKind: candidate.kind,
     commandLabel: candidate.name,
     commandRaw,
+    commandId: candidate.id,
     commandName: candidate.name,
   };
 }

--- a/frontend/src/features/assistant/components/agent/agent-input.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-input.tsx
@@ -311,6 +311,7 @@ export function AgentInput({
             <AgentMentionSuggestions
               key="mention-suggestions"
               clearanceHeight={pendingClearanceHeight}
+              mode={mentionSuggestions.mode}
               items={mentionSuggestions.items}
               selectedIndex={mentionSuggestions.selectedIndex}
               status={mentionSuggestions.status}

--- a/frontend/src/features/assistant/components/agent/agent-mention-suggestions.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-mention-suggestions.tsx
@@ -1,25 +1,37 @@
-import { BookOpen, FileText, Folder, ScrollText, NotebookText, UserRound } from "lucide-react";
+import {
+  BookOpen,
+  FileText,
+  Folder,
+  Package,
+  ScrollText,
+  NotebookText,
+  UserRound,
+} from "lucide-react";
 import { motion } from "motion/react";
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import type { CSSProperties } from "react";
 import { useTranslation } from "react-i18next";
 
-import type { AssistantMentionCandidate } from "@/features/assistant/lib/mention-text";
-
-import type { AgentComposerSuggestionStatus } from "./agent-composer-editor";
+import type {
+  AgentComposerSuggestionItem,
+  AgentComposerSuggestionMode,
+  AgentComposerSuggestionStatus,
+} from "./agent-composer-editor";
 
 interface AgentMentionSuggestionsProps {
   clearanceHeight: number;
-  items: AssistantMentionCandidate[];
+  mode: AgentComposerSuggestionMode;
+  items: AgentComposerSuggestionItem[];
   selectedIndex: number;
   status: AgentComposerSuggestionStatus;
   visible: boolean;
-  onSelect: (item: AssistantMentionCandidate, index: number) => void;
+  onSelect: (item: AgentComposerSuggestionItem, index: number) => void;
   onSelectedIndexChange: (index: number) => void;
   onClose: () => void;
 }
 
-function getItemIcon(kind: AssistantMentionCandidate["kind"]) {
+function getItemIcon(kind: AgentComposerSuggestionItem["kind"]) {
+  if (kind === "skill") return <Package size={14} />;
   if (kind === "volume") return <BookOpen size={14} />;
   if (kind === "note") return <NotebookText size={14} />;
   if (kind === "note_category") return <Folder size={14} />;
@@ -29,9 +41,11 @@ function getItemIcon(kind: AssistantMentionCandidate["kind"]) {
 }
 
 function getItemMeta(
-  item: AssistantMentionCandidate,
+  item: AgentComposerSuggestionItem,
   t: (key: string, options?: Record<string, unknown>) => string,
 ): string {
+  if (item.kind === "skill") return item.description;
+
   const base =
     item.kind === "volume"
       ? t("assistant.mentionKind.volume")
@@ -51,15 +65,23 @@ function getItemMeta(
 
 function getStateMessage(
   status: AgentComposerSuggestionStatus,
+  mode: AgentComposerSuggestionMode,
   t: (key: string) => string,
 ): string {
-  if (status === "idle") return t("assistant.mentionSearch.idle");
-  if (status === "loading") return t("assistant.mentionSearch.loading");
-  return t("assistant.mentionSearch.empty");
+  if (mode === "command") {
+    if (status === "loading") return t("assistant.commandSearch.loading");
+    if (status === "empty") return t("assistant.mentionSearch.empty");
+    return t("assistant.commandSearch.prompt");
+  }
+  const keyPrefix = "assistant.mentionSearch";
+  if (status === "idle") return t(`${keyPrefix}.idle`);
+  if (status === "loading") return t(`${keyPrefix}.loading`);
+  return t(`${keyPrefix}.empty`);
 }
 
 export function AgentMentionSuggestions({
   clearanceHeight,
+  mode,
   items,
   selectedIndex,
   status,
@@ -70,16 +92,38 @@ export function AgentMentionSuggestions({
 }: AgentMentionSuggestionsProps) {
   const { t } = useTranslation();
   const listRef = useRef<HTMLDivElement>(null);
+  const shouldScrollSelectionRef = useRef(false);
   const normalizedClearanceHeight = Math.max(clearanceHeight, 0);
   const style = {
     "--ai-sidebar-mention-clearance-height": `${normalizedClearanceHeight}px`,
   } as CSSProperties;
 
   useEffect(() => {
-    if (!visible || status !== "ready" || !listRef.current) return;
-    const element = listRef.current.children[selectedIndex] as HTMLElement | undefined;
+    if (!visible || status !== "ready" || !listRef.current || !shouldScrollSelectionRef.current) {
+      return;
+    }
+    const element = listRef.current.querySelector<HTMLElement>(
+      `[data-suggestion-index="${selectedIndex}"]`,
+    );
     element?.scrollIntoView({ block: "nearest" });
+    shouldScrollSelectionRef.current = false;
   }, [selectedIndex, status, visible]);
+
+  const handleSelectedIndexChange = useCallback(
+    (index: number) => {
+      shouldScrollSelectionRef.current = true;
+      onSelectedIndexChange(index);
+    },
+    [onSelectedIndexChange],
+  );
+
+  const handleMouseEnter = useCallback(
+    (index: number) => {
+      shouldScrollSelectionRef.current = false;
+      onSelectedIndexChange(index);
+    },
+    [onSelectedIndexChange],
+  );
 
   useEffect(() => {
     if (!visible) return undefined;
@@ -91,13 +135,13 @@ export function AgentMentionSuggestions({
           if (!hasSelectableItems) break;
           event.preventDefault();
           event.stopPropagation();
-          onSelectedIndexChange((selectedIndex + 1) % items.length);
+          handleSelectedIndexChange((selectedIndex + 1) % items.length);
           break;
         case "ArrowUp":
           if (!hasSelectableItems) break;
           event.preventDefault();
           event.stopPropagation();
-          onSelectedIndexChange((selectedIndex - 1 + items.length) % items.length);
+          handleSelectedIndexChange((selectedIndex - 1 + items.length) % items.length);
           break;
         case "Enter":
         case "Tab":
@@ -118,9 +162,54 @@ export function AgentMentionSuggestions({
     return () => {
       document.removeEventListener("keydown", handleKeyDown, true);
     };
-  }, [items, onClose, onSelect, onSelectedIndexChange, selectedIndex, status, visible]);
+  }, [handleSelectedIndexChange, items, onClose, onSelect, selectedIndex, status, visible]);
 
   if (!visible) return null;
+
+  const hasCommandGroup = mode === "command" && status === "ready" && items.length > 0;
+  const suggestionContent =
+    status === "ready" && items.length > 0 ? (
+      <div
+        ref={listRef}
+        className="agent-mention-suggestions-list"
+      >
+        {hasCommandGroup && (
+          <div className="agent-command-suggestion-header">{t("assistant.commandKind.skill")}</div>
+        )}
+        {items.map((item, index) => (
+          <button
+            key={`${item.kind}-${item.id}`}
+            type="button"
+            className="agent-mention-suggestion-item"
+            data-suggestion-index={index}
+            data-selected={index === selectedIndex}
+            onClick={() => onSelect(item, index)}
+            onMouseEnter={() => handleMouseEnter(index)}
+          >
+            <span
+              className="agent-mention-suggestion-icon"
+              aria-hidden="true"
+            >
+              {getItemIcon(item.kind)}
+            </span>
+            <span className="agent-mention-suggestion-copy">
+              <span className="agent-mention-suggestion-title">
+                {item.kind === "skill" ? item.name : item.title}
+              </span>
+              <span className="agent-mention-suggestion-kind">{getItemMeta(item, t)}</span>
+            </span>
+          </button>
+        ))}
+        {hasCommandGroup && (
+          <div
+            className="agent-command-suggestion-divider"
+            aria-hidden="true"
+          />
+        )}
+      </div>
+    ) : (
+      <div className="agent-mention-suggestion-state">{getStateMessage(status, mode, t)}</div>
+    );
 
   return (
     <div
@@ -128,7 +217,10 @@ export function AgentMentionSuggestions({
       style={style}
     >
       <div className="ai-sidebar-mention-card-stack">
-        <div className="ai-sidebar-mention-card">
+        <div
+          className="ai-sidebar-mention-card"
+          data-variant={mode}
+        >
           <motion.div
             className="ai-sidebar-mention-card-body"
             initial={{ opacity: 0, height: 0 }}
@@ -136,36 +228,7 @@ export function AgentMentionSuggestions({
             exit={{ opacity: 0, height: 0 }}
             transition={{ duration: 0.18, ease: "easeOut" }}
           >
-            {status === "ready" && items.length > 0 ? (
-              <div
-                ref={listRef}
-                className="agent-mention-suggestions-list"
-              >
-                {items.map((item, index) => (
-                  <button
-                    key={`${item.kind}-${item.id}`}
-                    type="button"
-                    className="agent-mention-suggestion-item"
-                    data-selected={index === selectedIndex}
-                    onClick={() => onSelect(item, index)}
-                    onMouseEnter={() => onSelectedIndexChange(index)}
-                  >
-                    <span
-                      className="agent-mention-suggestion-icon"
-                      aria-hidden="true"
-                    >
-                      {getItemIcon(item.kind)}
-                    </span>
-                    <span className="agent-mention-suggestion-copy">
-                      <span className="agent-mention-suggestion-title">{item.title}</span>
-                      <span className="agent-mention-suggestion-kind">{getItemMeta(item, t)}</span>
-                    </span>
-                  </button>
-                ))}
-              </div>
-            ) : (
-              <div className="agent-mention-suggestion-state">{getStateMessage(status, t)}</div>
-            )}
+            {suggestionContent}
           </motion.div>
           <div
             aria-hidden="true"

--- a/frontend/src/features/assistant/components/agent/agent-mentions.css
+++ b/frontend/src/features/assistant/components/agent/agent-mentions.css
@@ -112,6 +112,20 @@
   overflow: hidden;
 }
 
+.agent-command-suggestion-header {
+  padding: 8px 12px 3px;
+  color: var(--gray-10);
+  font-size: var(--font-size-sm);
+  line-height: 1.3;
+  text-align: left;
+}
+
+.agent-command-suggestion-divider {
+  height: 1px;
+  margin: 6px 12px 0;
+  background: var(--gray-a4);
+}
+
 .agent-mention-suggestions-list {
   max-height: calc(8 * 28px + 12px);
   padding: 6px;

--- a/frontend/src/features/assistant/components/agent/extensions/command-node-view.tsx
+++ b/frontend/src/features/assistant/components/agent/extensions/command-node-view.tsx
@@ -15,6 +15,7 @@ export function CommandNodeView({ node, selected }: NodeViewProps) {
     raw: String(node.attrs.commandRaw ?? ""),
     kind,
     attrs: {
+      id: String(node.attrs.commandId ?? ""),
       name: String(node.attrs.commandName ?? ""),
     },
     body: "",

--- a/frontend/src/features/assistant/components/agent/extensions/command-node-view.tsx
+++ b/frontend/src/features/assistant/components/agent/extensions/command-node-view.tsx
@@ -1,0 +1,36 @@
+import { NodeViewWrapper, type NodeViewProps } from "@tiptap/react";
+
+import {
+  getCommandDisplayLabel,
+  type AssistantCommandKind,
+  type AssistantCommandToken,
+} from "@/features/assistant/lib/command-text";
+
+import { MentionChip } from "../mention-chip";
+
+export function CommandNodeView({ node, selected }: NodeViewProps) {
+  const kind = (node.attrs.commandKind ?? "skill") as AssistantCommandKind;
+  const token: AssistantCommandToken = {
+    markup: "command",
+    raw: String(node.attrs.commandRaw ?? ""),
+    kind,
+    attrs: {
+      name: String(node.attrs.commandName ?? ""),
+    },
+    body: "",
+  };
+
+  return (
+    <NodeViewWrapper
+      as="span"
+      data-command-kind={kind}
+      draggable={false}
+    >
+      <MentionChip
+        kind={kind}
+        label={getCommandDisplayLabel(token)}
+        selected={selected}
+      />
+    </NodeViewWrapper>
+  );
+}

--- a/frontend/src/features/assistant/components/agent/extensions/command-node.ts
+++ b/frontend/src/features/assistant/components/agent/extensions/command-node.ts
@@ -1,0 +1,84 @@
+import { Node, mergeAttributes } from "@tiptap/core";
+import { ReactNodeViewRenderer } from "@tiptap/react";
+
+import { CommandNodeView } from "./command-node-view";
+
+export interface AssistantCommandNodeAttributes {
+  commandKind: string;
+  commandLabel: string;
+  commandRaw: string;
+  commandName: string;
+}
+
+declare module "@tiptap/core" {
+  interface Commands<ReturnType> {
+    assistantCommand: {
+      insertAssistantCommand: (attrs: AssistantCommandNodeAttributes) => ReturnType;
+    };
+  }
+}
+
+export const CommandNode = Node.create({
+  name: "assistantCommand",
+  group: "inline",
+  inline: true,
+  atom: true,
+  selectable: true,
+  draggable: false,
+
+  addAttributes() {
+    return {
+      commandKind: { default: "" },
+      commandLabel: { default: "" },
+      commandRaw: { default: "" },
+      commandName: { default: "" },
+    };
+  },
+
+  parseHTML() {
+    return [
+      {
+        tag: 'span[data-assistant-command="true"]',
+        getAttrs: (node) => {
+          if (!(node instanceof HTMLElement)) return false;
+          return {
+            commandKind: node.dataset.commandKind ?? "",
+            commandLabel: node.dataset.commandLabel ?? "",
+            commandRaw: node.dataset.commandRaw ?? "",
+            commandName: node.dataset.commandName ?? "",
+          };
+        },
+      },
+    ];
+  },
+
+  renderHTML({ HTMLAttributes }) {
+    return [
+      "span",
+      mergeAttributes(HTMLAttributes, {
+        "data-assistant-command": "true",
+        "data-command-kind": HTMLAttributes.commandKind || "",
+        "data-command-label": HTMLAttributes.commandLabel || "",
+        "data-command-raw": HTMLAttributes.commandRaw || "",
+        "data-command-name": HTMLAttributes.commandName || "",
+      }),
+      HTMLAttributes.commandLabel || "",
+    ];
+  },
+
+  addNodeView() {
+    return ReactNodeViewRenderer(CommandNodeView);
+  },
+
+  addCommands() {
+    return {
+      insertAssistantCommand:
+        (attrs: AssistantCommandNodeAttributes) =>
+        ({ commands }) =>
+          commands.insertContent({
+            type: this.name,
+            attrs,
+          }),
+    };
+  },
+});

--- a/frontend/src/features/assistant/components/agent/extensions/command-node.ts
+++ b/frontend/src/features/assistant/components/agent/extensions/command-node.ts
@@ -7,6 +7,7 @@ export interface AssistantCommandNodeAttributes {
   commandKind: string;
   commandLabel: string;
   commandRaw: string;
+  commandId: string;
   commandName: string;
 }
 
@@ -31,6 +32,7 @@ export const CommandNode = Node.create({
       commandKind: { default: "" },
       commandLabel: { default: "" },
       commandRaw: { default: "" },
+      commandId: { default: "" },
       commandName: { default: "" },
     };
   },
@@ -45,6 +47,7 @@ export const CommandNode = Node.create({
             commandKind: node.dataset.commandKind ?? "",
             commandLabel: node.dataset.commandLabel ?? "",
             commandRaw: node.dataset.commandRaw ?? "",
+            commandId: node.dataset.commandId ?? "",
             commandName: node.dataset.commandName ?? "",
           };
         },
@@ -60,6 +63,7 @@ export const CommandNode = Node.create({
         "data-command-kind": HTMLAttributes.commandKind || "",
         "data-command-label": HTMLAttributes.commandLabel || "",
         "data-command-raw": HTMLAttributes.commandRaw || "",
+        "data-command-id": HTMLAttributes.commandId || "",
         "data-command-name": HTMLAttributes.commandName || "",
       }),
       HTMLAttributes.commandLabel || "",

--- a/frontend/src/features/assistant/components/agent/extensions/mention-node-view.tsx
+++ b/frontend/src/features/assistant/components/agent/extensions/mention-node-view.tsx
@@ -12,6 +12,7 @@ export function MentionNodeView({ node, selected, extension }: NodeViewProps) {
   const kind = (node.attrs.mentionKind ?? "chapter") as AssistantMentionKind;
   const label = (node.attrs.mentionLabel ?? node.attrs.mentionRaw ?? kind) as string;
   const token: AssistantMentionToken = {
+    markup: "mention",
     raw: String(node.attrs.mentionRaw ?? ""),
     kind,
     attrs: {

--- a/frontend/src/features/assistant/components/agent/inline-mention-text.tsx
+++ b/frontend/src/features/assistant/components/agent/inline-mention-text.tsx
@@ -1,9 +1,10 @@
 import { forwardRef } from "react";
 
+import { getCommandDisplayLabel } from "@/features/assistant/lib/command-text";
 import {
   getMentionNavigationTarget,
   getMentionDisplayLabel,
-  parseMentionText,
+  parseAssistantMarkup,
 } from "@/features/assistant/lib/mention-text";
 
 import { MentionChip } from "./mention-chip";
@@ -17,7 +18,7 @@ interface InlineMentionTextProps {
 
 export const InlineMentionText = forwardRef<HTMLSpanElement, InlineMentionTextProps>(
   function InlineMentionText({ text, className, singleLine = false, onOpenMentionChapter }, ref) {
-    const segments = parseMentionText(text);
+    const segments = parseAssistantMarkup(text);
     const classes = [
       "agent-inline-mention-text",
       singleLine ? "agent-inline-mention-text--single-line" : "",
@@ -34,6 +35,12 @@ export const InlineMentionText = forwardRef<HTMLSpanElement, InlineMentionTextPr
         {segments.map((segment, index) =>
           typeof segment === "string" ? (
             <span key={`text-${index}`}>{segment}</span>
+          ) : segment.markup === "command" ? (
+            <MentionChip
+              key={`command-${index}-${segment.raw}`}
+              kind={segment.kind}
+              label={getCommandDisplayLabel(segment)}
+            />
           ) : (
             <MentionChip
               key={`mention-${index}-${segment.raw}`}

--- a/frontend/src/features/assistant/components/agent/mention-chip.tsx
+++ b/frontend/src/features/assistant/components/agent/mention-chip.tsx
@@ -5,15 +5,18 @@ import {
   Quote,
   ScrollText,
   NotebookText,
+  Package,
   UserRound,
 } from "lucide-react";
 import type { ReactNode } from "react";
 
+import type { AssistantCommandKind } from "@/features/assistant/lib/command-text";
 import type { AssistantMentionKind } from "@/features/assistant/lib/mention-text";
 
 import "./agent-mentions.css";
 
-function getMentionIcon(kind: AssistantMentionKind): ReactNode {
+function getMentionIcon(kind: AssistantMentionKind | AssistantCommandKind): ReactNode {
+  if (kind === "skill") return <Package size={14} />;
   if (kind === "volume") return <BookOpen size={14} />;
   if (kind === "chapter") return <FileText size={14} />;
   if (kind === "note") return <NotebookText size={14} />;
@@ -29,7 +32,7 @@ export function MentionChip({
   selected = false,
   onClick,
 }: {
-  kind: AssistantMentionKind;
+  kind: AssistantMentionKind | AssistantCommandKind;
   label: string;
   selected?: boolean;
   onClick?: () => void;

--- a/frontend/src/features/assistant/lib/command-text.ts
+++ b/frontend/src/features/assistant/lib/command-text.ts
@@ -12,8 +12,10 @@ export interface AssistantCommandToken {
 
 const ATTR_RE = /([A-Za-z_][A-Za-z0-9_]*)="([^"]*)"/g;
 
-export function buildSkillCommandTag(name: string): string {
-  return `<of-skill name="${escapeCommandAttribute(name)}" />`;
+export function buildSkillCommandTag(id: string, name: string): string {
+  return (
+    `<of-skill id="${escapeCommandAttribute(id)}" ` + `name="${escapeCommandAttribute(name)}" />`
+  );
 }
 
 export function getCommandDisplayLabel(token: AssistantCommandToken): string {

--- a/frontend/src/features/assistant/lib/command-text.ts
+++ b/frontend/src/features/assistant/lib/command-text.ts
@@ -1,0 +1,61 @@
+export type { AssistantCommandCandidate } from "@/lib/command.types";
+
+export type AssistantCommandKind = "skill";
+
+export interface AssistantCommandToken {
+  markup: "command";
+  raw: string;
+  kind: AssistantCommandKind;
+  attrs: Record<string, string>;
+  body: string;
+}
+
+const ATTR_RE = /([A-Za-z_][A-Za-z0-9_]*)="([^"]*)"/g;
+
+export function buildSkillCommandTag(name: string): string {
+  return `<of-skill name="${escapeCommandAttribute(name)}" />`;
+}
+
+export function getCommandDisplayLabel(token: AssistantCommandToken): string {
+  return token.attrs.name?.trim() || token.kind;
+}
+
+export function parseCommandAttributes(rawAttrs: string): Record<string, string> {
+  return Array.from(rawAttrs.matchAll(ATTR_RE)).reduce<Record<string, string>>((result, match) => {
+    const [, key, value] = match;
+    if (!key) return result;
+    result[key] = decodeCommandEntities(value ?? "");
+    return result;
+  }, {});
+}
+
+export function findActiveCommandQuery(textBeforeCursor: string): {
+  query: string;
+  replaceLength: number;
+} | null {
+  const match = textBeforeCursor.match(/(?:^|\s)\/([^\s/]*)$/);
+  if (!match) return null;
+  const query = match[1] ?? "";
+  return {
+    query,
+    replaceLength: query.length + 1,
+  };
+}
+
+function escapeCommandAttribute(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function decodeCommandEntities(text: string): string {
+  return text
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&");
+}

--- a/frontend/src/features/assistant/lib/mention-text.ts
+++ b/frontend/src/features/assistant/lib/mention-text.ts
@@ -1,6 +1,9 @@
 import type { AssistantMentionCandidate } from "@/lib/mention.types";
 import { pinyinMatch } from "@/lib/pinyin-search";
 
+import type { AssistantCommandToken } from "./command-text";
+import { parseCommandAttributes } from "./command-text";
+
 export type { AssistantMentionCandidate } from "@/lib/mention.types";
 
 export type AssistantMentionKind =
@@ -12,16 +15,18 @@ export type AssistantMentionKind =
   | "character";
 
 export interface AssistantMentionToken {
+  markup: "mention";
   raw: string;
   kind: AssistantMentionKind;
   attrs: Record<string, string>;
   body: string;
 }
 
-export type AssistantMentionSegment = string | AssistantMentionToken;
+export type AssistantMarkupSegment = string | AssistantMentionToken | AssistantCommandToken;
+export type AssistantMentionSegment = AssistantMarkupSegment;
 
-const MENTION_RE =
-  /<of-mention\b(?<attrsSelf>[^<>]*?)\s*\/>|<of-mention\b(?<attrsBlock>[^<>]*?)>(?<body>.*?)<\/of-mention\s*>/gs;
+const MARKUP_RE =
+  /<of-mention\b(?<attrsSelf>[^<>]*?)\s*\/>|<of-mention\b(?<attrsBlock>[^<>]*?)>(?<body>.*?)<\/of-mention\s*>|<of-skill\b(?<skillAttrs>[^<>]*?)\s*\/>/gs;
 const ATTR_RE = /([A-Za-z_][A-Za-z0-9_]*)="([^"]*)"/g;
 
 function inferMentionKind(attrs: Record<string, string>): AssistantMentionKind {
@@ -64,13 +69,13 @@ function parseAttrs(rawAttrs: string): Record<string, string> {
   }, {});
 }
 
-export function parseMentionText(text: string): AssistantMentionSegment[] {
-  if (!text || !text.includes("<of-mention")) return [text];
+export function parseAssistantMarkup(text: string): AssistantMarkupSegment[] {
+  if (!text || (!text.includes("<of-mention") && !text.includes("<of-skill"))) return [text];
 
-  const segments: AssistantMentionSegment[] = [];
+  const segments: AssistantMarkupSegment[] = [];
   let cursor = 0;
 
-  for (const match of text.matchAll(MENTION_RE)) {
+  for (const match of text.matchAll(MARKUP_RE)) {
     const start = match.index ?? 0;
     const raw = match[0];
     if (!raw) continue;
@@ -79,9 +84,22 @@ export function parseMentionText(text: string): AssistantMentionSegment[] {
       segments.push(text.slice(cursor, start));
     }
 
+    if (match.groups?.skillAttrs !== undefined) {
+      segments.push({
+        markup: "command",
+        raw,
+        kind: "skill",
+        attrs: parseCommandAttributes(match.groups.skillAttrs.trim()),
+        body: "",
+      });
+      cursor = start + raw.length;
+      continue;
+    }
+
     const attrs = parseAttrs((match.groups?.attrsSelf ?? match.groups?.attrsBlock ?? "").trim());
     const kind = inferMentionKind(attrs);
     segments.push({
+      markup: "mention",
       raw,
       kind,
       attrs,
@@ -95,6 +113,10 @@ export function parseMentionText(text: string): AssistantMentionSegment[] {
   }
 
   return segments;
+}
+
+export function parseMentionText(text: string): AssistantMentionSegment[] {
+  return parseAssistantMarkup(text);
 }
 
 function escapeHtml(text: string): string {
@@ -124,10 +146,21 @@ function buildMentionHtml(token: AssistantMentionToken): string {
   );
 }
 
+function buildCommandHtml(token: AssistantCommandToken): string {
+  return (
+    `<span data-assistant-command="true"` +
+    ` data-command-kind="${escapeHtmlAttr(token.kind)}"` +
+    ` data-command-raw="${escapeHtmlAttr(token.raw)}"` +
+    ` data-command-label="${escapeHtmlAttr(token.attrs.name ?? token.kind)}"` +
+    ` data-command-name="${escapeHtmlAttr(token.attrs.name ?? "")}"` +
+    `></span>`
+  );
+}
+
 export function mentionTextToHtml(text: string): string {
   if (!text) return "";
 
-  const segments = parseMentionText(text);
+  const segments = parseAssistantMarkup(text);
   const paragraphs: string[] = [""];
 
   const appendText = (value: string) => {
@@ -145,7 +178,8 @@ export function mentionTextToHtml(text: string): string {
       appendText(segment);
       return;
     }
-    paragraphs[paragraphs.length - 1] += buildMentionHtml(segment);
+    paragraphs[paragraphs.length - 1] +=
+      segment.markup === "command" ? buildCommandHtml(segment) : buildMentionHtml(segment);
   });
 
   return paragraphs.map((paragraph) => `<p>${paragraph}</p>`).join("");

--- a/frontend/src/features/assistant/lib/mention-text.ts
+++ b/frontend/src/features/assistant/lib/mention-text.ts
@@ -85,11 +85,17 @@ export function parseAssistantMarkup(text: string): AssistantMarkupSegment[] {
     }
 
     if (match.groups?.skillAttrs !== undefined) {
+      const attrs = parseCommandAttributes(match.groups.skillAttrs.trim());
+      if (!attrs.id?.trim()) {
+        segments.push(raw);
+        cursor = start + raw.length;
+        continue;
+      }
       segments.push({
         markup: "command",
         raw,
         kind: "skill",
-        attrs: parseCommandAttributes(match.groups.skillAttrs.trim()),
+        attrs,
         body: "",
       });
       cursor = start + raw.length;
@@ -151,6 +157,7 @@ function buildCommandHtml(token: AssistantCommandToken): string {
     `<span data-assistant-command="true"` +
     ` data-command-kind="${escapeHtmlAttr(token.kind)}"` +
     ` data-command-raw="${escapeHtmlAttr(token.raw)}"` +
+    ` data-command-id="${escapeHtmlAttr(token.attrs.id ?? "")}"` +
     ` data-command-label="${escapeHtmlAttr(token.attrs.name ?? token.kind)}"` +
     ` data-command-name="${escapeHtmlAttr(token.attrs.name ?? "")}"` +
     `></span>`

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1631,6 +1631,13 @@
       "loading": "Searching",
       "empty": "No matching content found"
     },
+    "commandKind": {
+      "skill": "Skill"
+    },
+    "commandSearch": {
+      "prompt": "Type freely",
+      "loading": "Searching"
+    },
     "thinkingTitle": "Reasoning",
     "collapseThinking": "Collapse reasoning",
     "expandThinking": "Expand reasoning",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1694,6 +1694,13 @@
       "loading": "检索中",
       "empty": "未找到匹配内容"
     },
+    "commandKind": {
+      "skill": "技能"
+    },
+    "commandSearch": {
+      "prompt": "随心输入",
+      "loading": "检索中"
+    },
     "thinkingTitle": "推理",
     "collapseThinking": "收起推理内容",
     "expandThinking": "展开推理内容",

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -81,6 +81,7 @@ import type {
   CharacterListResponse,
   CharacterUpdate,
 } from "./character.types";
+import type { AssistantCommandCandidate } from "./command.types";
 import type { AssistantMentionCandidate } from "./mention.types";
 import type {
   Project,
@@ -743,6 +744,15 @@ function transformMentionCandidate(raw: Record<string, unknown>): AssistantMenti
   };
 }
 
+function transformCommandCandidate(raw: Record<string, unknown>): AssistantCommandCandidate {
+  return {
+    kind: "skill",
+    id: raw.id as string,
+    name: raw.name as string,
+    description: raw.description as string,
+  };
+}
+
 /**
  * 获取卷-章节树
  */
@@ -767,6 +777,20 @@ export async function searchMentionCandidates(
     signal,
   });
   return ((response.data.items as Record<string, unknown>[]) ?? []).map(transformMentionCandidate);
+}
+
+export async function searchCommands(
+  projectId: string,
+  query: string,
+  limit = 20,
+  kind: "skill" = "skill",
+  signal?: AbortSignal,
+): Promise<AssistantCommandCandidate[]> {
+  const response = await apiClient.get<Record<string, unknown>>(`/projects/${projectId}/commands`, {
+    params: { query, limit, kind },
+    signal,
+  });
+  return ((response.data.items as Record<string, unknown>[]) ?? []).map(transformCommandCandidate);
 }
 
 /**

--- a/frontend/src/lib/command.types.ts
+++ b/frontend/src/lib/command.types.ts
@@ -1,0 +1,6 @@
+export interface AssistantCommandCandidate {
+  kind: "skill";
+  id: string;
+  name: string;
+  description: string;
+}


### PR DESCRIPTION
## PR 标题

chore(agent): 支持 Skill Command 引用

## 变更说明

- 问题: Agent 编辑器与执行链路缺少完整的 Skill Command 引用支持，Command 信息无法在各上下文中统一传递。
- 重要性: 让 Command 引用在检索、编辑器展示、历史记录、上下文构建和 agent 运行过程中保持一致。
- 变化: 新增 Command 查询接口与服务；增加编辑器节点、提示和文本转换；接入 canonical command 解析及 agent/subagent 上下文；补充相关测试。

## 关联 Issue / PR

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因

无

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

无
