### PR TITLE
chore(model): 添加 OpenAI Compatible (Responses) 提供商

### DIFF
--- a/backend/app/models/adapters/__init__.py
+++ b/backend/app/models/adapters/__init__.py
@@ -20,6 +20,7 @@ from app.models.adapters.openai_compat_family import (
     NvidiaAIEndpointsAdapter,
 )
 from app.models.adapters.openai_compatible import OpenAICompatibleAdapter
+from app.models.adapters.openai_responses_compatible import OpenAIResponsesCompatibleAdapter
 from app.models.adapters.openrouter import OpenRouterAdapter
 
 __all__ = [
@@ -36,6 +37,7 @@ __all__ = [
     "NvidiaAIEndpointsAdapter",
     "OpenAIAdapter",
     "OpenAICompatibleAdapter",
+    "OpenAIResponsesCompatibleAdapter",
     "OpenRouterAdapter",
 ]
 

--- a/backend/app/models/adapters/openai_responses_compatible.py
+++ b/backend/app/models/adapters/openai_responses_compatible.py
@@ -1,0 +1,24 @@
+"""OpenAI Responses API-compatible provider adapter."""
+
+import httpx
+
+from app.models.adapters.openai_compatible import OpenAICompatibleAdapter
+
+
+class OpenAIResponsesCompatibleAdapter(OpenAICompatibleAdapter):
+    """Adapter for custom providers exposing the OpenAI Responses API."""
+
+    @property
+    def provider_type(self) -> str:
+        return "openai-compatible-responses"
+
+    def supports_embedding(self) -> bool:
+        return False
+
+    def supports_rerank(self) -> bool:
+        return False
+
+    async def get_embedding_models(
+        self, client: httpx.AsyncClient, base_url: str, api_key: str
+    ) -> list[dict[str, str]]:
+        return []

--- a/backend/app/models/catalog/service.py
+++ b/backend/app/models/catalog/service.py
@@ -194,7 +194,10 @@ class ModelProviderCatalogService:
     ) -> CatalogMatch | None:
         providers = await self.list_providers()
 
-        if provider_type != "openai-compatible":
+        if provider_type not in {
+            "openai-compatible",
+            "openai-compatible-responses",
+        }:
             provider = next(
                 (item for item in providers if item.provider_type == provider_type),
                 None,
@@ -231,7 +234,7 @@ class ModelProviderCatalogService:
         supported = set()
         if provider_type in _REGISTERED_PROVIDER_TYPES:
             supported.update(AdapterRegistry.get_supported_task_types(provider_type))
-        if catalog_match is not None:
+        if catalog_match is not None and provider_type != "openai-compatible-responses":
             try:
                 provider = self._find_provider(
                     self._load_current_snapshot()[0], catalog_match.catalog_provider_type

--- a/backend/app/models/clients/model_factory.py
+++ b/backend/app/models/clients/model_factory.py
@@ -295,6 +295,14 @@ def create_chat_model(config: ModelConfig) -> Runnable[LanguageModelInput, BaseM
             max_retries=0,
         ))
 
+    if provider == "openai-compatible-responses":
+        from langchain_openai import ChatOpenAI
+
+        return ChatOpenAI(
+            **_openai_compatible_kwargs(config),
+            use_responses_api=True,
+        )
+
     if provider == "nvidia-ai-endpoints":
         from langchain_nvidia_ai_endpoints import ChatNVIDIA
 

--- a/backend/app/models/entities/model_provider.py
+++ b/backend/app/models/entities/model_provider.py
@@ -35,7 +35,7 @@ class ModelProvider(SQLModel, table=True):
         description=(
             "Provider type: anthropic, openai, google-genai, ollama, groq, "
             "huggingface, mistral, nvidia-ai-endpoints, cohere, openrouter, "
-            "amazon-nova, deepseek, openai-compatible"
+            "amazon-nova, deepseek, openai-compatible, openai-compatible-responses"
         ),
     )
     is_builtin: bool = Field(default=False, description="是否为内置提供商（不可删除/编辑）")

--- a/backend/app/models/registry.py
+++ b/backend/app/models/registry.py
@@ -22,6 +22,9 @@ from app.models.adapters.openai_compat_family import (
     NvidiaAIEndpointsAdapter,
 )
 from app.models.adapters.openai_compatible import OpenAICompatibleAdapter
