### PR TITLE
fix(desktop): 修复 Linux 系统下 webview preload 无法加载的问题

### DIFF
--- a/desktop/src/preload/frontend-host-preload-path.mts
+++ b/desktop/src/preload/frontend-host-preload-path.mts
@@ -1,0 +1,5 @@
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export function getFrontendHostPreloadPath(metaUrl: string): string {
+  return pathToFileURL(fileURLToPath(new URL("./frontend-host-preload.cjs", metaUrl))).href;
+}

--- a/desktop/src/preload/preload.mts
+++ b/desktop/src/preload/preload.mts
@@ -1,5 +1,4 @@
 import { contextBridge, ipcRenderer, webFrame } from "electron";
-import { fileURLToPath } from "node:url";
 import {
   IpcChannels,
   type BackupDataRequest,
@@ -33,6 +32,7 @@ import {
   type UpdateState,
 } from "../shared/ipc.js";
 import type { DesktopConfig, DesktopInstance } from "../shared/config.js";
+import { getFrontendHostPreloadPath } from "./frontend-host-preload-path.mjs";
 
 const MIN_ZOOM_FACTOR = 0.7;
 const MAX_ZOOM_FACTOR = 2.0;
@@ -110,7 +110,7 @@ const desktopApi = {
     ipcRenderer.invoke(IpcChannels.restoreData, { instanceId, sourcePath } satisfies RestoreDataRequest),
   inspectLocalRuntime: (installDir: string): Promise<InspectLocalRuntimeResult> =>
     ipcRenderer.invoke(IpcChannels.inspectLocalRuntime, { installDir } satisfies InspectLocalRuntimeRequest),
-  frontendHostPreloadPath: fileURLToPath(new URL("./frontend-host-preload.cjs", import.meta.url)),
+  frontendHostPreloadPath: getFrontendHostPreloadPath(import.meta.url),
   minimizeWindow: (): Promise<void> => ipcRenderer.invoke(IpcChannels.minimizeWindow),
   toggleMaximizeWindow: (): Promise<void> => ipcRenderer.invoke(IpcChannels.toggleMaximizeWindow),
   toggleFullScreen: (): Promise<void> => ipcRenderer.invoke(IpcChannels.toggleFullScreen),


### PR DESCRIPTION
## PR 标题

fix(desktop): 修复 Linux 系统下 webview preload 无法加载的问题

## 变更说明

- 问题: Linux 下 webview 的 preload 传入 POSIX 文件路径后，会相对 `app://setup/ui.html` 解析为 `app:` URL 并被 Electron 拒绝加载。
- 重要性: preload 未加载会导致壳层主题、字体和语言无法同步，同时 webview 内的快捷键与 Ctrl+滚轮缩放失效。
- 变化: 将 frontend host preload 的路径显式转换为 `file:` URL，消除对平台路径解析行为的依赖。

## 关联 Issue / PR

Closes #336

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因

`<webview>` 的 `preload` 属性要求最终解析结果使用 `file:` 协议。Windows 将盘符路径规范化为 `file:` URL；Linux 的绝对 POSIX 路径会被相对壳层的 `app:` URL 解析，因此 Electron 拒绝加载 preload。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

无
