### PR TITLE
fix(agent): 规范化 write_plan 结果并修复被压缩时计划丢失的问题

### DIFF
--- a/backend/app/agent_runtime/context/compaction/service.py
+++ b/backend/app/agent_runtime/context/compaction/service.py
@@ -10,8 +10,10 @@ from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.agent_runtime.context.compaction.window import CompactionWindow
+from app.agent_runtime.context.types import ContextMessage
 from app.agent_runtime.graph.state import AgentRuntimeState
 from app.agent_runtime.model_config import to_client_model_config
+from app.agent_runtime.plan import service as plan_service
 from app.agent_runtime.persistence import compaction_repo
 from app.agent_runtime.persistence import repo as message_repo
 from app.agent_runtime.persistence.compaction_types import (
@@ -28,6 +30,55 @@ UsageSink = Callable[[dict[str, Any]], Awaitable[None] | None]
 PromptRole = Literal["system", "user", "assistant"]
 
 _SURROGATE_RE = re.compile(r"[\ud800-\udfff]")
+
+
+def _tool_call_name(tool_call: object) -> str | None:
+    if not isinstance(tool_call, Mapping):
+        return None
+    name = tool_call.get("name")
+    if isinstance(name, str) and name:
+        return name
+    function = tool_call.get("function")
+    if isinstance(function, Mapping):
+        function_name = function.get("name")
+        if isinstance(function_name, str) and function_name:
+            return function_name
+    return None
+
+
+def _has_write_plan_tool(messages: list[ContextMessage]) -> bool:
+    for message in messages:
+        if message.role == "assistant" and any(
+            _tool_call_name(tool_call) == "write_plan"
+            for tool_call in message.tool_calls or []
+        ):
+            return True
+        if message.role != "tool":
+            continue
+        if message.name == "write_plan":
+            return True
+        metadata = message.metadata or {}
+        if metadata.get("tool_name") == "write_plan":
+            return True
+    return False
+
+
+async def _current_plan_block(
+    db_session: AsyncSession,
+    *,
+    session_id: str,
+    outside_messages: list[ContextMessage],
+) -> str | None:
+    if _has_write_plan_tool(outside_messages):
+        return None
+    try:
+        todos = await plan_service.get_plan_todos(db_session, session_id)
+    except Exception:
+        logger.opt(exception=True).warning("Failed to load current plan for compaction")
+        return None
+    if todos is None:
+        return None
+    return _sanitize_surrogates(plan_service.format_current_plan(todos))
 
 
 class CompactionError(RuntimeError):
@@ -116,6 +167,13 @@ async def compact_window(
             error=exc,
         )
         raise
+
+    if plan_block := await _current_plan_block(
+        db_session,
+        session_id=session_id,
+        outside_messages=window.outside_messages,
+    ):
+        summary = f"{summary}\n\n{plan_block}"
 
     usage = _extract_usage(response)
     token_input, token_output, token_cache = _token_counts(usage)

--- a/backend/app/agent_runtime/context/compaction/window.py
+++ b/backend/app/agent_runtime/context/compaction/window.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import NoReturn
 
 from app.agent_runtime.context.compaction.config import (
@@ -26,6 +26,7 @@ class CompactionWindow:
     messages: list[ContextMessage]
     source_input_tokens: int
     transcript: str
+    outside_messages: list[ContextMessage] = field(default_factory=list)
 
 
 def _seq(message: ContextMessage) -> int | None:
@@ -107,10 +108,19 @@ def select_compaction_window(
     if not seqs:
         _raise_no_window()
 
+    start_seq = min(seqs)
+    end_seq = max(seqs)
+    outside_messages = [
+        message
+        for message in history_messages
+        if (seq := _seq(message)) is None or seq < start_seq or seq > end_seq
+    ]
+
     return CompactionWindow(
-        start_seq=min(seqs),
-        end_seq=max(seqs),
+        start_seq=start_seq,
+        end_seq=end_seq,
         messages=window_messages,
         source_input_tokens=source_input_tokens,
         transcript=to_transcript(window_messages),
+        outside_messages=outside_messages,
     )

--- a/backend/app/agent_runtime/plan/service.py
+++ b/backend/app/agent_runtime/plan/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from typing import Any
 
@@ -13,6 +14,17 @@ from app.agent_runtime.tools.errors import ToolExecutionError
 
 PLAN_STATUSES = {"pending", "in_progress", "completed"}
 PLAN_PRIORITIES = {"low", "medium", "high"}
+
+
+def format_plan_todos(todos: Sequence[Mapping[str, str]]) -> str:
+    return "\n\n".join(
+        f"[{index} {todo['status']} / {todo['priority']} priority]\n{todo['content']}"
+        for index, todo in enumerate(todos, start=1)
+    )
+
+
+def format_current_plan(todos: Sequence[Mapping[str, str]]) -> str:
+    return f"<current_plan>\n{format_plan_todos(todos)}\n</current_plan>"
 
 
 def _resolve_session_id(runtime_state: dict[str, Any]) -> str:
@@ -41,15 +53,29 @@ def _normalize_todo(payload: dict[str, Any]) -> dict[str, str]:
 
 def _serialize_todos(todos: list[PlanTodoRecord]) -> dict[str, list[dict[str, str]]]:
     return {
-        "todos": [
-            {
-                "content": todo.content,
-                "status": todo.status,
-                "priority": todo.priority,
-            }
-            for todo in todos
-        ]
+        "todos": _todo_payloads(todos),
     }
+
+
+def _todo_payloads(todos: Sequence[PlanTodoRecord]) -> list[dict[str, str]]:
+    return [
+        {
+            "content": todo.content,
+            "status": todo.status,
+            "priority": todo.priority,
+        }
+        for todo in todos
+    ]
+
+
+async def get_plan_todos(
+    session: AsyncSession,
+    session_id: str,
+) -> list[dict[str, str]] | None:
+    plan = await plan_repo.get_plan_by_session(session, session_id)
+    if plan is None:
+        return None
+    return _todo_payloads(await plan_repo.list_todos_by_plan(session, plan.id))
 
 
 async def write_plan(

--- a/backend/app/agent_runtime/tools/impls/plan/write_plan.py
+++ b/backend/app/agent_runtime/tools/impls/plan/write_plan.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import json
 from typing import Any
 
 from pydantic import BaseModel
@@ -64,18 +63,13 @@ class WritePlanTool(AgentTool):
     async def _execute(self, todos: list[Any]) -> str:
         session = await create_session()
         try:
-            await plan_service.write_plan(
+            snapshot = await plan_service.write_plan(
                 session,
                 runtime_state=self._state,
                 todos=[_todo_payload(todo) for todo in todos],
             )
             await session.commit()
-            return json.dumps(
-                {
-                    "success": True,
-                },
-                ensure_ascii=False,
-            )
+            return plan_service.format_plan_todos(snapshot["todos"])
         except Exception:
             await session.rollback()
             raise

--- a/backend/tests/agent_runtime/context/test_compaction_primitives.py
+++ b/backend/tests/agent_runtime/context/test_compaction_primitives.py
@@ -215,6 +215,7 @@ def test_window_selects_middle_messages_after_first_user_and_before_tail() -> No
     assert window.start_seq == 2
     assert window.end_seq == 3
     assert window.messages == messages[1:3]
+    assert window.outside_messages == [messages[0], messages[3], messages[4]]
     assert window.source_input_tokens >= 2_000
     assert "<assistant>" in window.transcript
     assert "<user>" in window.transcript

--- a/backend/tests/agent_runtime/context/test_compaction_service.py
+++ b/backend/tests/agent_runtime/context/test_compaction_service.py
@@ -18,7 +18,12 @@ from app.agent_runtime.context.types import ContextMessage
 from app.agent_runtime.graph.state import AgentRuntimeState
 from app.agent_runtime.persistence import compaction_repo
 from app.agent_runtime.persistence import repo as message_repo
-from app.agent_runtime.persistence.model import AgentContextCompaction, AgentRunMessage
+from app.agent_runtime.persistence.model import (
+    AgentContextCompaction,
+    AgentRunMessage,
+    PlanRecord,
+    PlanTodoRecord,
+)
 from app.agent_runtime.runner.session_runner import SessionRunner
 from app.storage.models.chapter import Chapter
 from app.storage.models.project import Project
@@ -47,6 +52,8 @@ _TABLES = [
     _table(Task),
     _table(AgentContextCompaction),
     _table(AgentRunMessage),
+    _table(PlanRecord),
+    _table(PlanTodoRecord),
 ]
 
 
@@ -246,6 +253,127 @@ async def test_compact_window_persists_raw_summary_and_emits_events_and_usage(
         "compaction_id": result.id,
         "trigger": "manual",
     }
+
+
+@pytest.mark.asyncio
+async def test_compact_window_appends_current_plan_when_outside_window_has_no_write_plan(
+    db_session: AsyncSession,
+    state: AgentRuntimeState,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_model = FakeModel(_ai_message("摘要正文"))
+    current_todos = [
+        {
+            "content": "Run verification",
+            "status": "in_progress",
+            "priority": "high",
+        },
+        {
+            "content": "Prepare delivery",
+            "status": "pending",
+            "priority": "medium",
+        },
+    ]
+    window = CompactionWindow(
+        start_seq=2,
+        end_seq=5,
+        messages=[ContextMessage(role="assistant", content="old")],
+        outside_messages=[
+            ContextMessage(
+                role="assistant",
+                content="recent work",
+                metadata={"part": "history", "seq": 6},
+            )
+        ],
+        source_input_tokens=321,
+        transcript="<assistant>old</assistant>",
+    )
+
+    monkeypatch.setattr(
+        "app.agent_runtime.context.compaction.service.create_chat_model",
+        lambda _config: fake_model,
+    )
+    monkeypatch.setattr(
+        "app.agent_runtime.context.compaction.service.prompt_chain_service.get_latest_version_with_entries_or_default",
+        AsyncMock(return_value=_prompt_version()),
+    )
+    get_plan_todos = AsyncMock(return_value=current_todos)
+    monkeypatch.setattr(
+        "app.agent_runtime.context.compaction.service.plan_service.get_plan_todos",
+        get_plan_todos,
+    )
+
+    result = await compact_window(
+        db_session,
+        state=state,
+        window=window,
+        trigger="manual",
+    )
+
+    expected_plan = (
+        "<current_plan>\n"
+        "[1 in_progress / high priority]\n"
+        "Run verification\n\n"
+        "[2 pending / medium priority]\n"
+        "Prepare delivery\n"
+        "</current_plan>"
+    )
+    assert result.summary == f"摘要正文\n\n{expected_plan}"
+    get_plan_todos.assert_awaited_once_with(db_session, state["session_id"])
+
+
+@pytest.mark.asyncio
+async def test_compact_window_does_not_append_current_plan_when_outside_window_has_write_plan(
+    db_session: AsyncSession,
+    state: AgentRuntimeState,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake_model = FakeModel(_ai_message("摘要正文"))
+    window = CompactionWindow(
+        start_seq=2,
+        end_seq=5,
+        messages=[ContextMessage(role="assistant", content="old")],
+        outside_messages=[
+            ContextMessage(
+                role="assistant",
+                content="",
+                tool_calls=[
+                    {
+                        "id": "call-write-plan",
+                        "name": "write_plan",
+                        "args": {"todos": []},
+                    }
+                ],
+                metadata={"part": "history", "seq": 6},
+            )
+        ],
+        source_input_tokens=321,
+        transcript="<assistant>old</assistant>",
+    )
+
+    monkeypatch.setattr(
+        "app.agent_runtime.context.compaction.service.create_chat_model",
+        lambda _config: fake_model,
+    )
+    monkeypatch.setattr(
+        "app.agent_runtime.context.compaction.service.prompt_chain_service.get_latest_version_with_entries_or_default",
+        AsyncMock(return_value=_prompt_version()),
+    )
+    get_plan_todos = AsyncMock()
+    monkeypatch.setattr(
+        "app.agent_runtime.context.compaction.service.plan_service.get_plan_todos",
+        get_plan_todos,
+    )
+
+    result = await compact_window(
+        db_session,
+        state=state,
+        window=window,
+        trigger="manual",
+    )
+
+    assert result.summary == "摘要正文"
+    get_plan_todos.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/plan/test_service.py
+++ b/backend/tests/agent_runtime/plan/test_service.py
@@ -20,6 +20,29 @@ def _state(
     return state
 
 
+def test_format_plan_todos_uses_numbered_status_and_priority_blocks() -> None:
+    assert plan_service.format_plan_todos(
+        [
+            _todo("Inspect the outline", "completed", "high"),
+            _todo("Run verification", "pending", "medium"),
+        ]
+    ) == (
+        "[1 completed / high priority]\n"
+        "Inspect the outline\n\n"
+        "[2 pending / medium priority]\n"
+        "Run verification"
+    )
+
+
+def test_format_current_plan_wraps_formatted_todos() -> None:
+    assert plan_service.format_current_plan([_todo("Inspect the outline", "pending", "low")]) == (
+        "<current_plan>\n"
+        "[1 pending / low priority]\n"
+        "Inspect the outline\n"
+        "</current_plan>"
+    )
+
+
 @pytest.mark.asyncio
 async def test_write_plan_replaces_the_complete_todo_list_in_one_session(
     session: AsyncSession,

--- a/backend/tests/agent_runtime/tools/test_plan_tools.py
+++ b/backend/tests/agent_runtime/tools/test_plan_tools.py
@@ -1,4 +1,3 @@
-import json
 from collections.abc import Iterator
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -40,7 +39,7 @@ def _fake_session():
 
 
 @pytest.mark.asyncio
-async def test_write_plan_tool_returns_success_status_after_replacing_session_todos() -> None:
+async def test_write_plan_tool_returns_formatted_todos_after_replacing_session_todos() -> None:
     session = _fake_session()
     snapshot = {
         "todos": [
@@ -48,7 +47,12 @@ async def test_write_plan_tool_returns_success_status_after_replacing_session_to
                 "content": "Review the outline",
                 "status": "in_progress",
                 "priority": "high",
-            }
+            },
+            {
+                "content": "Run the checks",
+                "status": "pending",
+                "priority": "medium",
+            },
         ]
     }
 
@@ -68,10 +72,12 @@ async def test_write_plan_tool_returns_success_status_after_replacing_session_to
         )[0]
         result = await tool.ainvoke({"todos": snapshot["todos"]})
 
-    payload = json.loads(result)
-    assert payload == {
-        "success": True,
-    }
+    assert result == (
+        "[1 in_progress / high priority]\n"
+        "Review the outline\n\n"
+        "[2 pending / medium priority]\n"
+        "Run the checks"
+    )
     assert write_plan_service.await_args is not None
     assert write_plan_service.await_args.kwargs["runtime_state"]["session_id"] == "session-1"
     assert write_plan_service.await_args.kwargs["todos"] == snapshot["todos"]


### PR DESCRIPTION
## PR 标题

fix(agent): 规范化 write_plan 结果并修复被压缩时计划丢失的问题

## 变更说明

- 问题: `write_plan` 仅返回成功标记，压缩摘要在计划工具调用被压缩后无法可靠保留当前计划。
- 重要性: 长流程或上下文压缩后，Agent 可能无法恢复自己的工作计划。
- 变化: 返回带编号、状态和优先级的计划文本；压缩范围外没有 `write_plan` 时，将持久化的当前计划追加到 summary 末尾。
- 验证: Agent Runtime 测试 803/803 通过，Ruff 检查通过。

## 关联 Issue / PR

Closes #344

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因

计划已持久化到数据库，但 `write_plan` 的工具结果没有携带计划内容，且 compact 只保留摘要和压缩范围外的消息。计划工具调用进入压缩范围后，模型上下文中缺少可靠的当前计划快照。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和修改文件类型检查，无新增报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

全局 `ty check` 仍有仓库中未涉及本次变更的既有类型诊断；本次修改的生产文件类型检查通过。未修改前端代码。
