### PR TITLE
chore: 允许在回复 ask_user 工具时选择忽略

### DIFF
--- a/backend/app/agent_runtime/graph/react_agent.py
+++ b/backend/app/agent_runtime/graph/react_agent.py
@@ -1137,6 +1137,9 @@ def create_react_agent(
             ):
                 is_done = True
                 final_output = outcome["tool_args"]
+            if not is_done and tool_name == "ask_user" and outcome["payload"].get("status") == "user_skipped":
+                is_done = True
+                final_output = outcome["payload"]
             if active_audit is not None:
                 active_audit.record_tool_call(
                     tool_name=tool_name,

--- a/backend/app/agent_runtime/runner/checkpointer.py
+++ b/backend/app/agent_runtime/runner/checkpointer.py
@@ -73,6 +73,17 @@ def _get_db_path() -> str:
     return str(target_path)
 
 
+async def _configure_checkpoint_connection(conn: aiosqlite.Connection) -> None:
+    for pragma in (
+        "PRAGMA journal_mode=WAL",
+        "PRAGMA synchronous=NORMAL",
+        "PRAGMA busy_timeout=30000",
+    ):
+        cursor = await conn.execute(pragma)
+        await cursor.close()
+    await conn.commit()
+
+
 async def get_checkpointer() -> AsyncSqliteSaver:
     global _checkpointer
     if _checkpointer is None:
@@ -87,6 +98,7 @@ async def get_checkpointer() -> AsyncSqliteSaver:
         if not db_path_exists:
             await conn.execute("PRAGMA auto_vacuum = INCREMENTAL")
             await _mark_incremental_auto_vacuum_migration_completed(conn)
+        await _configure_checkpoint_connection(conn)
         _checkpointer = AsyncSqliteSaver(
             conn,
             serde=JsonPlusSerializer(

--- a/backend/app/agent_runtime/runner/session_runner.py
+++ b/backend/app/agent_runtime/runner/session_runner.py
@@ -1157,6 +1157,7 @@ class SessionRunner:
         reason: Literal["done", "cancelled", "error"] = "done"
         try:
             resume_value: dict[str, Any] | dict[str, dict[str, Any]] = payload
+            is_terminal_skip_resume = payload.get("skipped") is True
             if payload.get("action_type") == "interrupt_batch":
                 state = await graph.aget_state(
                     {"configurable": {"thread_id": self.session_id}}
@@ -1180,6 +1181,12 @@ class SessionRunner:
                     pending_by_id
                 ):
                     raise ValueError("必须一次提交本批全部并行中断响应")
+                is_terminal_skip_resume = any(
+                    isinstance(response, dict)
+                    and response.get("action_type") == "clarification"
+                    and response.get("skipped") is True
+                    for response in responses
+                )
                 resume_value = {
                     response["interrupt_id"]: response for response in responses
                 }
@@ -1217,8 +1224,14 @@ class SessionRunner:
                 if matching is None or not resume_id:
                     raise ValueError("待恢复的问题不存在或已处理")
                 resume_value = {resume_id: payload}
+            stream_options = (
+                {"durability": "exit"} if is_terminal_skip_resume else {}
+            )
             async for event in graph.astream_events(
-                Command(resume=resume_value), config=config, version="v2"
+                Command(resume=resume_value),
+                config=config,
+                version="v2",
+                **stream_options,
             ):
                 event_dict = cast(dict[str, Any], event)
                 if self._cancel_event.is_set():

--- a/backend/app/agent_runtime/tools/impls/interaction/ask_user.py
+++ b/backend/app/agent_runtime/tools/impls/interaction/ask_user.py
@@ -51,5 +51,10 @@ class AskUserTool(AgentTool):
             "questions": [question.model_dump(mode="json") for question in questions],
         }
         response = interrupt(payload)
+        if isinstance(response, dict) and response.get("skipped") is True:
+            return json.dumps(
+                {"status": "user_skipped", "error": "用户忽略了提问"},
+                ensure_ascii=False,
+            )
         answers = response.get("answer") if isinstance(response, dict) else None
         return json.dumps(answers if isinstance(answers, list) else [], ensure_ascii=False)

--- a/backend/app/api/routers/agent_runtime.py
+++ b/backend/app/api/routers/agent_runtime.py
@@ -1143,6 +1143,7 @@ async def submit_agent_question_answer(
         "action_type": "clarification",
         "action_id": body.action_id,
         "answer": [item.model_dump(mode="json") for item in body.answer],
+        "skipped": body.skipped,
     }
     registry = get_agent_run_registry()
     async with _agent_session_lifecycle_lock(registry, session_id):

--- a/backend/app/api/routers/agent_runtime.py
+++ b/backend/app/api/routers/agent_runtime.py
@@ -1143,8 +1143,9 @@ async def submit_agent_question_answer(
         "action_type": "clarification",
         "action_id": body.action_id,
         "answer": [item.model_dump(mode="json") for item in body.answer],
-        "skipped": body.skipped,
     }
+    if body.skipped:
+        payload["skipped"] = True
     registry = get_agent_run_registry()
     async with _agent_session_lifecycle_lock(registry, session_id):
         revision_id, claimed_revision = await _claim_agent_session_resume(session, session_id)

--- a/backend/app/api/schemas/agent.py
+++ b/backend/app/api/schemas/agent.py
@@ -127,9 +127,8 @@ class AgentQuestionAnswerRequest(BaseModel):
     """提交 Agent 澄清问题回答请求。"""
 
     action_id: str = Field(..., description="澄清请求ID")
-    answer: list["AgentQuestionAnswerItem"] = Field(
-        ..., min_length=1, description="澄清问题回答"
-    )
+    answer: list["AgentQuestionAnswerItem"] = Field(default_factory=list, description="澄清问题回答")
+    skipped: bool = Field(default=False, description="是否忽略本次提问")
 
 
 class AgentQuestionAnswerItem(BaseModel):
@@ -158,6 +157,7 @@ class AgentInterruptResponseItem(BaseModel):
         default=None,
         description="澄清问题回答",
     )
+    skipped: bool = Field(default=False, description="是否忽略本次提问")
 
 
 class AgentInterruptResumeRequest(BaseModel):

--- a/backend/app/api/schemas/agent.py
+++ b/backend/app/api/schemas/agent.py
@@ -157,7 +157,7 @@ class AgentInterruptResponseItem(BaseModel):
         default=None,
         description="澄清问题回答",
     )
