### PR TITLE
fix(agent): 修复批量工具审批数量限制

### DIFF
--- a/backend/app/api/schemas/agent.py
+++ b/backend/app/api/schemas/agent.py
@@ -167,7 +167,7 @@ class AgentInterruptResumeRequest(BaseModel):
     responses: list[AgentInterruptResponseItem] = Field(
         ...,
         min_length=1,
-        max_length=10,
+        max_length=20,
         description="本批全部中断响应",
     )
 

--- a/backend/tests/api/test_agent.py
+++ b/backend/tests/api/test_agent.py
@@ -3733,6 +3733,43 @@ class TestAgentAPI:
         await asyncio.sleep(0.05)
         mock_resume.assert_awaited_once_with("batch-1", responses)
 
+    async def test_submit_interrupt_batch_accepts_maximum_tool_batch(
+        self, client: AsyncClient
+    ) -> None:
+        target = await _seed_agent_target(client)
+        session_response = await client.post(
+            "/api/v1/agent/sessions",
+            json={
+                "project_id": target["project_id"],
+                "model_id": target["model_id"],
+                "max_iterations": 5,
+            },
+        )
+        session_id = session_response.json()["session_id"]
+        responses = [
+            {
+                "interrupt_id": f"approval-{index}",
+                "action_type": "tool_approval",
+                "approval_id": f"approval-{index}",
+                "approved": True,
+            }
+            for index in range(20)
+        ]
+
+        with patch(
+            "app.api.routers.agent_runtime.SessionRunner.resume_interrupt_batch",
+            new=AsyncMock(return_value=None),
+        ) as mock_resume:
+            response = await client.post(
+                f"/api/v1/agent/sessions/{session_id}/interrupt-resume",
+                json={"batch_id": "batch-maximum", "responses": responses},
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["success"] is True
+        await asyncio.sleep(0.05)
+        mock_resume.assert_awaited_once_with("batch-maximum", responses)
+
     async def test_rollback_session_uses_revision_id_and_restores_data(
         self,
         client: AsyncClient,


### PR DESCRIPTION
## PR 标题

fix(agent): 修复批量工具审批数量限制

## 变更说明

- 问题: Agent 单批最多可产生 20 个工具审批，但批量恢复接口仅允许 10 个响应，第 11 项起会返回 422。
- 重要性: 用户完成全部审批后会看到“工具审批失败”，会话无法继续。
- 变化: 将批量响应上限对齐为 20，并新增最大批次的 API 回归测试。
- 验证: `uv run pytest tests/api/test_agent.py -q`、`uv run ruff check .`、`uv run ty check app` 均通过。

## 关联 Issue / PR

Closes #337

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因

工具批次大小为 20，而 `AgentInterruptResumeRequest.responses` 的最大长度为 10，前后端批次参数不一致。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

无
