### PR TITLE
chore(openrouter): 添加 OpenRouter 提供商应用归因

### DIFF
--- a/backend/app/models/adapters/openrouter.py
+++ b/backend/app/models/adapters/openrouter.py
@@ -7,6 +7,7 @@ import httpx
 from loguru import logger
 
 from app.models.adapters.base import BaseAdapter
+from app.models.helpers.openrouter_attribution import get_openrouter_attribution_headers
 
 
 class OpenRouterAdapter(BaseAdapter):
@@ -21,7 +22,10 @@ class OpenRouterAdapter(BaseAdapter):
     ) -> list[dict[str, str]]:
         """获取LLM模型列表（/models端点）。"""
         url = f"{self._normalize_url(base_url)}/models"
-        headers = self._build_auth_header(api_key)
+        headers = {
+            **self._build_auth_header(api_key),
+            **get_openrouter_attribution_headers(),
+        }
 
         try:
             response = await client.get(url, headers=headers)
@@ -44,7 +48,10 @@ class OpenRouterAdapter(BaseAdapter):
     ) -> list[dict[str, str]]:
         """获取Embedding模型列表（/embeddings/models端点）。"""
         url = f"{self._normalize_url(base_url)}/embeddings/models"
-        headers = self._build_auth_header(api_key)
+        headers = {
+            **self._build_auth_header(api_key),
+            **get_openrouter_attribution_headers(),
+        }
 
         try:
             response = await client.get(url, headers=headers)

--- a/backend/app/models/clients/embedding_client.py
+++ b/backend/app/models/clients/embedding_client.py
@@ -12,6 +12,8 @@ from langchain_core.embeddings import Embeddings
 from loguru import logger
 from pydantic import SecretStr
 
+from app.models.helpers.openrouter_attribution import get_openrouter_attribution_headers
+
 
 @dataclass
 class EmbeddingConfig:
@@ -133,6 +135,8 @@ class EmbeddingClient:
                 "check_embedding_ctx_length": False,
                 "model_kwargs": {"encoding_format": "float"},
             }
+            if config.provider_type == "openrouter":
+                openai_kwargs["default_headers"] = get_openrouter_attribution_headers()
             if config.dimensions is not None:
                 openai_kwargs["dimensions"] = config.dimensions
 

--- a/backend/app/models/clients/model_factory.py
+++ b/backend/app/models/clients/model_factory.py
@@ -20,6 +20,11 @@ from app.models.clients.model_params import (
     is_non_default,
     with_default,
 )
+from app.models.helpers.openrouter_attribution import (
+    OPENROUTER_APP_CATEGORIES,
+    OPENROUTER_APP_TITLE,
+    OPENROUTER_APP_URL,
+)
 
 
 @dataclass
