### PR TITLE
chore(editor): 支持章节编辑器可选行号显示

### DIFF
--- a/backend/app/api/routers/settings.py
+++ b/backend/app/api/routers/settings.py
@@ -90,6 +90,7 @@ SETTING_KEY_AUDIT_PERSIST_DETAILS = AUDIT_DETAILS_PERSISTENCE_SETTING_KEY
 SETTING_KEY_EDITOR_AUTO_INDENT = "editor_auto_indent"
 SETTING_KEY_EDITOR_AUTO_CONVERT_PUNCTUATION = "editor_auto_convert_punctuation"
 SETTING_KEY_EDITOR_AUTO_PAIR_SYMBOLS = "editor_auto_pair_symbols"
+SETTING_KEY_EDITOR_SHOW_LINE_NUMBERS = "editor_show_line_numbers"
 # 默认值
 DEFAULT_SETTINGS = {
     SETTING_KEY_LANGUAGE: "zh-CN",
@@ -118,6 +119,7 @@ DEFAULT_SETTINGS = {
     SETTING_KEY_EDITOR_AUTO_INDENT: "true",
     SETTING_KEY_EDITOR_AUTO_CONVERT_PUNCTUATION: "false",
     SETTING_KEY_EDITOR_AUTO_PAIR_SYMBOLS: "false",
+    SETTING_KEY_EDITOR_SHOW_LINE_NUMBERS: "false",
 }
 
 
@@ -384,6 +386,13 @@ code_font_family=settings_dict.get(
             ),
             default=False,
         ),
+        editor_show_line_numbers=_parse_bool_setting(
+            settings_dict.get(
+                SETTING_KEY_EDITOR_SHOW_LINE_NUMBERS,
+                DEFAULT_SETTINGS[SETTING_KEY_EDITOR_SHOW_LINE_NUMBERS],
+            ),
+            default=False,
+        ),
     )
 
 
@@ -564,6 +573,11 @@ async def update_settings(
     if request.editor_auto_pair_symbols is not None:
         settings_to_update[SETTING_KEY_EDITOR_AUTO_PAIR_SYMBOLS] = json.dumps(
             request.editor_auto_pair_symbols,
+            ensure_ascii=False,
+        )
+    if request.editor_show_line_numbers is not None:
+        settings_to_update[SETTING_KEY_EDITOR_SHOW_LINE_NUMBERS] = json.dumps(
+            request.editor_show_line_numbers,
             ensure_ascii=False,
         )
 

--- a/backend/app/api/schemas/setting.py
+++ b/backend/app/api/schemas/setting.py
@@ -87,6 +87,10 @@ class SettingsResponse(BaseModel):
         default=False,
         description="输入成对符号的左符号时是否自动补齐右符号",
     )
+    editor_show_line_numbers: bool = Field(
+        default=False,
+        description="是否在章节编辑器中显示行号",
+    )
 
 
 class SettingsUpdateRequest(BaseModel):
@@ -148,6 +152,10 @@ class SettingsUpdateRequest(BaseModel):
     editor_auto_pair_symbols: bool | None = Field(
         default=None,
         description="输入成对符号的左符号时是否自动补齐右符号",
+    )
+    editor_show_line_numbers: bool | None = Field(
+        default=None,
+        description="是否在章节编辑器中显示行号",
     )
 
 

--- a/backend/tests/api/test_settings.py
+++ b/backend/tests/api/test_settings.py
@@ -103,6 +103,7 @@ async def test_get_settings_default(client: AsyncClient) -> None:
     assert data["editor_auto_indent"] is True
     assert data["editor_auto_convert_punctuation"] is False
     assert data["editor_auto_pair_symbols"] is False
+    assert data["editor_show_line_numbers"] is False
 
 
 @pytest.mark.asyncio
@@ -451,6 +452,22 @@ async def test_update_settings_editor_auto_pair_symbols(client: AsyncClient) -> 
     follow_up = await client.get("/api/v1/settings")
     assert follow_up.status_code == 200
     assert follow_up.json()["editor_auto_pair_symbols"] is True
+
+
+@pytest.mark.asyncio
+async def test_update_settings_editor_show_line_numbers(client: AsyncClient) -> None:
+    """编辑器行号显示开关应可持久化。"""
+    response = await client.put(
+        "/api/v1/settings",
+        json={"editor_show_line_numbers": True},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["editor_show_line_numbers"] is True
+
+    follow_up = await client.get("/api/v1/settings")
+    assert follow_up.status_code == 200
+    assert follow_up.json()["editor_show_line_numbers"] is True
 
 
 @pytest.mark.asyncio

--- a/frontend/src/features/settings/components/editor-settings.tsx
+++ b/frontend/src/features/settings/components/editor-settings.tsx
@@ -42,6 +42,13 @@ export function EditorSettings() {
         });
       }
 