-    skipped: bool = Field(default=False, description="是否忽略本次提问")
+    skipped: bool | None = Field(default=None, description="是否忽略本次提问")
 
 
 class AgentInterruptResumeRequest(BaseModel):

--- a/backend/tests/agent_runtime/test_checkpointer.py
+++ b/backend/tests/agent_runtime/test_checkpointer.py
@@ -213,6 +213,34 @@ async def test_get_checkpointer_creates_db():
         await reset_checkpointer()
 
 
+async def test_get_checkpointer_configures_concurrent_sqlite_writes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    db_path = tmp_path / "test_checkpoints.db"
+    monkeypatch.setenv("AGENT_CHECKPOINT_DB", str(db_path))
+    await reset_checkpointer()
+
+    try:
+        checkpointer = await get_checkpointer()
+        values: dict[str, object] = {}
+        for pragma in ("journal_mode", "synchronous", "busy_timeout"):
+            cursor = await checkpointer.conn.execute(f"PRAGMA {pragma}")
+            try:
+                row = await cursor.fetchone()
+            finally:
+                await cursor.close()
+            values[pragma] = row[0] if row else None
+
+        assert values == {
+            "journal_mode": "wal",
+            "synchronous": 1,
+            "busy_timeout": 30000,
+        }
+    finally:
+        await reset_checkpointer()
+
+
 async def test_get_checkpointer_uses_backend_data_default_path(monkeypatch):
     with tempfile.TemporaryDirectory() as tmpdir:
         repo_root = Path(tmpdir)