@@ -212,6 +217,9 @@ def create_chat_model(config: ModelConfig) -> Runnable[LanguageModelInput, BaseM
             model=config.model_id,
             api_key=config.api_key,
             base_url=config.base_url or None,
+            app_url=OPENROUTER_APP_URL,
+            app_title=OPENROUTER_APP_TITLE,
+            app_categories=list(OPENROUTER_APP_CATEGORIES),
             temperature=_non_default(config.temperature, DEFAULT_TEMPERATURE),
             top_p=_non_default(config.top_p, DEFAULT_TOP_P),
             max_tokens=config.max_tokens,

--- a/backend/app/models/clients/rerank_client.py
+++ b/backend/app/models/clients/rerank_client.py
@@ -20,6 +20,7 @@ from app.core.errors import (
     ValidationError,
 )
 from app.models.clients.client_factory import ClientFactory
+from app.models.helpers.openrouter_attribution import get_openrouter_attribution_headers
 
 
 DEFAULT_RERANK_TIMEOUT = 60
@@ -96,13 +97,16 @@ class RerankClient:
             async with ClientFactory.create_client(
                 timeout=float(self.config.request_timeout)
             ) as client:
+                headers = {
+                    "Authorization": f"Bearer {self.config.api_key}",
+                    "Content-Type": "application/json",
+                }
+                if self.config.provider_type == "openrouter":
+                    headers.update(get_openrouter_attribution_headers())
                 response = await client.post(
                     f"{self.config.base_url.rstrip('/')}/rerank",
                     json=payload,
-                    headers={
-                        "Authorization": f"Bearer {self.config.api_key}",
-                        "Content-Type": "application/json",
-                    },
+                    headers=headers,
                 )
         except httpx.TimeoutException as exc:
             raise ProviderTimeoutError("Rerank request timed out") from exc

--- a/backend/app/models/helpers/__init__.py
+++ b/backend/app/models/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable model helpers."""

--- a/backend/app/models/helpers/openrouter_attribution.py
+++ b/backend/app/models/helpers/openrouter_attribution.py
@@ -1,0 +1,14 @@
+"""OpenRouter application attribution settings."""
+
+OPENROUTER_APP_URL = "https://github.com/syrizelink/OpenFic"
+OPENROUTER_APP_TITLE = "OpenFic"
+OPENROUTER_APP_CATEGORIES = ("creative-writing", "writing-assistant")
+
+
+def get_openrouter_attribution_headers() -> dict[str, str]:
+    """Return headers used to attribute requests to OpenFic in OpenRouter."""
+    return {
+        "HTTP-Referer": OPENROUTER_APP_URL,
+        "X-OpenRouter-Title": OPENROUTER_APP_TITLE,
+        "X-OpenRouter-Categories": ",".join(OPENROUTER_APP_CATEGORIES),
+    }

--- a/backend/tests/models/test_openrouter_attribution.py
+++ b/backend/tests/models/test_openrouter_attribution.py
@@ -1,0 +1,89 @@
+import httpx
+import pytest
+import respx
+
+from app.models.adapters.openrouter import OpenRouterAdapter
+from app.models.clients.embedding_client import EmbeddingClient, EmbeddingConfig
+from app.models.clients.model_factory import ModelConfig, create_chat_model
+from app.models.clients.rerank_client import RerankClient, RerankConfig
+
+
+_APP_ATTRIBUTION_HEADERS = {
+    "HTTP-Referer": "https://github.com/syrizelink/OpenFic",
+    "X-OpenRouter-Title": "OpenFic",
+    "X-OpenRouter-Categories": "creative-writing,writing-assistant",
+}
+
+
+def test_create_chat_model_openrouter_adds_app_attribution() -> None:
+    model = create_chat_model(
+        ModelConfig(
+            provider_type="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_key="sk-or-test",
+            model_id="openai/gpt-5.2",
+        )
+    )
+
+    assert model.app_url == "https://github.com/syrizelink/OpenFic"
+    assert model.app_title == "OpenFic"
+    assert model.app_categories == ["creative-writing", "writing-assistant"]
+
+
+def test_openrouter_embeddings_add_app_attribution() -> None:
+    client = EmbeddingClient(
+        EmbeddingConfig(
+            provider_type="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_key="sk-or-test",
+            model_id="openai/text-embedding-3-small",
+        )
+    )
+
+    embeddings = client._get_embeddings()
+
+    assert embeddings.default_headers == _APP_ATTRIBUTION_HEADERS  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_openrouter_model_discovery_sends_app_attribution() -> None:
+    route = respx.get("https://openrouter.ai/api/v1/models").mock(
+        return_value=httpx.Response(200, json={"data": []})
+    )
+
+    async with httpx.AsyncClient() as client:
+        models = await OpenRouterAdapter().get_llm_models(
+            client, "https://openrouter.ai/api/v1", "sk-or-test"
+        )
+
+    assert models == []
+    for name, value in _APP_ATTRIBUTION_HEADERS.items():
+        assert route.calls[0].request.headers[name] == value
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_openrouter_rerank_sends_app_attribution() -> None:
+    route = respx.post("https://openrouter.ai/api/v1/rerank").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "model": "test-reranker",
+                "results": [{"index": 0, "relevance_score": 0.9}],
+            },
+        )
+    )
+    client = RerankClient(
+        RerankConfig(
+            provider_type="openrouter",
+            base_url="https://openrouter.ai/api/v1",
+            api_key="sk-or-test",
+            model_id="test-reranker",
+        )
+    )
+
+    await client.rerank("query", ["document"])
+
+    for name, value in _APP_ATTRIBUTION_HEADERS.items():
+        assert route.calls[0].request.headers[name] == value


### PR DESCRIPTION
## PR 标题

`chore(openrouter): 添加 OpenRouter 提供商应用归因`

## 变更说明

- 问题: OpenRouter 请求未携带应用归因信息。
- 重要性: OpenRouter 无法在排名和分析中识别 OpenFic 的使用情况。
- 变化: 为聊天、Embedding、Rerank 和模型列表请求添加应用 URL、名称及 `creative-writing`、`writing-assistant` 分类。
- 验证: 43 个相关测试、全量 Ruff 和 `ty` 检查通过。

## 关联 Issue / PR

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因

无

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

无
