### PR TITLE
chore(provider): 支持 Gemini Compatible 自定义提供商

### DIFF
--- a/backend/app/models/adapters/__init__.py
+++ b/backend/app/models/adapters/__init__.py
@@ -9,6 +9,7 @@ from app.models.adapters.base import BaseAdapter
 from app.models.adapters.anthropic import AnthropicAdapter
 from app.models.adapters.anthropic_compatible import AnthropicCompatibleAdapter
 from app.models.adapters.deepseek import DeepSeekAdapter
+from app.models.adapters.gemini_compatible import GeminiCompatibleAdapter
 from app.models.adapters.google_genai import GoogleGenAIAdapter
 from app.models.adapters.mistral import MistralAdapter
 from app.models.adapters.openai import OpenAIAdapter
@@ -30,6 +31,7 @@ __all__ = [
     "AnthropicCompatibleAdapter",
     "CohereAdapter",
     "DeepSeekAdapter",
+    "GeminiCompatibleAdapter",
     "GoogleGenAIAdapter",
     "GroqAdapter",
     "HuggingFaceAdapter",

--- a/backend/app/models/adapters/gemini_compatible.py
+++ b/backend/app/models/adapters/gemini_compatible.py
@@ -1,0 +1,78 @@
+"""Gemini-compatible provider adapter."""
+
+from collections.abc import Mapping
+
+import httpx
+
+from app.models.adapters.base import BaseAdapter
+
+
+class GeminiCompatibleAdapter(BaseAdapter):
+    """Gemini native provider adapter supporting LLM model discovery only."""
+
+    @property
+    def provider_type(self) -> str:
+        return "gemini-compatible"
+
+    def supports_embedding(self) -> bool:
+        return False
+
+    async def get_llm_models(
+        self,
+        client: httpx.AsyncClient,
+        base_url: str,
+        api_key: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+    ) -> list[dict[str, str]]:
+        url = self._normalize_url(base_url)
+        models_url = (
+            f"{url}/models" if url.endswith("/v1beta") else f"{url}/v1beta/models"
+        )
+        request_headers = {
+            key: value
+            for key, value in (headers or {}).items()
+            if key.lower() != "x-goog-api-key"
+        }
+        request_headers["x-goog-api-key"] = api_key
+        response = await client.get(
+            models_url,
+            headers=request_headers,
+        )
+        response.raise_for_status()
+        data = response.json()
+
+        models: list[dict[str, str]] = []
+        for model in data.get("models", []):
+            if not isinstance(model, dict):
+                continue
+            model_name = model.get("name")
+            methods = model.get("supportedGenerationMethods")
+            if not isinstance(model_name, str):
+                continue
+            if methods is not None and (
+                not isinstance(methods, list) or "generateContent" not in methods
+            ):
+                continue
+
+            model_id = model_name.removeprefix("models/")
+            if not model_id:
+                continue
+            display_name = model.get("displayName")
+            models.append(
+                {
+                    "id": model_id,
+                    "name": display_name if isinstance(display_name, str) else model_id,
+                }
+            )
+        return models
+
+    async def get_embedding_models(
+        self,
+        client: httpx.AsyncClient,
+        base_url: str,
+        api_key: str,
+        *,
+        headers: Mapping[str, str] | None = None,
+    ) -> list[dict[str, str]]:
+        return []

--- a/backend/app/models/adapters/google_genai.py
+++ b/backend/app/models/adapters/google_genai.py
@@ -18,6 +18,22 @@ from app.models.adapters.base import BaseAdapter
 class GoogleGenAIAdapter(BaseAdapter):
     """Google Generative AI适配器，支持LLM和Embedding。"""
 
+    @staticmethod
+    def _build_request_headers(
+        api_key: str, headers: Mapping[str, str] | None
+    ) -> dict[str, str]:
+        request_headers = {
+            key: value
+            for key, value in (headers or {}).items()
+            if key.lower() != "x-goog-api-key"
+        }
+        request_headers["x-goog-api-key"] = api_key
+        return request_headers
+
+    def _build_models_url(self, base_url: str) -> str:
+        url = self._normalize_url(base_url)
+        return f"{url}/models" if url.endswith("/v1beta") else f"{url}/v1beta/models"
+
     @property
     def provider_type(self) -> str:
         return "google-genai"
@@ -31,18 +47,22 @@ class GoogleGenAIAdapter(BaseAdapter):
         headers: Mapping[str, str] | None = None,
     ) -> list[dict[str, str]]:
         """获取LLM模型列表（supportedGenerationMethods包含generateContent）。"""