--- a/backend/tests/agent_runtime/test_session_runner.py
+++ b/backend/tests/agent_runtime/test_session_runner.py
@@ -625,6 +625,79 @@ async def test_resume_targets_the_approved_parallel_tool_interrupt():
 
 
 @pytest.mark.asyncio
+async def test_resume_user_skip_uses_exit_durability():
+    runner = SessionRunner(
+        session_id="sess_resume_skip",
+        task_id="task_resume_skip",
+        model_config={
+            "provider_type": "openai",
+            "model_id": "gpt",
+            "api_key": "k",
+            "base_url": "",
+            "max_context_tokens": 8000,
+        },
+    )
+    captured: dict = {}
+
+    class _Graph:
+        def __init__(self) -> None:
+            self.state_reads = 0
+
+        async def astream_events(self, command, *args, **kwargs):
+            captured["command"] = command
+            captured["kwargs"] = kwargs
+            if False:
+                yield None
+
+        async def aget_state(self, *args, **kwargs):
+            self.state_reads += 1
+            if self.state_reads <= 2:
+                return SimpleNamespace(
+                    next=("tools",),
+                    tasks=(
+                        SimpleNamespace(
+                            interrupts=(
+                                SimpleNamespace(
+                                    id="question-1",
+                                    value={"type": "ask_user", "action_id": "question-1"},
+                                ),
+                            )
+                        ),
+                    ),
+                    values={"current_revision_id": "rev-skip"},
+                )
+            return SimpleNamespace(next=(), tasks=(), values={"current_revision_id": "rev-skip"})
+
+    fake_session = MagicMock(close=AsyncMock(), commit=AsyncMock())
+    fake_persister = MagicMock(handle=AsyncMock(), finalize=AsyncMock())
+
+    with patch.object(runner, "_get_graph", AsyncMock(return_value=_Graph())), \
+         patch(
+             "app.agent_runtime.runner.session_runner.finalize_revision_status",
+             AsyncMock(),
+         ), \
+         patch(
+             "app.agent_runtime.runner.session_runner.revision_repo.get_by_id",
+             AsyncMock(return_value=None),
+         ), \
+         patch(
+             "app.agent_runtime.runner.session_runner.create_session",
+             AsyncMock(return_value=fake_session),
+         ), \
+         patch.object(runner, "_make_persister", MagicMock(return_value=fake_persister)):
+        await runner.resume(
+            {
+                "action_type": "clarification",
+                "action_id": "question-1",
+                "answer": [],
+                "skipped": True,
+            }
+        )
+
+    assert captured["kwargs"]["durability"] == "exit"
+
+
+@pytest.mark.asyncio
 async def test_resume_restores_all_parallel_interrupts_in_one_command() -> None:
     runner = SessionRunner(
         session_id="sess_resume_batch",

--- a/backend/tests/agent_runtime/tools/test_ask_user.py
+++ b/backend/tests/agent_runtime/tools/test_ask_user.py
@@ -69,6 +69,21 @@ class TestAskUser:
         data = json.loads(result)
         assert data == interrupt_response["answer"]
 
+    async def test_ask_user_returns_user_skipped_result(self):
+        from app.agent_runtime.tools.impls.interaction.ask_user import AskUserTool
+
+        tool = AskUserTool(_state=_make_state())
+        with patch("app.agent_runtime.tools.impls.interaction.ask_user.interrupt") as mock_interrupt:
+            mock_interrupt.return_value = {
+                "action_type": "clarification",
+                "action_id": "question-1",
+                "answer": [],
+                "skipped": True,
+            }
+            result = await tool.ainvoke(_valid_input())
+
+        assert json.loads(result) == {"status": "user_skipped", "error": "用户忽略了提问"}
+
     async def test_ask_user_accepts_more_than_five_questions(self):
         from app.agent_runtime.tools.impls.interaction.ask_user import AskUserTool
 

--- a/frontend/src/features/assistant/components/agent/agent-sidebar.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-sidebar.tsx
@@ -229,6 +229,7 @@ export function useAgentSidebar({
             : undefined
         }
         onSubmitQuestionAnswer={submitAgentQuestionAnswer}
+        onSkipQuestion={(actionId) => void submitAgentQuestionAnswer(actionId, [], true)}
         onBatchDecision={(panel, decision) => {
           const message = agentMessages.find((item) => item.id === panel.id);
           if (message) void handleBatchDecision(message, decision);

--- a/frontend/src/features/assistant/components/agent/agent-special-panels.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-special-panels.tsx
@@ -10,6 +10,7 @@ interface AgentSpecialPanelsProps {
   embedded?: boolean;
   onApproveTool?: (approvalId: string, approved: boolean) => void;
   onSubmitQuestionAnswer?: (actionId: string, answer: ClarificationAnswerItem[]) => void;
+  onSkipQuestion?: (actionId: string) => void;
   onBatchDecision?: (
     panel: AgentSpecialPanel,
     decision: { approved?: boolean; answer?: ClarificationAnswerItem[] },
@@ -22,6 +23,7 @@ export function AgentSpecialPanels({
   embedded = false,
   onApproveTool,
   onSubmitQuestionAnswer,
+  onSkipQuestion,
   onBatchDecision,
   readOnly = false,
 }: AgentSpecialPanelsProps) {
@@ -56,6 +58,7 @@ export function AgentSpecialPanels({
               panel={panel}
               readOnly={readOnly}
               onSubmitQuestionAnswer={onSubmitQuestionAnswer}
+              onSkipQuestion={onSkipQuestion}
               onBatchDecision={panel.batchId ? onBatchDecision : undefined}
             />
           );

--- a/frontend/src/features/assistant/components/agent/message-blocks/messages/special/clarification-question-flow.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/messages/special/clarification-question-flow.tsx
@@ -1,5 +1,6 @@
 import { Box, Button, Flex, Text } from "@radix-ui/themes";
 import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { ClarificationQuestion } from "../../../../../../../lib/agent.types";
@@ -12,6 +13,7 @@ interface ClarificationQuestionBodyProps {
 }
 
 interface ClarificationQuestionActionsProps {
+  leadingAction?: ReactNode;
   model: ClarificationQuestionFlowModel;
 }
 
@@ -76,7 +78,10 @@ export function ClarificationQuestionBody({
   return bodyClassName ? <Box className={bodyClassName}>{content}</Box> : content;
 }
 
-export function ClarificationQuestionActions({ model }: ClarificationQuestionActionsProps) {
+export function ClarificationQuestionActions({
+  leadingAction,
+  model,
+}: ClarificationQuestionActionsProps) {
   const { t } = useTranslation();
   const { prompt } = model;
   if (prompt.questions.length === 0) return null;
@@ -88,12 +93,18 @@ export function ClarificationQuestionActions({ model }: ClarificationQuestionAct
         justify="between"
         style={{ width: "100%" }}
       >
-        <Text
-          size="1"
-          color="gray"
+        <Flex
+          align="center"
+          gap="2"
         >
-          {model.currentStep + 1} / {prompt.questions.length}
-        </Text>
+          {leadingAction}
+          <Text
+            size="1"
+            color="gray"
+          >
+            {model.currentStep + 1} / {prompt.questions.length}
+          </Text>
+        </Flex>
         <Flex gap="2">
           {model.currentStep > 0 && (
             <Button
@@ -133,7 +144,12 @@ export function ClarificationQuestionActions({ model }: ClarificationQuestionAct
   if (!model.canRenderSubmit) return null;
 
   return (
-    <Flex justify="end">
+    <Flex
+      align="center"
+      justify="between"
+      style={{ width: "100%" }}
+    >
+      {leadingAction}
       <Button
         size="1"
         onClick={model.handleSubmit}

--- a/frontend/src/features/assistant/components/agent/message-blocks/panels/clarification-special-panel.css
+++ b/frontend/src/features/assistant/components/agent/message-blocks/panels/clarification-special-panel.css
@@ -1,0 +1,9 @@
+.agent-clarification-skip-button {
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.agent-clarification-skip-button:hover {
+  background: transparent;
+}

--- a/frontend/src/features/assistant/components/agent/message-blocks/panels/clarification-special-panel.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/panels/clarification-special-panel.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, IconButton, Text, Tooltip } from "@radix-ui/themes";
+import { Box, Button, Flex, IconButton, Text, Tooltip } from "@radix-ui/themes";
 import { ChevronDown, ChevronUp, HelpCircle } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -20,9 +20,10 @@ import { SpecialPanelShell } from "./special-panel-shell";
 interface ClarificationSpecialPanelProps {
   panel: AgentQuestionSpecialPanel;
   onSubmitQuestionAnswer?: (actionId: string, answer: ClarificationAnswerItem[]) => void;
+  onSkipQuestion?: (actionId: string) => void;
   onBatchDecision?: (
     panel: AgentSpecialPanel,
-    decision: { answer: ClarificationAnswerItem[] },
+    decision: { answer?: ClarificationAnswerItem[]; skipped?: boolean },
   ) => void;
   readOnly?: boolean;
 }
@@ -30,6 +31,7 @@ interface ClarificationSpecialPanelProps {
 export function ClarificationSpecialPanel({
   panel,
   onSubmitQuestionAnswer,
+  onSkipQuestion,
   onBatchDecision,
   readOnly = false,
 }: ClarificationSpecialPanelProps) {
@@ -41,6 +43,7 @@ export function ClarificationSpecialPanel({
       summary={panel.summary}
       readOnly={readOnly}
       onSubmitQuestionAnswer={onSubmitQuestionAnswer}
+      onSkipQuestion={onSkipQuestion}
       onBatchDecision={onBatchDecision}
     />
   );
@@ -51,9 +54,10 @@ interface ClarificationSpecialPanelContentProps {
   prompt: ClarificationPromptData;
   summary: string;
   onSubmitQuestionAnswer?: (actionId: string, answer: ClarificationAnswerItem[]) => void;
+  onSkipQuestion?: (actionId: string) => void;
   onBatchDecision?: (
     panel: AgentSpecialPanel,
-    decision: { answer: ClarificationAnswerItem[] },
+    decision: { answer?: ClarificationAnswerItem[]; skipped?: boolean },
   ) => void;
   readOnly?: boolean;
 }
@@ -63,6 +67,7 @@ function ClarificationSpecialPanelContent({
   prompt,
   summary,
   onSubmitQuestionAnswer,
+  onSkipQuestion,
   onBatchDecision,
   readOnly = false,
 }: ClarificationSpecialPanelContentProps) {
@@ -156,7 +161,31 @@ function ClarificationSpecialPanelContent({
           : undefined
       }
       content={content}
-      actions={readOnly ? undefined : <ClarificationQuestionActions model={model} />}
+      actions={
+        readOnly ? undefined : (
+          <ClarificationQuestionActions
+            model={model}
+            leadingAction={
+              <Button
+                variant="ghost"
+                color="gray"
+                size="1"
+                type="button"
+                className="agent-clarification-skip-button"
+                onClick={() => {
+                  if (onBatchDecision) {
+                    onBatchDecision(panel, { skipped: true });
+                    return;
+                  }
+                  onSkipQuestion?.(prompt.actionId);
+                }}
+              >
+                {t("assistant.clarification.ignore")}
+              </Button>
+            }
+          />
+        )
+      }
     />
   );
 }

--- a/frontend/src/features/assistant/hooks/use-agent-session.ts
+++ b/frontend/src/features/assistant/hooks/use-agent-session.ts
@@ -1117,7 +1117,7 @@ export function useAgentSession({
   );
 
   const submitQuestionAnswer = useCallback(
-    async (actionId: string, answer: ClarificationAnswerItem[]) => {
+    async (actionId: string, answer: ClarificationAnswerItem[], skipped = false) => {
       if (!sessionId) {
         toast.error(i18n.t("assistant.sessionNotFound"));
         return;
@@ -1143,7 +1143,7 @@ export function useAgentSession({
           attachAgentSocket(sessionId);
           await joinAgentSession(sessionId);
         }
-        await submitAgentQuestionAnswer(sessionId, actionId, answer);
+        await submitAgentQuestionAnswer(sessionId, actionId, answer, skipped);
       } catch (error) {
         console.error("Question answer failed:", error);
         updateTranscriptState((current) => ({
@@ -1161,7 +1161,7 @@ export function useAgentSession({
   const handleBatchDecision = useCallback(
     async (
       panel: AgentMessage,
-      decision: { approved?: boolean; answer?: ClarificationAnswerItem[] },
+      decision: { approved?: boolean; answer?: ClarificationAnswerItem[]; skipped?: boolean },
     ) => {
       const batchId = panel.interruptBatchId;
       if (!batchId || panel.interruptBatchTotal === undefined) return;
@@ -1173,7 +1173,7 @@ export function useAgentSession({
         action_type: panel.type === "approval" ? "tool_approval" : "clarification",
         ...(panel.type === "approval"
           ? { approval_id: interruptId, approved: decision.approved }
-          : { action_id: interruptId, answer: decision.answer }),
+          : { action_id: interruptId, answer: decision.answer, skipped: decision.skipped }),
       };
       const decisionCount = Object.keys(current.decisions).length;
       const batchTotal = panel.interruptBatchTotal ?? current.panels.length;
@@ -1197,6 +1197,7 @@ export function useAgentSession({
             approved: typeof item.approved === "boolean" ? item.approved : undefined,
             action_id: typeof item.action_id === "string" ? item.action_id : undefined,
             answer: Array.isArray(item.answer) ? item.answer : undefined,
+            skipped: item.skipped === true,
           })),
         );
         interruptBatchRef.current = null;

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1750,6 +1750,7 @@
       "previous": "Previous",
       "next": "Next",
       "submit": "Submit answers",
+      "ignore": "Ignore",
       "customInput": "Type your own answer",
       "customInputDescription": "Enter a custom answer",
       "customInputPlaceholder": "Enter a custom answer...",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1813,6 +1813,7 @@
       "previous": "上一步",
       "next": "下一步",
       "submit": "提交回答",
+      "ignore": "忽略",
       "customInput": "自行输入",
       "customInputDescription": "输入自定义回答",
       "customInputPlaceholder": "输入自定义回答...",

--- a/frontend/src/lib/agent.types.ts
+++ b/frontend/src/lib/agent.types.ts
@@ -364,6 +364,7 @@ export interface AgentInterruptBatchResponse {
   approved?: boolean;
   action_id?: string;
   answer?: ClarificationAnswerItem[];
+  skipped?: boolean;
 }
 
 export interface AgentQuestionAnswerResponse {

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -2408,10 +2408,12 @@ export async function submitAgentQuestionAnswer(
   sessionId: string,
   actionId: string,
   answer: ClarificationAnswerItem[],
+  skipped = false,
 ): Promise<AgentQuestionAnswerResponse | void> {
   const response = await apiClient.post(`/agent/sessions/${sessionId}/question-answer`, {
     action_id: actionId,
     answer,
+    skipped,
   });
   return response.data;
 }


### PR DESCRIPTION
## PR 标题

chore: 允许在回复 ask_user 工具时选择忽略

## 变更说明

- 问题: ask_user 回答面板没有忽略入口，用户无法跳过当前提问并结束会话。
- 重要性: 忽略后需要将工具消息标记为用户跳过错误，并确保 Agent 不再继续下一轮。
- 变化: 添加前端忽略按钮及 clarification 跳过标记，完善后端终态处理。
- 变化: 对终止型恢复使用 exit durability，并优化 checkpoint SQLite 写入配置，减少并行写入等待。

## 关联 Issue / PR

Closes #255

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因

ask_user 原有回答流程没有用户跳过分支；终止恢复默认仍会沿途持久化大量 checkpoint，导致会话结束延迟。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

普通 Agent 流程继续使用原有 async durability；仅用户忽略这种确定终止的恢复流程使用 exit durability。
