### PR TITLE
chore(auth): 增加可选的应用密码认证

### DIFF
--- a/backend/app/api/routers/auth.py
+++ b/backend/app/api/routers/auth.py
@@ -1,0 +1,89 @@
+"""Authentication endpoints for the optional application password gate."""
+
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.api.routers.settings import get_settings
+from app.auth import AUTH_COOKIE_MAX_AGE, AUTH_COOKIE_NAME, AuthService
+from app.storage.database import get_session
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+class AuthStatusResponse(BaseModel):
+    enabled: bool
+    authenticated: bool
+
+
+class AuthLoginRequest(BaseModel):
+    password: str
+    trust_device: bool = False
+
+
+class PublicPreferencesResponse(BaseModel):
+    language: str
+    theme: str
+    font_family: str
+    code_font_family: str
+    base_font_size: int
+    editor_font_size: int
+
+
+def get_auth_service(request: Request) -> AuthService:
+    return request.app.state.auth_service
+
+
+@router.get("/status", response_model=AuthStatusResponse)
+async def auth_status(
+    request: Request,
+    auth_service: AuthService = Depends(get_auth_service),
+) -> AuthStatusResponse:
+    return AuthStatusResponse(
+        enabled=auth_service.enabled,
+        authenticated=auth_service.verify_cookie_value(request.cookies.get(AUTH_COOKIE_NAME)),
+    )
+
+
+@router.get("/preferences", response_model=PublicPreferencesResponse)
+async def public_preferences(
+    session: Annotated[AsyncSession, Depends(get_session)],
+) -> PublicPreferencesResponse:
+    settings = await get_settings(session)
+    return PublicPreferencesResponse(
+        language=settings.language,
+        theme=settings.theme,
+        font_family=settings.font_family,
+        code_font_family=settings.code_font_family,
+        base_font_size=settings.base_font_size,
+        editor_font_size=settings.editor_font_size,
+    )
+
+
+@router.post("/login", response_model=AuthStatusResponse)
+async def login(
+    payload: AuthLoginRequest,
+    request: Request,
+    response: Response,
+    auth_service: AuthService = Depends(get_auth_service),
+) -> AuthStatusResponse:
+    if not auth_service.enabled:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND)
+    if not auth_service.verify_password(payload.password):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid password",
+        )
+
+    response.set_cookie(
+        key=AUTH_COOKIE_NAME,
+        value=auth_service.create_cookie_value(),
+        max_age=AUTH_COOKIE_MAX_AGE if payload.trust_device else None,
+        httponly=True,
+        secure=request.url.scheme == "https",
+        samesite="lax",
+        path="/",
+    )
+    return AuthStatusResponse(enabled=True, authenticated=True)

--- a/backend/app/auth.py
+++ b/backend/app/auth.py
@@ -1,0 +1,130 @@
+"""Application-level password authentication."""
+
+from dataclasses import dataclass
+from hmac import compare_digest
+from http.cookies import SimpleCookie
+
+from itsdangerous import BadSignature, URLSafeTimedSerializer
+from starlette.datastructures import Headers
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+AUTH_COOKIE_NAME = "openfic_auth"
+AUTH_COOKIE_MAX_AGE = 30 * 24 * 60 * 60
+_AUTH_COOKIE_SALT = "openfic-auth-cookie"
+
+
+@dataclass(frozen=True)
+class AuthService:
+    """Validate the configured shared password and sign login cookies."""
+
+    password: str | None
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.password)
+
+    def verify_password(self, candidate: str) -> bool:
+        return self.enabled and compare_digest(candidate, self.password or "")
+
+    def create_cookie_value(self) -> str:
+        if not self.enabled:
+            raise RuntimeError("Authentication is not enabled")
+        serializer = URLSafeTimedSerializer(self.password or "", salt=_AUTH_COOKIE_SALT)
+        return serializer.dumps("authenticated")
+
+    def verify_cookie_value(self, value: str | None) -> bool:
+        if not self.enabled or not value:
+            return False
+
+        serializer = URLSafeTimedSerializer(self.password or "", salt=_AUTH_COOKIE_SALT)
+        try:
+            return serializer.loads(value, max_age=AUTH_COOKIE_MAX_AGE) == "authenticated"
+        except BadSignature:
+            return False
+
+
+class AuthMiddleware:
+    """Protect backend resources while leaving the frontend shell public."""
+
+    _STATIC_PROTECTED_PREFIXES = (
+        "/socket.io",
+        "/icons/",
+        "/covers/",
+        "/character-images/",
+        "/agent-attachments/",
+        "/docs",
+        "/redoc",
+        "/openapi.json",
+    )
+
+    def __init__(self, app: ASGIApp, auth_service: AuthService, api_prefix: str) -> None:
+        self.app = app
+        self.auth_service = auth_service
+        self.api_prefix = api_prefix.rstrip("/")
+        self._protected_prefixes = (
+            f"{self.api_prefix}/",
+            *self._STATIC_PROTECTED_PREFIXES,
+        )
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if not self.auth_service.enabled or scope["type"] not in {"http", "websocket"}:
+            await self.app(scope, receive, send)
+            return
+
+        if scope["type"] == "http" and scope.get("method") == "OPTIONS":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        if path.startswith(f"{self.api_prefix}/auth/") or path in {
+            f"{self.api_prefix}/health",
+            f"{self.api_prefix}/health/shutdown",
+        } or not path.startswith(self._protected_prefixes):
+            await self.app(scope, receive, send)
+            return
+
+        if self._has_valid_cookie(scope):
+            await self.app(scope, receive, send)
+            return
+
+        if scope["type"] == "websocket":
+            await self._reject_websocket(scope, send)
+            return
+
+        response = JSONResponse(
+            {"detail": "Authentication required"},
+            status_code=401,
+            headers={"WWW-Authenticate": "Cookie"},
+        )
+        await response(scope, receive, send)
+
+    async def _reject_websocket(self, scope: Scope, send: Send) -> None:
+        if "websocket.http.response" not in (scope.get("extensions") or {}):
+            await send({"type": "websocket.close", "code": 1008})
+            return
+
+        body = b'{"detail":"Authentication required"}'
+        await send(
+            {
+                "type": "websocket.http.response.start",
+                "status": 401,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(body)).encode("ascii")),
+                    (b"www-authenticate", b"Cookie"),
+                    (b"x-openfic-auth", b"required"),
+                ],
+            }
+        )
+        await send({"type": "websocket.http.response.body", "body": body})
+
+    def _has_valid_cookie(self, scope: Scope) -> bool:
+        cookie_header = Headers(scope=scope).get("cookie")
+        if not cookie_header:
+            return False
+
+        cookies = SimpleCookie()
+        cookies.load(cookie_header)
+        cookie = cookies.get(AUTH_COOKIE_NAME)
+        return self.auth_service.verify_cookie_value(cookie.value if cookie else None)