-        url = f"{self._normalize_url(base_url)}/models"
+        url = self._build_models_url(base_url)
         
         try:
-            response = await client.get(url, params={"key": api_key})
+            response = await client.get(
+                url, headers=self._build_request_headers(api_key, headers)
+            )
             response.raise_for_status()
             data = response.json()
 
             models = []
             for model in data.get("models", []):
-                methods = model.get("supportedGenerationMethods", [])
+                methods = model.get("supportedGenerationMethods")
                 # LLM模型支持generateContent
-                if "generateContent" in methods:
+                if methods is None or (
+                    isinstance(methods, list) and "generateContent" in methods
+                ):
                     model_name = model.get("name", "")
                     if model_name.startswith("models/"):
                         model_id = model_name[7:]
@@ -71,16 +91,18 @@ class GoogleGenAIAdapter(BaseAdapter):
         headers: Mapping[str, str] | None = None,
     ) -> list[dict[str, str]]:
         """获取Embedding模型列表（supportedGenerationMethods包含embedContent）。"""
-        url = f"{self._normalize_url(base_url)}/models"
+        url = self._build_models_url(base_url)
         
         try:
-            response = await client.get(url, params={"key": api_key})
+            response = await client.get(
+                url, headers=self._build_request_headers(api_key, headers)
+            )
             response.raise_for_status()
             data = response.json()
 
             models = []
             for model in data.get("models", []):
-                methods = model.get("supportedGenerationMethods", [])
+                methods = model.get("supportedGenerationMethods") or []
                 # Embedding模型支持embedContent
                 if "embedContent" in methods:
                     model_name = model.get("name", "")

