### PR TITLE
fix(frontend): 修复输入法组合输入的标点转换冲突

### DIFF
--- a/frontend/src/features/writing/lib/editor-config.ts
+++ b/frontend/src/features/writing/lib/editor-config.ts
@@ -11,7 +11,8 @@ import History from "@tiptap/extension-history";
 import Paragraph from "@tiptap/extension-paragraph";
 import Placeholder from "@tiptap/extension-placeholder";
 import Text from "@tiptap/extension-text";
-import { Plugin, TextSelection } from "@tiptap/pm/state";
+import { Plugin, TextSelection, type Transaction } from "@tiptap/pm/state";
+import type { EditorView } from "@tiptap/pm/view";
 import { Extension } from "@tiptap/react";
 
 import { serializeClipboardText } from "@/components/editor-clipboard";
@@ -134,6 +135,13 @@ function convertHalfwidthPunctuation(text: string, precedingText: string): strin
   return result;
 }
 
+function isCompositionTextInput(
+  view: Pick<EditorView, "composing">,
+  defaultTransaction: () => Transaction,
+): boolean {
+  return view.composing || defaultTransaction().getMeta("composition") !== undefined;
+}
+
 const TabIndent = Extension.create({
   name: "tabIndent",
 
@@ -182,8 +190,8 @@ function createAutoConvertPunctuation(shouldConvert: () => boolean) {
       return [
         new Plugin({
           props: {
-            handleTextInput(view, from, to, text) {
-              if (!shouldConvert()) {
+            handleTextInput(view, from, to, text, defaultTransaction) {
+              if (!shouldConvert() || isCompositionTextInput(view, defaultTransaction)) {
                 return false;
               }
 
@@ -211,8 +219,13 @@ function createAutoPairSymbols(shouldPair: () => boolean, shouldConvertPunctuati
       return [
         new Plugin({
           props: {
-            handleTextInput(view, from, to, text) {
-              if (!shouldPair() || from !== to || Array.from(text).length !== 1) {
+            handleTextInput(view, from, to, text, defaultTransaction) {
+              if (
+                !shouldPair() ||
+                from !== to ||
+                Array.from(text).length !== 1 ||
+                isCompositionTextInput(view, defaultTransaction)
+              ) {
                 return false;
               }
 


### PR DESCRIPTION
## PR 标题

fix(frontend): 修复输入法组合输入的标点转换冲突

## 变更说明

- 问题：中文输入法使用单引号分词时，编辑器会将其当作普通半角标点转换。
- 重要性：开启自动转换和成对符号补全后，单引号可能被转换为全角引号或补全为一对全角引号，影响中文输入法候选词分词。
- 变化：识别编辑器当前的 IME 组合状态及 `composition` 提交事务，跳过自动标点转换和成对符号补全，普通键盘输入保持原行为。
- 验证：已运行前端类型检查、lint、格式检查和生产构建。

## 关联 Issue / PR

Closes #327

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因

编辑器的 `handleTextInput` 同时接收键盘直接输入和输入法组合文本。原实现没有区分这两类输入，自动转换插件和成对符号插件会处理中文输入法用于分词的单引号。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

临时回归测试已按要求在提交前删除，未新增前端测试文件。此前临时测试覆盖了组合输入、直接输入和同时启用成对补全的场景，结果为 3/3 通过。

本地验证命令：

- `pnpm type-check`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`

Windows 真机输入法回归仍需在目标系统上验证。