--- a/backend/app/cli.py
+++ b/backend/app/cli.py
@@ -56,6 +56,9 @@ def handle_serve(args: argparse.Namespace) -> None:
     configure_standard_logging()
     os.environ["OPENFIC_SERVER_HOST"] = args.host
     os.environ["OPENFIC_SERVER_PORT"] = str(args.port)
+    auth_password = getattr(args, "auth_password", None)
+    if auth_password is not None:
+        os.environ["OPENFIC_AUTH_PASSWORD"] = auth_password
 
     import uvicorn
     from app.main import app as asgi_app, fastapi_app
@@ -85,6 +88,7 @@ def build_parser() -> argparse.ArgumentParser:
     serve_parser = subparsers.add_parser("serve", help="启动本地服务")
     serve_parser.add_argument("--host", default=_DEFAULT_HOST, help=f"绑定地址（默认 {_DEFAULT_HOST}）")
     serve_parser.add_argument("--port", type=int, default=_DEFAULT_PORT, help=f"绑定端口（默认 {_DEFAULT_PORT}）")
+    serve_parser.add_argument("--auth-password", default=None, help="启用应用密码保护")
     serve_parser.set_defaults(handler=handle_serve)
 
     version_parser = subparsers.add_parser("version", help="显示版本号")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -23,6 +23,7 @@ from starlette.types import Scope
 from app.api.exceptions import register_exception_handlers
 from app.api.middleware import AccessLogMiddleware
 from app.api.routers import (
+    auth,
     agent_definitions,
     agent_memories,
     agent_rules,
@@ -54,6 +55,7 @@ from app.api.routers import (
     world_info,
     world_info_entries,
 )
+from app.auth import AuthMiddleware, AuthService
 from app.audit import start_audit_queue, stop_audit_queue
 from app.agent_runtime.persistence.child_runs import cancel_interrupted_child_runs
 from app.audit.queue import load_audit_details_persistence
@@ -683,6 +685,7 @@ def create_app() -> FastAPI:
         version=app_settings.app_version,
         lifespan=lifespan,
     )
+    app.state.auth_service = AuthService(app_settings.auth_password)
     app.state.catalog_icon_proxy_service = model_icons.CatalogIconProxyService()
 
     install_telemetry_sink()
@@ -690,7 +693,8 @@ def create_app() -> FastAPI:
     # CORS middleware
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=[],
+        allow_origin_regex=".*",
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
@@ -698,6 +702,7 @@ def create_app() -> FastAPI:
     app.add_middleware(AccessLogMiddleware)
 
     # Mount routers
+    app.include_router(auth.router, prefix=app_settings.api_v1_prefix)
     app.include_router(health.router, prefix=app_settings.api_v1_prefix)
     app.include_router(runtime_config.router, prefix=app_settings.api_v1_prefix)
     app.include_router(projects.router, prefix=app_settings.api_v1_prefix)
@@ -768,4 +773,8 @@ def create_app() -> FastAPI:
 
 fastapi_app = create_app()
 asgi_app = init_socketio(fastapi_app)
-app = asgi_app
+app = AuthMiddleware(
+    asgi_app,
+    fastapi_app.state.auth_service,
+    app_settings.api_v1_prefix,
+)

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from cryptography.fernet import Fernet
 from loguru import logger
-from pydantic import field_validator
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -83,6 +83,9 @@ class Settings(BaseSettings):
 
     # API
     api_v1_prefix: str = "/api/v1"
+
+    # Optional application password gate. Empty or unset means disabled.
+    auth_password: str | None = Field(default=None, validation_alias="OPENFIC_AUTH_PASSWORD")
 
     # Server
     host: str = "0.0.0.0"