--- a/backend/app/models/catalog/service.py
+++ b/backend/app/models/catalog/service.py
@@ -197,6 +197,7 @@ class ModelProviderCatalogService:
         if provider_type not in {
             "openai-compatible",
             "openai-compatible-responses",
+            "gemini-compatible",
         }:
             provider = next(
                 (item for item in providers if item.provider_type == provider_type),
@@ -234,7 +235,10 @@ class ModelProviderCatalogService:
         supported = set()
         if provider_type in _REGISTERED_PROVIDER_TYPES:
             supported.update(AdapterRegistry.get_supported_task_types(provider_type))
-        if catalog_match is not None and provider_type != "openai-compatible-responses":
+        if catalog_match is not None and provider_type not in {
+            "openai-compatible-responses",
+            "gemini-compatible",
+        }:
             try:
                 provider = self._find_provider(
                     self._load_current_snapshot()[0], catalog_match.catalog_provider_type

--- a/backend/app/models/clients/model_factory.py
+++ b/backend/app/models/clients/model_factory.py
@@ -95,6 +95,11 @@ def _stream_chunk_timeout() -> float | None:
     return settings.llm_chunk_timeout
 
 
+def _gemini_compatible_base_url(base_url: str) -> str:
+    normalized_url = base_url.rstrip("/")
+    return normalized_url.removesuffix("/v1beta")
+
+
 def _openai_compatible_kwargs(config: ModelConfig) -> dict[str, Any]:
     kwargs = _compact_kwargs(
         model=config.model_id,
@@ -167,6 +172,27 @@ def create_chat_model(config: ModelConfig) -> Runnable[LanguageModelInput, BaseM
         if config.base_url:
             google_kwargs["client_options"] = {"api_endpoint": config.base_url}
         return ChatGoogleGenerativeAI(**google_kwargs)
+
+    if provider == "gemini-compatible":
+        from langchain_google_genai import ChatGoogleGenerativeAI
+
+        gemini_kwargs = _compact_kwargs(
+            model=config.model_id,
+            google_api_key=config.api_key,
+            temperature=_non_default(config.temperature, DEFAULT_TEMPERATURE),
+            top_p=_non_default(config.top_p, DEFAULT_TOP_P),
+            top_k=_non_default(config.top_k, DEFAULT_TOP_K),
+            max_output_tokens=config.max_tokens,
+            thinking_level=_three_level_reasoning_effort(reasoning_effort),
+            additional_headers=config.custom_headers or None,
+            max_retries=0,
+            api_version="v1beta",
+        )
+        if config.base_url:
+            gemini_kwargs["client_options"] = {
+                "api_endpoint": _gemini_compatible_base_url(config.base_url)
+            }
+        return ChatGoogleGenerativeAI(**gemini_kwargs)
 
     if provider == "deepseek":
         from langchain_deepseek import ChatDeepSeek

--- a/backend/app/models/entities/model_provider.py
+++ b/backend/app/models/entities/model_provider.py
@@ -40,7 +40,8 @@ class ModelProvider(SQLModel, table=True):
         description=(
             "Provider type: anthropic, openai, google-genai, ollama, groq, "
             "huggingface, mistral, nvidia-ai-endpoints, cohere, openrouter, "
-            "amazon-nova, deepseek, openai-compatible, openai-compatible-responses"
+            "amazon-nova, deepseek, openai-compatible, openai-compatible-responses, "
+            "gemini-compatible"
         ),
     )
     is_builtin: bool = Field(default=False, description="是否为内置提供商（不可删除/编辑）")

--- a/backend/app/models/registry.py
+++ b/backend/app/models/registry.py
@@ -11,6 +11,7 @@ from app.models.adapters.base import BaseAdapter
 from app.models.adapters.anthropic import AnthropicAdapter
 from app.models.adapters.anthropic_compatible import AnthropicCompatibleAdapter
 from app.models.adapters.deepseek import DeepSeekAdapter
+from app.models.adapters.gemini_compatible import GeminiCompatibleAdapter
 from app.models.adapters.google_genai import GoogleGenAIAdapter
 from app.models.adapters.mistral import MistralAdapter
 from app.models.adapters.openai import OpenAIAdapter
@@ -36,6 +37,7 @@ class AdapterRegistry:
         "openai": OpenAIAdapter,
         "anthropic": AnthropicAdapter,
         "anthropic-compatible": AnthropicCompatibleAdapter,
+        "gemini-compatible": GeminiCompatibleAdapter,
         "google-genai": GoogleGenAIAdapter,
         "ollama": OpenAICompatibleAdapter,
         "groq": GroqAdapter,

--- a/backend/app/models/services/model_provider_service.py
+++ b/backend/app/models/services/model_provider_service.py
@@ -26,6 +26,7 @@ CUSTOM_PROVIDER_TYPES = frozenset(
         "openai-compatible",
         "openai-compatible-responses",
         "anthropic-compatible",
+        "gemini-compatible",
     }
 )
 
@@ -75,6 +76,8 @@ class ModelProviderService:
     ) -> list[str]:
         if provider.is_builtin:
             return ["embedding", "rerank"]
+        if provider.provider_type == "gemini-compatible":
+            return ["llm"]
         if catalog_match is None:
             catalog_match = await self.get_catalog_match(provider)
         return self.catalog_service.get_supported_task_types(
@@ -224,6 +227,7 @@ class ModelProviderService:
             "openai-compatible",
             "openai-compatible-responses",
             "anthropic-compatible",
+            "gemini-compatible",
         }:
             return url
 
@@ -386,6 +390,8 @@ class ModelProviderService:
             if provider_type == "anthropic-compatible"
             else "openai-compatible-responses"
             if provider_type == "openai-compatible-responses"
+            else "gemini-compatible"
+            if provider_type == "gemini-compatible"
             else "openai-compatible"
         )
         adapter = AdapterRegistry.get_adapter(runtime_provider_type)