+from app.models.adapters.openai_responses_compatible import (
+    OpenAIResponsesCompatibleAdapter,
+)
 from app.models.adapters.openrouter import OpenRouterAdapter
 
 
@@ -44,6 +47,7 @@ class AdapterRegistry:
         "openrouter": OpenRouterAdapter,
         "amazon-nova": AmazonNovaAdapter,
         "openai-compatible": OpenAICompatibleAdapter,
+        "openai-compatible-responses": OpenAIResponsesCompatibleAdapter,
     }
 
     @classmethod

--- a/backend/app/models/services/model_provider_service.py
+++ b/backend/app/models/services/model_provider_service.py
@@ -138,7 +138,11 @@ class ModelProviderService:
         return provider
 
     async def _resolve_provider_url(self, provider_type: str, url: str) -> str:
-        if provider_type in {"openai-compatible", "anthropic-compatible"}:
+        if provider_type in {
+            "openai-compatible",
+            "openai-compatible-responses",
+            "anthropic-compatible",
+        }:
             return url
 
         try:
@@ -272,6 +276,8 @@ class ModelProviderService:
         runtime_provider_type = (
             "anthropic-compatible"
             if provider_type == "anthropic-compatible"
+            else "openai-compatible-responses"
+            if provider_type == "openai-compatible-responses"
             else "openai-compatible"
         )
         adapter = AdapterRegistry.get_adapter(runtime_provider_type)
@@ -312,6 +318,8 @@ class ModelProviderService:
         runtime_provider_type = (
             "anthropic-compatible"
             if provider.provider_type == "anthropic-compatible"
+            else "openai-compatible-responses"
+            if provider.provider_type == "openai-compatible-responses"
             else "openai-compatible"
         )
         if not AdapterRegistry.is_supported(runtime_provider_type, task_type):

--- a/backend/tests/agent_runtime/test_model_factory.py
+++ b/backend/tests/agent_runtime/test_model_factory.py
@@ -493,6 +493,22 @@ def test_create_chat_model_openai_compatible_enables_stream_usage_for_custom_bas
     assert model.stream_usage is True
 
 