+      if (previousSettings && patch.editor_show_line_numbers !== undefined) {
+        queryClient.setQueryData<Settings>(["settings"], {
+          ...previousSettings,
+          editorShowLineNumbers: patch.editor_show_line_numbers,
+        });
+      }
+
       return { previousSettings };
     },
     onSuccess: (nextSettings) => {
@@ -205,6 +212,37 @@ export function EditorSettings() {
             aria-label={t("settings.editorAutoPairSymbols")}
             onCheckedChange={(checked) => {
               updateMutation.mutate({ editor_auto_pair_symbols: checked });
+            }}
+          />
+        </Flex>
+
+        <Flex
+          align="center"
+          justify="between"
+          gap="4"
+        >
+          <Flex
+            direction="column"
+            gap="1"
+          >
+            <Text
+              size="2"
+              weight="medium"
+            >
+              {t("settings.editorShowLineNumbers")}
+            </Text>
+            <Text
+              size="1"
+              color="gray"
+            >
+              {t("settings.editorShowLineNumbersHint")}
+            </Text>
+          </Flex>
+          <Switch
+            checked={settings.editorShowLineNumbers}
+            aria-label={t("settings.editorShowLineNumbers")}
+            onCheckedChange={(checked) => {
+              updateMutation.mutate({ editor_show_line_numbers: checked });
             }}
           />
         </Flex>

--- a/frontend/src/features/settings/lib/settings-api.ts
+++ b/frontend/src/features/settings/lib/settings-api.ts
@@ -51,6 +51,7 @@ export function transformSettings(raw: SettingsResponse): Settings {
     editorAutoIndent: raw.editor_auto_indent ?? true,
     editorAutoConvertPunctuation: raw.editor_auto_convert_punctuation ?? false,
     editorAutoPairSymbols: raw.editor_auto_pair_symbols ?? false,
+    editorShowLineNumbers: raw.editor_show_line_numbers ?? false,
   };
 }
 

--- a/frontend/src/features/settings/lib/settings.types.ts
+++ b/frontend/src/features/settings/lib/settings.types.ts
@@ -50,6 +50,7 @@ export interface Settings {
   editorAutoIndent: boolean;
   editorAutoConvertPunctuation: boolean;
   editorAutoPairSymbols: boolean;
+  editorShowLineNumbers: boolean;
 }
 
 /** 设置响应（后端格式） */
@@ -81,6 +82,7 @@ export interface SettingsResponse {
   editor_auto_indent?: boolean;
   editor_auto_convert_punctuation?: boolean;
   editor_auto_pair_symbols?: boolean;
+  editor_show_line_numbers?: boolean;
 }
 
 /** 设置更新请求 */
@@ -112,6 +114,7 @@ export interface SettingsUpdateRequest {
   editor_auto_indent?: boolean;
   editor_auto_convert_punctuation?: boolean;
   editor_auto_pair_symbols?: boolean;
+  editor_show_line_numbers?: boolean;
 }
 
 export interface AuditDetailsStorage {

--- a/frontend/src/features/writing/components/chapter-editor.tsx
+++ b/frontend/src/features/writing/components/chapter-editor.tsx
@@ -115,6 +115,7 @@ function ChapterEditorContent({
     queryKey: ["settings"],
     queryFn: fetchSettings,
   });
+  const showLineNumbers = settings?.editorShowLineNumbers ?? false;
   const autoIndentRef = useRef(settings?.editorAutoIndent ?? false);
   const autoConvertPunctuationRef = useRef(settings?.editorAutoConvertPunctuation ?? false);
   const autoPairSymbolsRef = useRef(settings?.editorAutoPairSymbols ?? false);
@@ -673,7 +674,7 @@ function ChapterEditorContent({
       <Box
         ref={containerRef}
         style={{ flex: 1, minHeight: 0, overflow: "auto" }}
-        className={`tiptap-editor-wrapper ${scrollbarProps.className}`}
+        className={`tiptap-editor-wrapper${showLineNumbers ? " tiptap-editor-wrapper--line-numbers" : ""} ${scrollbarProps.className}`}
         onWheel={scrollbarProps.onWheel}
         onMouseMove={scrollbarProps.onMouseMove}
         onMouseLeave={scrollbarProps.onMouseLeave}
@@ -681,10 +682,9 @@ function ChapterEditorContent({
         onClick={isAgentLocked ? showLockedToast : undefined}
       >
         <Box
+          className="chapter-editor-content"
           style={{
             maxWidth: editorMaxWidth,
-            margin: "0 auto",
-            padding: "0 24px",
           }}
         >
           <TitleInput
@@ -705,7 +705,7 @@ function ChapterEditorContent({
           >
             <EditorContent
               editor={editor}
-              className="tiptap-editor"
+              className={`tiptap-editor${showLineNumbers ? " tiptap-editor--line-numbers" : ""}`}
             />
           </Box>
         </Box>

--- a/frontend/src/features/writing/components/chapter-editor.tsx
+++ b/frontend/src/features/writing/components/chapter-editor.tsx
@@ -56,6 +56,10 @@ interface WordsCountModule {
 
 const wordsCount = (wordsCountModule as unknown as WordsCountModule).wordsCount;
 
+function getLineNumberDigits(lineCount: number): number {
+  return String(Math.max(lineCount, 1)).length;
+}
+
 interface ChapterEditorProps {
   chapterId: string | null;
   scrollTop?: number;
@@ -144,6 +148,7 @@ function ChapterEditorContent({
   const [isSaving, setIsSaving] = useState(false);
   const [findReplaceMode, setFindReplaceMode] = useState<"closed" | "find" | "replace">("closed");
   const [wordCount, setWordCount] = useState(() => wordsCount(initialDraft.content));
+  const [lineNumberDigits, setLineNumberDigits] = useState(1);
   const saveStatus = isSaving ? "saving" : hasChanges ? "unsaved" : "saved";
   const latestDraftRef = useRef(initialDraft);
   const latestDraftUpdatedAtRef = useRef(initialDraftUpdatedAt);
@@ -313,9 +318,11 @@ function ChapterEditorContent({
     onUpdate: ({ editor }) => {
       if (isAgentLocked) return;
       syncDirtyStateFromEditor(editor);
+      setLineNumberDigits(getLineNumberDigits(editor.state.doc.childCount));
       setWordCount(wordsCount(editor.getText()));
     },
     onCreate: ({ editor }) => {
+      setLineNumberDigits(getLineNumberDigits(editor.state.doc.childCount));
       setWordCount(wordsCount(editor.getText()));
     },
   });
@@ -470,6 +477,7 @@ function ChapterEditorContent({
 
     if (currentContent !== nextContent) {
       editor.commands.setContent(nextContent, { emitUpdate: false });
+      setLineNumberDigits(getLineNumberDigits(editor.state.doc.childCount));
       queueMicrotask(() => {
         setWordCount(wordsCount(editor.getText()));
       });
@@ -639,6 +647,10 @@ function ChapterEditorContent({
   }, [addSelectionToConversation, chapter.id, chapter.title, editor, onAddToConversation, t]);
 
   const editorMaxWidth = 800;
+  const lineNumberWidth = `max(1.5rem, calc(${lineNumberDigits}ch + 0.25rem))`;
+  const lineNumberWidthStyle = showLineNumbers
+    ? ({ "--editor-line-number-width": lineNumberWidth } as React.CSSProperties)
+    : undefined;
 
   return (
     <Box
@@ -685,6 +697,7 @@ function ChapterEditorContent({
           className="chapter-editor-content"
           style={{
             maxWidth: editorMaxWidth,
+            ...lineNumberWidthStyle,
           }}
         >
           <TitleInput

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -820,6 +820,8 @@
     "editorAutoPairSymbolsHint": "Automatically complete paired symbols while typing.",
     "editorAutoPairSymbolsTooltipSymbols": "Supported symbols: () [] {} \"\" '' （）【】「」『』《》“”‘’",
     "editorAutoPairSymbolsTooltipLabel": "About auto-completing paired symbols",
+    "editorShowLineNumbers": "Show line numbers",
+    "editorShowLineNumbersHint": "Show line numbers for explicit line breaks in the chapter editor; soft-wrapped lines do not receive new numbers.",
     "increaseFontSize": "Increase font size",
     "decreaseFontSize": "Decrease font size",
     "fontOptionSystemDefault": "System default",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -820,6 +820,8 @@
     "editorAutoPairSymbolsHint": "输入成对的符号时，自动补齐对应符号。",
     "editorAutoPairSymbolsTooltipSymbols": "支持的符号：() [] {} \"\" '' （）【】「」『』《》“”‘’",
     "editorAutoPairSymbolsTooltipLabel": "自动补齐成对符号说明",
+    "editorShowLineNumbers": "显示行号",
+    "editorShowLineNumbersHint": "按显式换行显示章节内容的行号；自动换行不会产生新的行号。",
     "increaseFontSize": "增大字号",
     "decreaseFontSize": "减小字号",
     "fontOptionSystemDefault": "系统默认",

--- a/frontend/src/styles/overrides/tiptap.css
+++ b/frontend/src/styles/overrides/tiptap.css
@@ -15,11 +15,17 @@
   counter-reset: editor-line;
 }
 
+.tiptap-editor--line-numbers {
+  --editor-line-number-scale: 0.75;
+}
+
 .tiptap-editor-wrapper--line-numbers {
   container-type: inline-size;
 }
 
 .chapter-editor-content {
+  --editor-line-number-gap: 1rem;
+  --editor-line-number-width: 2.5rem;
   margin: 0 auto;
   padding: 0 24px;
 }
@@ -27,7 +33,7 @@
 @container (max-width: 900px) {
   .tiptap-editor-wrapper--line-numbers > .chapter-editor-content {
     margin-inline-end: 0;
-    margin-inline-start: 3.5rem;
+    margin-inline-start: calc(var(--editor-line-number-width) + var(--editor-line-number-gap));
   }
 }
 
@@ -38,9 +44,9 @@
 
 .tiptap-editor--line-numbers .ProseMirror > p::after {
   position: absolute;
-  inset-inline-start: -3.5rem;
+  inset-inline-start: calc(0rem - var(--editor-line-number-width) - var(--editor-line-number-gap));
   top: 0.1em;
-  width: 2.5rem;
+  width: var(--editor-line-number-width);
   color: var(--gray-a9);
   content: counter(editor-line);
   font-family: var(--code-font-family, ui-monospace, monospace);
@@ -49,9 +55,21 @@
   line-height: inherit;
   pointer-events: none;
   text-align: end;
-  transform: scale(0.75);
+  transform: scale(var(--editor-line-number-scale, 0.75));
   transform-origin: right center;
+  white-space: nowrap;
   user-select: none;
+}
+
+@media (max-width: 767px) {
+  .tiptap-editor--line-numbers {
+    --editor-line-number-scale: 0.65;
+  }
+
+  .tiptap-editor-wrapper--line-numbers > .chapter-editor-content {
+    --editor-line-number-gap: 0.25rem;
+    margin-inline-start: max(0px, calc(var(--editor-line-number-width) - 1.5rem));
+  }
 }
 
 .tiptap-editor p {

--- a/frontend/src/styles/overrides/tiptap.css
+++ b/frontend/src/styles/overrides/tiptap.css
@@ -11,6 +11,49 @@
   outline: none;
 }
 
+.tiptap-editor--line-numbers .ProseMirror {
+  counter-reset: editor-line;
+}
+
+.tiptap-editor-wrapper--line-numbers {
+  container-type: inline-size;
+}
+
+.chapter-editor-content {
+  margin: 0 auto;
+  padding: 0 24px;
+}
+
+@container (max-width: 900px) {
+  .tiptap-editor-wrapper--line-numbers > .chapter-editor-content {
+    margin-inline-end: 0;
+    margin-inline-start: 3.5rem;
+  }
+}
+
+.tiptap-editor--line-numbers .ProseMirror > p {
+  position: relative;
+  counter-increment: editor-line;
+}
+
+.tiptap-editor--line-numbers .ProseMirror > p::after {
+  position: absolute;
+  inset-inline-start: -3.5rem;
+  top: 0.1em;
+  width: 2.5rem;
+  color: var(--gray-a9);
+  content: counter(editor-line);
+  font-family: var(--code-font-family, ui-monospace, monospace);
+  font-size: inherit;
+  font-variant-numeric: tabular-nums;
+  line-height: inherit;
+  pointer-events: none;
+  text-align: end;
+  transform: scale(0.75);
+  transform-origin: right center;
+  user-select: none;
+}
+
 .tiptap-editor p {
   margin-bottom: 1em;
 }


### PR DESCRIPTION
## PR 标题

chore(editor): 支持章节编辑器可选行号显示

## 变更说明

- 问题: 章节编辑器缺少可选的行号显示，启用后在窄区域和多位数行号下会影响布局。
- 重要性: 行号便于章节内容定位，同时不能挤压正文或破坏移动端阅读体验。
- 变化: 在“设置-编辑器”增加默认关闭的行号开关，并持久化设置；行号按当前最大行号位数动态调整宽度，支持桌面端和移动端布局。

## 关联 Issue / PR

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因

无

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

无