@@ -436,6 +442,8 @@ class ModelProviderService:
             if provider.provider_type == "anthropic-compatible"
             else "openai-compatible-responses"
             if provider.provider_type == "openai-compatible-responses"
+            else "gemini-compatible"
+            if provider.provider_type == "gemini-compatible"
             else "openai-compatible"
         )
         if not AdapterRegistry.is_supported(runtime_provider_type, task_type):

--- a/backend/tests/agent_runtime/test_model_factory.py
+++ b/backend/tests/agent_runtime/test_model_factory.py
@@ -83,6 +83,28 @@ def test_create_chat_model_anthropic_compatible_uses_anthropic_client_with_custo
     assert model.max_retries == 0
 
 
+def test_create_chat_model_gemini_compatible_uses_custom_native_client():
+    config = ModelConfig(
+        provider_type="gemini-compatible",
+        base_url="https://gateway.example/gemini",
+        api_key="test-key",
+        model_id="gemini-custom",
+        custom_headers={"X-Provider-Token": "custom-token"},
+        reasoning_effort="max",
+    )
+
+    model = create_chat_model(config)
+
+    from langchain_google_genai import ChatGoogleGenerativeAI
+
+    assert isinstance(model, ChatGoogleGenerativeAI)
+    assert model.base_url == {"api_endpoint": "https://gateway.example/gemini"}
+    assert model.api_version == "v1beta"
+    assert model.additional_headers == {"X-Provider-Token": "custom-token"}
+    assert model.thinking_level == "high"
+    assert model.max_retries == 0
+
+
 def test_create_chat_model_custom_providers_send_custom_headers():
     openai_model = create_chat_model(
         ModelConfig(

--- a/backend/tests/api/test_model_providers.py
+++ b/backend/tests/api/test_model_providers.py
@@ -412,6 +412,72 @@ async def test_validate_openai_responses_compatible_provider_discovers_models(
 
 @pytest.mark.asyncio
 @respx.mock
+async def test_validate_gemini_compatible_provider_discovers_llm_models(
+    client: AsyncClient,
+):
+    route = respx.get("https://gateway.example/v1beta/models").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "models": [
+                    {
+                        "name": "models/gemini-2.5-flash",
+                        "displayName": "Gemini 2.5 Flash",
+                        "supportedGenerationMethods": ["generateContent"],
+                    },
+                    {
+                        "name": "models/text-embedding-004",
+                        "displayName": "Text Embedding 004",
+                        "supportedGenerationMethods": ["embedContent"],
+                    },
+                    {
+                        "name": "models/legacy-model",
+                        "displayName": "Legacy Model",
+                        "supportedGenerationMethods": None,
+                    },
+                ]
+            },
+        )
+    )
+
+    response = await client.post(
+        "/api/v1/model-providers/validate",
+        json={
+            "provider_type": "gemini-compatible",
+            "url": "https://gateway.example",
+            "api_key": "test-key",
+            "custom_headers": [
+                {"key": "X-Provider-Token", "value": "custom-token"}
+            ],
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "success": True,
+        "message": "连接验证成功",
+        "models": [
+            {
+                "id": "gemini-2.5-flash",
+                "name": "Gemini 2.5 Flash",
+                "task_type": None,
+                "metadata": None,
+            },
+            {
+                "id": "legacy-model",
+                "name": "Legacy Model",
+                "task_type": None,
+                "metadata": None,
+            },
+        ],
+    }
+    assert "key" not in route.calls[0].request.url.params
+    assert route.calls[0].request.headers["x-goog-api-key"] == "test-key"
+    assert route.calls[0].request.headers["x-provider-token"] == "custom-token"
+
+
+@pytest.mark.asyncio
+@respx.mock
 async def test_get_anthropic_compatible_provider_models_discovers_models(
     client: AsyncClient,
     session: AsyncSession,

--- a/backend/tests/models/test_gemini_compatible_adapter.py
+++ b/backend/tests/models/test_gemini_compatible_adapter.py
@@ -1,0 +1,84 @@
+import httpx
+import pytest
+
+from app.models.registry import AdapterRegistry
+
+
+class _RecordingClient:
+    def __init__(self) -> None:
+        self.requests: list[tuple[str, object, dict[str, str]]] = []
+
+    async def get(self, url: str, **kwargs: object) -> httpx.Response:
+        params = kwargs.get("params")
+        headers = kwargs.get("headers")
+        self.requests.append(
+            (url, params, headers if isinstance(headers, dict) else {})
+        )
+        return httpx.Response(
+            200,
+            json={
+                "models": [
+                    {
+                        "name": "models/gemini-2.5-flash",
+                        "displayName": "Gemini 2.5 Flash",
+                        "supportedGenerationMethods": ["generateContent"],
+                    },
+                    {
+                        "name": "models/text-embedding-004",
+                        "displayName": "Text Embedding 004",
+                        "supportedGenerationMethods": ["embedContent"],
+                    },
+                    {
+                        "name": "models/legacy-model",
+                        "displayName": "Legacy Model",
+                        "supportedGenerationMethods": None,
+                    },
+                ]
+            },
+            request=httpx.Request("GET", url),
+        )
+
+
+@pytest.mark.asyncio
+async def test_gemini_compatible_adapter_discovers_llm_models_from_native_endpoint() -> None:
+    adapter = AdapterRegistry.get_adapter("gemini-compatible")
+    client = _RecordingClient()
+
+    models = await adapter.get_llm_models(
+        client,  # type: ignore[arg-type]
+        "https://gateway.example",
+        "test-key",
+        headers={"X-Provider-Token": "custom-token"},
+    )
+
+    assert adapter.provider_type == "gemini-compatible"
+    assert adapter.supports_llm()
+    assert not adapter.supports_embedding()
+    assert not adapter.supports_rerank()
+    assert models == [
+        {"id": "gemini-2.5-flash", "name": "Gemini 2.5 Flash"},
+        {"id": "legacy-model", "name": "Legacy Model"},
+    ]
+    assert client.requests == [
+        (
+            "https://gateway.example/v1beta/models",
+            None,
+            {
+                "x-goog-api-key": "test-key",
+                "X-Provider-Token": "custom-token",
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_gemini_compatible_adapter_does_not_discover_embedding_models() -> None:
+    adapter = AdapterRegistry.get_adapter("gemini-compatible")
+
+    models = await adapter.get_embedding_models(
+        _RecordingClient(),  # type: ignore[arg-type]
+        "https://gateway.example",
+        "test-key",
+    )
+
+    assert models == []

--- a/backend/tests/models/test_google_genai_adapter.py
+++ b/backend/tests/models/test_google_genai_adapter.py
@@ -1,0 +1,79 @@
+import httpx
+import pytest
+
+from app.models.registry import AdapterRegistry
+
+
+class _RecordingClient:
+    def __init__(self) -> None:
+        self.requests: list[tuple[str, object, dict[str, str]]] = []
+
+    async def get(self, url: str, **kwargs: object) -> httpx.Response:
+        params = kwargs.get("params")
+        headers = kwargs.get("headers")
+        self.requests.append(
+            (url, params, headers if isinstance(headers, dict) else {})
+        )
+        return httpx.Response(
+            200,
+            json={
+                "models": [
+                    {
+                        "name": "models/gemini-2.5-flash",
+                        "displayName": "Gemini 2.5 Flash",
+                        "supportedGenerationMethods": ["generateContent"],
+                    },
+                    {
+                        "name": "models/text-embedding-004",
+                        "displayName": "Text Embedding 004",
+                        "supportedGenerationMethods": ["embedContent"],
+                    },
+                    {
+                        "name": "models/legacy-model",
+                        "displayName": "Legacy Model",
+                        "supportedGenerationMethods": None,
+                    },
+                ]
+            },
+            request=httpx.Request("GET", url),
+        )
+
+
+@pytest.mark.parametrize(
+    ("method_name", "expected_models"),
+    [
+        (
+            "get_llm_models",
+            [
+                {"id": "gemini-2.5-flash", "name": "Gemini 2.5 Flash"},
+                {"id": "legacy-model", "name": "Legacy Model"},
+            ],
+        ),
+        (
+            "get_embedding_models",
+            [{"id": "text-embedding-004", "name": "Text Embedding 004"}],
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_google_genai_adapter_uses_header_and_ignores_null_methods(
+    method_name: str,
+    expected_models: list[dict[str, str]],
+) -> None:
+    adapter = AdapterRegistry.get_adapter("google-genai")
+    client = _RecordingClient()
+
+    models = await getattr(adapter, method_name)(
+        client,  # type: ignore[arg-type]
+        "https://gateway.example",
+        "test-key",
+    )
+
+    assert models == expected_models
+    assert client.requests == [
+        (
+            "https://gateway.example/v1beta/models",
+            None,
+            {"x-goog-api-key": "test-key"},
+        )
+    ]

--- a/backend/tests/models/test_model_provider_service.py
+++ b/backend/tests/models/test_model_provider_service.py
@@ -8,6 +8,7 @@ import json
 import pytest
 
 from app.core.encryption import EncryptionService
+from app.models.catalog import CatalogMatch
 from app.models.entities.model_provider import ModelProvider
 from app.models.registry import AdapterRegistry
 from app.models.services.model_provider_service import ModelProviderService
@@ -176,6 +177,85 @@ async def test_validate_openai_responses_compatible_connection_uses_its_adapter(
 
     assert models == [{"id": "llm-1", "name": "LLM 1"}]
     assert requested_provider_types == ["openai-compatible-responses"]
+
+
+@pytest.mark.asyncio
+async def test_validate_gemini_compatible_connection_uses_its_adapter(monkeypatch):
+    encryption_service = EncryptionService("id-hEPdEELwlgep9FQhcYQtX7ow188l7WHwy65qOZGQ=")
+    service = ModelProviderService(encryption_service)
+    requested_provider_types: list[str] = []
+
+    def get_adapter(cls, provider_type: str):
+        requested_provider_types.append(provider_type)
+        return _FakeAdapter()
+
+    monkeypatch.setattr(AdapterRegistry, "get_adapter", classmethod(get_adapter))
+
+    models = await service.validate_and_get_models(
+        "gemini-compatible",
+        "https://gateway.example",
+        "test-key",
+    )
+
+    assert models == [{"id": "llm-1", "name": "LLM 1"}]
+    assert requested_provider_types == ["gemini-compatible"]
+
+
+@pytest.mark.asyncio
+async def test_get_available_models_uses_gemini_compatible_adapter(monkeypatch):
+    encryption_service = EncryptionService("id-hEPdEELwlgep9FQhcYQtX7ow188l7WHwy65qOZGQ=")
+    service = ModelProviderService(encryption_service)
+    provider = ModelProvider(
+        name="Gemini Compatible",
+        url="https://gateway.example",
+        api_key_encrypted=encryption_service.encrypt("test-key"),
+        provider_type="gemini-compatible",
+    )
+    requested_provider_types: list[str] = []
+
+    def get_adapter(cls, provider_type: str):
+        requested_provider_types.append(provider_type)
+        return _FakeAdapter()
+
+    def is_supported(cls, provider_type: str, task_type: str) -> bool:
+        requested_provider_types.append(provider_type)
+        return task_type == "llm"
+
+    monkeypatch.setattr(AdapterRegistry, "get_adapter", classmethod(get_adapter))
+    monkeypatch.setattr(AdapterRegistry, "is_supported", classmethod(is_supported))
+
+    models = await service.get_available_models(provider, "llm")
+
+    assert models == [{"id": "llm-1", "name": "LLM 1"}]
+    assert requested_provider_types == ["gemini-compatible", "gemini-compatible"]
+
+
+@pytest.mark.asyncio
+async def test_gemini_compatible_supported_task_types_are_llm_only(monkeypatch):
+    encryption_service = EncryptionService("id-hEPdEELwlgep9FQhcYQtX7ow188l7WHwy65qOZGQ=")
+
+    class _CatalogService:
+        def get_supported_task_types(self, provider_type, catalog_match=None):
+            return ["embedding", "llm", "rerank"]
+
+    service = ModelProviderService(encryption_service, catalog_service=_CatalogService())
+    provider = ModelProvider(
+        name="Gemini Compatible",
+        url="https://gateway.example",
+        api_key_encrypted=encryption_service.encrypt("test-key"),
+        provider_type="gemini-compatible",
+    )
+
+    supported_task_types = await service.get_supported_task_types(
+        provider,
+        catalog_match=CatalogMatch(
+            catalog_provider_type="google-genai",
+            display_name="Google Generative AI",
+            matched_via="api",
+        ),
+    )
+
+    assert supported_task_types == ["llm"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/models/test_model_registry.py
+++ b/backend/tests/models/test_model_registry.py
@@ -23,5 +23,6 @@ def test_registry_lists_only_current_first_class_provider_types() -> None:
         "openai-compatible",
         "openai-compatible-responses",
         "anthropic-compatible",
+        "gemini-compatible",
     }
     assert "google-vertex" not in AdapterRegistry.list_providers()

--- a/frontend/src/components/provider-id-select.tsx
+++ b/frontend/src/components/provider-id-select.tsx
@@ -42,6 +42,12 @@ const ANTHROPIC_COMPATIBLE_OPTION: ProviderIdSelectOption = {
   iconPath: null,
 };
 
+const GEMINI_COMPATIBLE_OPTION: ProviderIdSelectOption = {
+  value: "gemini-compatible",
+  label: "Gemini Compatible",
+  iconPath: null,
+};
+
 export function ProviderIdSelect({
   value,
   onChange,
@@ -65,6 +71,7 @@ export function ProviderIdSelect({
       OPENAI_COMPATIBLE_OPTION,
       OPENAI_RESPONSES_COMPATIBLE_OPTION,
       ANTHROPIC_COMPATIBLE_OPTION,
+      GEMINI_COMPATIBLE_OPTION,
     ]) {
       if (!catalogOptions.some((option) => option.value === compatibleOption.value)) {
         catalogOptions.push(compatibleOption);

--- a/frontend/src/features/settings/lib/provider-utils.ts
+++ b/frontend/src/features/settings/lib/provider-utils.ts
@@ -18,6 +18,7 @@ const CUSTOM_PROVIDER_TYPES = new Set([
   "openai-compatible",
   "openai-compatible-responses",
   "anthropic-compatible",
+  "gemini-compatible",
 ]);
 
 export function supportsEmbeddingDimensions(providerType: string): boolean {
@@ -58,6 +59,7 @@ export function getProviderDisplayName(providerType: string): string {
     "openai-compatible": "OpenAI Compatible",
     "openai-compatible-responses": "OpenAI Compatible (Responses)",
     "anthropic-compatible": "Anthropic Compatible",
+    "gemini-compatible": "Gemini Compatible",
     builtin: "Builtin",
   };
 


### PR DESCRIPTION
## PR 标题

chore(provider): 支持 Gemini Compatible 自定义提供商

## 变更说明

- 问题: 自定义提供商缺少 Gemini 原生协议支持，正常 Google Provider 的模型发现也存在认证和空字段兼容问题。
- 重要性: 无法稳定使用 Gemini 兼容服务，部分接口会返回 0 个模型，API Key 还可能出现在请求 URL 中。
- 变化: 新增 `gemini-compatible` 类型，支持 `/v1beta/models` 模型发现和 Google 客户端调用。
- 变化: 模型发现改用 `x-goog-api-key` 请求头，并兼容缺失或为空的 `supportedGenerationMethods` 字段。
- 变化: 增加后端适配器、服务路由、前端选择器和回归测试。

## 关联 Issue / PR

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因

原有实现没有 Gemini Compatible 类型；Google 模型发现使用 URL 查询参数传递 API Key，并假设 `supportedGenerationMethods` 始终是可迭代列表。部分兼容服务返回空字段，导致模型被全部过滤或触发异常。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

Gemini Compatible 的服务 URL 应填写服务根地址，模型发现会请求 `<URL>/v1beta/models`。本次未新增数据库迁移。
