### PR TITLE
fix(agent): 阻止 ask_user 传入空问题导致中断

### DIFF
--- a/backend/app/agent_runtime/tools/impls/interaction/ask_user.py
+++ b/backend/app/agent_runtime/tools/impls/interaction/ask_user.py
@@ -21,6 +21,7 @@ class Question(BaseModel):
 
 class AskUserInput(BaseModel):
     questions: list[Question] = Field(
+        min_length=1,
         description="问题列表，同一批问题之间不得存在答案依赖关系",
     )
 

--- a/backend/tests/agent_runtime/tools/test_ask_user.py
+++ b/backend/tests/agent_runtime/tools/test_ask_user.py
@@ -34,6 +34,17 @@ def _valid_input() -> dict:
 
 
 class TestAskUser:
+    async def test_ask_user_rejects_empty_questions(self):
+        from app.agent_runtime.tools.impls.interaction.ask_user import AskUserTool
+
+        tool = AskUserTool(_state=_make_state())
+
+        with patch("app.agent_runtime.tools.impls.interaction.ask_user.interrupt") as mock_interrupt:
+            result = await tool.ainvoke({"questions": []})
+
+        assert "参数校验失败" in result
+        mock_interrupt.assert_not_called()
+
     async def test_ask_user_triggers_interrupt(self):
         from langgraph.errors import GraphInterrupt
         from app.agent_runtime.tools.impls.interaction.ask_user import AskUserTool

--- a/frontend/src/features/assistant/components/agent/agent-special-panels-state.ts
+++ b/frontend/src/features/assistant/components/agent/agent-special-panels-state.ts
@@ -76,6 +76,7 @@ function isVisibleActiveSpecialPanelMessage(message: AgentMessage): boolean {
 }
 
 function getQuestionSummary(prompt: ClarificationPromptData): string {
+  if (prompt.questions.length === 0) return "";
   return i18n.t("assistant.tools.questionCount", { count: prompt.questions.length });
 }
 
@@ -86,8 +87,6 @@ export function getAgentSpecialPanels(messages: AgentMessage[]): AgentSpecialPan
 
       if (message.type === "question") {
         const prompt = getClarificationPromptData(message);
-        if (prompt.questions.length === 0) return panels;
-
         panels.push({
           id: message.id,
           kind: "question",

--- a/frontend/src/features/assistant/components/agent/message-blocks/panels/clarification-special-panel.tsx
+++ b/frontend/src/features/assistant/components/agent/message-blocks/panels/clarification-special-panel.tsx
@@ -73,6 +73,7 @@ function ClarificationSpecialPanelContent({
 }: ClarificationSpecialPanelContentProps) {
   const { t } = useTranslation();
   const [isCollapsed, setIsCollapsed] = useState(false);
+  const hasQuestions = prompt.questions.length > 0;
   const model = useClarificationQuestionFlow(prompt, {
     onSubmitQuestionAnswer: (actionId, answer) => {
       if (onBatchDecision) {
@@ -85,7 +86,21 @@ function ClarificationSpecialPanelContent({
   const collapseLabel = isCollapsed
     ? t("assistant.specialPanels.expandQuestionPanel")
     : t("assistant.specialPanels.collapseQuestionPanel");
-  const content = readOnly ? (
+  const handleSkip = () => {
+    if (onBatchDecision) {
+      onBatchDecision(panel, { skipped: true });
+      return;
+    }
+    onSkipQuestion?.(prompt.actionId);
+  };
+  const content = !hasQuestions ? (
+    <Text
+      size="2"
+      color="red"
+    >
+      {t("assistant.specialPanels.invalidQuestion")}
+    </Text>
+  ) : readOnly ? (
     <Flex
       direction="column"
       gap="3"
@@ -162,7 +177,7 @@ function ClarificationSpecialPanelContent({
       }
       content={content}
       actions={
-        readOnly ? undefined : (
+        readOnly ? undefined : hasQuestions ? (
           <ClarificationQuestionActions
             model={model}
             leadingAction={
@@ -172,18 +187,23 @@ function ClarificationSpecialPanelContent({
                 size="1"
                 type="button"
                 className="agent-clarification-skip-button"
-                onClick={() => {
-                  if (onBatchDecision) {
-                    onBatchDecision(panel, { skipped: true });
-                    return;
-                  }
-                  onSkipQuestion?.(prompt.actionId);
-                }}
+                onClick={handleSkip}
               >
                 {t("assistant.clarification.ignore")}
               </Button>
             }
           />
+        ) : (
+          <Button
+            variant="ghost"
+            color="gray"
+            size="1"
+            type="button"
+            className="agent-clarification-skip-button"
+            onClick={handleSkip}
+          >
+            {t("assistant.clarification.ignore")}
+          </Button>
         )
       }
     />

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1779,6 +1779,7 @@
     },
     "specialPanels": {
       "clarificationTitle": "More information needed",
+      "invalidQuestion": "The Agent returned an empty question, which cannot be answered. Ignore it to end this session.",
       "collapseQuestionPanel": "Collapse question panel",
       "expandQuestionPanel": "Expand question panel",
       "approvalTitle": "Approval required",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1842,6 +1842,7 @@
     },
     "specialPanels": {
       "clarificationTitle": "需要补充信息",
+      "invalidQuestion": "Agent 返回了空问题，无法回答。请忽略以结束本次会话。",
       "collapseQuestionPanel": "收起提问面板",
       "expandQuestionPanel": "展开提问面板",
       "approvalTitle": "需要审批",


### PR DESCRIPTION
## PR 标题

fix(agent): 阻止 ask_user 传入空问题导致中断

## 变更说明

- 问题: `ask_user` 接受空问题数组后会创建没有可操作面板的暂停状态。
- 重要性: 会话会卡在等待回答，用户无法继续、忽略或停止会话。
- 变化: 服务端拒绝空问题数组；前端为历史空中断展示错误说明和“忽略”操作。
- 验证: 定向后端测试、后端 lint/typecheck 与前端 type-check/lint/format:check 均通过。

## 关联 Issue / PR

Closes #338

## 变更类型

- [x] 错误修复 (fix)
- [ ] 新功能 (feat)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因

`AskUserInput.questions` 未限制最小长度，空数组通过校验后直接触发中断；前端收到空问题时会进入等待回答状态，但不会渲染提问面板。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

无