+def test_create_chat_model_openai_responses_compatible_uses_responses_api():
+    config = ModelConfig(
+        provider_type="openai-compatible-responses",
+        base_url="https://gateway.example/v1",
+        api_key="sk-test",
+        model_id="responses-model",
+    )
+    model = create_chat_model(config)
+
+    from langchain_openai import ChatOpenAI
+
+    assert isinstance(model, ChatOpenAI)
+    assert model.use_responses_api is True
+    assert str(model.root_client.base_url) == "https://gateway.example/v1/"
+
+
 def test_create_chat_model_deepseek_enables_stream_usage():
     config = ModelConfig(
         provider_type="deepseek",

--- a/backend/tests/api/test_model_providers.py
+++ b/backend/tests/api/test_model_providers.py
@@ -294,6 +294,40 @@ async def test_validate_anthropic_compatible_provider_discovers_models(
 
 @pytest.mark.asyncio
 @respx.mock
+async def test_validate_openai_responses_compatible_provider_discovers_models(
+    client: AsyncClient,
+):
+    route = respx.get("https://gateway.example/v1/models").mock(
+        return_value=httpx.Response(
+            200,
+            json={"data": [{"id": "responses-model", "name": "Responses Model"}]},
+        )
+    )
+
+    response = await client.post(
+        "/api/v1/model-providers/validate",
+        json={
+            "provider_type": "openai-compatible-responses",
+            "url": "https://gateway.example",
+            "api_key": "test-key",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    assert response.json()["models"] == [
+        {
+            "id": "responses-model",
+            "name": "Responses Model",
+            "task_type": None,
+            "metadata": None,
+        }
+    ]
+    assert route.calls[0].request.headers["authorization"] == "Bearer test-key"
+
+
+@pytest.mark.asyncio
+@respx.mock
 async def test_get_anthropic_compatible_provider_models_discovers_models(
     client: AsyncClient,
     session: AsyncSession,

--- a/backend/tests/models/test_model_provider_catalog_service.py
+++ b/backend/tests/models/test_model_provider_catalog_service.py
@@ -438,6 +438,24 @@ async def test_catalog_service_matches_openai_compatible_provider_by_exact_api(
 
 
 @pytest.mark.asyncio
+async def test_catalog_service_matches_openai_responses_compatible_provider_by_exact_api(
+    tmp_path: Path,
+) -> None:
+    service = _build_service(tmp_path)
+
+    match = await service.match_saved_provider(
+        "openai-compatible-responses",
+        "https://api.openai.com/v1/",
+    )
+
+    assert match is not None
+    assert match.catalog_provider_type == "openai"
+    assert service.get_supported_task_types(
+        "openai-compatible-responses", catalog_match=match
+    ) == ["llm"]
+
+
+@pytest.mark.asyncio
 async def test_catalog_service_caches_snapshot_until_refresh(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/tests/models/test_model_provider_service.py
+++ b/backend/tests/models/test_model_provider_service.py
@@ -111,6 +111,30 @@ async def test_validate_anthropic_compatible_connection_uses_its_adapter(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_validate_openai_responses_compatible_connection_uses_its_adapter(
+    monkeypatch,
+):
+    encryption_service = EncryptionService("id-hEPdEELwlgep9FQhcYQtX7ow188l7WHwy65qOZGQ=")
+    service = ModelProviderService(encryption_service)
+    requested_provider_types: list[str] = []
+
+    def get_adapter(cls, provider_type: str):
+        requested_provider_types.append(provider_type)
+        return _FakeAdapter()
+
+    monkeypatch.setattr(AdapterRegistry, "get_adapter", classmethod(get_adapter))
+
+    models = await service.validate_and_get_models(
+        "openai-compatible-responses",
+        "https://gateway.example",
+        "test-key",
+    )
+
+    assert models == [{"id": "llm-1", "name": "LLM 1"}]
+    assert requested_provider_types == ["openai-compatible-responses"]
+
+
+@pytest.mark.asyncio
 async def test_validate_native_anthropic_connection_keeps_openai_compatible_discovery(
     monkeypatch,
 ):
@@ -160,6 +184,38 @@ async def test_get_available_models_uses_anthropic_compatible_adapter(monkeypatc
 
     assert models == [{"id": "llm-1", "name": "LLM 1"}]
     assert requested_provider_types == ["anthropic-compatible", "anthropic-compatible"]
+
+
+@pytest.mark.asyncio
+async def test_get_available_models_uses_openai_responses_compatible_adapter(monkeypatch):
+    encryption_service = EncryptionService("id-hEPdEELwlgep9FQhcYQtX7ow188l7WHwy65qOZGQ=")
+    service = ModelProviderService(encryption_service)
+    provider = ModelProvider(
+        name="OpenAI Responses Compatible",
+        url="https://gateway.example",
+        api_key_encrypted=encryption_service.encrypt("test-key"),
+        provider_type="openai-compatible-responses",
+    )
+    requested_provider_types: list[str] = []
+
+    def get_adapter(cls, provider_type: str):
+        requested_provider_types.append(provider_type)
+        return _FakeAdapter()
+
+    def is_supported(cls, provider_type: str, task_type: str) -> bool:
+        requested_provider_types.append(provider_type)
+        return task_type == "llm"
+
+    monkeypatch.setattr(AdapterRegistry, "get_adapter", classmethod(get_adapter))
+    monkeypatch.setattr(AdapterRegistry, "is_supported", classmethod(is_supported))
+
+    models = await service.get_available_models(provider, "llm")
+
+    assert models == [{"id": "llm-1", "name": "LLM 1"}]
+    assert requested_provider_types == [
+        "openai-compatible-responses",
+        "openai-compatible-responses",
+    ]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/models/test_model_registry.py
+++ b/backend/tests/models/test_model_registry.py
@@ -21,6 +21,7 @@ def test_registry_lists_only_current_first_class_provider_types() -> None:
         "amazon-nova",
         "deepseek",
         "openai-compatible",
+        "openai-compatible-responses",
         "anthropic-compatible",
     }
     assert "google-vertex" not in AdapterRegistry.list_providers()

--- a/backend/tests/models/test_openai_responses_compatible_adapter.py
+++ b/backend/tests/models/test_openai_responses_compatible_adapter.py
@@ -1,0 +1,42 @@
+import httpx
+import pytest
+
+from app.models.registry import AdapterRegistry
+
+
+class _RecordingClient:
+    def __init__(self) -> None:
+        self.requests: list[tuple[str, dict[str, str]]] = []
+
+    async def get(self, url: str, **kwargs: object) -> httpx.Response:
+        headers = kwargs.get("headers")
+        self.requests.append((url, headers if isinstance(headers, dict) else {}))
+        return httpx.Response(
+            200,
+            json={"data": [{"id": "responses-model", "name": "Responses Model"}]},
+            request=httpx.Request("GET", url),
+        )
+
+
+@pytest.mark.asyncio
+async def test_openai_responses_compatible_adapter_discovers_llm_models_only() -> None:
+    adapter = AdapterRegistry.get_adapter("openai-compatible-responses")
+    client = _RecordingClient()
+
+    models = await adapter.get_llm_models(
+        client,  # type: ignore[arg-type]
+        "https://gateway.example",
+        "test-key",
+    )
+
+    assert adapter.provider_type == "openai-compatible-responses"
+    assert adapter.supports_llm()
+    assert not adapter.supports_embedding()
+    assert not adapter.supports_rerank()
+    assert models == [{"id": "responses-model", "name": "Responses Model"}]
+    assert client.requests == [
+        (
+            "https://gateway.example/v1/models",
+            {"Authorization": "Bearer test-key"},
+        )
+    ]

--- a/frontend/src/components/provider-id-select.tsx
+++ b/frontend/src/components/provider-id-select.tsx
@@ -30,6 +30,12 @@ const OPENAI_COMPATIBLE_OPTION: ProviderIdSelectOption = {
   iconPath: null,
 };
 
+const OPENAI_RESPONSES_COMPATIBLE_OPTION: ProviderIdSelectOption = {
+  value: "openai-compatible-responses",
+  label: "OpenAI Compatible (Responses)",
+  iconPath: null,
+};
+
 const ANTHROPIC_COMPATIBLE_OPTION: ProviderIdSelectOption = {
   value: "anthropic-compatible",
   label: "Anthropic Compatible",
@@ -55,7 +61,11 @@ export function ProviderIdSelect({
       iconPath: provider.iconPath,
     }));
 
-    for (const compatibleOption of [OPENAI_COMPATIBLE_OPTION, ANTHROPIC_COMPATIBLE_OPTION]) {
+    for (const compatibleOption of [
+      OPENAI_COMPATIBLE_OPTION,
+      OPENAI_RESPONSES_COMPATIBLE_OPTION,
+      ANTHROPIC_COMPATIBLE_OPTION,
+    ]) {
       if (!catalogOptions.some((option) => option.value === compatibleOption.value)) {
         catalogOptions.push(compatibleOption);
       }

--- a/frontend/src/features/settings/components/connections-settings.tsx
+++ b/frontend/src/features/settings/components/connections-settings.tsx
@@ -23,7 +23,11 @@ import {
   deleteProvider,
 } from "../lib/model-api";
 import { ProviderIcon } from "../lib/provider-icons";
-import { getProviderDisplayName, resolveProviderDisplayName } from "../lib/provider-utils";
+import {
+  getProviderDisplayName,
+  isCustomProviderType,
+  resolveProviderDisplayName,
+} from "../lib/provider-utils";
 import { AgentSettingsLockNotice } from "./agent-settings-lock-notice";
 import { ConnectionFormDialog } from "./connection-form-dialog";
 
@@ -244,8 +248,7 @@ export function ConnectionsSettings({
                           weight="medium"
                         >
                           {connection.name ||
-                            (connection.providerType === "openai-compatible" ||
-                            connection.providerType === "anthropic-compatible"
+                            (isCustomProviderType(connection.providerType)
                               ? connection.url
                               : null) ||
                             resolveProviderDisplayName(connection)}
@@ -262,8 +265,7 @@ export function ConnectionsSettings({
                           {connection.catalogMatch?.displayName ||
                             getProviderDisplayName(connection.providerType)}
                         </Text>
-                        {(connection.providerType === "openai-compatible" ||
-                          connection.providerType === "anthropic-compatible") &&
+                        {isCustomProviderType(connection.providerType) &&
                           !connection.catalogMatch && (
                             <>
                               <Text

--- a/frontend/src/features/settings/components/model-form-dialog.tsx
+++ b/frontend/src/features/settings/components/model-form-dialog.tsx
@@ -25,6 +25,7 @@ import {
 } from "../lib/model-api";
 import {
   isSelectableModelProvider,
+  isCustomProviderType,
   resolveProviderCatalogType,
   resolveProviderDisplayName,
   supportsEmbeddingDimensions,
@@ -647,8 +648,8 @@ export function ModelFormDialog({
                     {t(`models.${errors.modelId.message}`)}
                   </Text>
                 )}
-                {(selectedProvider?.providerType === "openai-compatible" ||
-                  selectedProvider?.providerType === "anthropic-compatible") &&
+                {selectedProvider &&
+                  isCustomProviderType(selectedProvider.providerType) &&
                   !selectedCatalogProviderType &&
                   !loadingModels && (
                     <Text

--- a/frontend/src/features/settings/lib/provider-utils.ts
+++ b/frontend/src/features/settings/lib/provider-utils.ts
@@ -14,6 +14,12 @@ const EMBEDDING_DIMENSIONS_SUPPORTED_PROVIDER_TYPES = new Set<ProviderType>([
   "nvidia-ai-endpoints",
 ]);
 
+const CUSTOM_PROVIDER_TYPES = new Set([
+  "openai-compatible",
+  "openai-compatible-responses",
+  "anthropic-compatible",
+]);
+
 export function supportsEmbeddingDimensions(providerType: string): boolean {
   return EMBEDDING_DIMENSIONS_SUPPORTED_PROVIDER_TYPES.has(providerType);
 }
@@ -26,6 +32,10 @@ export function hasSelectableModelProvider(
   providers: Array<Pick<ModelProvider, "isBuiltin">>,
 ): boolean {
   return providers.some(isSelectableModelProvider);
+}
+
+export function isCustomProviderType(providerType: string): boolean {
+  return CUSTOM_PROVIDER_TYPES.has(providerType);
 }
 
 /**
@@ -46,6 +56,7 @@ export function getProviderDisplayName(providerType: string): string {
     "amazon-nova": "Amazon Nova",
     deepseek: "DeepSeek",
     "openai-compatible": "OpenAI Compatible",
+    "openai-compatible-responses": "OpenAI Compatible (Responses)",
     "anthropic-compatible": "Anthropic Compatible",
     builtin: "Builtin",
   };
@@ -60,7 +71,7 @@ export function getProviderUrl(
   providerType: string,
   catalogProviders?: ModelProviderCatalogProvider[],
 ): string | null {
-  if (providerType === "openai-compatible" || providerType === "anthropic-compatible") {
+  if (isCustomProviderType(providerType)) {
     return null;
   }
 
@@ -71,10 +82,7 @@ export function getProviderUrl(
 }
 
 export function resolveProviderCatalogType(provider: ModelProvider): string | null {
-  if (
-    provider.providerType === "openai-compatible" ||
-    provider.providerType === "anthropic-compatible"
-  ) {
+  if (isCustomProviderType(provider.providerType)) {
     return provider.catalogMatch?.catalogProviderType ?? null;
   }
 


### PR DESCRIPTION
## PR 标题

chore(model): 添加 OpenAI Compatible (Responses) 提供商

## 变更说明

- 问题: 现有自定义提供商缺少使用 OpenAI Responses API 协议的选项。
- 重要性: 使用 Responses API 的兼容服务无法复用现有 OpenAI Compatible 的 Chat Completions 配置。
- 变化: 新增 `openai-compatible-responses` 类型，支持自定义 Base URL，复用模型发现接口，并通过 `ChatOpenAI` 开启 Responses API；该类型仅支持 LLM。
- 验证: 后端 1564 个测试全部通过，前端 type-check、lint、format:check 和生产构建全部通过。

## 关联 Issue / PR

Related to #345

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因

无

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

新提供商通过 `GET /v1/models` 获取模型列表，运行时使用 Responses API；Embedding 和 Rerank 不在该类型支持范围内。
