### PR TITLE
fix(agent): 统一工具错误处理

### DIFF
--- a/backend/app/agent_runtime/context/processors/filter.py
+++ b/backend/app/agent_runtime/context/processors/filter.py
@@ -164,7 +164,23 @@ def filter_tool_result_metadata_content(content: str) -> str:
         return message
     error = payload.get("error")
     if isinstance(error, str) and error.strip():
-        return error.strip()
+        message = error.strip()
+        if visible_fields := {
+            key: payload[key]
+            for key in _MODEL_VISIBLE_FAILURE_FIELDS
+            if key in payload
+        }:
+            return json.dumps(
+                {
+                    "type": "fail",
+                    "success": False,
+                    "code": "execution_failed",
+                    "message": message,
+                    **visible_fields,
+                },
+                ensure_ascii=False,
+            )
+        return message
     if "metadata" not in payload:
         return content
     return json.dumps(

--- a/backend/app/agent_runtime/context/processors/filter.py
+++ b/backend/app/agent_runtime/context/processors/filter.py
@@ -143,9 +143,21 @@ def filter_tool_result_metadata_content(content: str) -> str:
     payload = _parse_tool_result(content)
     if payload is None:
         return content
+    if payload.get("type") == "control":
+        if "metadata" not in payload:
+            return content
+        return json.dumps(
+            {key: value for key, value in payload.items() if key != "metadata"},
+            ensure_ascii=False,
+        )
     if payload.get("type") == "fail" or payload.get("success") is False:
         message = payload.get("message") or payload.get("error")
-        message = message.strip() if isinstance(message, str) else "工具执行失败"
+        if not isinstance(message, str) or not message.strip():
+            code = payload.get("code")
+            code = code if isinstance(code, str) and code else "execution_failed"
+            message = f"工具错误（{code}）：未提供具体错误消息"
+        else:
+            message = message.strip()
         visible_fields = {
             key: payload[key]
             for key in _MODEL_VISIBLE_FAILURE_FIELDS

--- a/backend/app/agent_runtime/context/processors/filter.py
+++ b/backend/app/agent_runtime/context/processors/filter.py
@@ -5,6 +5,7 @@ from typing import Any
 from app.agent_runtime.context.types import ContextMessage
 
 _DROPPED_KINDS = {"thinking", "reasoning", "ui_only"}
+_MODEL_VISIBLE_FAILURE_FIELDS = ("dispatch_id", "agent_key", "agent_number")
 
 
 def _is_history(m: ContextMessage) -> bool:
@@ -140,7 +141,31 @@ def _parse_tool_result(content: str) -> dict[str, Any] | None:
 def filter_tool_result_metadata_content(content: str) -> str:
     """返回可发送给模型的工具结果内容。"""
     payload = _parse_tool_result(content)
-    if payload is None or "metadata" not in payload:
+    if payload is None:
+        return content
+    if payload.get("type") == "fail" or payload.get("success") is False:
+        message = payload.get("message") or payload.get("error")
+        message = message.strip() if isinstance(message, str) else "工具执行失败"
+        visible_fields = {
+            key: payload[key]
+            for key in _MODEL_VISIBLE_FAILURE_FIELDS
+            if key in payload
+        }
+        if visible_fields:
+            return json.dumps(
+                {
+                    key: payload[key]
+                    for key in ("type", "success", "code")
+                    if key in payload
+                }
+                | {"message": message, **visible_fields},
+                ensure_ascii=False,
+            )
+        return message
+    error = payload.get("error")
+    if isinstance(error, str) and error.strip():
+        return error.strip()
+    if "metadata" not in payload:
         return content
     return json.dumps(
         {key: value for key, value in payload.items() if key != "metadata"},

--- a/backend/app/agent_runtime/graph/react_agent.py
+++ b/backend/app/agent_runtime/graph/react_agent.py
@@ -59,6 +59,13 @@ from app.agent_runtime.graph.llm_invoke import (
     load_llm_invoke_settings,
 )
 from app.agent_runtime.persistence import compaction_repo
+from app.agent_runtime.tools.base import AgentTool
+from app.agent_runtime.tools.errors import (
+    ToolFailure,
+    log_tool_failure,
+    normalize_tool_failure_result,
+    serialize_tool_failure,
+)
 from app.agent_runtime.tool_call_recovery import (
     build_malformed_tool_call_error,
     is_malformed_tool_call,
@@ -203,11 +210,21 @@ def _tool_result_payload(value: Any) -> tuple[dict[str, Any], bool]:
         except json.JSONDecodeError:
             return {"output": value}, True
         if isinstance(parsed, dict):
-            return parsed, "error" not in parsed
+            success = parsed.get("success")
+            return parsed, (
+                success
+                if isinstance(success, bool)
+                else parsed.get("type") != "fail" and "error" not in parsed
+            )
         return {"output": parsed}, True
     if isinstance(value, Mapping):
         payload = dict(value)
-        return payload, "error" not in payload
+        success = payload.get("success")
+        return payload, (
+            success
+            if isinstance(success, bool)
+            else payload.get("type") != "fail" and "error" not in payload
+        )
     return {"output": value}, True
 
 
@@ -913,10 +930,14 @@ def create_react_agent(
             return {key: [outcome]}
 
         if state.get("tool_dispatch_denied"):
-            payload = {
-                "error": "dispatch_subagent allows at most 10 dispatches per PA turn"
-            }
-            result = json.dumps(payload, ensure_ascii=False)
+            failure = ToolFailure(
+                code="limit_exceeded",
+                message="dispatch_subagent allows at most 10 dispatches per PA turn",
+                trace={"source": "tool_dispatch"},
+            )
+            log_tool_failure(failure, tool_name=tool_name, tool_call_id=tool_id)
+            payload = failure.to_result()
+            result = serialize_tool_failure(failure)
             return outcome_update(
                 {
                         "index": tool_index,
@@ -935,8 +956,15 @@ def create_react_agent(
             )
 
         if is_malformed_tool_call(tool_call):
-            payload = build_malformed_tool_call_error(tool_call)
-            result = json.dumps(payload, ensure_ascii=False)
+            malformed_payload = build_malformed_tool_call_error(tool_call)
+            failure = ToolFailure(
+                code="malformed_tool_call",
+                message=str(malformed_payload["message"]),
+                trace={"source": "tool_call_recovery"},
+            )
+            log_tool_failure(failure, tool_name=tool_name, tool_call_id=tool_id)
+            payload = failure.to_result()
+            result = serialize_tool_failure(failure)
             return outcome_update(
                 {
                         "index": tool_index,
@@ -956,8 +984,14 @@ def create_react_agent(
 
         tool_instance = tool_map.get(tool_name)
         if tool_instance is None:
-            payload = {"error": f"tool '{tool_name}' not found."}
-            result = f"Error: tool '{tool_name}' not found."
+            failure = ToolFailure(
+                code="tool_not_found",
+                message=f"未找到工具：{tool_name}",
+                trace={"source": "tool_dispatch"},
+            )
+            log_tool_failure(failure, tool_name=tool_name, tool_call_id=tool_id)
+            payload = failure.to_result()
+            result = serialize_tool_failure(failure)
             return outcome_update(
                 {
                         "index": tool_index,
@@ -1007,15 +1041,8 @@ def create_react_agent(
                 tool_result_sink = _get_configurable(config).get("tool_result_sink")
                 if callable(tool_result_sink):
                     rejected_payload = dict(prepared_outcome.get("payload") or {})
-                    rejected_payload.update(
-                        {
-                            "type": "fail",
-                            "success": False,
-                            "reason": "tool_error",
-                            "tool_call_id": tool_id,
-                            "tool_name": tool_name,
-                        }
-                    )
+                    rejected_payload.setdefault("tool_call_id", tool_id)
+                    rejected_payload.setdefault("tool_name", tool_name)
                     await _maybe_await(
                         tool_result_sink(
                             {
@@ -1081,6 +1108,8 @@ def create_react_agent(
             if isolated_session is not None:
                 await _close_maybe(isolated_session)
 
+        if not isinstance(tool_instance, AgentTool):
+            result, _ = normalize_tool_failure_result(result)
         payload, success = _tool_result_payload(result)
         if phase == "prepare" and not getattr(
             tool_instance, "execute_during_prepare", False
@@ -1173,6 +1202,11 @@ def create_react_agent(
             f"Agent 单轮最多调用 {TOOL_BATCH_SIZE} 个工具，"
             "超出上限的工具调用未执行"
         )
+        failure = ToolFailure(
+            code="limit_exceeded",
+            message=error_message,
+            trace={"source": "tool_dispatch"},
+        )
         for message in reversed(state["messages"]):
             if isinstance(message, AIMessage) and message.tool_calls:
                 for offset, tool_call in enumerate(
@@ -1182,8 +1216,9 @@ def create_react_agent(
                     tool_id = str(tool_call.get("id") or "")
                     tool_args = tool_call.get("args")
                     tool_args = tool_args if isinstance(tool_args, dict) else {}
-                    payload = {"error": error_message}
-                    result = json.dumps(payload, ensure_ascii=False)
+                    log_tool_failure(failure, tool_name=tool_name, tool_call_id=tool_id)
+                    payload = failure.to_result()
+                    result = serialize_tool_failure(failure)
                     excess_outcomes.append(
                         {
                             "index": TOOL_BATCH_SIZE + offset,
@@ -1207,14 +1242,12 @@ def create_react_agent(
             tool_result_sink = _get_configurable(config).get("tool_result_sink")
             if callable(tool_result_sink):
                 for outcome in excess_outcomes:
-                    output_payload = {
-                        "type": "fail",
-                        "success": False,
-                        "reason": "tool_error",
-                        "message": error_message,
-                        "tool_call_id": outcome["tool_call_id"],
-                        "tool_name": outcome["tool_name"],
-                    }
+                    output_payload = failure.to_result(
+                        {
+                            "tool_call_id": outcome["tool_call_id"],
+                            "tool_name": outcome["tool_name"],
+                        }
+                    )
                     result = tool_result_sink(
                         {
                             "session_id": _get_configurable(config).get("session_id"),

--- a/backend/app/agent_runtime/graph/react_agent.py
+++ b/backend/app/agent_runtime/graph/react_agent.py
@@ -1167,7 +1167,6 @@ def create_react_agent(
                 _record_audit_error(active_audit, exc)
             failure = tool_failure_from_exception(
                 exc,
-                code="execution_failed",
                 source="tool_execution",
             )
             log_tool_failure(
@@ -1176,6 +1175,23 @@ def create_react_agent(
                 tool_call_id=tool_id,
                 exception=exc,
             )
+            if phase == "execute":
+                tool_result_sink = _get_configurable(config).get("tool_result_sink")
+                if callable(tool_result_sink):
+                    output_payload = failure.to_result(
+                        {"tool_call_id": tool_id, "tool_name": tool_name}
+                    )
+                    await _maybe_await(
+                        tool_result_sink(
+                            {
+                                "session_id": _get_configurable(config).get("session_id"),
+                                "tool_call_id": tool_id,
+                                "tool_name": tool_name,
+                                "input": tool_args,
+                                "output": output_payload,
+                            }
+                        )
+                    )
             return outcome_update(failure_outcome(failure))
         finally:
             if isolated_session is not None:

--- a/backend/app/agent_runtime/graph/react_agent.py
+++ b/backend/app/agent_runtime/graph/react_agent.py
@@ -62,9 +62,11 @@ from app.agent_runtime.persistence import compaction_repo
 from app.agent_runtime.tools.base import AgentTool
 from app.agent_runtime.tools.errors import (
     ToolFailure,
+    ToolResult,
     log_tool_failure,
     normalize_tool_failure_result,
     serialize_tool_failure,
+    tool_failure_from_exception,
 )
 from app.agent_runtime.tool_call_recovery import (
     build_malformed_tool_call_error,
@@ -108,6 +110,35 @@ class ReactState(TypedDict, total=False):
 # ---------------------------------------------------------------------------
 
 
+def _checkpoint_safe_value(value: Any, active_ids: set[int] | None = None) -> Any:
+    if value is None or isinstance(value, (bool, int, float, bytes)):
+        return value
+    if isinstance(value, str):
+        return str(value)
+
+    active_ids = active_ids if active_ids is not None else set()
+    value_id = id(value)
+    if value_id in active_ids:
+        return "<recursive>"
+    active_ids.add(value_id)
+    try:
+        if isinstance(value, Mapping):
+            return {
+                str(key): _checkpoint_safe_value(item, active_ids)
+                for key, item in value.items()
+            }
+        if isinstance(value, (list, tuple)):
+            return [_checkpoint_safe_value(item, active_ids) for item in value]
+        if isinstance(value, (set, frozenset)):
+            return [_checkpoint_safe_value(item, active_ids) for item in value]
+        model_dump = getattr(value, "model_dump", None)
+        if callable(model_dump):
+            return _checkpoint_safe_value(model_dump(mode="python"), active_ids)
+        return str(value)
+    finally:
+        active_ids.remove(value_id)
+
+
 async def _invoke_model(
     model: Any,
     messages: list[BaseMessage],
@@ -133,10 +164,23 @@ async def _invoke_model(
 
     normalized = AIMessage(
         content=extract_text_content(response.content),
-        additional_kwargs=dict(response.additional_kwargs or {}),
-        response_metadata=dict(response.response_metadata or {}),
-        tool_calls=recover_message_tool_calls(response),
-        usage_metadata=response.usage_metadata,
+        additional_kwargs=cast(
+            dict[str, Any],
+            _checkpoint_safe_value(response.additional_kwargs or {}),
+        ),
+        response_metadata=cast(
+            dict[str, Any],
+            _checkpoint_safe_value(response.response_metadata or {}),
+        ),
+        tool_calls=cast(
+            list[dict[str, Any]],
+            _checkpoint_safe_value(recover_message_tool_calls(response)),
+        ),
+        usage_metadata=(
+            cast(dict[str, Any], _checkpoint_safe_value(response.usage_metadata))
+            if response.usage_metadata is not None
+            else None
+        ),
         id=response.id,
         name=response.name,
     )
@@ -203,28 +247,29 @@ def _record_audit_error(audit: LLMCallAudit, exc: BaseException) -> None:
     )
 
 
+def _tool_result_success(payload: Mapping[str, Any]) -> bool:
+    success = payload.get("success")
+    return (
+        success
+        if isinstance(success, bool)
+        else payload.get("type") != "fail" and "error" not in payload
+    )
+
+
 def _tool_result_payload(value: Any) -> tuple[dict[str, Any], bool]:
+    if isinstance(value, ToolResult):
+        return value.payload, _tool_result_success(value.payload)
     if isinstance(value, str):
         try:
             parsed = json.loads(value)
         except json.JSONDecodeError:
             return {"output": value}, True
         if isinstance(parsed, dict):
-            success = parsed.get("success")
-            return parsed, (
-                success
-                if isinstance(success, bool)
-                else parsed.get("type") != "fail" and "error" not in parsed
-            )
+            return parsed, _tool_result_success(parsed)
         return {"output": parsed}, True
     if isinstance(value, Mapping):
         payload = dict(value)
-        success = payload.get("success")
-        return payload, (
-            success
-            if isinstance(success, bool)
-            else payload.get("type") != "fail" and "error" not in payload
-        )
+        return payload, _tool_result_success(payload)
     return {"output": value}, True
 
 
@@ -929,6 +974,24 @@ def create_react_agent(
             key = "tool_prepared_outcomes" if phase == "prepare" else "tool_outcomes"
             return {key: [outcome]}
 
+        def failure_outcome(failure: ToolFailure) -> dict[str, Any]:
+            payload = failure.to_result()
+            result = serialize_tool_failure(failure)
+            return {
+                "index": tool_index,
+                "tool_call_id": tool_id,
+                "tool_name": tool_name,
+                "tool_args": tool_args,
+                "message": ToolMessage(
+                    content=result,
+                    tool_call_id=tool_id,
+                    name=tool_name,
+                ),
+                "payload": payload,
+                "success": False,
+                "latency_ms": int((time.perf_counter() - started_at) * 1000),
+            }
+
         if state.get("tool_dispatch_denied"):
             failure = ToolFailure(
                 code="limit_exceeded",
@@ -1102,8 +1165,18 @@ def create_react_agent(
         except Exception as exc:
             if active_audit is not None:
                 _record_audit_error(active_audit, exc)
-            await _finish_active_audit(status="error")
-            raise
+            failure = tool_failure_from_exception(
+                exc,
+                code="execution_failed",
+                source="tool_execution",
+            )
+            log_tool_failure(
+                failure,
+                tool_name=tool_name,
+                tool_call_id=tool_id,
+                exception=exc,
+            )
+            return outcome_update(failure_outcome(failure))
         finally:
             if isolated_session is not None:
                 await _close_maybe(isolated_session)

--- a/backend/app/agent_runtime/persistence/persister.py
+++ b/backend/app/agent_runtime/persistence/persister.py
@@ -208,12 +208,12 @@ class MessagePersister:
         for tool_call in tool_calls:
             if not is_malformed_tool_call(tool_call):
                 continue
-            content = _failure_content(
-                code="malformed_tool_call",
-                message="工具参数 JSON 无法解析，未执行工具调用",
-                source="tool_call_recovery",
-                tool_name=tool_call["name"],
-                tool_call_id=tool_call["id"],
+            content = serialize_tool_failure(
+                ToolFailure(
+                    code="malformed_tool_call",
+                    message="工具参数 JSON 无法解析，未执行工具调用",
+                    trace={"source": "tool_call_recovery"},
+                )
             )
             await self._write(
                 role="tool",
@@ -292,6 +292,7 @@ class MessagePersister:
                 failure,
                 tool_name=tool_name,
                 tool_call_id=tool_call_id,
+                exception=error if isinstance(error, BaseException) else None,
             )
             content = serialize_tool_failure(failure)
         await self._write(

--- a/backend/app/agent_runtime/persistence/persister.py
+++ b/backend/app/agent_runtime/persistence/persister.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import Literal
 
+from langgraph.errors import GraphInterrupt
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.content_blocks import extract_reasoning_content, extract_text_content
@@ -18,14 +19,38 @@ from app.agent_runtime.persistence.child_runs import (
 )
 from app.agent_runtime.persistence.errors import PersistenceWriteError
 from app.agent_runtime.runner.event_scope import is_subagent_child_event
+from app.agent_runtime.tools.errors import (
+    ToolErrorCode,
+    ToolFailure,
+    log_tool_failure,
+    serialize_tool_failure,
+    tool_failure_from_error,
+)
 from app.agent_runtime.tool_call_recovery import (
-    build_malformed_tool_call_error,
     is_malformed_tool_call,
     reconcile_tool_call_chunks,
     recover_message_tool_calls,
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _failure_content(
+    *,
+    code: ToolErrorCode,
+    message: str,
+    source: str,
+    tool_name: str,
+    tool_call_id: str | None,
+    extra: dict[str, object] | None = None,
+) -> str:
+    failure = ToolFailure(
+        code=code,
+        message=message,
+        trace={"source": source},
+    )
+    log_tool_failure(failure, tool_name=tool_name, tool_call_id=tool_call_id)
+    return serialize_tool_failure(failure, extra)
 
 
 @dataclass
@@ -183,13 +208,17 @@ class MessagePersister:
         for tool_call in tool_calls:
             if not is_malformed_tool_call(tool_call):
                 continue
+            content = _failure_content(
+                code="malformed_tool_call",
+                message="工具参数 JSON 无法解析，未执行工具调用",
+                source="tool_call_recovery",
+                tool_name=tool_call["name"],
+                tool_call_id=tool_call["id"],
+            )
             await self._write(
                 role="tool",
                 status="complete",
-                content=json.dumps(
-                    build_malformed_tool_call_error(tool_call),
-                    ensure_ascii=False,
-                ),
+                content=content,
                 tool_call_id=tool_call["id"],
                 tool_name=tool_call["name"],
             )
@@ -243,11 +272,10 @@ class MessagePersister:
         if not tool_call_id or not tool_name:
             return
 
-        self._previewed_tool_runs.add(run_id)
-        await self._write(
-            role="tool",
-            status="complete",
-            content=json.dumps(
+        error = event.get("data", {}).get("error")
+        if isinstance(error, GraphInterrupt):
+            self._previewed_tool_runs.add(run_id)
+            content = json.dumps(
                 {
                     "type": "ok",
                     "success": True,
@@ -257,10 +285,24 @@ class MessagePersister:
                     "tool_name": tool_name,
                 },
                 ensure_ascii=False,
-            ),
+            )
+        else:
+            failure = tool_failure_from_error(error, source="subagent_tool")
+            log_tool_failure(
+                failure,
+                tool_name=tool_name,
+                tool_call_id=tool_call_id,
+            )
+            content = serialize_tool_failure(failure)
+        await self._write(
+            role="tool",
+            status="complete",
+            content=content,
             tool_call_id=tool_call_id,
             tool_name=tool_name,
         )
+        if not isinstance(error, GraphInterrupt):
+            self._pending_tools.pop(run_id, None)
 
     async def persist_node_event(self, payload: dict) -> None:
         if payload.get("session_id") != self.session_id:
@@ -481,7 +523,13 @@ class MessagePersister:
                     await self._write(
                         role="tool",
                         status="aborted",
-                        content="[中断] 工具未执行",
+                        content=_failure_content(
+                            code="execution_failed",
+                            message="工具未执行",
+                            source="persistence_finalize",
+                            tool_name=tc["name"],
+                            tool_call_id=tc["id"],
+                        ),
                         tool_call_id=tc["id"],
                         tool_name=tc["name"],
                     )
@@ -498,7 +546,14 @@ class MessagePersister:
                 await self._write(
                     role="tool",
                     status="aborted",
-                    content=content or "[中断] 工具执行未完成",
+                    content=content
+                    or _failure_content(
+                        code="execution_failed",
+                        message="工具执行未完成",
+                        source="persistence_finalize",
+                        tool_name=pending.tool_name,
+                        tool_call_id=pending.tool_call_id,
+                    ),
                     tool_call_id=pending.tool_call_id,
                     tool_name=pending.tool_name,
                 )
@@ -544,14 +599,17 @@ class MessagePersister:
         if child_run is None or not child_run.is_active:
             return None
 
-        return json.dumps(
-            {
+        return _failure_content(
+            code="execution_failed",
+            message="subagent 会话已被用户中断，要通知其继续工作请使用 notify_subagent",
+            source="persistence_finalize",
+            tool_name=pending.tool_name,
+            tool_call_id=pending.tool_call_id,
+            extra={
                 "dispatch_id": child_run.dispatch_id,
                 "agent_key": child_run.agent_key,
                 "agent_number": get_child_run_agent_number(child_run.metadata_json),
-                "error": "subagent 会话已被用户中断，要通知其继续工作请使用 notify_subagent",
             },
-            ensure_ascii=False,
         )
 
     @staticmethod

--- a/backend/app/agent_runtime/runner/checkpointer.py
+++ b/backend/app/agent_runtime/runner/checkpointer.py
@@ -282,24 +282,27 @@ def _message_type_paths(
 
 class _CheckpointSerializer(JsonPlusSerializer):
     def dumps_typed(self, obj: Any) -> tuple[str, bytes]:
-        sanitized = _sanitize_checkpoint_value(obj)
         try:
-            return super().dumps_typed(sanitized)
+            return super().dumps_typed(obj)
         except TypeError as original_error:
+            sanitized = _sanitize_checkpoint_value(obj)
             logger.bind(
                 checkpoint_root_type=f"{type(obj).__module__}.{type(obj).__name__}",
                 checkpoint_message_paths=_message_type_paths(obj),
             ).error("checkpoint msgpack serialization fallback activated")
             try:
-                return super().dumps_typed(_plain_checkpoint_value(obj))
-            except TypeError as fallback_error:
-                logger.bind(
-                    checkpoint_root_type=f"{type(obj).__module__}.{type(obj).__name__}",
-                    checkpoint_message_paths=_message_type_paths(obj),
-                ).opt(exception=fallback_error).error(
-                    "checkpoint msgpack serialization fallback failed"
-                )
-                raise original_error
+                return super().dumps_typed(sanitized)
+            except TypeError:
+                try:
+                    return super().dumps_typed(_plain_checkpoint_value(obj))
+                except TypeError as fallback_error:
+                    logger.bind(
+                        checkpoint_root_type=f"{type(obj).__module__}.{type(obj).__name__}",
+                        checkpoint_message_paths=_message_type_paths(obj),
+                    ).opt(exception=fallback_error).error(
+                        "checkpoint msgpack serialization fallback failed"
+                    )
+                    raise original_error
 
 
 def _default_db_path() -> Path:

--- a/backend/app/agent_runtime/runner/checkpointer.py
+++ b/backend/app/agent_runtime/runner/checkpointer.py
@@ -1,16 +1,21 @@
 import asyncio
+import dataclasses
 import os
 import shutil
 import time
-from collections.abc import Callable
+from collections import deque
+from collections.abc import Callable, Mapping
 from contextlib import suppress
 from pathlib import Path
+from typing import Any
 
 import aiosqlite
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import Checkpoint, copy_checkpoint
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
+from loguru import logger
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
@@ -35,7 +40,266 @@ _CHECKPOINT_CLEANUP_BATCH_SIZE = 500
 _VACUUM_MIN_FREE_BYTES = 64 * 1024 * 1024
 _INCREMENTAL_VACUUM_BATCH_BYTES = 64 * 1024 * 1024
 _VACUUM_PROGRESS_STEP = 10
+_MSGPACK_INT_MIN = -(1 << 63)
+_MSGPACK_INT_MAX = (1 << 63) - 1
 CheckpointMaintenanceProgress = Callable[[str, float | None, int, int], None]
+
+
+def _checkpoint_integer(value: int) -> int | str:
+    return value if _MSGPACK_INT_MIN <= value <= _MSGPACK_INT_MAX else str(value)
+
+
+def _sanitize_message_field(value: Any, active_ids: set[int]) -> Any:
+    if value is None or isinstance(value, (bool, float, bytes)):
+        return value
+    if isinstance(value, int):
+        return _checkpoint_integer(value)
+    if isinstance(value, str):
+        return str(value)
+    if isinstance(value, BaseMessage):
+        return _sanitize_checkpoint_value(value, active_ids)
+
+    value_id = id(value)
+    if value_id in active_ids:
+        return "<recursive>"
+    active_ids.add(value_id)
+    try:
+        if isinstance(value, Mapping):
+            return {
+                str(key): _sanitize_message_field(item, active_ids)
+                for key, item in value.items()
+            }
+        if isinstance(value, (list, tuple, set, frozenset)):
+            return [_sanitize_message_field(item, active_ids) for item in value]
+        model_dump = getattr(value, "model_dump", None)
+        if callable(model_dump):
+            return _sanitize_message_field(model_dump(mode="python"), active_ids)
+        return str(value)
+    finally:
+        active_ids.remove(value_id)
+
+
+def _sanitize_checkpoint_value(value: Any, active_ids: set[int] | None = None) -> Any:
+    active_ids = active_ids if active_ids is not None else set()
+    if value is None or isinstance(value, (bool, float, bytes)):
+        return value
+    if isinstance(value, int):
+        return _checkpoint_integer(value)
+    if isinstance(value, str):
+        return str(value)
+    if isinstance(value, BaseMessage):
+        value_id = id(value)
+        if value_id in active_ids:
+            return "<recursive>"
+        active_ids.add(value_id)
+        try:
+            def field(item: Any) -> Any:
+                return _sanitize_message_field(item, active_ids)
+
+            common = {
+                "additional_kwargs": field(value.additional_kwargs),
+                "response_metadata": field(value.response_metadata),
+                "id": value.id,
+                "name": value.name,
+            }
+            if isinstance(value, AIMessage):
+                return AIMessage(
+                    content=field(value.content),
+                    tool_calls=field(value.tool_calls),
+                    invalid_tool_calls=field(value.invalid_tool_calls),
+                    usage_metadata=field(value.usage_metadata),
+                    **common,
+                )
+            if isinstance(value, ToolMessage):
+                return ToolMessage(
+                    content=field(value.content),
+                    tool_call_id=value.tool_call_id,
+                    artifact=field(value.artifact),
+                    status=value.status,
+                    **common,
+                )
+            if isinstance(value, HumanMessage):
+                return HumanMessage(content=field(value.content), **common)
+            if isinstance(value, SystemMessage):
+                return SystemMessage(content=field(value.content), **common)
+            return value
+        finally:
+            active_ids.remove(value_id)
+    if isinstance(value, Mapping):
+        value_id = id(value)
+        if value_id in active_ids:
+            return "<recursive>"
+        active_ids.add(value_id)
+        try:
+            return {
+                _checkpoint_integer(key) if isinstance(key, int) else key: _sanitize_checkpoint_value(
+                    item, active_ids
+                )
+                for key, item in value.items()
+            }
+        finally:
+            active_ids.remove(value_id)
+    if isinstance(value, list):
+        value_id = id(value)
+        if value_id in active_ids:
+            return "<recursive>"
+        active_ids.add(value_id)
+        try:
+            return [_sanitize_checkpoint_value(item, active_ids) for item in value]
+        finally:
+            active_ids.remove(value_id)
+    if isinstance(value, tuple):
+        value_id = id(value)
+        if value_id in active_ids:
+            return "<recursive>"
+        active_ids.add(value_id)
+        try:
+            sanitized = tuple(_sanitize_checkpoint_value(item, active_ids) for item in value)
+            if hasattr(value, "_fields"):
+                return type(value)(*sanitized)
+            return sanitized
+        finally:
+            active_ids.remove(value_id)
+    if isinstance(value, deque):
+        return deque(
+            (_sanitize_checkpoint_value(item, active_ids) for item in value),
+            maxlen=value.maxlen,
+        )
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        value_id = id(value)
+        if value_id in active_ids:
+            return "<recursive>"
+        active_ids.add(value_id)
+        try:
+            fields = {
+                field.name: _sanitize_checkpoint_value(getattr(value, field.name), active_ids)
+                for field in dataclasses.fields(value)
+            }
+            return dataclasses.replace(value, **fields)
+        finally:
+            active_ids.remove(value_id)
+    return value
+
+
+def _plain_checkpoint_value(value: Any, active_ids: set[int] | None = None) -> Any:
+    active_ids = active_ids if active_ids is not None else set()
+    if value is None or isinstance(value, (bool, float, bytes)):
+        return value
+    if isinstance(value, int):
+        return _checkpoint_integer(value)
+    if isinstance(value, str):
+        return str(value)
+
+    value_id = id(value)
+    if value_id in active_ids:
+        return "<recursive>"
+    active_ids.add(value_id)
+    try:
+        if isinstance(value, Mapping):
+            return {
+                str(key): _plain_checkpoint_value(item, active_ids)
+                for key, item in value.items()
+            }
+        if isinstance(value, (list, tuple, set, frozenset, deque)):
+            return [_plain_checkpoint_value(item, active_ids) for item in value]
+        if dataclasses.is_dataclass(value) and not isinstance(value, type):
+            return {
+                field.name: _plain_checkpoint_value(getattr(value, field.name), active_ids)
+                for field in dataclasses.fields(value)
+            }
+        model_dump = getattr(value, "model_dump", None)
+        if callable(model_dump):
+            return _plain_checkpoint_value(model_dump(mode="python"), active_ids)
+        value_dict = getattr(value, "__dict__", None)
+        if isinstance(value_dict, dict):
+            return {
+                str(key): _plain_checkpoint_value(item, active_ids)
+                for key, item in value_dict.items()
+            }
+        return str(value)
+    finally:
+        active_ids.remove(value_id)
+
+
+def _message_type_paths(
+    value: Any,
+    *,
+    path: str = "$",
+    active_ids: set[int] | None = None,
+) -> list[str]:
+    active_ids = active_ids if active_ids is not None else set()
+    value_id = id(value)
+    if value_id in active_ids:
+        return []
+    active_ids.add(value_id)
+    try:
+        paths: list[str] = []
+        if isinstance(value, BaseMessage) or type(value).__name__ in {
+            "AIMessage",
+            "AIMessageChunk",
+        }:
+            paths.append(f"{path}:{type(value).__module__}.{type(value).__name__}")
+        if isinstance(value, Mapping):
+            for key, item in value.items():
+                paths.extend(
+                    _message_type_paths(
+                        item,
+                        path=f"{path}.{key}",
+                        active_ids=active_ids,
+                    )
+                )
+        elif isinstance(value, (list, tuple, set, frozenset, deque)):
+            for index, item in enumerate(value):
+                paths.extend(
+                    _message_type_paths(
+                        item,
+                        path=f"{path}[{index}]",
+                        active_ids=active_ids,
+                    )
+                )
+        elif dataclasses.is_dataclass(value) and not isinstance(value, type):
+            for field in dataclasses.fields(value):
+                paths.extend(
+                    _message_type_paths(
+                        getattr(value, field.name),
+                        path=f"{path}.{field.name}",
+                        active_ids=active_ids,
+                    )
+                )
+        elif isinstance(getattr(value, "__dict__", None), dict):
+            for key, item in vars(value).items():
+                paths.extend(
+                    _message_type_paths(
+                        item,
+                        path=f"{path}.{key}",
+                        active_ids=active_ids,
+                    )
+                )
+        return paths[:20]
+    finally:
+        active_ids.remove(value_id)
+
+
+class _CheckpointSerializer(JsonPlusSerializer):
+    def dumps_typed(self, obj: Any) -> tuple[str, bytes]:
+        sanitized = _sanitize_checkpoint_value(obj)
+        try:
+            return super().dumps_typed(sanitized)
+        except TypeError as original_error:
+            logger.bind(
+                checkpoint_root_type=f"{type(obj).__module__}.{type(obj).__name__}",
+                checkpoint_message_paths=_message_type_paths(obj),
+            ).error("checkpoint msgpack serialization fallback activated")
+            try:
+                return super().dumps_typed(_plain_checkpoint_value(obj))
+            except TypeError as fallback_error:
+                logger.bind(
+                    checkpoint_root_type=f"{type(obj).__module__}.{type(obj).__name__}",
+                    checkpoint_message_paths=_message_type_paths(obj),
+                ).opt(exception=fallback_error).error(
+                    "checkpoint msgpack serialization fallback failed"
+                )
+                raise original_error
 
 
 def _default_db_path() -> Path:
@@ -101,7 +365,7 @@ async def get_checkpointer() -> AsyncSqliteSaver:
         await _configure_checkpoint_connection(conn)
         _checkpointer = AsyncSqliteSaver(
             conn,
-            serde=JsonPlusSerializer(
+            serde=_CheckpointSerializer(
                 allowed_msgpack_modules=_ALLOWED_MSGPACK_MODULES,
             ),
         )

--- a/backend/app/agent_runtime/runner/event_translator.py
+++ b/backend/app/agent_runtime/runner/event_translator.py
@@ -1,7 +1,9 @@
 from langchain_core.messages import ToolMessage
+from langgraph.errors import GraphInterrupt
 
 from app.agent_runtime.content_blocks import extract_reasoning_content, extract_text_content
 from app.agent_runtime.runner.event_scope import is_subagent_child_event
+from app.agent_runtime.tools.errors import tool_failure_from_error
 from app.agent_runtime.tool_call_recovery import (
     build_malformed_tool_call_error,
     is_malformed_tool_call,
@@ -97,6 +99,19 @@ class EventTranslator:
 
         if kind == "on_tool_error" and self._allow_subagent_child_events:
             tool_call_id = self._extract_tool_call_id(event)
+            error = event.get("data", {}).get("error")
+            output = (
+                {
+                    "type": "ok",
+                    "success": True,
+                    "reason": "approval_preview",
+                    "message": "需要审批",
+                    "tool_call_id": tool_call_id,
+                    "tool_name": event.get("name"),
+                }
+                if isinstance(error, GraphInterrupt)
+                else tool_failure_from_error(error, source="subagent_tool").to_result()
+            )
             return {
                 "name": "agent:tool_result",
                 "data": {
@@ -105,14 +120,7 @@ class EventTranslator:
                     "tool_call_id": tool_call_id,
                     "tool": event.get("name"),
                     "input": event.get("data", {}).get("input"),
-                    "output": {
-                        "type": "ok",
-                        "success": True,
-                        "reason": "approval_preview",
-                        "message": "需要审批",
-                        "tool_call_id": tool_call_id,
-                        "tool_name": event.get("name"),
-                    },
+                    "output": output,
                 },
             }
 

--- a/backend/app/agent_runtime/runner/session_runner.py
+++ b/backend/app/agent_runtime/runner/session_runner.py
@@ -327,11 +327,11 @@ class SessionRunner:
         status_session = await create_session()
         try:
             revision_status = "interrupted" if resumable_state is not None else "failed"
-            await finalize_revision_status(status_session, revision_id, revision_status)
+            finalized = await finalize_revision_status(status_session, revision_id, revision_status)
             await status_session.commit()
         finally:
             await status_session.close()
-        if resumable_state is not None:
+        if resumable_state is not None and finalized:
             await self._emit_pending_interrupts(resumable_state)
         await self._clear_replay_session()
 

--- a/backend/app/agent_runtime/runner/session_runner.py
+++ b/backend/app/agent_runtime/runner/session_runner.py
@@ -292,10 +292,24 @@ class SessionRunner:
     async def _handle_stream_failure(
         self,
         *,
+        graph: CompiledStateGraph | None = None,
         revision_id: str | None,
         error_type: Literal["persistence_failure", "runtime_failure"],
         exc: Exception,
     ) -> None:
+        resumable_state = None
+        if graph is not None:
+            try:
+                candidate_state = await graph.aget_state(
+                    {"configurable": {"thread_id": self.session_id}}
+                )
+            except Exception:
+                candidate_state = None
+            if candidate_state is not None and (
+                getattr(candidate_state, "next", ()) or _interrupt_payloads(candidate_state)
+            ):
+                resumable_state = candidate_state
+
         if self._persister is not None:
             try:
                 await self._persister.finalize(reason="error")
@@ -312,10 +326,13 @@ class SessionRunner:
         )
         status_session = await create_session()
         try:
-            await finalize_revision_status(status_session, revision_id, "failed")
+            revision_status = "interrupted" if resumable_state is not None else "failed"
+            await finalize_revision_status(status_session, revision_id, revision_status)
             await status_session.commit()
         finally:
             await status_session.close()
+        if resumable_state is not None:
+            await self._emit_pending_interrupts(resumable_state)
         await self._clear_replay_session()
 
     async def _emit_pending_interrupts(self, state: object) -> None:
@@ -819,6 +836,7 @@ class SessionRunner:
         self._cancel_event.clear()
         reason: Literal["done", "cancelled", "error"] = "done"
         revision = None
+        graph: CompiledStateGraph | None = None
         try:
             history_messages = await self._prepare_run_persistence()
             graph = await self._get_graph()
@@ -912,6 +930,7 @@ class SessionRunner:
             return
         except PersistenceError as e:
             await self._handle_stream_failure(
+                graph=graph,
                 revision_id=revision.id if revision is not None else None,
                 error_type="persistence_failure",
                 exc=e,
@@ -919,6 +938,7 @@ class SessionRunner:
             raise
         except Exception as e:
             await self._handle_stream_failure(
+                graph=graph,
                 revision_id=revision.id if revision is not None else None,
                 error_type="runtime_failure",
                 exc=e,
@@ -1289,6 +1309,7 @@ class SessionRunner:
             return
         except PersistenceError as e:
             await self._handle_stream_failure(
+                graph=graph,
                 revision_id=revision_id,
                 error_type="persistence_failure",
                 exc=e,
@@ -1296,6 +1317,7 @@ class SessionRunner:
             raise
         except Exception as e:
             await self._handle_stream_failure(
+                graph=graph,
                 revision_id=revision_id,
                 error_type="runtime_failure",
                 exc=e,

--- a/backend/app/agent_runtime/tool_call_recovery.py
+++ b/backend/app/agent_runtime/tool_call_recovery.py
@@ -6,6 +6,8 @@ from typing import Any, cast
 
 from json_repair import loads as repair_json_loads
 
+from app.agent_runtime.tools.errors import ToolFailure
+
 MALFORMED_TOOL_CALL_MARKER = "__malformed_tool_call__"
 MALFORMED_TOOL_CALL_RAW_ARGS = "__raw_args__"
 MALFORMED_TOOL_CALL_ERROR = "__parse_error__"
@@ -168,16 +170,8 @@ def tool_call_input(tool_call: Mapping[str, Any]) -> Any:
 
 
 def build_malformed_tool_call_error(tool_call: Mapping[str, Any]) -> dict[str, Any]:
-    raw_args = tool_call_input(tool_call)
-    return {
-        "type": "fail",
-        "success": False,
-        "recoverable": False,
-        "reason": "malformed_tool_call",
-        "message": MALFORMED_TOOL_CALL_MESSAGE,
-        "error": MALFORMED_TOOL_CALL_MESSAGE,
-        "data": None,
-        "tool_call_id": tool_call.get("id"),
-        "tool_name": tool_call.get("name"),
-        "raw_args": raw_args,
-    }
+    return ToolFailure(
+        code="malformed_tool_call",
+        message=MALFORMED_TOOL_CALL_MESSAGE,
+        trace={"source": "tool_call_recovery"},
+    ).to_result()

--- a/backend/app/agent_runtime/tools/base.py
+++ b/backend/app/agent_runtime/tools/base.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, TypeAlias, cast
 
 from langchain_core.runnables.config import var_child_runnable_config
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import BaseTool
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.tools.errors import (
@@ -20,14 +21,45 @@ from app.agent_runtime.tools.errors import (
 )
 
 
+_PYDANTIC_HELP_URL = re.compile(
+    r"\s*For further information visit https://errors\.pydantic\.dev/\S+"
+)
+
+
+def _format_validation_error(error: object) -> str:
+    if isinstance(error, ValidationError):
+        details: list[str] = []
+        for item in error.errors():
+            location = ".".join(str(part) for part in item.get("loc", ())) or "<root>"
+            message = " ".join(str(item.get("msg", "Validation error")).split())
+            error_type = item.get("type")
+            detail = f"{location}: {message}"
+            if error_type:
+                detail += f" [type={error_type}"
+                if "input" in item:
+                    input_value = item["input"]
+                    detail += (
+                        f", input_value={input_value!r},"
+                        f" input_type={type(input_value).__name__}"
+                    )
+                detail += "]"
+            details.append(detail)
+        if details:
+            return f"参数校验失败（{len(details)} 个错误）:\n" + "\n".join(
+                f"- {detail}" for detail in details
+            )
+
+    return "参数校验失败: " + _PYDANTIC_HELP_URL.sub("", str(error)).strip()
+
+
 def _validation_error_to_json(error: object) -> str:
-    return serialize_tool_failure(
-        ToolFailure(
-            code="validation_error",
-            message=f"参数校验失败: {error}",
-            trace={"source": "validation"},
-        )
+    failure = ToolFailure(
+        code="validation_error",
+        message=_format_validation_error(error),
+        trace={"source": "validation"},
     )
+    log_tool_failure(failure, tool_name="<validation>", tool_call_id=None)
+    return serialize_tool_failure(failure)
 
 
 @dataclass
@@ -234,6 +266,7 @@ class AgentTool(BaseTool):
                 failure,
                 tool_name=self.name,
                 tool_call_id=self.tool_call_id,
+                exception=e,
             )
             return serialize_tool_failure(failure)
         except Exception as e:

--- a/backend/app/agent_runtime/tools/base.py
+++ b/backend/app/agent_runtime/tools/base.py
@@ -10,11 +10,24 @@ from langchain_core.tools import BaseTool
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.agent_runtime.tools.errors import ToolExecutionError
+from app.agent_runtime.tools.errors import (
+    ToolExecutionError,
+    ToolFailure,
+    log_tool_failure,
+    normalize_tool_failure_result,
+    serialize_tool_failure,
+    tool_failure_from_exception,
+)
 
 
 def _validation_error_to_json(error: object) -> str:
-    return json.dumps({"error": f"参数校验失败: {error}"}, ensure_ascii=False)
+    return serialize_tool_failure(
+        ToolFailure(
+            code="validation_error",
+            message=f"参数校验失败: {error}",
+            trace={"source": "validation"},
+        )
+    )
 
 
 @dataclass
@@ -197,7 +210,10 @@ class AgentTool(BaseTool):
                     ):
                         return json.dumps(
                             {
-                                "error": "工具调用已被用户拒绝",
+                                "type": "control",
+                                "success": False,
+                                "status": "approval_denied",
+                                "message": "工具调用已被用户拒绝",
                                 "approval_id": resume_value.get("approval_id"),
                                 "tool_name": self.name,
                             },
@@ -213,11 +229,33 @@ class AgentTool(BaseTool):
                 raise NotImplementedError("AgentTool subclasses must define _execute")
             output = await cast(Callable[..., Awaitable[str]], execute)(**validated_args)
         except ToolExecutionError as e:
-            return json.dumps({"error": str(e)}, ensure_ascii=False)
+            failure = tool_failure_from_exception(e, source="tool_execution")
+            log_tool_failure(
+                failure,
+                tool_name=self.name,
+                tool_call_id=self.tool_call_id,
+            )
+            return serialize_tool_failure(failure)
         except Exception as e:
             if "GraphInterrupt" in type(e).__name__:
                 raise
-            return json.dumps({"error": f"工具执行异常: {e}"}, ensure_ascii=False)
+            failure = tool_failure_from_exception(
+                e,
+                code="execution_failed",
+                source="tool_execution",
+            )
+            failure = ToolFailure(
+                code=failure.code,
+                message=f"工具执行异常: {failure.message}",
+                trace=failure.trace,
+            )
+            log_tool_failure(
+                failure,
+                tool_name=self.name,
+                tool_call_id=self.tool_call_id,
+                exception=e,
+            )
+            return serialize_tool_failure(failure)
 
         hook_ctx.output = output
         for hook in self._post_hooks:
@@ -226,7 +264,14 @@ class AgentTool(BaseTool):
                 output = hook_result.output
                 hook_ctx.output = output
 
-        return output
+        normalized_output, failure = normalize_tool_failure_result(output)
+        if failure is not None:
+            log_tool_failure(
+                failure,
+                tool_name=self.name,
+                tool_call_id=self.tool_call_id,
+            )
+        return cast(str, normalized_output)
 
     def _run(self, *args: Any, **kwargs: Any) -> str:
         raise NotImplementedError("Use ainvoke")

--- a/backend/app/agent_runtime/tools/errors.py
+++ b/backend/app/agent_runtime/tools/errors.py
@@ -57,7 +57,7 @@ def _error_code(value: object) -> ToolErrorCode:
 class ToolFailure:
     code: ToolErrorCode
     message: str
-    trace: dict[str, str] = field(default_factory=dict)
+    trace: dict[str, Any] = field(default_factory=dict)
 
     def to_result(self, extra: Mapping[str, Any] | None = None) -> dict[str, Any]:
         result = dict(extra or {})
@@ -83,13 +83,33 @@ class ToolExecutionError(Exception):
         super().__init__(message)
 
 
+class ToolResult(str):
+    payload: dict[str, Any]
+
+    def __new__(
+        cls,
+        value: str,
+        payload: dict[str, Any],
+    ) -> ToolResult:
+        result = str.__new__(cls, value)
+        result.payload = payload
+        return result
+
+
+def _error_message(error: object) -> str:
+    message = str(error).strip() if error is not None else ""
+    if message and message != "None":
+        return message
+    return f"{type(error).__name__} 未提供具体错误消息"
+
+
 def tool_failure_from_exception(
     error: BaseException,
     *,
     code: ToolErrorCode | None = None,
     source: str,
 ) -> ToolFailure:
-    message = str(error).strip() or "工具执行失败"
+    message = _error_message(error)
     return ToolFailure(
         code=_error_code(code or getattr(error, "code", None)),
         message=message,
@@ -103,23 +123,21 @@ def tool_failure_from_error(
     code: ToolErrorCode | None = None,
     source: str,
 ) -> ToolFailure:
-    if isinstance(error, ToolExecutionError):
+    if isinstance(error, ToolFailure):
+        return error
+    if isinstance(error, BaseException):
         return tool_failure_from_exception(error, code=code, source=source)
     return ToolFailure(
         code=_error_code(code),
-        message="工具执行失败",
+        message=_error_message(error),
         trace={
             "source": source,
-            **(
-                {"exception_type": type(error).__name__}
-                if isinstance(error, BaseException)
-                else {}
-            ),
+            "error_type": type(error).__name__,
         },
     )
 
 
-def tool_failure_from_result(value: object) -> tuple[ToolFailure, dict[str, Any]] | None:
+def _parse_tool_result(value: object) -> dict[str, Any] | None:
     if isinstance(value, str):
         try:
             payload = json.loads(value)
@@ -129,8 +147,13 @@ def tool_failure_from_result(value: object) -> tuple[ToolFailure, dict[str, Any]
         payload = dict(value)
     else:
         return None
+    return payload if isinstance(payload, dict) else None
 
-    if not isinstance(payload, dict) or payload.get("type") == "control":
+
+def _failure_from_payload(
+    payload: dict[str, Any],
+) -> tuple[ToolFailure, dict[str, Any]] | None:
+    if payload.get("type") == "control":
         return None
 
     is_failure = (
@@ -141,17 +164,24 @@ def tool_failure_from_result(value: object) -> tuple[ToolFailure, dict[str, Any]
     if not is_failure:
         return None
 
-    message = payload.get("message") or payload.get("error")
+    message = payload.get("message")
     if not isinstance(message, str) or not message.strip():
-        message = "工具执行失败"
+        message = payload.get("error")
+    if not isinstance(message, str) or not message.strip():
+        message = f"工具错误（{_error_code(payload.get('code'))}）：未提供具体错误消息"
 
     extra = {key: item for key, item in payload.items() if key not in _FAILURE_FIELDS}
     failure = ToolFailure(
         code=_error_code(payload.get("code")),
         message=message.strip(),
-        trace={"source": "tool_result"},
+        trace={"source": "tool_result", "result": payload},
     )
     return failure, extra
+
+
+def tool_failure_from_result(value: object) -> tuple[ToolFailure, dict[str, Any]] | None:
+    payload = _parse_tool_result(value)
+    return _failure_from_payload(payload) if payload is not None else None
 
 
 def serialize_tool_failure(
@@ -162,11 +192,19 @@ def serialize_tool_failure(
 
 
 def normalize_tool_failure_result(value: object) -> tuple[object, ToolFailure | None]:
-    normalized = tool_failure_from_result(value)
+    if isinstance(value, ToolResult):
+        return value, None
+    payload = _parse_tool_result(value)
+    if payload is None:
+        return value, None
+    normalized = _failure_from_payload(payload)
     if normalized is None:
+        if isinstance(value, str):
+            return ToolResult(value, payload), None
         return value, None
     failure, extra = normalized
-    return serialize_tool_failure(failure, extra), failure
+    result = serialize_tool_failure(failure, extra)
+    return ToolResult(result, failure.to_result(extra)), failure
 
 
 def log_tool_failure(
@@ -183,6 +221,14 @@ def log_tool_failure(
         **failure.trace,
     )
     if exception is not None:
-        logger_context.error("Agent 工具执行失败")
+        logger_context.opt(exception=exception).error("Agent 工具执行失败")
+        return
+    diagnostic = failure.trace.get("result")
+    if diagnostic is not None:
+        logger_context.warning(
+            "Agent 工具执行失败: {} trace={}",
+            failure.message,
+            diagnostic,
+        )
         return
     logger_context.warning("Agent 工具执行失败: {}", failure.message)

--- a/backend/app/agent_runtime/tools/errors.py
+++ b/backend/app/agent_runtime/tools/errors.py
@@ -183,6 +183,6 @@ def log_tool_failure(
         **failure.trace,
     )
     if exception is not None:
-        logger_context.opt(exception=exception).error("Agent 工具执行失败: {}", failure.message)
+        logger_context.error("Agent 工具执行失败")
         return
     logger_context.warning("Agent 工具执行失败: {}", failure.message)

--- a/backend/app/agent_runtime/tools/errors.py
+++ b/backend/app/agent_runtime/tools/errors.py
@@ -1,2 +1,188 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal, cast
+
+from loguru import logger
+
+ToolErrorCode = Literal[
+    "validation_error",
+    "not_found",
+    "conflict",
+    "permission_denied",
+    "malformed_tool_call",
+    "tool_not_found",
+    "limit_exceeded",
+    "dependency_unavailable",
+    "execution_failed",
+]
+
+_TOOL_ERROR_CODES: set[str] = {
+    "validation_error",
+    "not_found",
+    "conflict",
+    "permission_denied",
+    "malformed_tool_call",
+    "tool_not_found",
+    "limit_exceeded",
+    "dependency_unavailable",
+    "execution_failed",
+}
+_FAILURE_FIELDS = {
+    "type",
+    "success",
+    "code",
+    "message",
+    "error",
+    "reason",
+    "trace",
+    "metadata",
+    "data",
+    "recoverable",
+    "raw_args",
+    "tool_call_id",
+    "tool_name",
+}
+
+
+def _error_code(value: object) -> ToolErrorCode:
+    if isinstance(value, str) and value in _TOOL_ERROR_CODES:
+        return cast(ToolErrorCode, value)
+    return "execution_failed"
+
+
+@dataclass(frozen=True)
+class ToolFailure:
+    code: ToolErrorCode
+    message: str
+    trace: dict[str, str] = field(default_factory=dict)
+
+    def to_result(self, extra: Mapping[str, Any] | None = None) -> dict[str, Any]:
+        result = dict(extra or {})
+        result.update(
+            {
+                "type": "fail",
+                "success": False,
+                "code": self.code,
+                "message": self.message,
+            }
+        )
+        return result
+
+
 class ToolExecutionError(Exception):
-    pass
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: ToolErrorCode = "execution_failed",
+    ) -> None:
+        self.code = _error_code(code)
+        super().__init__(message)
+
+
+def tool_failure_from_exception(
+    error: BaseException,
+    *,
+    code: ToolErrorCode | None = None,
+    source: str,
+) -> ToolFailure:
+    message = str(error).strip() or "工具执行失败"
+    return ToolFailure(
+        code=_error_code(code or getattr(error, "code", None)),
+        message=message,
+        trace={"source": source, "exception_type": type(error).__name__},
+    )
+
+
+def tool_failure_from_error(
+    error: object,
+    *,
+    code: ToolErrorCode | None = None,
+    source: str,
+) -> ToolFailure:
+    if isinstance(error, ToolExecutionError):
+        return tool_failure_from_exception(error, code=code, source=source)
+    return ToolFailure(
+        code=_error_code(code),
+        message="工具执行失败",
+        trace={
+            "source": source,
+            **(
+                {"exception_type": type(error).__name__}
+                if isinstance(error, BaseException)
+                else {}
+            ),
+        },
+    )
+
+
+def tool_failure_from_result(value: object) -> tuple[ToolFailure, dict[str, Any]] | None:
+    if isinstance(value, str):
+        try:
+            payload = json.loads(value)
+        except json.JSONDecodeError:
+            return None
+    elif isinstance(value, Mapping):
+        payload = dict(value)
+    else:
+        return None
+
+    if not isinstance(payload, dict) or payload.get("type") == "control":
+        return None
+
+    is_failure = (
+        payload.get("type") == "fail"
+        or payload.get("success") is False
+        or isinstance(payload.get("error"), str)
+    )
+    if not is_failure:
+        return None
+
+    message = payload.get("message") or payload.get("error")
+    if not isinstance(message, str) or not message.strip():
+        message = "工具执行失败"
+
+    extra = {key: item for key, item in payload.items() if key not in _FAILURE_FIELDS}
+    failure = ToolFailure(
+        code=_error_code(payload.get("code")),
+        message=message.strip(),
+        trace={"source": "tool_result"},
+    )
+    return failure, extra
+
+
+def serialize_tool_failure(
+    failure: ToolFailure,
+    extra: Mapping[str, Any] | None = None,
+) -> str:
+    return json.dumps(failure.to_result(extra), ensure_ascii=False)
+
+
+def normalize_tool_failure_result(value: object) -> tuple[object, ToolFailure | None]:
+    normalized = tool_failure_from_result(value)
+    if normalized is None:
+        return value, None
+    failure, extra = normalized
+    return serialize_tool_failure(failure, extra), failure
+
+
+def log_tool_failure(
+    failure: ToolFailure,
+    *,
+    tool_name: str,
+    tool_call_id: str | None,
+    exception: BaseException | None = None,
+) -> None:
+    logger_context = logger.bind(
+        tool_name=tool_name,
+        tool_call_id=tool_call_id,
+        error_code=failure.code,
+        **failure.trace,
+    )
+    if exception is not None:
+        logger_context.opt(exception=exception).error("Agent 工具执行失败: {}", failure.message)
+        return
+    logger_context.warning("Agent 工具执行失败: {}", failure.message)

--- a/backend/app/agent_runtime/tools/impls/chapter/update_index.py
+++ b/backend/app/agent_runtime/tools/impls/chapter/update_index.py
@@ -1,6 +1,7 @@
 from pydantic import BaseModel
 
 from app.agent_runtime.tools.base import AgentTool
+from app.agent_runtime.tools.errors import ToolFailure, serialize_tool_failure
 from app.agent_runtime.tools.registry import ToolRegistry
 from app.background.jobs import service as background_service
 from app.retrieval.chapter_index import enqueue_project_index_update
@@ -27,8 +28,13 @@ class UpdateIndexTool(AgentTool):
                 project_id=self.project_id,
             )
             if result is None:
-                await session.commit()
-                return "当前项目未启用索引或未配置可用的嵌入模型，无法更新索引。"
+                return serialize_tool_failure(
+                    ToolFailure(
+                        code="dependency_unavailable",
+                        message="当前项目未启用索引或未配置可用的嵌入模型，无法更新索引。",
+                        trace={"source": "chapter_index"},
+                    )
+                )
 
             schedule_emit_index_status(session, self.project_id)
             await background_service.commit_and_notify(session)

--- a/backend/app/agent_runtime/tools/impls/interaction/ask_user.py
+++ b/backend/app/agent_runtime/tools/impls/interaction/ask_user.py
@@ -54,7 +54,12 @@ class AskUserTool(AgentTool):
         response = interrupt(payload)
         if isinstance(response, dict) and response.get("skipped") is True:
             return json.dumps(
-                {"status": "user_skipped", "error": "用户忽略了提问"},
+                {
+                    "type": "control",
+                    "success": False,
+                    "status": "user_skipped",
+                    "message": "用户忽略了提问",
+                },
                 ensure_ascii=False,
             )
         answers = response.get("answer") if isinstance(response, dict) else None

--- a/backend/app/api/routers/agent_runtime.py
+++ b/backend/app/api/routers/agent_runtime.py
@@ -358,6 +358,24 @@ async def _ensure_agent_session_resumable(
         )
 
 
+async def _checkpoint_has_pending_interrupt(session_id: str) -> bool:
+    checkpointer = await get_checkpointer()
+    checkpoint = await checkpointer.aget_tuple(
+        {"configurable": {"thread_id": session_id}}
+    )
+    return (
+        any(
+            len(pending_write) >= 3
+            and pending_write[1] == "__interrupt__"
+            and isinstance(pending_write[2], list)
+            and bool(pending_write[2])
+            for pending_write in checkpoint.pending_writes or []
+        )
+        if checkpoint is not None
+        else False
+    )
+
+
 async def _claim_agent_session_resume(
     session: AsyncSession,
     session_id: str,
@@ -379,6 +397,14 @@ async def _claim_agent_session_resume(
         return revision_id, True
 
     revision = await revision_repo.get_by_id(session, revision_id)
+    if revision is not None and revision.status == "failed":
+        if await _checkpoint_has_pending_interrupt(session_id):
+            if await revision_repo.recover_failed_revision(session, revision_id):
+                await session.commit()
+                if await revision_repo.claim_interrupted_revision(session, revision_id):
+                    await session.commit()
+                    return revision_id, True
+                revision = await revision_repo.get_by_id(session, revision_id)
     if revision is not None and revision.status == "cancelled":
         await _ensure_agent_session_resumable(session, session_id)
     if allow_active and revision is not None and revision.status == "active":

--- a/backend/app/api/routers/agent_runtime.py
+++ b/backend/app/api/routers/agent_runtime.py
@@ -358,11 +358,19 @@ async def _ensure_agent_session_resumable(
         )
 
 
-async def _checkpoint_has_pending_interrupt(session_id: str) -> bool:
+async def _checkpoint_has_pending_interrupt(session_id: str, revision_id: str) -> bool:
     checkpointer = await get_checkpointer()
     checkpoint = await checkpointer.aget_tuple(
         {"configurable": {"thread_id": session_id}}
     )
+    checkpoint_data = getattr(checkpoint, "checkpoint", None) if checkpoint is not None else None
+    channel_values = (
+        checkpoint_data.get("channel_values")
+        if isinstance(checkpoint_data, dict)
+        else None
+    )
+    if not isinstance(channel_values, dict) or channel_values.get("current_revision_id") != revision_id:
+        return False
     return (
         any(
             len(pending_write) >= 3
@@ -398,7 +406,7 @@ async def _claim_agent_session_resume(
 
     revision = await revision_repo.get_by_id(session, revision_id)
     if revision is not None and revision.status == "failed":
-        if await _checkpoint_has_pending_interrupt(session_id):
+        if await _checkpoint_has_pending_interrupt(session_id, revision_id):
             if await revision_repo.recover_failed_revision(session, revision_id):
                 await session.commit()
                 if await revision_repo.claim_interrupted_revision(session, revision_id):

--- a/backend/app/storage/repos/revision_repo.py
+++ b/backend/app/storage/repos/revision_repo.py
@@ -272,6 +272,21 @@ async def claim_interrupted_revision(session: AsyncSession, revision_id: str) ->
     return cast("CursorResult[Any]", result).rowcount == 1
 
 
+async def recover_failed_revision(session: AsyncSession, revision_id: str) -> bool:
+    """Restore a failed revision when its checkpoint still contains an interrupt."""
+    from sqlalchemy import update as sql_update
+
+    now = datetime.now(UTC)
+    result = await session.execute(
+        sql_update(Revision)
+        .where(col(Revision.id) == revision_id)
+        .where(col(Revision.status) == "failed")
+        .values(status="interrupted", finished_at=now, updated_at=now)
+    )
+    await session.flush()
+    return cast("CursorResult[Any]", result).rowcount == 1
+
+
 async def release_active_revision_claim(session: AsyncSession, revision_id: str) -> bool:
     """Return a failed resume launch to its interrupted state without reviving a cancel."""
     from sqlalchemy import update as sql_update

--- a/backend/tests/agent_runtime/context/processors/test_filter.py
+++ b/backend/tests/agent_runtime/context/processors/test_filter.py
@@ -1,3 +1,4 @@
+import json
 from typing import Literal
 
 from app.agent_runtime.context.processors.filter import (
@@ -112,3 +113,38 @@ def test_tool_result_metadata_content_keeps_success_result() -> None:
     content = '{"success":true,"metadata":{"note_diff":{"note_id":"note-1"}}}'
 
     assert filter_tool_result_metadata_content(content) == '{"success": true}'
+
+
+def test_tool_failure_content_exposes_only_message_to_model() -> None:
+    content = (
+        '{"type":"fail","success":false,"code":"not_found",'
+        '"message":"未找到章节：第三章",'
+        '"trace":{"exception_type":"ToolExecutionError"}}'
+    )
+
+    assert filter_tool_result_metadata_content(content) == "未找到章节：第三章"
+
+
+def test_tool_failure_content_keeps_legacy_error_compatible() -> None:
+    content = '{"error":"未找到章节：第三章","metadata":{"internal":"value"}}'
+
+    assert filter_tool_result_metadata_content(content) == "未找到章节：第三章"
+
+
+def test_tool_failure_content_keeps_subagent_resume_identity() -> None:
+    content = (
+        '{"type":"fail","success":false,"code":"execution_failed",'
+        '"message":"子代理会话已被用户中断",'
+        '"dispatch_id":"dispatch-1","agent_key":"writer",'
+        '"agent_number":"#1001","trace":{"source":"persistence_finalize"}}'
+    )
+
+    assert json.loads(filter_tool_result_metadata_content(content)) == {
+        "type": "fail",
+        "success": False,
+        "code": "execution_failed",
+        "message": "子代理会话已被用户中断",
+        "dispatch_id": "dispatch-1",
+        "agent_key": "writer",
+        "agent_number": "#1001",
+    }

--- a/backend/tests/agent_runtime/context/processors/test_filter.py
+++ b/backend/tests/agent_runtime/context/processors/test_filter.py
@@ -165,3 +165,27 @@ def test_tool_failure_content_keeps_subagent_resume_identity() -> None:
         "agent_key": "writer",
         "agent_number": "#1001",
     }
+
+
+def test_tool_control_content_preserves_control_state() -> None:
+    content = (
+        '{"type":"control","success":false,"status":"approval_denied",'
+        '"message":"工具调用已被用户拒绝","approval_id":"approval-1",'
+        '"metadata":{"internal":"value"}}'
+    )
+
+    assert json.loads(filter_tool_result_metadata_content(content)) == {
+        "type": "control",
+        "success": False,
+        "status": "approval_denied",
+        "message": "工具调用已被用户拒绝",
+        "approval_id": "approval-1",
+    }
+
+
+def test_tool_failure_content_identifies_missing_message_by_code() -> None:
+    content = '{"type":"fail","success":false,"code":"not_found"}'
+
+    assert filter_tool_result_metadata_content(content) == (
+        "工具错误（not_found）：未提供具体错误消息"
+    )

--- a/backend/tests/agent_runtime/context/processors/test_filter.py
+++ b/backend/tests/agent_runtime/context/processors/test_filter.py
@@ -131,6 +131,23 @@ def test_tool_failure_content_keeps_legacy_error_compatible() -> None:
     assert filter_tool_result_metadata_content(content) == "未找到章节：第三章"
 
 
+def test_tool_failure_content_keeps_legacy_subagent_resume_identity() -> None:
+    content = (
+        '{"dispatch_id":"dispatch-1","agent_key":"writer",'
+        '"agent_number":"#1001","error":"子代理会话已被用户中断"}'
+    )
+
+    assert json.loads(filter_tool_result_metadata_content(content)) == {
+        "type": "fail",
+        "success": False,
+        "code": "execution_failed",
+        "message": "子代理会话已被用户中断",
+        "dispatch_id": "dispatch-1",
+        "agent_key": "writer",
+        "agent_number": "#1001",
+    }
+
+
 def test_tool_failure_content_keeps_subagent_resume_identity() -> None:
     content = (
         '{"type":"fail","success":false,"code":"execution_failed",'

--- a/backend/tests/agent_runtime/graph/test_react_agent_audit.py
+++ b/backend/tests/agent_runtime/graph/test_react_agent_audit.py
@@ -228,7 +228,7 @@ async def test_react_agent_records_model_errors_in_audit(
 
 
 @pytest.mark.asyncio
-async def test_react_agent_records_unhandled_tool_errors_in_audit(
+async def test_react_agent_normalizes_tool_errors_in_audit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
@@ -253,6 +253,7 @@ async def test_react_agent_records_unhandled_tool_errors_in_audit(
         name="writer",
         tools=[tool],
         termination=TerminationCondition(mode="no_tool_call"),
+        max_iterations=2,
     )
     graph = create_react_agent(config, model=model)
     response = AIMessage(
@@ -260,17 +261,16 @@ async def test_react_agent_records_unhandled_tool_errors_in_audit(
         tool_calls=[{"id": "call_1", "name": "fail_tool", "args": {}}],
     )
 
-    async def _mock_invoke(*_args, **_kwargs):
-        return response
+    responses = iter([response, AIMessage(content="recovered")])
 
-    with (
-        patch(
-            "app.agent_runtime.graph.react_agent._invoke_model",
-            side_effect=_mock_invoke,
-        ),
-        pytest.raises(RuntimeError, match="tool runtime failure"),
+    async def _mock_invoke(*_args, **_kwargs):
+        return next(responses)
+
+    with patch(
+        "app.agent_runtime.graph.react_agent._invoke_model",
+        side_effect=_mock_invoke,
     ):
-        await graph.ainvoke(
+        result = await graph.ainvoke(
             {
                 "messages": [HumanMessage(content="go")],
                 "iteration_count": 0,
@@ -297,7 +297,8 @@ async def test_react_agent_records_unhandled_tool_errors_in_audit(
             "error_status_code": None,
         }
     ]
-    assert audit.finished == ["error"]
+    assert result["messages"][-1].content == "recovered"
+    assert audit.finished == ["success", "success"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/persistence/test_persister.py
+++ b/backend/tests/agent_runtime/persistence/test_persister.py
@@ -2,6 +2,7 @@
 
 import json
 from datetime import UTC, datetime
+from unittest.mock import patch
 
 import pytest
 from langchain_core.messages import AIMessage, AIMessageChunk
@@ -490,7 +491,7 @@ async def test_persister_persists_subagent_tool_error_as_canonical_failure(
         "type": "fail",
         "success": False,
         "code": "execution_failed",
-        "message": "工具执行失败",
+        "message": "write failed",
     }
 
 
@@ -791,24 +792,26 @@ async def test_persister_persists_unrecoverable_invalid_tool_call_with_synthesiz
             )
         },
     })
-    await p.handle({
-        "event": "on_chat_model_end",
-        "run_id": "child-run-invalid-tool-call-no-id",
-        "tags": ["subagent_child"],
-        "data": {
-            "output": AIMessage(
-                content="",
-                invalid_tool_calls=[
-                    {
-                        "name": "write_plan",
-                        "args": "<<<<",
-                        "error": "invalid json",
-                        "type": "invalid_tool_call",
-                    }
-                ],
-            )
-        },
-    })
+    with patch.object(persister_module, "log_tool_failure") as log_failure:
+        await p.handle({
+            "event": "on_chat_model_end",
+            "run_id": "child-run-invalid-tool-call-no-id",
+            "tags": ["subagent_child"],
+            "data": {
+                "output": AIMessage(
+                    content="",
+                    invalid_tool_calls=[
+                        {
+                            "name": "write_plan",
+                            "args": "<<<<",
+                            "error": "invalid json",
+                            "type": "invalid_tool_call",
+                        }
+                    ],
+                )
+            },
+        })
+    log_failure.assert_not_called()
 
     items = await repo.list_by_session(db_session, sid)
     assert len(items) == 2

--- a/backend/tests/agent_runtime/persistence/test_persister.py
+++ b/backend/tests/agent_runtime/persistence/test_persister.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 import pytest
 from langchain_core.messages import AIMessage, AIMessageChunk
 from langchain_core.messages.tool import invalid_tool_call
+from langgraph.errors import GraphInterrupt
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.persistence import repo
@@ -246,10 +247,10 @@ async def test_persister_replaces_approval_preview_with_rejected_result(
             "tool_call_id": "call-rejected",
             "tool_name": "edit_note",
             "output": {
-                "type": "fail",
+                "type": "control",
                 "success": False,
-                "reason": "tool_error",
-                "error": "工具调用已被用户拒绝",
+                "status": "approval_denied",
+                "message": "工具调用已被用户拒绝",
             },
         }
     )
@@ -257,10 +258,10 @@ async def test_persister_replaces_approval_preview_with_rejected_result(
     messages = await repo.list_by_session(db_session, session_id)
     assert len(messages) == 1
     assert json.loads(messages[0].content) == {
-        "type": "fail",
+        "type": "control",
         "success": False,
-        "reason": "tool_error",
-        "error": "工具调用已被用户拒绝",
+        "status": "approval_denied",
+        "message": "工具调用已被用户拒绝",
     }
 
 
@@ -366,7 +367,7 @@ async def test_persister_persists_subagent_child_events_when_opted_in(
 
 
 @pytest.mark.asyncio
-async def test_persister_persists_subagent_tool_error_when_approval_interrupts(
+async def test_persister_persists_subagent_tool_approval_preview(
     db_session: AsyncSession, db_session_factory, sample_task
 ):
     sid = "child-session-tool-error"
@@ -422,7 +423,7 @@ async def test_persister_persists_subagent_tool_error_when_approval_interrupts(
         "tags": ["subagent_child"],
         "data": {
             "input": {"value": "plan child beats"},
-            "error": RuntimeError("approval required"),
+            "error": GraphInterrupt(()),
         },
         "metadata": {"tool_call_id": "call-write-plan"},
     })
@@ -439,7 +440,58 @@ async def test_persister_persists_subagent_tool_error_when_approval_interrupts(
     assert items[1].status == "complete"
     assert items[1].tool_call_id == "call-write-plan"
     assert items[1].tool_name == "write_plan"
-    assert "\"reason\": \"approval_preview\"" in items[1].content
+    assert json.loads(items[1].content) == {
+        "type": "ok",
+        "success": True,
+        "reason": "approval_preview",
+        "message": "需要审批",
+        "tool_call_id": "call-write-plan",
+        "tool_name": "write_plan",
+    }
+
+
+@pytest.mark.asyncio
+async def test_persister_persists_subagent_tool_error_as_canonical_failure(
+    db_session: AsyncSession, db_session_factory, sample_task
+):
+    persister = MessagePersister(
+        session_id="child-session-tool-error",
+        task_id=sample_task.id,
+        project_id=sample_task.project_id,
+        db_session_factory=db_session_factory,
+        allow_subagent_child_events=True,
+    )
+    await persister.handle(
+        {
+            "event": "on_tool_start",
+            "name": "write_plan",
+            "run_id": "child-tool-error",
+            "tags": ["subagent_child"],
+            "data": {"input": {"value": "plan child beats"}},
+            "metadata": {"tool_call_id": "call-write-plan"},
+        }
+    )
+    await persister.handle(
+        {
+            "event": "on_tool_error",
+            "name": "write_plan",
+            "run_id": "child-tool-error",
+            "tags": ["subagent_child"],
+            "data": {"error": RuntimeError("write failed")},
+            "metadata": {"tool_call_id": "call-write-plan"},
+        }
+    )
+    await persister.finalize(reason="error")
+
+    items = await repo.list_by_session(db_session, "child-session-tool-error")
+
+    assert len(items) == 1
+    assert json.loads(items[0].content) == {
+        "type": "fail",
+        "success": False,
+        "code": "execution_failed",
+        "message": "工具执行失败",
+    }
 
 
 @pytest.mark.asyncio
@@ -771,7 +823,12 @@ async def test_persister_persists_unrecoverable_invalid_tool_call_with_synthesiz
     assert tool.role == "tool"
     assert tool.tool_call_id == synthesized_id
     assert tool.tool_name == "write_plan"
-    assert '"reason": "malformed_tool_call"' in tool.content
+    assert json.loads(tool.content) == {
+        "type": "fail",
+        "success": False,
+        "code": "malformed_tool_call",
+        "message": "工具参数 JSON 无法解析，未执行工具调用",
+    }
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/persistence/test_persister_finalize.py
+++ b/backend/tests/agent_runtime/persistence/test_persister_finalize.py
@@ -54,7 +54,12 @@ async def test_finalize_writes_partial_assistant_with_resolvable_tool_call(
     tool = next(m for m in items if m.role == "tool")
     assert tool.tool_call_id == "c1"
     assert tool.tool_name == "read_chapter"
-    assert "中断" in tool.content
+    assert json.loads(tool.content) == {
+        "type": "fail",
+        "success": False,
+        "code": "execution_failed",
+        "message": "工具未执行",
+    }
 
 
 @pytest.mark.asyncio
@@ -224,6 +229,12 @@ async def test_finalize_writes_aborted_for_tool_started_not_ended(
     assert items[0].status == "aborted"
     assert items[0].tool_call_id == "tc1"
     assert items[0].tool_name == "write_chapter"
+    assert json.loads(items[0].content) == {
+        "type": "fail",
+        "success": False,
+        "code": "execution_failed",
+        "message": "工具执行未完成",
+    }
 
 
 @pytest.mark.asyncio
@@ -313,7 +324,10 @@ async def test_finalize_preserves_cancelled_subagent_tool_identity_in_history(
         "dispatch_id": "dispatch-cancelled",
         "agent_key": "writer",
         "agent_number": "#1001",
-        "error": "subagent 会话已被用户中断，要通知其继续工作请使用 notify_subagent",
+        "type": "fail",
+        "success": False,
+        "code": "execution_failed",
+        "message": "subagent 会话已被用户中断，要通知其继续工作请使用 notify_subagent",
     }
 
 

--- a/backend/tests/agent_runtime/runner/test_subagent_runner.py
+++ b/backend/tests/agent_runtime/runner/test_subagent_runner.py
@@ -7,6 +7,7 @@ import pytest
 import pytest_asyncio
 from langchain_core.messages import AIMessage
 from langchain_core.messages import AIMessageChunk
+from langgraph.errors import GraphInterrupt
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
@@ -1335,7 +1336,7 @@ async def test_subagent_runner_emits_child_tool_result_for_tool_error_before_int
                 "tags": ["subagent_child"],
                 "data": {
                     "input": {"value": "plan child beats"},
-                    "error": RuntimeError("approval required"),
+                    "error": GraphInterrupt(()),
                 },
                 "metadata": {"tool_call_id": "call-create-plan"},
             }
@@ -1426,6 +1427,14 @@ async def test_subagent_runner_emits_child_tool_result_for_tool_error_before_int
     assert child_tool_results[0]["tool_call_id"] == "call-create-plan"
     assert child_tool_results[0]["tool"] == "write_plan"
     assert child_tool_results[0]["input"] == {"value": "plan child beats"}
+    assert child_tool_results[0]["output"] == {
+        "type": "ok",
+        "success": True,
+        "reason": "approval_preview",
+        "message": "需要审批",
+        "tool_call_id": "call-create-plan",
+        "tool_name": "write_plan",
+    }
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/test_checkpointer.py
+++ b/backend/tests/agent_runtime/test_checkpointer.py
@@ -101,6 +101,27 @@ def test_checkpoint_serializer_stringifies_out_of_range_integer_metadata() -> No
     assert restored[0].response_metadata["provider_counter"] == str(oversized_integer)
 
 
+def test_checkpoint_serializer_skips_sanitization_for_serializable_values(monkeypatch) -> None:
+    serializer = checkpointer_mod._CheckpointSerializer(
+        allowed_msgpack_modules=checkpointer_mod._ALLOWED_MSGPACK_MODULES,
+    )
+    sanitize_calls = 0
+    original_sanitize = checkpointer_mod._sanitize_checkpoint_value
+
+    def track_sanitize(value, active_ids=None):
+        nonlocal sanitize_calls
+        sanitize_calls += 1
+        return original_sanitize(value, active_ids)
+
+    monkeypatch.setattr(checkpointer_mod, "_sanitize_checkpoint_value", track_sanitize)
+
+    message_type, payload = serializer.dumps_typed({"message": "complete"})
+
+    assert message_type == "msgpack"
+    assert payload
+    assert sanitize_calls == 0
+
+
 @pytest.mark.asyncio
 async def test_get_checkpointer_restores_legacy_question_checkpoint(
     monkeypatch, tmp_path

--- a/backend/tests/agent_runtime/test_checkpointer.py
+++ b/backend/tests/agent_runtime/test_checkpointer.py
@@ -1,4 +1,5 @@
 from contextlib import closing
+from dataclasses import dataclass
 import os
 import sqlite3
 import tempfile
@@ -9,6 +10,7 @@ from unittest.mock import AsyncMock
 
 import app.agent_runtime.runner.checkpointer as checkpointer_mod
 import aiosqlite
+from langchain_core.messages import AIMessage
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import Checkpoint
 from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
@@ -33,6 +35,70 @@ from app.storage.models.revision import Revision
 from app.storage.models.task import Task
 
 pytestmark = pytest.mark.usefixtures("fast_checkpoint_sqlite")
+
+
+@dataclass(frozen=True)
+class _CheckpointTaskState:
+    message: AIMessage
+
+
+def test_checkpoint_serializer_sanitizes_cyclic_ai_message() -> None:
+    serializer = checkpointer_mod._CheckpointSerializer(
+        allowed_msgpack_modules=checkpointer_mod._ALLOWED_MSGPACK_MODULES,
+    )
+    message = AIMessage(content="complete output")
+    message.response_metadata["self"] = message
+
+    message_type, payload = serializer.dumps_typed([message])
+
+    assert message_type == "msgpack"
+    assert payload
+
+
+def test_checkpoint_serializer_sanitizes_message_inside_dataclass() -> None:
+    serializer = checkpointer_mod._CheckpointSerializer(
+        allowed_msgpack_modules=checkpointer_mod._ALLOWED_MSGPACK_MODULES,
+    )
+    message = AIMessage(content="complete output")
+    message.response_metadata["self"] = message
+
+    message_type, payload = serializer.dumps_typed([_CheckpointTaskState(message)])
+
+    assert message_type == "msgpack"
+    assert payload
+
+
+def test_checkpoint_serializer_falls_back_for_unknown_message_wrapper() -> None:
+    class MessageWrapper:
+        def __init__(self, message: AIMessage) -> None:
+            self.message = message
+
+    serializer = checkpointer_mod._CheckpointSerializer(
+        allowed_msgpack_modules=checkpointer_mod._ALLOWED_MSGPACK_MODULES,
+    )
+    message = AIMessage(content="complete output")
+    message.response_metadata["self"] = message
+
+    message_type, payload = serializer.dumps_typed([MessageWrapper(message)])
+
+    assert message_type == "msgpack"
+    assert payload
+
+
+def test_checkpoint_serializer_stringifies_out_of_range_integer_metadata() -> None:
+    serializer = checkpointer_mod._CheckpointSerializer(
+        allowed_msgpack_modules=checkpointer_mod._ALLOWED_MSGPACK_MODULES,
+    )
+    oversized_integer = 1 << 100
+    message = AIMessage(
+        content="complete output",
+        response_metadata={"provider_counter": oversized_integer},
+    )
+
+    message_type, payload = serializer.dumps_typed([message])
+    restored = serializer.loads_typed((message_type, payload))
+
+    assert restored[0].response_metadata["provider_counter"] == str(oversized_integer)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/test_event_translator.py
+++ b/backend/tests/agent_runtime/test_event_translator.py
@@ -269,8 +269,40 @@ def test_translate_chat_model_stream_synthesizes_tool_call_id_without_model_id()
     assert end_result["data"]["tool_call_id"] == synthesized_id
     assert end_result["data"]["tool"] == "write_plan"
     assert end_result["data"]["input"] == "<<<<"
-    assert end_result["data"]["output"]["reason"] == "malformed_tool_call"
-    assert end_result["data"]["output"]["success"] is False
+    assert end_result["data"]["output"] == {
+        "type": "fail",
+        "success": False,
+        "code": "malformed_tool_call",
+        "message": "工具参数 JSON 无法解析，未执行工具调用",
+    }
+
+
+def test_translate_subagent_tool_error_returns_canonical_failure():
+    translator = EventTranslator(
+        session_id="child_thread_001",
+        allow_subagent_child_events=True,
+    )
+    event = {
+        "event": "on_tool_error",
+        "name": "write_plan",
+        "run_id": "child-tool-error",
+        "data": {
+            "input": {},
+            "error": RuntimeError("database password=super-secret"),
+        },
+        "metadata": {"tool_call_id": "call-write"},
+        "tags": ["subagent_child"],
+    }
+
+    result = single_event(translator.translate(event))
+
+    assert result["name"] == "agent:tool_result"
+    assert result["data"]["output"] == {
+        "type": "fail",
+        "success": False,
+        "code": "execution_failed",
+        "message": "工具执行失败",
+    }
 
 
 def test_translate_chat_model_stream_empty_content():

--- a/backend/tests/agent_runtime/test_event_translator.py
+++ b/backend/tests/agent_runtime/test_event_translator.py
@@ -301,7 +301,7 @@ def test_translate_subagent_tool_error_returns_canonical_failure():
         "type": "fail",
         "success": False,
         "code": "execution_failed",
-        "message": "工具执行失败",
+        "message": "database password=super-secret",
     }
 
 

--- a/backend/tests/agent_runtime/test_orchestrator_graph.py
+++ b/backend/tests/agent_runtime/test_orchestrator_graph.py
@@ -2,9 +2,12 @@ import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
+import aiosqlite
 import pytest
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage
 from langgraph.checkpoint.memory import InMemorySaver
+from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
+from langgraph.checkpoint.sqlite.aio import AsyncSqliteSaver
 from langgraph.types import Command
 from pydantic import BaseModel
 
@@ -244,7 +247,12 @@ async def test_orchestrator_resumes_all_parallel_tool_approvals_once() -> None:
             ),
             patch.object(_OrchestratorApprovalTool, "_execute", execute),
         ):
-            await graph.ainvoke(initial_state, config=runtime_config)
+            async for _event in graph.astream_events(
+                initial_state,
+                config=runtime_config,
+                version="v2",
+            ):
+                pass
             state = await graph.aget_state(runtime_config)
             interrupts = [
                 interrupt
@@ -285,3 +293,132 @@ async def test_orchestrator_resumes_all_parallel_tool_approvals_once() -> None:
         ToolRegistry._tools = registered_tools
 
     assert executed_values == [str(index) for index in range(1, 6)]
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_sqlite_checkpoint_survives_batch_approval_completion(
+    tmp_path,
+) -> None:
+    from app.agent_runtime.graph.orchestrator.graph import build_orchestrator_graph
+
+    registered_tools = dict(ToolRegistry._tools)
+    ToolRegistry._tools[_ORCHESTRATOR_APPROVAL_TOOL_NAME] = _OrchestratorApprovalTool
+    connection = await aiosqlite.connect(tmp_path / "checkpoints.db")
+    checkpointer = AsyncSqliteSaver(
+        connection,
+        serde=JsonPlusSerializer(
+            allowed_msgpack_modules=(
+                ("app.agent_runtime.tools.impls.interaction.ask_user", "Question"),
+                (
+                    "app.agent_runtime.tools.impls.interaction.ask_user",
+                    "QuestionOption",
+                ),
+            )
+        ),
+    )
+    await checkpointer.setup()
+    graph = build_orchestrator_graph(checkpointer=checkpointer)
+    response = AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "id": f"call-approval-{index}",
+                "name": _ORCHESTRATOR_APPROVAL_TOOL_NAME,
+                "args": {"value": f"approved-{index}"},
+            }
+            for index in range(1, 3)
+        ],
+    )
+    runtime_config = {
+        "configurable": {
+            "thread_id": "orchestrator-sqlite-approval",
+            "db_session": object(),
+            "model_config": {
+                "provider_type": "openai",
+                "model_id": "gpt-test",
+                "api_key": "key",
+                "base_url": "",
+                "max_context_tokens": 8000,
+            },
+        }
+    }
+    initial_state = {
+        "session_id": "orchestrator-sqlite-approval",
+        "task_id": "task-1",
+        "project_id": "project-1",
+        "model_config": runtime_config["configurable"]["model_config"],
+        "agent_key": "build",
+        "messages": [],
+        "user_request": "run approval",
+        "is_completed": False,
+        "error": None,
+        "retry_count": 0,
+        "current_revision_id": "rev-1",
+    }
+    response_chunks = [
+        AIMessageChunk(
+            content="",
+            tool_calls=response.tool_calls,
+        ),
+        AIMessageChunk(content="complete output"),
+    ]
+
+    async def failing_execute(self, value: str) -> str:
+        raise RuntimeError(f"approval tool failed: {value}")
+
+    class Model:
+        def bind_tools(self, _tools):
+            return self
+
+        async def astream(self, _messages):
+            yield response_chunks.pop(0)
+
+    try:
+        with (
+            patch(
+                "app.agent_runtime.graph.orchestrator.graph.create_chat_model",
+                return_value=Model(),
+            ),
+            patch(
+                "app.agent_runtime.graph.orchestrator.graph._primary_tool_names",
+                AsyncMock(return_value=[_ORCHESTRATOR_APPROVAL_TOOL_NAME]),
+            ),
+            patch(
+                "app.agent_runtime.graph.orchestrator.graph._primary_build_hooks",
+                AsyncMock(return_value=[]),
+            ),
+            patch(
+                "app.agent_runtime.graph.orchestrator.graph.auth_hook",
+                _interrupt_for_approval,
+            ),
+            patch(
+                "app.agent_runtime.graph.react_agent.build_context_parts",
+                AsyncMock(return_value=[ContextMessage(role="user", content="run approval")]),
+            ),
+            patch.object(_OrchestratorApprovalTool, "_execute", failing_execute),
+        ):
+            await graph.ainvoke(initial_state, config=runtime_config)
+            state = await graph.aget_state(runtime_config)
+            interrupts = [
+                interrupt
+                for task in state.tasks
+                for interrupt in getattr(task, "interrupts", ())
+            ]
+            assert len(interrupts) == 2
+            resume = {
+                interrupt.id: {
+                    "action_type": "tool_approval",
+                    "approval_id": interrupt.id,
+                    "approved": True,
+                }
+                for interrupt in interrupts
+            }
+            async for _event in graph.astream_events(
+                Command(resume=resume),
+                config=runtime_config,
+                version="v2",
+            ):
+                pass
+    finally:
+        await connection.close()
+        ToolRegistry._tools = registered_tools

--- a/backend/tests/agent_runtime/test_react_agent.py
+++ b/backend/tests/agent_runtime/test_react_agent.py
@@ -14,6 +14,7 @@ from app.agent_runtime.types import TerminationCondition, ReactAgentConfig
 from app.agent_runtime.graph.react_agent import (
     _invoke_model,
     _invoke_tool,
+    _tool_result_payload,
     create_react_agent,
     ReactState,
 )
@@ -784,8 +785,74 @@ async def test_react_agent_emits_tool_error_for_unrecoverable_invalid_tool_call_
     assert executed_calls == []
     assert isinstance(result["messages"][-1], ToolMessage)
     assert result["messages"][-1].tool_call_id == "call_1"
-    assert '"reason": "malformed_tool_call"' in result["messages"][-1].content
-    assert "write_plan" in result["messages"][-1].content
+    assert json.loads(result["messages"][-1].content) == {
+        "type": "fail",
+        "success": False,
+        "code": "malformed_tool_call",
+        "message": "工具参数 JSON 无法解析，未执行工具调用",
+    }
+
+
+def test_tool_result_payload_treats_canonical_failure_as_failure() -> None:
+    payload, success = _tool_result_payload(
+        '{"type":"fail","success":false,"code":"not_found","message":"未找到章节"}'
+    )
+
+    assert payload["code"] == "not_found"
+    assert success is False
+
+
+def test_tool_result_payload_treats_failed_type_as_failure_without_success() -> None:
+    payload, success = _tool_result_payload(
+        '{"type":"fail","code":"not_found","message":"未找到章节"}'
+    )
+
+    assert payload["code"] == "not_found"
+    assert success is False
+
+
+@pytest.mark.asyncio
+async def test_react_agent_returns_canonical_failure_for_unknown_tool() -> None:
+    config = ReactAgentConfig(
+        name="composer",
+        tools=[_add_tool()],
+        termination=TerminationCondition(mode="no_tool_call"),
+        max_iterations=2,
+    )
+    graph = create_react_agent(config)
+    calls = 0
+
+    async def _mock_invoke(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return AIMessage(
+                content="",
+                tool_calls=[{"id": "call_unknown", "name": "missing_tool", "args": {}}],
+            )
+        return AIMessage(content="done")
+
+    with patch(
+        "app.agent_runtime.graph.react_agent._invoke_model", side_effect=_mock_invoke
+    ):
+        result = await graph.ainvoke(
+            {
+                "messages": [HumanMessage(content="run")],
+                "iteration_count": 0,
+                "is_done": False,
+                "final_output": None,
+            }
+        )
+
+    tool_message = next(
+        message for message in result["messages"] if isinstance(message, ToolMessage)
+    )
+    assert json.loads(tool_message.content) == {
+        "type": "fail",
+        "success": False,
+        "code": "tool_not_found",
+        "message": "未找到工具：missing_tool",
+    }
 
 
 @pytest.mark.asyncio
@@ -890,6 +957,10 @@ async def test_react_agent_passes_runtime_config_and_tool_call_id_to_agent_tools
         patch(
             "app.agent_runtime.graph.react_agent.build_context",
             new=AsyncMock(return_value=[HumanMessage(content="Use a tool")]),
+        ),
+        patch(
+            "app.agent_runtime.graph.react_agent.normalize_tool_failure_result",
+            side_effect=AssertionError("AgentTool result was normalized twice"),
         ),
     ):
         await graph.ainvoke(
@@ -1079,8 +1150,15 @@ async def test_react_agent_does_not_execute_tool_after_approval_is_rejected() ->
     assert executed == []
     assert len(tool_results) == 1
     assert tool_results[0]["tool_call_id"] == "call_reject"
-    assert tool_results[0]["output"]["success"] is False
-    assert tool_results[0]["output"]["type"] == "fail"
+    assert tool_results[0]["output"] == {
+        "type": "control",
+        "success": False,
+        "status": "approval_denied",
+        "message": "工具调用已被用户拒绝",
+        "approval_id": pending[0].id,
+        "tool_name": "approval_tool",
+        "tool_call_id": "call_reject",
+    }
 
 
 @pytest.mark.asyncio
@@ -1141,10 +1219,22 @@ async def test_react_agent_rejects_more_than_twenty_tool_calls_before_execution(
         if isinstance(message, ToolMessage) and "最多调用" in message.content
     )
     assert error_message.tool_call_id == "call_20"
+    assert json.loads(error_message.content) == {
+        "type": "fail",
+        "success": False,
+        "code": "limit_exceeded",
+        "message": "Agent 单轮最多调用 20 个工具，超出上限的工具调用未执行",
+    }
     assert len(tool_results) == 1
     assert tool_results[0]["tool_call_id"] == "call_20"
-    assert tool_results[0]["output"]["success"] is False
-    assert tool_results[0]["output"]["reason"] == "tool_error"
+    assert tool_results[0]["output"] == {
+        "type": "fail",
+        "success": False,
+        "code": "limit_exceeded",
+        "message": "Agent 单轮最多调用 20 个工具，超出上限的工具调用未执行",
+        "tool_call_id": "call_20",
+        "tool_name": "counting_tool",
+    }
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/test_react_agent.py
+++ b/backend/tests/agent_runtime/test_react_agent.py
@@ -1,6 +1,6 @@
 import asyncio
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, ToolMessage
 from langchain_core.messages.tool import invalid_tool_call
@@ -147,6 +147,23 @@ async def test_invoke_model_extracts_anthropic_text_content_blocks() -> None:
     assert response.content == "可见回复"
 
 
+@pytest.mark.asyncio
+async def test_invoke_model_sanitizes_nested_message_metadata() -> None:
+    nested_message = AIMessage(content="nested")
+
+    class StreamingModel:
+        async def astream(self, _messages):
+            yield AIMessageChunk(
+                content="完成",
+                response_metadata={"raw_message": nested_message},
+            )
+
+    response = await _invoke_model(StreamingModel(), [HumanMessage(content="Hello")])
+
+    assert response.response_metadata["raw_message"]["content"] == "nested"
+    assert not isinstance(response.response_metadata["raw_message"], AIMessage)
+
+
 def test_create_react_agent_returns_compiled_graph(dummy_tool):
     config = ReactAgentConfig(
         name="test",
@@ -197,6 +214,63 @@ def test_react_agent_terminates_on_no_tool_call(dummy_tool):
             assert result["is_done"] is True
 
     asyncio.run(_run())
+
+
+@pytest.mark.asyncio
+async def test_react_agent_normalizes_structured_tool_exception() -> None:
+    async def failing_tool() -> str:
+        raise RuntimeError("structured tool failure")
+
+    tool = StructuredTool.from_function(
+        coroutine=failing_tool,
+        name="failing_tool",
+        description="fails",
+    )
+    model = Mock()
+    model.bind_tools.return_value = model
+    responses = iter(
+        [
+            AIMessage(
+                content="",
+                tool_calls=[{"id": "call-1", "name": "failing_tool", "args": {}}],
+            ),
+            AIMessage(content="recovered"),
+        ]
+    )
+
+    async def invoke_model(*_args, **_kwargs):
+        return next(responses)
+
+    config = ReactAgentConfig(
+        name="writer",
+        tools=[tool],
+        termination=TerminationCondition(mode="no_tool_call"),
+        max_iterations=2,
+    )
+
+    with patch(
+        "app.agent_runtime.graph.react_agent._invoke_model",
+        side_effect=invoke_model,
+    ):
+        result = await create_react_agent(config, model=model).ainvoke(
+            {
+                "messages": [HumanMessage(content="go")],
+                "iteration_count": 0,
+                "is_done": False,
+                "final_output": None,
+            }
+        )
+
+    tool_messages = [
+        message for message in result["messages"] if isinstance(message, ToolMessage)
+    ]
+    assert json.loads(tool_messages[0].content) == {
+        "type": "fail",
+        "success": False,
+        "code": "execution_failed",
+        "message": "structured tool failure",
+    }
+    assert result["messages"][-1].content == "recovered"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/test_react_agent.py
+++ b/backend/tests/agent_runtime/test_react_agent.py
@@ -10,6 +10,7 @@ from langgraph.types import Command
 from pydantic import BaseModel
 
 from app.agent_runtime.tools.base import AgentTool, HookResult
+from app.agent_runtime.tools.errors import ToolExecutionError
 from app.agent_runtime.types import TerminationCondition, ReactAgentConfig
 from app.agent_runtime.graph.react_agent import (
     _invoke_model,
@@ -247,6 +248,7 @@ async def test_react_agent_normalizes_structured_tool_exception() -> None:
         termination=TerminationCondition(mode="no_tool_call"),
         max_iterations=2,
     )
+    tool_results: list[dict] = []
 
     with patch(
         "app.agent_runtime.graph.react_agent._invoke_model",
@@ -258,7 +260,8 @@ async def test_react_agent_normalizes_structured_tool_exception() -> None:
                 "iteration_count": 0,
                 "is_done": False,
                 "final_output": None,
-            }
+            },
+            config={"configurable": {"tool_result_sink": tool_results.append}},
         )
 
     tool_messages = [
@@ -271,6 +274,74 @@ async def test_react_agent_normalizes_structured_tool_exception() -> None:
         "message": "structured tool failure",
     }
     assert result["messages"][-1].content == "recovered"
+    assert tool_results == [
+        {
+            "session_id": None,
+            "tool_call_id": "call-1",
+            "tool_name": "failing_tool",
+            "input": {},
+            "output": {
+                "type": "fail",
+                "success": False,
+                "code": "execution_failed",
+                "message": "structured tool failure",
+                "tool_call_id": "call-1",
+                "tool_name": "failing_tool",
+            },
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_react_agent_preserves_structured_tool_error_code() -> None:
+    async def failing_tool() -> str:
+        raise ToolExecutionError("章节不存在", code="not_found")
+
+    tool = StructuredTool.from_function(
+        coroutine=failing_tool,
+        name="failing_tool",
+        description="fails",
+    )
+    model = Mock()
+    model.bind_tools.return_value = model
+    responses = iter(
+        [
+            AIMessage(
+                content="",
+                tool_calls=[{"id": "call-1", "name": "failing_tool", "args": {}}],
+            ),
+            AIMessage(content="recovered"),
+        ]
+    )
+
+    async def invoke_model(*_args, **_kwargs):
+        return next(responses)
+
+    with patch(
+        "app.agent_runtime.graph.react_agent._invoke_model",
+        side_effect=invoke_model,
+    ):
+        result = await create_react_agent(
+            ReactAgentConfig(
+                name="writer",
+                tools=[tool],
+                termination=TerminationCondition(mode="no_tool_call"),
+                max_iterations=2,
+            ),
+            model=model,
+        ).ainvoke(
+            {
+                "messages": [HumanMessage(content="go")],
+                "iteration_count": 0,
+                "is_done": False,
+                "final_output": None,
+            }
+        )
+
+    tool_message = next(
+        message for message in result["messages"] if isinstance(message, ToolMessage)
+    )
+    assert json.loads(tool_message.content)["code"] == "not_found"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/test_session_runner.py
+++ b/backend/tests/agent_runtime/test_session_runner.py
@@ -1108,7 +1108,7 @@ async def test_run_emits_error_and_marks_revision_failed_on_runtime_exception():
  
  
 @pytest.mark.asyncio
-async def test_resume_emits_error_and_marks_revision_failed_on_runtime_exception():
+async def test_resume_emits_error_and_keeps_pending_revision_resumable_on_runtime_exception():
     runner = SessionRunner(
         session_id="sess_resume_error_001",
         task_id="task_resume_error_001",
@@ -1172,7 +1172,7 @@ async def test_resume_emits_error_and_marks_revision_failed_on_runtime_exception
     finalize_revision_status.assert_awaited_once_with(
         fake_status_session,
         "rev_resume_1",
-        "failed",
+        "interrupted",
     )
     emit_mock.assert_any_await(
         "agent:error",

--- a/backend/tests/agent_runtime/test_session_runner.py
+++ b/backend/tests/agent_runtime/test_session_runner.py
@@ -1129,9 +1129,13 @@ async def test_resume_emits_error_and_keeps_pending_revision_resumable_on_runtim
                 yield None
 
         async def aget_state(self, _config):
+            interrupt = SimpleNamespace(
+                id="resume-interrupt",
+                value={"type": "tool_approval", "tool_name": "write_note", "args": {}},
+            )
             return SimpleNamespace(
                 next=("primary",),
-                tasks=(),
+                tasks=(SimpleNamespace(interrupts=(interrupt,)),),
                 values={"current_revision_id": "rev_resume_1"},
                 config={"configurable": {}},
             )
@@ -1142,6 +1146,7 @@ async def test_resume_emits_error_and_keeps_pending_revision_resumable_on_runtim
         handle=AsyncMock(),
         finalize=AsyncMock(),
         persist_node_event=AsyncMock(),
+        apply_interrupt_preview=AsyncMock(),
     )
 
     with patch.object(runner, "_get_graph", AsyncMock(return_value=_Graph())), patch(
@@ -1149,7 +1154,7 @@ async def test_resume_emits_error_and_keeps_pending_revision_resumable_on_runtim
         AsyncMock(side_effect=[fake_runtime_session, fake_status_session]),
     ), patch(
         "app.agent_runtime.runner.session_runner.finalize_revision_status",
-        AsyncMock(),
+        AsyncMock(return_value=False),
     ) as finalize_revision_status, patch(
         "app.agent_runtime.runner.session_runner.emit",
         AsyncMock(),
@@ -1183,6 +1188,8 @@ async def test_resume_emits_error_and_keeps_pending_revision_resumable_on_runtim
         },
         room=runner._room,
     )
+    event_names = [call.args[0] for call in emit_mock.await_args_list if call.args]
+    assert "agent:interrupt" not in event_names
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/tools/test_ask_user.py
+++ b/backend/tests/agent_runtime/tools/test_ask_user.py
@@ -93,7 +93,12 @@ class TestAskUser:
             }
             result = await tool.ainvoke(_valid_input())
 
-        assert json.loads(result) == {"status": "user_skipped", "error": "用户忽略了提问"}
+        assert json.loads(result) == {
+            "type": "control",
+            "success": False,
+            "status": "user_skipped",
+            "message": "用户忽略了提问",
+        }
 
     async def test_ask_user_accepts_more_than_five_questions(self):
         from app.agent_runtime.tools.impls.interaction.ask_user import AskUserTool

--- a/backend/tests/agent_runtime/tools/test_base.py
+++ b/backend/tests/agent_runtime/tools/test_base.py
@@ -44,7 +44,21 @@ class FailingTool(AgentTool):
 
     async def _execute(self, value: str) -> str:
         from app.agent_runtime.tools.errors import ToolExecutionError
-        raise ToolExecutionError("something went wrong")
+        raise ToolExecutionError("something went wrong", code="not_found")
+
+
+class LegacyFailingTool(AgentTool):
+    name: str = "legacy_failing"
+    description: str = "A tool with a legacy error result"
+    args_schema: type[BaseModel] = DummyInput
+
+    async def _execute(self, value: str) -> str:
+        return json.dumps(
+            {
+                "error": "something went wrong",
+                "metadata": {"trace": "legacy diagnostic detail"},
+            }
+        )
 
 
 def _make_state() -> dict:
@@ -73,18 +87,38 @@ async def test_agent_tool_project_id_from_state():
     assert tool.session_id == "sess-1"
 
 
-async def test_agent_tool_execution_error_returns_json():
+async def test_agent_tool_execution_error_returns_safe_failure_result():
     tool = FailingTool(_state=_make_state())
     result = await tool.ainvoke({"value": "test"})
-    assert '"error"' in result
-    assert "something went wrong" in result
+    assert json.loads(result) == {
+        "type": "fail",
+        "success": False,
+        "code": "not_found",
+        "message": "something went wrong",
+    }
 
 
-async def test_agent_tool_validation_error_returns_json():
+async def test_agent_tool_validation_error_returns_safe_failure_result():
     tool = DummyTool(_state=_make_state())
     result = await tool.ainvoke({"wrong_field": 123})
-    assert '"error"' in result
-    assert "参数校验失败" in result
+    payload = json.loads(result)
+    assert payload["type"] == "fail"
+    assert payload["success"] is False
+    assert payload["code"] == "validation_error"
+    assert "参数校验失败" in payload["message"]
+    assert "trace" not in payload
+
+
+async def test_agent_tool_normalizes_legacy_error_result():
+    tool = LegacyFailingTool(_state=_make_state())
+    result = await tool.ainvoke({"value": "test"})
+
+    assert json.loads(result) == {
+        "type": "fail",
+        "success": False,
+        "code": "execution_failed",
+        "message": "something went wrong",
+    }
 
 
 async def test_agent_tool_pre_hook_can_block():
@@ -160,7 +194,14 @@ async def test_agent_tool_does_not_execute_after_rejected_tool_approval():
         result = await tool.ainvoke({"value": "hello"})
 
     payload = json.loads(result)
-    assert payload["error"] == "工具调用已被用户拒绝"
+    assert payload == {
+        "type": "control",
+        "success": False,
+        "status": "approval_denied",
+        "message": "工具调用已被用户拒绝",
+        "approval_id": "approval-1",
+        "tool_name": "preview",
+    }
     assert executed == []
 
 

--- a/backend/tests/agent_runtime/tools/test_base.py
+++ b/backend/tests/agent_runtime/tools/test_base.py
@@ -47,6 +47,15 @@ class FailingTool(AgentTool):
         raise ToolExecutionError("something went wrong", code="not_found")
 
 
+class UnexpectedFailingTool(AgentTool):
+    name: str = "unexpected_failing"
+    description: str = "A tool with an unexpected exception"
+    args_schema: type[BaseModel] = DummyInput
+
+    async def _execute(self, value: str) -> str:
+        raise RuntimeError("database password=super-secret")
+
+
 class LegacyFailingTool(AgentTool):
     name: str = "legacy_failing"
     description: str = "A tool with a legacy error result"
@@ -96,6 +105,18 @@ async def test_agent_tool_execution_error_returns_safe_failure_result():
         "code": "not_found",
         "message": "something went wrong",
     }
+
+
+async def test_agent_tool_does_not_log_raw_unexpected_exception():
+    tool = UnexpectedFailingTool(_state=_make_state())
+
+    with patch("app.agent_runtime.tools.errors.logger") as logger:
+        result = await tool.ainvoke({"value": "test"})
+
+    bound_logger = logger.bind.return_value
+    bound_logger.error.assert_called_once_with("Agent 工具执行失败")
+    bound_logger.opt.assert_not_called()
+    assert json.loads(result)["code"] == "execution_failed"
 
 
 async def test_agent_tool_validation_error_returns_safe_failure_result():

--- a/backend/tests/agent_runtime/tools/test_base.py
+++ b/backend/tests/agent_runtime/tools/test_base.py
@@ -2,8 +2,10 @@ import json
 import pytest
 from pydantic import BaseModel
 from unittest.mock import patch
+from typing import Literal
 
 from app.agent_runtime.tools.base import AgentTool, HookContext, HookResult
+from app.agent_runtime.tools.errors import normalize_tool_failure_result
 
 
 class DummyInput(BaseModel):
@@ -18,6 +20,24 @@ class DummyTool(AgentTool):
 
     async def _execute(self, value: str) -> str:
         return f"executed:{value}"
+
+
+class RefInput(BaseModel):
+    type: Literal["order", "title"]
+
+
+class ComplexInput(BaseModel):
+    volume_ref: RefInput
+    chapter_ref: RefInput
+
+
+class ComplexValidationTool(AgentTool):
+    name: str = "complex_validation"
+    description: str = "A tool with nested validation errors"
+    args_schema: type[BaseModel] = ComplexInput
+
+    async def _execute(self, volume_ref: RefInput, chapter_ref: RefInput) -> str:
+        return "ok"
 
 
 class PreviewTool(AgentTool):
@@ -107,16 +127,38 @@ async def test_agent_tool_execution_error_returns_safe_failure_result():
     }
 
 
-async def test_agent_tool_does_not_log_raw_unexpected_exception():
+async def test_agent_tool_execution_error_logs_exception_traceback():
+    tool = FailingTool(_state=_make_state())
+
+    with patch("app.agent_runtime.tools.errors.logger") as logger:
+        await tool.ainvoke({"value": "test"})
+
+    bound_logger = logger.bind.return_value
+    bound_logger.opt.assert_called_once()
+    assert isinstance(bound_logger.opt.call_args.kwargs["exception"], Exception)
+    bound_logger.opt.return_value.error.assert_called_once_with(
+        "Agent 工具执行失败"
+    )
+
+
+async def test_agent_tool_preserves_unexpected_exception_message_and_logs_exception():
     tool = UnexpectedFailingTool(_state=_make_state())
 
     with patch("app.agent_runtime.tools.errors.logger") as logger:
         result = await tool.ainvoke({"value": "test"})
 
     bound_logger = logger.bind.return_value
-    bound_logger.error.assert_called_once_with("Agent 工具执行失败")
-    bound_logger.opt.assert_not_called()
-    assert json.loads(result)["code"] == "execution_failed"
+    bound_logger.opt.assert_called_once()
+    bound_logger.opt.return_value.error.assert_called_once_with("Agent 工具执行失败")
+    logged_exception = bound_logger.opt.call_args.kwargs["exception"]
+    assert isinstance(logged_exception, RuntimeError)
+    payload = json.loads(result)
+    assert payload == {
+        "type": "fail",
+        "success": False,
+        "code": "execution_failed",
+        "message": "工具执行异常: database password=super-secret",
+    }
 
 
 async def test_agent_tool_validation_error_returns_safe_failure_result():
@@ -130,15 +172,59 @@ async def test_agent_tool_validation_error_returns_safe_failure_result():
     assert "trace" not in payload
 
 
+async def test_agent_tool_validation_error_is_logged():
+    tool = DummyTool(_state=_make_state())
+
+    with patch("app.agent_runtime.tools.errors.logger") as logger:
+        await tool.ainvoke({"wrong_field": 123})
+
+    bound_logger = logger.bind.return_value
+    bound_logger.warning.assert_called_once()
+    assert "参数校验失败" in str(bound_logger.warning.call_args.args)
+
+
+async def test_agent_tool_validation_error_omits_repeated_pydantic_help_urls():
+    tool = ComplexValidationTool(_state=_make_state())
+
+    result = await tool.ainvoke(
+        {
+            "volume_ref": {"type": 123},
+            "chapter_ref": {"type": "invalid_type"},
+        }
+    )
+    message = json.loads(result)["message"]
+
+    assert "volume_ref.type" in message
+    assert "chapter_ref.type" in message
+    assert "Input should be 'order' or 'title'" in message
+    assert "For further information visit" not in message
+    assert "https://errors.pydantic.dev" not in message
+
+
 async def test_agent_tool_normalizes_legacy_error_result():
     tool = LegacyFailingTool(_state=_make_state())
-    result = await tool.ainvoke({"value": "test"})
+    with patch("app.agent_runtime.tools.errors.logger") as logger:
+        result = await tool.ainvoke({"value": "test"})
 
     assert json.loads(result) == {
         "type": "fail",
         "success": False,
         "code": "execution_failed",
         "message": "something went wrong",
+    }
+    warning_args = logger.bind.return_value.warning.call_args.args
+    assert "legacy diagnostic detail" in str(warning_args)
+
+
+def test_normalize_tool_failure_result_caches_parsed_payload() -> None:
+    result, failure = normalize_tool_failure_result(
+        '{"success":true,"items":[{"id":"chapter-1"}]}'
+    )
+
+    assert failure is None
+    assert getattr(result, "payload") == {
+        "success": True,
+        "items": [{"id": "chapter-1"}],
     }
 
 

--- a/backend/tests/agent_runtime/tools/test_chapter_tools.py
+++ b/backend/tests/agent_runtime/tools/test_chapter_tools.py
@@ -342,7 +342,7 @@ async def test_write_chapter_rejects_over_limit_content_without_creating() -> No
             }
         )
 
-    assert "内容超出限制" in json.loads(result)["error"]
+    assert "内容超出限制" in json.loads(result)["message"]
     create_chapter.assert_not_awaited()
 
 
@@ -787,8 +787,8 @@ async def test_delete_volume_requires_cascade_for_non_empty_volume() -> None:
             )
 
     data = json.loads(result)
-    assert "error" in data
-    assert "cascade=true" in data["error"]
+    assert data["type"] == "fail"
+    assert "cascade=true" in data["message"]
     mock_session.rollback.assert_called_once()
 
 

--- a/backend/tests/agent_runtime/tools/test_context_tools.py
+++ b/backend/tests/agent_runtime/tools/test_context_tools.py
@@ -346,7 +346,7 @@ async def test_create_character_rejects_over_limit_description_without_creating(
             {"name": "林舟", "description": "\n".join("内容" for _ in range(2001))}
         )
 
-    assert "内容超出限制" in json.loads(result)["error"]
+    assert "内容超出限制" in json.loads(result)["message"]
     mock_character_service.create_character.assert_not_awaited()
 
 
@@ -458,7 +458,7 @@ async def test_edit_character_rejects_over_limit_replacement_without_updating() 
             }
         )
 
-    assert "内容超出限制" in json.loads(result)["error"]
+    assert "内容超出限制" in json.loads(result)["message"]
     mock_character_service.update_character.assert_not_awaited()
 
 
@@ -587,7 +587,9 @@ async def test_read_world_entry_rejects_duplicate_titles() -> None:
 
         result = await tool.ainvoke({"title": "主角"})
 
-    assert json.loads(result) == {"error": "世界书条目标题不唯一: 主角"}
+    data = json.loads(result)
+    assert data["type"] == "fail"
+    assert data["message"] == "世界书条目标题不唯一: 主角"
 
 
 @pytest.mark.asyncio
@@ -732,7 +734,9 @@ async def test_create_world_entry_rejects_duplicate_title() -> None:
 
         result = await tool.ainvoke({"title": "主角", "content": "林舟"})
 
-    assert json.loads(result) == {"error": "世界书条目标题已存在: 主角"}
+    data = json.loads(result)
+    assert data["type"] == "fail"
+    assert data["message"] == "世界书条目标题已存在: 主角"
 
 
 @pytest.mark.asyncio
@@ -750,7 +754,7 @@ async def test_create_world_entry_rejects_over_limit_content_without_creating() 
             {"title": "主角", "content": "\n".join("内容" for _ in range(2001))}
         )
 
-    assert "内容超出限制" in json.loads(result)["error"]
+    assert "内容超出限制" in json.loads(result)["message"]
     mock_entry_service.create_entry.assert_not_awaited()
 
 
@@ -878,7 +882,7 @@ async def test_edit_world_entry_rejects_over_limit_replacement_without_updating(
             }
         )
 
-    assert "内容超出限制" in json.loads(result)["error"]
+    assert "内容超出限制" in json.loads(result)["message"]
     mock_entry_service.update_entry.assert_not_awaited()
 
 
@@ -906,7 +910,9 @@ async def test_edit_world_entry_rejects_duplicate_new_title() -> None:
 
         result = await tool.ainvoke({"title": "主角", "new_title": "反派"})
 
-    assert json.loads(result) == {"error": "世界书条目标题已存在: 反派"}
+    data = json.loads(result)
+    assert data["type"] == "fail"
+    assert data["message"] == "世界书条目标题已存在: 反派"
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/tools/test_dispatch_subagent.py
+++ b/backend/tests/agent_runtime/tools/test_dispatch_subagent.py
@@ -205,5 +205,8 @@ async def test_dispatch_subagent_returns_dispatch_id_when_child_request_is_cance
     assert result == {
         "dispatch_id": "dispatch-cancelled",
         "agent_number": 3,
-        "error": "subagent request was cancelled",
+        "type": "fail",
+        "success": False,
+        "code": "execution_failed",
+        "message": "subagent request was cancelled",
     }

--- a/backend/tests/agent_runtime/tools/test_note_tools.py
+++ b/backend/tests/agent_runtime/tools/test_note_tools.py
@@ -83,8 +83,8 @@ async def test_read_note_rejects_hidden_note() -> None:
             mock_session.close.assert_called_once()
 
     data = json.loads(result)
-    assert "error" in data
-    assert "已隐藏" in data["error"]
+    assert data["type"] == "fail"
+    assert "已隐藏" in data["message"]
 
 
 async def test_edit_note_rejects_locked_note() -> None:
@@ -114,8 +114,8 @@ async def test_edit_note_rejects_locked_note() -> None:
             mock_session.close.assert_called_once()
 
     data = json.loads(result)
-    assert "error" in data
-    assert "已锁定" in data["error"]
+    assert data["type"] == "fail"
+    assert "已锁定" in data["message"]
 
 
 async def test_edit_note_returns_success_and_diff_metadata() -> None:
@@ -244,8 +244,8 @@ async def test_delete_note_rejects_hidden_note() -> None:
             mock_session.close.assert_called_once()
 
     data = json.loads(result)
-    assert "error" in data
-    assert "已隐藏" in data["error"]
+    assert data["type"] == "fail"
+    assert "已隐藏" in data["message"]
 
 
 async def test_delete_note_rejects_locked_note() -> None:
@@ -267,8 +267,8 @@ async def test_delete_note_rejects_locked_note() -> None:
             mock_session.close.assert_called_once()
 
     data = json.loads(result)
-    assert "error" in data
-    assert "已锁定" in data["error"]
+    assert data["type"] == "fail"
+    assert "已锁定" in data["message"]
 
 
 async def test_delete_note_returns_success_and_diff_metadata() -> None:
@@ -473,7 +473,7 @@ async def test_write_note_rejects_over_limit_content_without_creating() -> None:
             }
         )
 
-    assert "内容超出限制" in json.loads(result)["error"]
+    assert "内容超出限制" in json.loads(result)["message"]
     create_note.assert_not_awaited()
 
 
@@ -593,8 +593,8 @@ async def test_move_note_rejects_locked_note() -> None:
             mock_session.close.assert_called_once()
 
     data = json.loads(result)
-    assert "error" in data
-    assert "已锁定" in data["error"]
+    assert data["type"] == "fail"
+    assert "已锁定" in data["message"]
 
 
 async def test_move_note_returns_success_and_metadata() -> None:
@@ -877,7 +877,7 @@ async def test_edit_note_category_rejects_duplicate_sibling_title() -> None:
                 {"category_ref": {"id": "cat-1"}, "new_title": "新分类"}
             )
 
-    assert json.loads(result)["error"] == "同级分类已存在同名标题: 新分类"
+    assert json.loads(result)["message"] == "同级分类已存在同名标题: 新分类"
     update_category.assert_not_awaited()
 
 
@@ -900,7 +900,7 @@ async def test_edit_note_category_rejects_category_from_another_project() -> Non
                 {"category_ref": {"id": "cat-1"}, "new_title": "新分类"}
             )
 
-    assert json.loads(result)["error"] == "分类不属于当前项目"
+    assert json.loads(result)["message"] == "分类不属于当前项目"
 
 
 async def test_delete_note_category_cascades_and_records_revisions() -> None:
@@ -1026,7 +1026,7 @@ async def test_delete_note_category_rejects_category_from_another_project() -> N
         ):
             result = await tool.ainvoke({"category_ref": {"id": "cat-1"}})
 
-    assert json.loads(result)["error"] == "分类不属于当前项目"
+    assert json.loads(result)["message"] == "分类不属于当前项目"
 
 
 def test_edit_note_input_rejects_empty_old_content() -> None:

--- a/backend/tests/agent_runtime/tools/test_search_chapters.py
+++ b/backend/tests/agent_runtime/tools/test_search_chapters.py
@@ -259,8 +259,8 @@ async def test_search_chapters_returns_json_error_without_default_embedding_mode
         )
     )
 
-    assert "error" in data
-    assert "default_embedding_model" in data["error"]
+    assert data["type"] == "fail"
+    assert "default_embedding_model" in data["message"]
 
 
 @pytest.mark.asyncio
@@ -736,8 +736,8 @@ async def test_search_chapters_rejects_non_embedding_default_model(
         )
     )
 
-    assert "error" in data
-    assert "不是 embedding 模型" in data["error"]
+    assert data["type"] == "fail"
+    assert "不是 embedding 模型" in data["message"]
 
 
 @pytest.mark.asyncio
@@ -757,8 +757,8 @@ async def test_search_chapters_rejects_embedding_model_without_dimensions(
         )
     )
 
-    assert "error" in data
-    assert "缺少 embedding dimensions" in data["error"]
+    assert data["type"] == "fail"
+    assert "缺少 embedding dimensions" in data["message"]
 
 
 @pytest.mark.asyncio
@@ -816,10 +816,10 @@ async def test_search_chapters_hides_embedding_client_init_error_details(
         )
     )
 
-    assert "error" in data
-    assert "embedding client 初始化失败" in data["error"]
-    assert "sk-provider" not in data["error"]
-    assert "/tmp/provider-config" not in data["error"]
+    assert data["type"] == "fail"
+    assert "embedding client 初始化失败" in data["message"]
+    assert "sk-provider" not in data["message"]
+    assert "/tmp/provider-config" not in data["message"]
     assert retrieval.queries == []
 
 
@@ -869,11 +869,11 @@ async def test_search_chapters_hides_external_retrieval_error_details(
         )
     )
 
-    assert "error" in data
-    assert "章节检索执行失败" in data["error"]
-    assert "sk-secret" not in data["error"]
-    assert "LanceDB" not in data["error"]
-    assert "/tmp/private-table" not in data["error"]
+    assert data["type"] == "fail"
+    assert "章节检索执行失败" in data["message"]
+    assert "sk-secret" not in data["message"]
+    assert "LanceDB" not in data["message"]
+    assert "/tmp/private-table" not in data["message"]
 
 
 @pytest.mark.asyncio
@@ -1184,7 +1184,12 @@ async def test_update_index_tool_enqueues_outdated_chapters(
 
     monkeypatch.setattr(module, "enqueue_project_index_update", _fake_enqueue_disabled)
     result = await tool.ainvoke({}, config={"configurable": {"db_session": None}})
-    assert "未启用" in result
+    assert json.loads(result) == {
+        "type": "fail",
+        "success": False,
+        "code": "dependency_unavailable",
+        "message": "当前项目未启用索引或未配置可用的嵌入模型，无法更新索引。",
+    }
 
 
 class _FakeSession:

--- a/backend/tests/agent_runtime/tools/test_skill_tools.py
+++ b/backend/tests/agent_runtime/tools/test_skill_tools.py
@@ -213,7 +213,7 @@ async def test_activate_skill_rejects_unauthorized_skill():
     ):
         result = await tool.ainvoke({"skill_name": "pdf-processing"})
 
-    assert "技能不在该智能体的可用列表中" in json.loads(result)["error"]
+    assert "技能不在该智能体的可用列表中" in json.loads(result)["message"]
 
 
 @pytest.mark.asyncio
@@ -260,7 +260,7 @@ async def test_activate_skill_rejects_disabled_skill():
     ):
         result = await tool.ainvoke({"skill_name": "pdf-processing"})
 
-    assert "技能不在该智能体的可用列表中" in json.loads(result)["error"]
+    assert "技能不在该智能体的可用列表中" in json.loads(result)["message"]
 
 
 @pytest.mark.asyncio
@@ -299,7 +299,7 @@ async def test_reference_skill_rejects_unknown_reference():
             {"skill_name": "pdf-processing", "reference_name": "不存在"}
         )
 
-    assert "参考文档不存在" in json.loads(result)["error"]
+    assert "参考文档不存在" in json.loads(result)["message"]
 
 
 def test_load_builtin_skills_caches_until_skill_files_change(tmp_path, monkeypatch):

--- a/backend/tests/api/test_agent.py
+++ b/backend/tests/api/test_agent.py
@@ -1488,6 +1488,60 @@ class TestAgentAPI:
         launch_task.assert_awaited_once()
         launch_task.await_args.kwargs["coro"].close()
 
+    async def test_resume_recovers_failed_revision_with_pending_checkpoint(
+        self,
+        client: AsyncClient,
+        session,
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={"project_id": target["project_id"], "model_id": target["model_id"]},
+        )
+        payload = session_response.json()
+        session_id = payload["session_id"]
+        task = await task_service.get_task(session, payload["task_id"])
+        revision = Revision(
+            project_id=task.project_id,
+            task_id=task.id,
+            message="checkpoint write failed",
+            agent_session_id=session_id,
+            revision_type="agent",
+            status="failed",
+            is_checkpoint=True,
+            project_snapshot_title="Recoverable failure",
+            project_snapshot_word_count=0,
+            project_snapshot_chapter_count=0,
+        )
+        session.add(revision)
+        await session.flush()
+        task.current_revision_id = revision.id
+        session.add(task)
+        await session.commit()
+
+        checkpoint = SimpleNamespace(
+            pending_writes=[(None, "__interrupt__", [object()])]
+        )
+        with (
+            patch(
+                "app.api.routers.agent_runtime.get_checkpointer",
+                new=AsyncMock(return_value=SimpleNamespace(
+                    aget_tuple=AsyncMock(return_value=checkpoint)
+                )),
+            ),
+            patch("app.api.routers.agent_runtime._launch_task", new=AsyncMock()) as launch_task,
+        ):
+            response = await client.post(
+                f"/api/v1/agent/sessions/{session_id}/tool-approval",
+                json={"approval_id": "recoverable-approval", "approved": True},
+            )
+
+        await session.refresh(revision)
+        assert response.status_code == status.HTTP_200_OK
+        assert revision.status == "active"
+        launch_task.assert_awaited_once()
+        launch_task.await_args.kwargs["coro"].close()
+
     async def test_resume_claim_holds_session_lock_before_new_message_can_start(
         self,
         client: AsyncClient,

--- a/backend/tests/api/test_agent.py
+++ b/backend/tests/api/test_agent.py
@@ -31,6 +31,7 @@ from app.agent_runtime.streaming.replay_buffer import get_agent_event_replay_buf
 from app.api.routers.agent_runtime import (
     _SESSION_RUNNERS,
     _build_model_config,
+    _checkpoint_has_pending_interrupt,
     _launch_task,
 )
 from app.settings import settings
@@ -1520,6 +1521,7 @@ class TestAgentAPI:
         await session.commit()
 
         checkpoint = SimpleNamespace(
+            checkpoint={"channel_values": {"current_revision_id": revision.id}},
             pending_writes=[(None, "__interrupt__", [object()])]
         )
         with (
@@ -1541,6 +1543,21 @@ class TestAgentAPI:
         assert revision.status == "active"
         launch_task.assert_awaited_once()
         launch_task.await_args.kwargs["coro"].close()
+
+    async def test_failed_revision_recovery_requires_matching_checkpoint_revision(self) -> None:
+        checkpoint = SimpleNamespace(
+            checkpoint={"channel_values": {"current_revision_id": "revision-a"}},
+            pending_writes=[(None, "__interrupt__", [object()])],
+        )
+        with patch(
+            "app.api.routers.agent_runtime.get_checkpointer",
+            new=AsyncMock(
+                return_value=SimpleNamespace(
+                    aget_tuple=AsyncMock(return_value=checkpoint),
+                )
+            ),
+        ):
+            assert not await _checkpoint_has_pending_interrupt("session-a", "revision-b")
 
     async def test_resume_claim_holds_session_lock_before_new_message_can_start(
         self,


### PR DESCRIPTION
## PR 标题

`fix(agent): 统一工具错误处理`

## 变更说明

- 问题：工具异常、参数校验、审批/中断恢复和子代理失败恢复路径的错误结果与持久化行为不一致。
- 重要性：部分异常堆栈可能进入错误遥测，checkpoint 恢复还存在 revision 归属和序列化性能问题。
- 变化：统一工具错误结构与错误码，清理 Pydantic 校验附加链接，避免异常堆栈进入遥测，完善失败恢复与 checkpoint 处理。
- 测试：补充工具错误、checkpoint、审批恢复、会话恢复和 agent API 的回归测试。

## 关联 Issue / PR

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因

Agent runtime 中不同工具和恢复路径分别处理错误结果、异常信息和 checkpoint，导致错误结构不统一；恢复逻辑缺少对失败 revision 与 checkpoint 归属的校验，部分可序列化 checkpoint 也未优先使用原生序列化路径。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

已完成 1557 项测试、Ruff、`ty` 和 `git diff --check` 验证。后续可继续补充同一 `thread_id` 下失败恢复读取旧 revision checkpoint 的边界测试。