--- a/backend/tests/api/test_auth.py
+++ b/backend/tests/api/test_auth.py
@@ -1,0 +1,196 @@
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+import app.api.routers.auth as auth_router
+from app.api.routers.auth import router
+from app.api.schemas.setting import SettingsResponse
+from app.auth import AuthMiddleware, AuthService
+from app.storage.database import get_session
+from app.settings import Settings
+
+
+def _create_auth_test_app(password: str | None, api_prefix: str = "/api/v1") -> AuthMiddleware:
+    app = FastAPI()
+    auth_service = AuthService(password)
+    app.state.auth_service = auth_service
+    app.include_router(router, prefix=api_prefix)
+
+    @app.get(f"{api_prefix}/protected")
+    async def protected() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get(f"{api_prefix}/health")
+    async def health() -> dict[str, str]:
+        return {"status": "healthy"}
+
+    @app.get("/")
+    async def frontend() -> dict[str, str]:
+        return {"page": "frontend"}
+
+    return AuthMiddleware(app, auth_service, api_prefix)
+
+
+async def _request(app: AuthMiddleware, method: str, url: str, **kwargs) -> object:
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        return await client.request(method, url, **kwargs)
+
+
+async def test_auth_disabled_allows_protected_requests() -> None:
+    response = await _request(_create_auth_test_app(None), "GET", "/api/v1/protected")
+
+    assert response.status_code == 200
+
+
+def test_auth_password_can_be_loaded_from_environment(monkeypatch) -> None:
+    monkeypatch.setenv("OPENFIC_AUTH_PASSWORD", "secret")
+
+    settings = Settings(_env_file=None)
+
+    assert settings.auth_password == "secret"
+
+
+async def test_auth_status_reports_enabled_without_exposing_password() -> None:
+    response = await _request(_create_auth_test_app("secret"), "GET", "/api/v1/auth/status")
+
+    assert response.status_code == 200
+    assert response.json() == {"enabled": True, "authenticated": False}
+    assert "secret" not in response.text
+
+
+async def test_public_preferences_expose_only_interface_preferences(monkeypatch) -> None:
+    app = _create_auth_test_app("secret")
+
+    async def fake_get_settings(_session) -> SettingsResponse:
+        return SettingsResponse(
+            language="en",
+            theme="dark",
+            font_family="Noto Serif SC Variable",
+            code_font_family="JetBrains Mono Variable",
+            base_font_size=18,
+            editor_font_size=20,
+        )
+
+    async def fake_session():
+        yield object()
+
+    monkeypatch.setattr(auth_router, "get_settings", fake_get_settings)
+    app.app.dependency_overrides[get_session] = fake_session
+
+    response = await _request(app, "GET", "/api/v1/auth/preferences")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "language": "en",
+        "theme": "dark",
+        "font_family": "Noto Serif SC Variable",
+        "code_font_family": "JetBrains Mono Variable",
+        "base_font_size": 18,
+        "editor_font_size": 20,
+    }
+
+
+async def test_auth_blocks_protected_requests_until_login() -> None:
+    response = await _request(_create_auth_test_app("secret"), "GET", "/api/v1/protected")
+
+    assert response.status_code == 401
+
+
+async def test_auth_uses_configured_api_prefix() -> None:
+    app = _create_auth_test_app("secret", "/internal")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        protected_response = await client.get("/internal/protected")
+        login_response = await client.post(
+            "/internal/auth/login",
+            json={"password": "secret", "trust_device": False},
+        )
+        authenticated_response = await client.get("/internal/protected")
+
+    assert protected_response.status_code == 401
+    assert login_response.status_code == 200
+    assert authenticated_response.status_code == 200
+
+
+async def test_auth_rejects_wrong_password() -> None:
+    response = await _request(
+        _create_auth_test_app("secret"),
+        "POST",
+        "/api/v1/auth/login",
+        json={"password": "wrong", "trust_device": False},
+    )
+
+    assert response.status_code == 401
+
+
+async def test_auth_login_allows_session_cookie() -> None:
+    app = _create_auth_test_app("secret")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        login_response = await client.post(
+            "/api/v1/auth/login",
+            json={"password": "secret", "trust_device": False},
+        )
+        protected_response = await client.get("/api/v1/protected")
+
+    assert login_response.status_code == 200
+    assert "Max-Age=2592000" not in login_response.headers["set-cookie"]
+    assert protected_response.status_code == 200
+
+
+async def test_auth_login_trust_device_sets_thirty_day_cookie() -> None:
+    app = _create_auth_test_app("secret")
+    response = await _request(
+        app,
+        "POST",
+        "/api/v1/auth/login",
+        json={"password": "secret", "trust_device": True},
+    )
+
+    assert response.status_code == 200
+    assert "Max-Age=2592000" in response.headers["set-cookie"]
+    assert "HttpOnly" in response.headers["set-cookie"]
+
+
+async def test_auth_keeps_frontend_route_public() -> None:
+    response = await _request(_create_auth_test_app("secret"), "GET", "/")
+
+    assert response.status_code == 200
+
+
+async def test_auth_keeps_health_check_public() -> None:
+    response = await _request(_create_auth_test_app("secret"), "GET", "/api/v1/health")
+
+    assert response.status_code == 200
+
+
+async def test_auth_rejects_websocket_with_unauthorized_response() -> None:
+    app = _create_auth_test_app("secret")
+    sent_messages: list[dict[str, object]] = []
+
+    async def receive() -> dict[str, object]:
+        return {"type": "websocket.connect"}
+
+    async def send(message: dict[str, object]) -> None:
+        sent_messages.append(message)
+
+    await app(
+        {
+            "type": "websocket",
+            "asgi": {"version": "3.0", "spec_version": "2.4"},
+            "http_version": "1.1",
+            "scheme": "ws",
+            "server": ("test", 80),
+            "client": ("test", 123),
+            "root_path": "",
+            "path": "/socket.io/",
+            "raw_path": b"/socket.io/",
+            "query_string": b"",
+            "headers": [],
+            "subprotocols": [],
+            "state": {},
+            "extensions": {"websocket.http.response": {}},
+        },
+        receive,
+        send,
+    )
+
+    assert sent_messages[0]["type"] == "websocket.http.response.start"
+    assert sent_messages[0]["status"] == 401

