### PR TITLE
fix(backend): 修正兼容接口模型发现 URL

### DIFF
--- a/backend/app/models/adapters/anthropic_compatible.py
+++ b/backend/app/models/adapters/anthropic_compatible.py
@@ -1,4 +1,4 @@
-"""Anthropic-compatible adapter without a model discovery endpoint."""
+"""Anthropic-compatible provider adapter."""
 
 import httpx
 
@@ -18,7 +18,32 @@ class AnthropicCompatibleAdapter(BaseAdapter):
     async def get_llm_models(
         self, client: httpx.AsyncClient, base_url: str, api_key: str
     ) -> list[dict[str, str]]:
-        return []
+        url = self._normalize_url(base_url)
+        for suffix in ("/anthropic", "/claude"):
+            if url.endswith(suffix):
+                url = url.removesuffix(suffix)
+                break
+        if not url.endswith("/v1"):
+            url = f"{url}/v1"
+
+        response = await client.get(
+            f"{url}/models",
+            headers={
+                "x-api-key": api_key,
+                "anthropic-version": "2023-06-01",
+            },
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        return [
+            {
+                "id": model_id,
+                "name": model.get("display_name", model_id),
+            }
+            for model in data.get("data", [])
+            if (model_id := model.get("id"))
+        ]
 
     async def get_embedding_models(
         self, client: httpx.AsyncClient, base_url: str, api_key: str

--- a/backend/app/models/adapters/openai_compatible.py
+++ b/backend/app/models/adapters/openai_compatible.py
@@ -44,7 +44,8 @@ class OpenAICompatibleAdapter(BaseAdapter):
         self, client: httpx.AsyncClient, base_url: str, api_key: str
     ) -> list[dict[str, str]]:
         """获取所有可用模型。"""
-        url = f"{self._normalize_url(base_url)}/models"
+        url = self._normalize_url(base_url)
+        url = f"{url}/models" if url.endswith("/v1") else f"{url}/v1/models"
         headers = self._build_auth_header(api_key) if api_key else {}
 
         try:

--- a/backend/tests/api/test_model_providers.py
+++ b/backend/tests/api/test_model_providers.py
@@ -248,9 +248,24 @@ async def test_validate_provider_invalid_credentials(
 
 
 @pytest.mark.asyncio
-async def test_validate_anthropic_compatible_provider_succeeds_without_model_discovery(
+@respx.mock
+async def test_validate_anthropic_compatible_provider_discovers_models(
     client: AsyncClient,
 ):
+    route = respx.get("https://gateway.example/v1/models").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "data": [
+                    {
+                        "id": "claude-3-5-sonnet-20241022",
+                        "display_name": "Claude 3.5 Sonnet",
+                    }
+                ]
+            },
+        )
+    )
+
     response = await client.post(
         "/api/v1/model-providers/validate",
         json={
@@ -263,18 +278,35 @@ async def test_validate_anthropic_compatible_provider_succeeds_without_model_dis
     assert response.status_code == 200
     assert response.json() == {
         "success": True,
-        "message": "连接验证成功，但该提供商可能不支持模型列表 API",
-        "models": [],
+        "message": "连接验证成功",
+        "models": [
+            {
+                "id": "claude-3-5-sonnet-20241022",
+                "name": "Claude 3.5 Sonnet",
+                "task_type": None,
+                "metadata": None,
+            }
+        ],
     }
+    assert route.calls[0].request.headers["x-api-key"] == "test-key"
+    assert route.calls[0].request.headers["anthropic-version"] == "2023-06-01"
 
 
 @pytest.mark.asyncio
-async def test_get_anthropic_compatible_provider_models_returns_empty_success(
+@respx.mock
+async def test_get_anthropic_compatible_provider_models_discovers_models(
     client: AsyncClient,
     session: AsyncSession,
 ):
     from app.core.encryption import EncryptionService
     from app.settings import settings
+
+    respx.get("https://gateway.example/v1/models").mock(
+        return_value=httpx.Response(
+            200,
+            json={"data": [{"id": "claude-3-5-haiku-20241022"}]},
+        )
+    )
 
     encrypted_key = EncryptionService(settings.encryption_key).encrypt("test-key")
     provider = await model_provider_repo.create(
@@ -291,8 +323,15 @@ async def test_get_anthropic_compatible_provider_models_returns_empty_success(
     assert response.status_code == 200
     assert response.json() == {
         "success": True,
-        "message": "该提供商可能不支持模型列表 API",
-        "models": [],
+        "message": "获取模型列表成功",
+        "models": [
+            {
+                "id": "claude-3-5-haiku-20241022",
+                "name": "claude-3-5-haiku-20241022",
+                "task_type": "llm",
+                "metadata": None,
+            }
+        ],
     }
 
 

--- a/backend/tests/models/test_anthropic_compatible_adapter.py
+++ b/backend/tests/models/test_anthropic_compatible_adapter.py
@@ -18,13 +18,25 @@ class _RecordingClient:
 
 
 @pytest.mark.asyncio
-async def test_anthropic_compatible_adapter_only_supports_llm_without_model_discovery() -> None:
+@pytest.mark.parametrize(
+    ("base_url", "expected_url"),
+    [
+        ("https://gateway.example/anthropic", "https://gateway.example/v1/models"),
+        ("https://gateway.example/claude/", "https://gateway.example/v1/models"),
+        ("https://gateway.example/v1/anthropic", "https://gateway.example/v1/models"),
+        ("https://gateway.example/v1/claude/", "https://gateway.example/v1/models"),
+        ("https://gateway.example/v1/", "https://gateway.example/v1/models"),
+    ],
+)
+async def test_anthropic_compatible_adapter_discovers_models_from_v1_endpoint(
+    base_url: str, expected_url: str
+) -> None:
     adapter = AdapterRegistry.get_adapter("anthropic-compatible")
     client = _RecordingClient()
 
     models = await adapter.get_llm_models(
         client,  # type: ignore[arg-type]
-        "https://gateway.example/v1",
+        base_url,
         "test-key",
     )
 
@@ -32,5 +44,5 @@ async def test_anthropic_compatible_adapter_only_supports_llm_without_model_disc
     assert adapter.supports_llm()
     assert not adapter.supports_embedding()
     assert not adapter.supports_rerank()
-    assert models == []
-    assert client.urls == []
+    assert models == [{"id": "unexpected-model", "name": "unexpected-model"}]
+    assert client.urls == [expected_url]

--- a/backend/tests/models/test_openai_compatible_adapter.py
+++ b/backend/tests/models/test_openai_compatible_adapter.py
@@ -1,0 +1,32 @@
+import httpx
+import pytest
+import respx
+
+from app.models.registry import AdapterRegistry
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("base_url", "expected_url"),
+    [
+        ("https://gateway.example/v1/", "https://gateway.example/v1/models"),
+        ("https://gateway.example/openai", "https://gateway.example/openai/v1/models"),
+    ],
+)
+@respx.mock
+async def test_openai_compatible_adapter_discovers_models_from_v1_endpoint(
+    base_url: str, expected_url: str
+) -> None:
+    route = respx.get(expected_url).mock(
+        return_value=httpx.Response(
+            200,
+            json={"data": [{"id": "test-model", "name": "Test Model"}]},
+        )
+    )
+    adapter = AdapterRegistry.get_adapter("openai-compatible")
+
+    async with httpx.AsyncClient() as client:
+        models = await adapter.get_llm_models(client, base_url, "test-key")
+
+    assert models == [{"id": "test-model", "name": "Test Model"}]
+    assert route.called


### PR DESCRIPTION
## PR 标题

fix(backend): 修正兼容接口模型发现 URL

## 变更说明

- 问题: Anthropic Compatible 不会请求模型列表，OpenAI Compatible 在基础 URL 未包含 `/v1` 时请求了错误地址。
- 重要性: 使用兼容网关时，模型选择列表无法正常加载。
- 变化: Anthropic Compatible 会清理末尾的 `/anthropic` 或 `/claude`，再请求正确的模型列表端点。
- 变化: OpenAI Compatible 会根据 URL 是否以 `/v1` 结尾选择 `/models` 或 `/v1/models`。
- 验证: `uv run pytest tests/models/test_anthropic_compatible_adapter.py tests/models/test_openai_compatible_adapter.py tests/models/test_model_provider_service.py tests/api/test_model_providers.py -q`（27 passed）、`just lint`、`just type-check`。

## 关联 Issue / PR

Closes #340 

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因

兼容适配器未按模型列表接口的路径规则补齐 `/v1`，Anthropic Compatible 还直接返回空列表。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

无