--- a/backend/tests/socket/test_main_entrypoint.py
+++ b/backend/tests/socket/test_main_entrypoint.py
@@ -1,11 +1,13 @@
 import socketio  # type: ignore[import-untyped]
 
+from app.auth import AuthMiddleware
 from app.main import app, asgi_app, fastapi_app
 
 
-def test_default_app_entrypoint_is_socketio_asgi_app() -> None:
-    assert app is asgi_app
-    assert isinstance(app, socketio.ASGIApp)
+def test_default_app_entrypoint_wraps_socketio_asgi_app_with_auth() -> None:
+    assert isinstance(app, AuthMiddleware)
+    assert app.app is asgi_app
+    assert isinstance(asgi_app, socketio.ASGIApp)
 
 
 def test_background_sse_route_removed() -> None:

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -76,3 +76,41 @@ def test_handle_serve_passes_loop_factory_to_uvicorn(monkeypatch) -> None:
     assert sys.modules["uvicorn"].Config.call_args.kwargs["loop"] == "app.cli:_windows_selector_loop_factory"
     assert fastapi_app.state.uvicorn_server is uvicorn_server
     uvicorn_server.run.assert_called_once_with()
+
+
+def test_serve_parser_accepts_auth_password() -> None:
+    args = cli.build_parser().parse_args(["serve", "--auth-password", "secret"])
+
+    assert args.auth_password == "secret"
+
+
+def test_handle_serve_sets_auth_password_environment(monkeypatch) -> None:
+    uvicorn_config = Mock()
+    uvicorn_server = Mock()
+    fastapi_app = SimpleNamespace(state=SimpleNamespace())
+    monkeypatch.delenv("OPENFIC_AUTH_PASSWORD", raising=False)
+    monkeypatch.setattr(cli, "_ensure_data_dir", Mock())
+    monkeypatch.setattr(cli, "configure_standard_logging", Mock())
+    monkeypatch.setitem(
+        sys.modules,
+        "uvicorn",
+        SimpleNamespace(
+            Config=Mock(return_value=uvicorn_config),
+            Server=Mock(return_value=uvicorn_server),
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "app.main",
+        SimpleNamespace(app=object(), fastapi_app=fastapi_app),
+    )
+
+    cli.handle_serve(
+        type(
+            "Args",
+            (),
+            {"host": "127.0.0.1", "port": 8000, "auth_password": "secret"},
+        )()
+    )
+
+    assert cli.os.environ["OPENFIC_AUTH_PASSWORD"] == "secret"

--- a/desktop/src/main/protocol.ts
+++ b/desktop/src/main/protocol.ts
@@ -7,11 +7,80 @@ import { configureSystemProxy } from "./proxy.js";
 
 let runtimeConfig: RuntimeConfigResponse | null = null;
 const registeredPartitions = new Map<string, Promise<void>>();
+const configuredAuthSessions = new WeakSet<Electron.Session>();
+const capturedAuthCookies = new WeakMap<Electron.Session, string>();
 const SHARED_FONT_CSS_PATH = "/frontend-fonts.css";
 const SHARED_FONT_PREFIX = "/frontend-fonts/";
+const AUTH_COOKIE_NAME = "openfic_auth";
 
 export function setRuntimeConfig(config: RuntimeConfigResponse): void {
   runtimeConfig = config;
+}
+
+function getHeaderValues(headers: Record<string, string[]>, name: string): string[] {
+  const headerName = Object.keys(headers).find((key) => key.toLowerCase() === name);
+  return headerName ? headers[headerName] ?? [] : [];
+}
+
+function getAuthCookieFromSetCookie(headers: Record<string, string[]>): string | null {
+  for (const header of getHeaderValues(headers, "set-cookie")) {
+    const match = header.match(new RegExp(`^(${AUTH_COOKIE_NAME}=[^;]*)`, "i"));
+    if (match) return match[1] ?? null;
+  }
+  return null;
+}
+
+function isBackendRequest(url: string): boolean {
+  if (!runtimeConfig?.backendBaseUrl) return false;
+  try {
+    return new URL(url).origin === new URL(runtimeConfig.backendBaseUrl).origin;
+  } catch {
+    return false;
+  }
+}
+
+function addAuthCookie(requestHeaders: Record<string, string>, authCookie: string): void {
+  const cookieHeaderName = Object.keys(requestHeaders).find((key) => key.toLowerCase() === "cookie") ?? "Cookie";
+  const existingCookies = (requestHeaders[cookieHeaderName] ?? "")
+    .split(";")
+    .map((cookie) => cookie.trim())
+    .filter((cookie) => cookie && !cookie.toLowerCase().startsWith(`${AUTH_COOKIE_NAME}=`));
+  requestHeaders[cookieHeaderName] = [...existingCookies, authCookie].join("; ");
+}
+
+function configureAuthSession(targetSession: Electron.Session): void {
+  if (configuredAuthSessions.has(targetSession)) return;
+  configuredAuthSessions.add(targetSession);
+
+  targetSession.webRequest.onHeadersReceived((details, callback) => {
+    if (isBackendRequest(details.url)) {
+      const authCookie = getAuthCookieFromSetCookie(details.responseHeaders ?? {});
+      if (authCookie) capturedAuthCookies.set(targetSession, authCookie);
+    }
+    callback({ responseHeaders: details.responseHeaders });
+  });
+
+  targetSession.webRequest.onBeforeSendHeaders((details, callback) => {
+    if (!isBackendRequest(details.url)) {
+      callback({ requestHeaders: details.requestHeaders });
+      return;
+    }
+
+    void targetSession.cookies
+      .get({ url: runtimeConfig?.backendBaseUrl ?? details.url, name: AUTH_COOKIE_NAME })
+      .then((cookies) => {
+        const authCookie = cookies[0]
+          ? `${AUTH_COOKIE_NAME}=${cookies[0].value}`
+          : capturedAuthCookies.get(targetSession);
+        if (authCookie) addAuthCookie(details.requestHeaders, authCookie);
+        callback({ requestHeaders: details.requestHeaders });
+      })
+      .catch(() => {
+        const authCookie = capturedAuthCookies.get(targetSession);
+        if (authCookie) addAuthCookie(details.requestHeaders, authCookie);
+        callback({ requestHeaders: details.requestHeaders });
+      });
+  });
 }
 
 export function getFrontendDistDir(): string {
@@ -107,6 +176,7 @@ export function ensureAppProtocolForPartition(partition: string): Promise<void> 
   if (registered) return registered;
 
   const targetSession = session.fromPartition(partition);
+  configureAuthSession(targetSession);
   const registration = configureSystemProxy(targetSession).then(() => {
     targetSession.protocol.handle("app", handleAppRequest);
   });

--- a/frontend/src/features/auth/index.ts
+++ b/frontend/src/features/auth/index.ts
@@ -1,0 +1,1 @@
+export { AuthPage } from "./pages/auth-page";

--- a/frontend/src/features/auth/pages/auth-page.css
+++ b/frontend/src/features/auth/pages/auth-page.css
@@ -1,0 +1,83 @@
+.auth-page {
+  display: grid;
+  min-height: 100dvh;
+  place-items: center;
+  padding: 24px;
+  background: var(--color-background);
+}
+
+.auth-panel {
+  display: flex;
+  width: min(100%, 320px);
+  flex-direction: column;
+  align-items: center;
+  gap: 32px;
+}
+
+.auth-brand {
+  display: block;
+  width: min(100%, 188px);
+  aspect-ratio: 302.1817 / 66.9035;
+  background-color: var(--gray-12);
+  mask: url("/brand.svg") center / contain no-repeat;
+  -webkit-mask: url("/brand.svg") center / contain no-repeat;
+}
+
+.auth-form {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.auth-entry {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.auth-password-frame {
+  position: relative;
+  min-width: 0;
+  flex: 1;
+}
+
+.auth-password-frame[data-error="true"]::after {
+  position: absolute;
+  inset: 0;
+  border: 1px solid var(--red-9);
+  border-radius: var(--radius-2);
+  content: "";
+  pointer-events: none;
+}
+
+.auth-password-frame[data-error="true"]:focus-within::after {
+  border-color: var(--text-field-focus-color);
+}
+
+.auth-password {
+  width: 100%;
+}
+
+.auth-trust-device {
+  display: inline-flex;
+  align-items: center;
+  align-self: flex-start;
+  gap: 8px;
+  cursor: pointer;
+  color: var(--gray-11);
+}
+
+.auth-error {
+  display: block;
+  height: var(--line-height-2);
+  overflow: visible;
+  color: var(--red-11);
+  visibility: hidden;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.auth-error[data-visible="true"] {
+  visibility: visible;
+}

--- a/frontend/src/features/auth/pages/auth-page.tsx
+++ b/frontend/src/features/auth/pages/auth-page.tsx
@@ -1,0 +1,101 @@
+import { Checkbox, IconButton, Text, TextField } from "@radix-ui/themes";
+import axios from "axios";
+import { LockOpen } from "lucide-react";
+import { type FormEvent, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+import { loginWithPassword } from "@/lib/api-client";
+
+import "./auth-page.css";
+
+export function AuthPage() {
+  const { t } = useTranslation();
+  const [password, setPassword] = useState("");
+  const [trustDevice, setTrustDevice] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [hasLoginError, setHasLoginError] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setErrorMessage(null);
+    setHasLoginError(false);
+    setIsSubmitting(true);
+
+    try {
+      await loginWithPassword({ password, trust_device: trustDevice });
+      window.location.reload();
+    } catch (error) {
+      setHasLoginError(true);
+      if (axios.isAxiosError(error) && error.response?.status === 401) {
+        setErrorMessage(t("auth.invalidPassword"));
+      } else {
+        setErrorMessage(t("auth.loginFailed"));
+      }
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <main className="auth-page">
+      <section className="auth-panel">
+        <span
+          className="auth-brand"
+          role="img"
+          aria-label={t("common.appName")}
+        />
+        <form
+          className="auth-form"
+          onSubmit={handleSubmit}
+        >
+          <div className="auth-entry">
+            <div
+              className="auth-password-frame"
+              data-error={hasLoginError ? "true" : undefined}
+            >
+              <TextField.Root
+                className="auth-password"
+                type="password"
+                size="2"
+                placeholder={t("auth.passwordPlaceholder")}
+                aria-label={t("auth.passwordPlaceholder")}
+                value={password}
+                onChange={(event) => setPassword(event.target.value)}
+                onFocus={() => {
+                  setHasLoginError(false);
+                  setErrorMessage(null);
+                }}
+                autoFocus
+                required
+              />
+            </div>
+            <IconButton
+              type="submit"
+              size="2"
+              aria-label={t("auth.submit")}
+              title={isSubmitting ? t("auth.submitting") : t("auth.submit")}
+              disabled={isSubmitting}
+            >
+              <LockOpen size={17} />
+            </IconButton>
+          </div>
+          <label className="auth-trust-device">
+            <Checkbox
+              checked={trustDevice}
+              onCheckedChange={(checked) => setTrustDevice(checked === true)}
+            />
+            <Text size="2">{t("auth.trustDevice")}</Text>
+          </label>
+          <Text
+            className="auth-error"
+            data-visible={errorMessage ? "true" : undefined}
+            size="2"
+            role={errorMessage ? "alert" : undefined}
+          >
+            {errorMessage ?? "\u00a0"}
+          </Text>
+        </form>
+      </section>
+    </main>
+  );
+}

--- a/frontend/src/features/projects/lib/import-api.ts
+++ b/frontend/src/features/projects/lib/import-api.ts
@@ -3,7 +3,7 @@
  */
 
 import i18n from "@/i18n";
-import { apiClient, getApiBaseUrl } from "@/lib/api-client";
+import { apiClient, getApiBaseUrl, handleAuthenticationFailure } from "@/lib/api-client";
 
 /** 预览章节信息 */
 export interface PreviewChapter {
@@ -148,9 +148,11 @@ export async function confirmImportStream(
   const response = await fetch(`${getApiBaseUrl()}/import/confirm-stream`, {
     method: "POST",
     body: formData,
+    credentials: "include",
   });
 
   if (!response.ok) {
+    if (response.status === 401) handleAuthenticationFailure();
     throw new Error(`HTTP error! status: ${response.status}`);
   }
 

--- a/frontend/src/features/settings/lib/provider-icons.tsx
+++ b/frontend/src/features/settings/lib/provider-icons.tsx
@@ -70,7 +70,10 @@ export function ProviderIcon({ iconPath, size = 20 }: ProviderIconProps) {
 
     const cancelRequest = scheduleProviderIconRequest(async () => {
       try {
-        const response = await fetch(iconUrl, { signal: abortController.signal });
+        const response = await fetch(iconUrl, {
+          signal: abortController.signal,
+          credentials: "include",
+        });
         if (!response.ok) throw new Error(`Failed to load provider icon: ${response.status}`);
 
         const document = new DOMParser().parseFromString(await response.text(), "image/svg+xml");

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -21,6 +21,8 @@
     "initializationFailed": "Initialization failed",
     "initializationFailedWithStage": "Initialization failed: {{stage}}: {{reason}}",
     "initializationFailedWithReason": "Initialization failed: {{reason}}",
+    "initializationPreferences": "interface preferences",
+    "initializationAuth": "authentication status",
     "initializationHealth": "HTTP health check",
     "initializationSettings": "settings request",
     "initializationTiktoken": "tiktoken preload",
@@ -53,6 +55,14 @@
     "noMatchingOptions": "No matching options",
     "swUpdated": "App updated. Click to refresh.",
     "refresh": "Refresh"
+  },
+  "auth": {
+    "passwordPlaceholder": "Enter password",
+    "submit": "Log in",
+    "submitting": "Logging in...",
+    "trustDevice": "Trust this device",
+    "invalidPassword": "Incorrect password",
+    "loginFailed": "Login failed. Please try again."
   },
   "topbar": {
     "projects": "Projects",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -21,6 +21,8 @@
     "initializationFailed": "初始化失败",
     "initializationFailedWithStage": "初始化失败：{{stage}}：{{reason}}",
     "initializationFailedWithReason": "初始化失败：{{reason}}",
+    "initializationPreferences": "界面偏好",
+    "initializationAuth": "认证状态",
     "initializationHealth": "HTTP 健康检查",
     "initializationSettings": "设置接口",
     "initializationTiktoken": "tiktoken 预加载",
@@ -53,6 +55,14 @@
     "noMatchingOptions": "没有匹配选项",
     "swUpdated": "应用已更新，点击刷新",
     "refresh": "刷新"
+  },
+  "auth": {
+    "passwordPlaceholder": "请输入密码",
+    "submit": "登录",
+    "submitting": "登录中...",
+    "trustDevice": "信任该设备",
+    "invalidPassword": "密码错误",
+    "loginFailed": "登录失败，请重试"
   },
   "topbar": {
     "projects": "项目",

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -34,10 +34,23 @@ function getApiUrl(path: string): string {
 export const apiClient = axios.create({
   baseURL: getApiBaseUrl(),
   timeout: 120000,
+  withCredentials: true,
   headers: {
     "Content-Type": "application/json",
   },
 });
+
+let isAuthenticationRedirecting = false;
+
+export function handleAuthenticationFailure(): void {
+  if (typeof window === "undefined" || isAuthenticationRedirecting) return;
+  isAuthenticationRedirecting = true;
+  window.location.reload();
+}
+
+function isAuthenticationRequest(url: string | undefined): boolean {
+  return url?.includes("/auth/") ?? false;
+}
 
 apiClient.interceptors.request.use((config) => {
   config.baseURL = getApiBaseUrl();
@@ -48,6 +61,9 @@ apiClient.interceptors.request.use((config) => {
 apiClient.interceptors.response.use(
   (response) => response,
   (error) => {
+    if (error.response?.status === 401 && !isAuthenticationRequest(error.config?.url)) {
+      handleAuthenticationFailure();
+    }
     // 开发环境记录错误日志
     if (import.meta.env.DEV) {
       console.error("API Error:", error);
@@ -60,6 +76,40 @@ apiClient.interceptors.response.use(
 export interface HealthResponse {
   status: string;
   version: string;
+}
+
+export interface AuthStatusResponse {
+  enabled: boolean;
+  authenticated: boolean;
+}
+
+export interface AuthPreferencesResponse {
+  language: string;
+  theme: string;
+  font_family: string;
+  code_font_family: string;
+  base_font_size: number;
+  editor_font_size: number;
+}
+
+export interface AuthLoginRequest {
+  password: string;
+  trust_device: boolean;
+}
+
+export async function fetchAuthStatus(): Promise<AuthStatusResponse> {
+  const response = await apiClient.get<AuthStatusResponse>("/auth/status");
+  return response.data;
+}
+
+export async function fetchAuthPreferences(): Promise<AuthPreferencesResponse> {
+  const response = await apiClient.get<AuthPreferencesResponse>("/auth/preferences");
+  return response.data;
+}
+
+export async function loginWithPassword(payload: AuthLoginRequest): Promise<AuthStatusResponse> {
+  const response = await apiClient.post<AuthStatusResponse>("/auth/login", payload);
+  return response.data;
 }
 
 // 健康检查 API
@@ -1738,10 +1788,12 @@ export async function importWorldInfoEntriesStream(
     {
       method: "POST",
       body: formData,
+      credentials: "include",
     },
   );
 
   if (!response.ok) {
+    if (response.status === 401) handleAuthenticationFailure();
     throw new Error(`HTTP error! status: ${response.status}`);
   }
 

--- a/frontend/src/lib/posthog.ts
+++ b/frontend/src/lib/posthog.ts
@@ -38,6 +38,7 @@ async function fetchRuntimeConfig(): Promise<RuntimeConfigResponse | null> {
   try {
     const response = await fetch(`${getApiBaseUrl()}/runtime-config`, {
       cache: "no-store",
+      credentials: "include",
     });
     if (!response.ok) return null;
     return (await response.json()) as RuntimeConfigResponse;

--- a/frontend/src/lib/socket-client.ts
+++ b/frontend/src/lib/socket-client.ts
@@ -1,6 +1,7 @@
 import { io, type Socket } from "socket.io-client";
 
 import i18n from "../i18n";
+import { handleAuthenticationFailure } from "./api-client";
 import { publishSocketDiagnostic, type SocketDiagnosticPayload } from "./desktop-appearance-bridge";
 import { getConfiguredBackendBaseUrl, getRuntimeConfig } from "./runtime-config";
 
@@ -94,7 +95,12 @@ function describeSocketHttpStatus(status: number): string {
 async function probeSocketIoEndpoint(baseUrl: string): Promise<string | null> {
   const url = `${baseUrl.replace(/\/+$/, "")}/socket.io/?EIO=4&transport=polling`;
   try {
-    const response = await fetch(url, { method: "GET", cache: "no-store" });
+    const response = await fetch(url, {
+      method: "GET",
+      cache: "no-store",
+      credentials: "include",
+    });
+    if (response.status === 401) handleAuthenticationFailure();
     if (response.ok) return i18n.t("common.socketProbeOk");
     return describeSocketHttpStatus(response.status);
   } catch {
@@ -135,6 +141,7 @@ function bindConnectionStatus(socket: Socket): void {
     setConnectionStatus("disconnected");
     state.lastConnectionError = getErrorMessage(error);
     state.lastConnectionHttpStatus = getXhrHttpStatus(error);
+    if (state.lastConnectionHttpStatus === 401) handleAuthenticationFailure();
     state.lastConnectionTransport = getSocketTransport(socket);
     reportSocketDiagnostic("connect-error", socket, {
       active: socket.active,
@@ -175,12 +182,14 @@ export function getSocket(): Socket {
       ? io(nextSocketUrl, {
           path: "/socket.io",
           autoConnect: false,
+          withCredentials: true,
           transports: ["websocket", "polling"],
           tryAllTransports: true,
         })
       : io({
           path: "/socket.io",
           autoConnect: false,
+          withCredentials: true,
           transports: ["websocket", "polling"],
           tryAllTransports: true,
         });

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -8,6 +8,7 @@ import App from "./App.tsx";
 import { AppCrashFallback, GlobalLoading } from "./components";
 import { Toaster } from "./components/toaster";
 import { AppLayout } from "./features/app-shell";
+import { AuthPage } from "./features/auth";
 import { CharactersPage } from "./features/characters";
 import { PromptChainsPage } from "./features/prompt-chains";
 import { fetchSettings } from "./features/settings/lib/settings-api";
@@ -16,9 +17,15 @@ import { WorldInfoPage } from "./features/world-info";
 import { WritingPage } from "./features/writing";
 // 初始化 i18n
 import i18n, { type LanguageCode } from "./i18n";
-import { checkHealth } from "./lib/api-client";
+import { checkHealth, fetchAuthPreferences, fetchAuthStatus } from "./lib/api-client";
 import { publishDesktopAppearance, publishDesktopLanguage } from "./lib/desktop-appearance-bridge";
-import { applyCodeFontFamily, applyFontFamily, loadConfiguredFonts } from "./lib/font-utils";
+import {
+  applyBaseFontSize,
+  applyCodeFontFamily,
+  applyEditorFontSize,
+  applyFontFamily,
+  loadConfiguredFonts,
+} from "./lib/font-utils";
 import { getOrCreateRoot } from "./lib/get-or-create-root";
 import { captureException, initErrorTelemetry } from "./lib/posthog";
 import { loadRuntimeConfig } from "./lib/runtime-config";
@@ -56,7 +63,7 @@ const queryClient = new QueryClient({
 const FRONTEND_VERSION = __OPENFIC_FRONTEND_VERSION__;
 const INITIALIZATION_TIMEOUT_MS = 30_000;
 
-type InitializationStage = "health" | "settings" | "tiktoken" | "socket";
+type InitializationStage = "preferences" | "auth" | "health" | "settings" | "tiktoken" | "socket";
 
 class InitializationError extends Error {
   readonly stage: InitializationStage;
@@ -127,6 +134,8 @@ function getInitializationErrorMessage(error: unknown): string {
   }
 
   const stageLabels: Record<InitializationStage, string> = {
+    preferences: i18n.t("common.initializationPreferences"),
+    auth: i18n.t("common.initializationAuth"),
     health: i18n.t("common.initializationHealth"),
     settings: i18n.t("common.initializationSettings"),
     tiktoken: i18n.t("common.initializationTiktoken"),
@@ -207,6 +216,7 @@ function Root() {
   const [appearance, setAppearance] = useState<"light" | "dark">("light");
   const [settings, setSettings] = useState<Settings | null>(null);
   const [isReady, setIsReady] = useState(false);
+  const [requiresAuthentication, setRequiresAuthentication] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const toggleTheme = () => {
@@ -221,6 +231,31 @@ function Root() {
     const initializeApp = async () => {
       try {
         await loadRuntimeConfig();
+        const [preferences, authStatus] = await Promise.all([
+          withInitializationStage("preferences", fetchAuthPreferences()),
+          withInitializationStage("auth", fetchAuthStatus()),
+        ]);
+
+        applyFontFamily(preferences.font_family);
+        applyCodeFontFamily(preferences.code_font_family);
+        applyBaseFontSize(preferences.base_font_size);
+        applyEditorFontSize(preferences.editor_font_size);
+        void loadConfiguredFonts(preferences.font_family, preferences.code_font_family).catch(
+          () => undefined,
+        );
+        if (preferences.language === "zh-CN" || preferences.language === "en") {
+          await i18n.changeLanguage(preferences.language);
+        }
+        if (mounted) setAppearance(preferences.theme === "dark" ? "dark" : "light");
+
+        if (authStatus.enabled && !authStatus.authenticated) {
+          if (mounted) {
+            setRequiresAuthentication(true);
+            setIsReady(true);
+          }
+          return;
+        }
+
         void initErrorTelemetry();
 
         const [, settings] = await Promise.all([
@@ -241,12 +276,15 @@ function Root() {
 
         applyFontFamily(settings.fontFamily);
         applyCodeFontFamily(settings.codeFontFamily);
+        applyBaseFontSize(settings.baseFontSize);
+        applyEditorFontSize(settings.editorFontSize);
         // 字体加载失败不应阻塞初始化：回退到字体栈中的下一个字体即可。
         void loadConfiguredFonts(settings.fontFamily, settings.codeFontFamily).catch(
           () => undefined,
         );
 
         if (mounted) {
+          setRequiresAuthentication(false);
           setSettings(settings);
           setAppearance(settings.theme);
           setIsReady(true);
@@ -307,6 +345,8 @@ function Root() {
                 error={error}
                 onRetry={() => window.location.reload()}
               />
+            ) : requiresAuthentication ? (
+              <AuthPage />
             ) : (
               <ErrorBoundary
                 FallbackComponent={AppCrashFallback}
@@ -321,7 +361,7 @@ function Root() {
               </ErrorBoundary>
             )}
           </Theme>
-          {isReady ? <Toaster appearance={appearance} /> : null}
+          {isReady && !requiresAuthentication ? <Toaster appearance={appearance} /> : null}
         </>
       </QueryClientProvider>
     </StrictMode>


### PR DESCRIPTION
## PR 标题

`chore(auth): 增加可选的应用密码认证`

## 变更说明

- 问题：应用缺少可选的访问密码保护能力，认证 Cookie 在桌面端跨站请求中也可能丢失。
- 重要性：自托管部署需要通过共享密码限制 API、Socket.IO 和资源访问，同时保证 Web 与桌面端登录流程一致。
- 变化：后端增加密码登录、设备信任、签名 Cookie 和认证中间件，并保留认证状态、健康检查及前端壳的公开访问路径。
- 变化：前端增加认证页面、双语文案、公共偏好设置初始化，以及 API 和 Socket.IO 的认证失败处理。
- 变化：桌面端接收并转发后端认证 Cookie，补充后端认证、CLI 参数和 Socket 入口相关测试。

## 关联 Issue / PR

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因

无

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

- 后端：`just check` 通过，Ruff、ty 及 1522 项 pytest 全部通过。
- 前端：`pnpm lint`、`pnpm type-check` 和 `pnpm build` 通过。
- 桌面端：`pnpm lint`、`pnpm type-check` 和 `pnpm build:main` 通过。
- `git diff --check origin/main...HEAD` 通过。
