### PR TITLE
feat(agent): 新增会话/轮次级别的变更汇总面板

### DIFF
--- a/backend/app/agent_runtime/persistence/child_runs.py
+++ b/backend/app/agent_runtime/persistence/child_runs.py
@@ -195,6 +195,22 @@ async def list_child_runs_for_parent(
     return list(result.scalars().all())
 
 
+async def list_child_runs_for_parents(
+    session: AsyncSession,
+    parent_session_ids: Sequence[str],
+) -> list[AgentChildRun]:
+    """批量读取多个父 session 的直接 child run。"""
+    normalized_ids = list(dict.fromkeys(session_id for session_id in parent_session_ids if session_id))
+    if not normalized_ids:
+        return []
+    result = await session.execute(
+        select(AgentChildRun)
+        .where(col(AgentChildRun.parent_session_id).in_(normalized_ids))
+        .order_by(col(AgentChildRun.parent_session_id), col(AgentChildRun.created_at).asc())
+    )
+    return list(result.scalars().all())
+
+
 async def get_latest_child_run_requests(
     session: AsyncSession,
     child_run_ids: Sequence[str],

--- a/backend/app/agent_runtime/persistence/repo.py
+++ b/backend/app/agent_runtime/persistence/repo.py
@@ -1,10 +1,11 @@
 """Agent 运行时消息持久化的 CRUD。"""
 
 import json
+from collections.abc import Sequence
 from datetime import UTC, datetime
 from typing import cast
 
-from sqlalchemy import delete, func, select
+from sqlalchemy import delete, func, or_, select
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlmodel import col
@@ -144,6 +145,50 @@ async def list_by_session(
     except SQLAlchemyError as e:
         raise PersistenceLoadError(
             f"list_by_session failed for session {session_id}"
+        ) from e
+
+
+async def list_by_sessions(
+    session: AsyncSession,
+    session_ids: Sequence[str],
+    *,
+    roles: Sequence[str] | None = None,
+    tool_names: Sequence[str] | None = None,
+) -> dict[str, list[PersistedMessage]]:
+    """按 session 批量加载消息，并在内存中按 session 分组。"""
+    normalized_ids = list(dict.fromkeys(session_id for session_id in session_ids if session_id))
+    normalized_tool_names = list(
+        dict.fromkeys(tool_name for tool_name in tool_names or () if tool_name)
+    )
+    if not normalized_ids:
+        return {}
+    try:
+        query = select(AgentRunMessage).where(
+            col(AgentRunMessage.session_id).in_(normalized_ids)
+        )
+        if roles and normalized_tool_names:
+            query = query.where(
+                or_(
+                    col(AgentRunMessage.role).in_(roles),
+                    col(AgentRunMessage.tool_name).in_(normalized_tool_names),
+                )
+            )
+        elif roles:
+            query = query.where(col(AgentRunMessage.role).in_(roles))
+        elif normalized_tool_names:
+            query = query.where(col(AgentRunMessage.tool_name).in_(normalized_tool_names))
+        query = query.order_by(
+            col(AgentRunMessage.session_id),
+            col(AgentRunMessage.seq).asc(),
+        )
+        result = await session.execute(query)
+        messages_by_session: dict[str, list[PersistedMessage]] = {}
+        for row in result.scalars().all():
+            messages_by_session.setdefault(row.session_id, []).append(_row_to_dto(row))
+        return messages_by_session
+    except SQLAlchemyError as e:
+        raise PersistenceLoadError(
+            f"list_by_sessions failed for {len(normalized_ids)} sessions"
         ) from e
 
 

--- a/backend/app/agent_runtime/session_changes.py
+++ b/backend/app/agent_runtime/session_changes.py
@@ -1,0 +1,1013 @@
+"""Project persisted parent and subagent writes into session change data."""
+
+from __future__ import annotations
+
+import json
+from bisect import bisect_right
+from collections import defaultdict
+from dataclasses import dataclass, field, replace
+from difflib import SequenceMatcher
+from typing import Any, Literal, Sequence, cast
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlmodel import col
+
+from app.agent_runtime.persistence import repo as message_repo
+from app.agent_runtime.persistence.child_runs import (
+    get_child_run_agent_number,
+    list_child_runs_for_parents,
+)
+from app.agent_runtime.persistence.model import (
+    AgentChildRun,
+    AgentChildRunRequest,
+)
+from app.storage.models.revision import Revision
+
+
+ChangeKind = Literal["chapter", "note", "world_entry", "character"]
+ChangeLineType = Literal["context", "added", "removed"]
+ChangeSectionType = Literal["content", "title"]
+
+
+@dataclass
+class AgentChangeLine:
+    type: ChangeLineType
+    before_line_number: int | None
+    after_line_number: int | None
+    text: str
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "type": self.type,
+            "before_line_number": self.before_line_number,
+            "after_line_number": self.after_line_number,
+            "text": self.text,
+        }
+
+
+@dataclass
+class AgentChangeSection:
+    type: ChangeSectionType
+    lines: list[AgentChangeLine]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "type": self.type,
+            "lines": [line.to_payload() for line in self.lines],
+        }
+
+
+@dataclass
+class AgentChangeItem:
+    key: str
+    kind: ChangeKind
+    title: str
+    operation: str
+    sections: list[AgentChangeSection]
+    source_message_id: str
+    source: Literal["primary", "subagent", "session"]
+    title_before: str | None = None
+    title_after: str | None = None
+    path: list[str] = field(default_factory=list)
+    child_run_id: str | None = None
+    request_id: str | None = None
+    agent_key: str | None = None
+    agent_number: str | None = None
+    revision_id: str | None = None
+    added: int = 0
+    removed: int = 0
+    _content_before: list[str] | None = field(default=None, repr=False)
+    _content_after: list[str] | None = field(default=None, repr=False)
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "key": self.key,
+            "kind": self.kind,
+            "title": self.title,
+            "title_before": self.title_before,
+            "title_after": self.title_after,
+            "operation": self.operation,
+            "sections": [section.to_payload() for section in self.sections],
+            "added": self.added,
+            "removed": self.removed,
+            "source_message_id": self.source_message_id,
+            "source": self.source,
+            "path": self.path,
+            "child_run_id": self.child_run_id,
+            "request_id": self.request_id,
+            "agent_key": self.agent_key,
+            "agent_number": self.agent_number,
+            "revision_id": self.revision_id,
+        }
+
+
+@dataclass
+class AgentChangeSummary:
+    items: list[AgentChangeItem]
+
+    @property
+    def item_count(self) -> int:
+        return len(self.items)
+
+    @property
+    def added(self) -> int:
+        return sum(item.added for item in self.items)
+
+    @property
+    def removed(self) -> int:
+        return sum(item.removed for item in self.items)
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "item_count": self.item_count,
+            "added": self.added,
+            "removed": self.removed,
+            "items": [item.to_payload() for item in self.items],
+        }
+
+
+@dataclass
+class AgentSubagentRunChanges:
+    child_run_id: str
+    child_thread_id: str
+    request_id: str | None
+    child_user_message_id: str | None
+    agent_key: str
+    agent_number: str | None
+    changes: AgentChangeSummary
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "child_run_id": self.child_run_id,
+            "child_thread_id": self.child_thread_id,
+            "request_id": self.request_id,
+            "child_user_message_id": self.child_user_message_id,
+            "agent_key": self.agent_key,
+            "agent_number": self.agent_number,
+            "changes": self.changes.to_payload(),
+        }
+
+
+@dataclass
+class AgentTurnChanges:
+    revision_id: str
+    user_message_id: str | None
+    user_message_seq: int | None
+    changes: AgentChangeSummary
+    subagent_runs: list[AgentSubagentRunChanges]
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "revision_id": self.revision_id,
+            "user_message_id": self.user_message_id,
+            "user_message_seq": self.user_message_seq,
+            "changes": self.changes.to_payload(),
+            "subagent_runs": [run.to_payload() for run in self.subagent_runs],
+        }
+
+
+@dataclass
+class AgentSessionChanges:
+    session_id: str
+    turns: list[AgentTurnChanges]
+    session_changes: AgentChangeSummary
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "turns": [turn.to_payload() for turn in self.turns],
+            "session_changes": self.session_changes.to_payload(),
+        }
+
+
+@dataclass(frozen=True)
+class _ChangeCandidate:
+    row: object
+    definition: _ChangeDefinition
+    raw_diff: dict[str, Any]
+    revision_id: str | None
+    child_run: AgentChildRun | None = None
+    request_id: str | None = None
+
+
+@dataclass(frozen=True)
+class _ChangeDefinition:
+    kind: ChangeKind
+    metadata_key: str
+    id_field: str
+    title_fields: tuple[str, ...]
+
+
+_CHANGE_DEFINITIONS: tuple[_ChangeDefinition, ...] = (
+    _ChangeDefinition("chapter", "chapter_diff", "chapter_id", ("chapter_title", "title")),
+    _ChangeDefinition("note", "note_diff", "note_id", ("note_title", "title")),
+    _ChangeDefinition(
+        "world_entry",
+        "world_entry_diff",
+        "entry_id",
+        ("entry_title", "title", "name"),
+    ),
+    _ChangeDefinition(
+        "character",
+        "character_diff",
+        "character_id",
+        ("character_name", "title", "name"),
+    ),
+)
+
+_IGNORED_RESULT_REASONS = {"approval_preview", "ask_user_pending", "cancelled"}
+_CHANGE_TOOL_NAMES = (
+    "write_chapter",
+    "edit_chapter",
+    "delete_chapter",
+    "move_chapter_to_volume",
+    "write_note",
+    "edit_note",
+    "delete_note",
+    "move_note",
+    "create_world_entry",
+    "edit_world_entry",
+    "delete_world_entry",
+    "create_character",
+    "edit_character",
+    "delete_character",
+)
+
+
+def _as_record(value: object) -> dict[str, Any] | None:
+    return cast(dict[str, Any], value) if isinstance(value, dict) else None
+
+
+def _parse_content(value: object) -> dict[str, Any] | None:
+    if not isinstance(value, str):
+        return None
+    try:
+        parsed = json.loads(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _row_metadata(row: object) -> dict[str, Any]:
+    metadata = getattr(row, "metadata", None)
+    if isinstance(metadata, dict):
+        return metadata
+    raw_metadata = getattr(row, "message_metadata", None)
+    if not isinstance(raw_metadata, str):
+        return {}
+    try:
+        parsed = json.loads(raw_metadata)
+    except (TypeError, ValueError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _result_is_executed(row: object, result: dict[str, Any]) -> bool:
+    if getattr(row, "status", None) in {"aborted", "error"}:
+        return False
+    containers = [result]
+    data = _as_record(result.get("data"))
+    if data is not None:
+        containers.append(data)
+    for container in containers:
+        if container.get("success") is False:
+            return False
+        if container.get("type") == "preview":
+            return False
+        if container.get("reason") in _IGNORED_RESULT_REASONS:
+            return False
+        if container.get("error"):
+            return False
+    return True
+
+
+def _result_metadata(result: dict[str, Any]) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    containers = [result]
+    data = _as_record(result.get("data"))
+    if data is not None:
+        containers.append(data)
+    for container in containers:
+        raw_metadata = _as_record(container.get("metadata"))
+        if raw_metadata is not None:
+            metadata.update(raw_metadata)
+        for definition in _CHANGE_DEFINITIONS:
+            raw_diff = _as_record(container.get(definition.metadata_key))
+            if raw_diff is not None:
+                metadata[definition.metadata_key] = raw_diff
+    return metadata
+
+
+def _extract_candidates(
+    row: object,
+    *,
+    revision_id: str | None,
+    child_run: AgentChildRun | None = None,
+    request_id: str | None = None,
+) -> list[_ChangeCandidate]:
+    if getattr(row, "role", None) != "tool":
+        return []
+    result = _parse_content(getattr(row, "content", None))
+    if result is None or not _result_is_executed(row, result):
+        return []
+    metadata = _result_metadata(result)
+    return [
+        _ChangeCandidate(
+            row=row,
+            definition=definition,
+            raw_diff=raw_diff,
+            revision_id=revision_id,
+            child_run=child_run,
+            request_id=request_id,
+        )
+        for definition in _CHANGE_DEFINITIONS
+        if (raw_diff := _as_record(metadata.get(definition.metadata_key))) is not None
+    ]
+
+
+def _number(value: object) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _normalize_line(value: object) -> AgentChangeLine | None:
+    line = _as_record(value)
+    if line is None:
+        return None
+    line_type: ChangeLineType = (
+        "added"
+        if line.get("type") == "added"
+        else "removed"
+        if line.get("type") == "removed"
+        else "context"
+    )
+    text = line.get("text")
+    return AgentChangeLine(
+        type=line_type,
+        before_line_number=_number(
+            line.get("before_line_number", line.get("beforeLineNumber"))
+        ),
+        after_line_number=_number(
+            line.get("after_line_number", line.get("afterLineNumber"))
+        ),
+        text=text if isinstance(text, str) else "",
+    )
+
+
+def _normalize_sections(raw_diff: dict[str, Any]) -> list[AgentChangeSection]:
+    raw_sections = raw_diff.get("sections")
+    if not isinstance(raw_sections, list):
+        return []
+    sections: list[AgentChangeSection] = []
+    for raw_section in raw_sections:
+        section = _as_record(raw_section)
+        if section is None or section.get("type") not in {"content", "title"}:
+            continue
+        raw_lines = section.get("lines")
+        lines = []
+        if isinstance(raw_lines, list):
+            lines = [
+                line
+                for raw_line in raw_lines
+                if (line := _normalize_line(raw_line)) is not None
+            ]
+        sections.append(AgentChangeSection(type=section["type"], lines=lines))
+    return sections
+
+
+def _string(value: object) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _normalize_path(value: object) -> list[str]:
+    if isinstance(value, str):
+        return [part.strip() for part in value.split("/") if part.strip()]
+    if not isinstance(value, list):
+        return []
+    return [part.strip() for part in value if isinstance(part, str) and part.strip()]
+
+
+def _build_item(candidate: _ChangeCandidate) -> AgentChangeItem | None:
+    row = candidate.row
+    definition = candidate.definition
+    raw_diff = candidate.raw_diff
+    entity_id = _string(raw_diff.get(definition.id_field))
+    title = next(
+        (
+            title
+            for field in definition.title_fields
+            if (title := _string(raw_diff.get(field))) is not None
+        ),
+        definition.kind,
+    )
+    fallback_key = f"{title}:{getattr(row, 'id', '')}"
+    key = f"{definition.kind}:{entity_id or fallback_key}"
+    sections = _normalize_sections(raw_diff)
+    title_before_lines: list[str] = []
+    title_after_lines: list[str] = []
+    for section in sections:
+        if section.type != "title":
+            continue
+        title_before_lines, title_after_lines = _section_state(section)
+        break
+    content_sections = [section for section in sections if section.type == "content"]
+    operation = _string(raw_diff.get("operation")) or "update"
+    added = sum(
+        1
+        for section in content_sections
+        for line in section.lines
+        if line.type == "added"
+    )
+    removed = sum(
+        1
+        for section in content_sections
+        for line in section.lines
+        if line.type == "removed"
+    )
+    child_run = candidate.child_run
+    source: Literal["primary", "subagent"] = "subagent" if child_run else "primary"
+    content_before: list[str] | None = None
+    content_after: list[str] | None = None
+    if operation == "create":
+        content_before = []
+        content_after = [
+            line.text
+            for section in content_sections
+            for line in section.lines
+            if line.type in {"context", "added"}
+        ]
+    return AgentChangeItem(
+        key=key,
+        kind=definition.kind,
+        title=title,
+        title_before="\n".join(title_before_lines) if title_before_lines else None,
+        title_after="\n".join(title_after_lines) if title_after_lines else None,
+        operation=operation,
+        sections=content_sections,
+        source_message_id=str(getattr(row, "id", "")),
+        source=source,
+        path=_normalize_path(raw_diff.get("path")),
+        child_run_id=child_run.id if child_run else None,
+        request_id=candidate.request_id,
+        agent_key=child_run.agent_key if child_run else None,
+        agent_number=get_child_run_agent_number(child_run.metadata_json) if child_run else None,
+        revision_id=candidate.revision_id,
+        added=added,
+        removed=removed,
+        _content_before=content_before,
+        _content_after=content_after,
+    )
+
+
+def _section_state(section: AgentChangeSection) -> tuple[list[str], list[str]]:
+    before: list[str] = []
+    after: list[str] = []
+    for line in section.lines:
+        if line.type in {"context", "removed"}:
+            before.append(line.text)
+        if line.type in {"context", "added"}:
+            after.append(line.text)
+    return before, after
+
+
+def _build_diff_lines(before: list[str], after: list[str]) -> list[AgentChangeLine]:
+    lines: list[AgentChangeLine] = []
+    matcher = SequenceMatcher(a=before, b=after, autojunk=False)
+    before_line_number = 1
+    after_line_number = 1
+    for tag, before_start, before_end, after_start, after_end in matcher.get_opcodes():
+        if tag == "equal":
+            for offset in range(before_end - before_start):
+                lines.append(
+                    AgentChangeLine(
+                        type="context",
+                        before_line_number=before_line_number,
+                        after_line_number=after_line_number,
+                        text=before[before_start + offset],
+                    )
+                )
+                before_line_number += 1
+                after_line_number += 1
+            continue
+        if tag in {"delete", "replace"}:
+            for text in before[before_start:before_end]:
+                lines.append(
+                    AgentChangeLine(
+                        type="removed",
+                        before_line_number=before_line_number,
+                        after_line_number=None,
+                        text=text,
+                    )
+                )
+                before_line_number += 1
+        if tag in {"insert", "replace"}:
+            for text in after[after_start:after_end]:
+                lines.append(
+                    AgentChangeLine(
+                        type="added",
+                        before_line_number=None,
+                        after_line_number=after_line_number,
+                        text=text,
+                    )
+                )
+                after_line_number += 1
+    return lines
+
+
+def _apply_content_patch(
+    current: Sequence[str], sections: Sequence[AgentChangeSection]
+) -> list[str] | None:
+    """Apply a line-numbered partial Diff to a known current content state."""
+    changed_lines = [
+        line
+        for section in sections
+        for line in section.lines
+        if line.type != "context"
+    ]
+    if not changed_lines:
+        return list(current)
+
+    removed_lines = [line for line in changed_lines if line.type == "removed"]
+    if any(line.before_line_number is None for line in removed_lines):
+        return None
+    result = list(current)
+    for line in sorted(
+        removed_lines,
+        key=lambda item: item.before_line_number or 0,
+        reverse=True,
+    ):
+        index = (line.before_line_number or 0) - 1
+        if index < 0 or index >= len(result) or result[index] != line.text:
+            return None
+        result.pop(index)
+
+    added_lines = [line for line in changed_lines if line.type == "added"]
+    if any(line.after_line_number is None for line in added_lines):
+        return None
+    for line in sorted(
+        added_lines,
+        key=lambda item: item.after_line_number or 0,
+    ):
+        index = (line.after_line_number or 0) - 1
+        if index < 0 or index > len(result):
+            return None
+        result.insert(index, line.text)
+    return result
+
+
+def _content_sections_from_state(
+    before: Sequence[str], after: Sequence[str]
+) -> list[AgentChangeSection]:
+    if list(before) == list(after):
+        return []
+    return [
+        AgentChangeSection(
+            type="content",
+            lines=_build_diff_lines(list(before), list(after)),
+        )
+    ]
+
+
+def _copy_item(item: AgentChangeItem) -> AgentChangeItem:
+    return replace(item, sections=list(item.sections), path=list(item.path))
+
+
+def _merge_sections(
+    existing_sections: Sequence[AgentChangeSection],
+    incoming_sections: Sequence[AgentChangeSection],
+) -> list[AgentChangeSection]:
+    states: dict[ChangeSectionType, tuple[list[str], list[str]]] = {}
+    section_order: list[ChangeSectionType] = []
+    for section in existing_sections:
+        states[section.type] = _section_state(section)
+        section_order.append(section.type)
+    for section in incoming_sections:
+        before, after = _section_state(section)
+        if before == after:
+            continue
+        if section.type in states:
+            states[section.type] = (states[section.type][0], after)
+        else:
+            states[section.type] = (before, after)
+            section_order.append(section.type)
+    return [
+        AgentChangeSection(type=section_type, lines=_build_diff_lines(*states[section_type]))
+        for section_type in section_order
+        if states[section_type][0] != states[section_type][1]
+    ]
+
+
+def _merge_item(existing: AgentChangeItem, item: AgentChangeItem) -> None:
+    merged_from_known_state = False
+    if existing._content_before is not None and existing._content_after is not None:
+        if item.operation == "delete":
+            next_content = []
+        elif item.operation == "create" and item._content_after is not None:
+            next_content = list(item._content_after)
+        else:
+            next_content = _apply_content_patch(existing._content_after, item.sections)
+        if next_content is not None:
+            existing._content_after = next_content
+            existing.sections = _content_sections_from_state(
+                existing._content_before,
+                next_content,
+            )
+            merged_from_known_state = True
+
+    if not merged_from_known_state:
+        existing.sections = _merge_sections(existing.sections, item.sections)
+        existing._content_before = None
+        existing._content_after = None
+    if item.title_before is not None and existing.title_before is None:
+        existing.title_before = item.title_before
+    if item.title_after is not None:
+        existing.title_after = item.title_after
+    existing.added = sum(
+        1
+        for section in existing.sections
+        for line in section.lines
+        if line.type == "added"
+    )
+    existing.removed = sum(
+        1
+        for section in existing.sections
+        for line in section.lines
+        if line.type == "removed"
+    )
+    if item.operation == "delete":
+        existing.operation = "delete"
+    elif existing.operation != "create":
+        existing.operation = item.operation
+    if item.path or item.operation == "move":
+        existing.path = item.path
+    existing.source_message_id = item.source_message_id
+    existing.source = item.source
+    existing.child_run_id = item.child_run_id
+    existing.request_id = item.request_id
+    existing.agent_key = item.agent_key
+    existing.agent_number = item.agent_number
+    existing.revision_id = item.revision_id
+
+
+def _summary_from_candidates(
+    candidates: Sequence[_ChangeCandidate],
+    *,
+    source: Literal["primary", "subagent", "session"] | None = None,
+    item_cache: dict[int, AgentChangeItem] | None = None,
+) -> AgentChangeSummary:
+    items_by_key: dict[str, AgentChangeItem] = {}
+    first_operations: dict[str, str] = {}
+    for candidate in candidates:
+        item = item_cache.get(id(candidate)) if item_cache is not None else None
+        if item is None:
+            item = _build_item(candidate)
+        if item is None:
+            continue
+        if source is not None:
+            item = replace(item, source=source)
+        existing = items_by_key.get(item.key)
+        if existing is None:
+            items_by_key[item.key] = _copy_item(item)
+            first_operations[item.key] = item.operation
+        else:
+            _merge_item(existing, item)
+    return AgentChangeSummary(
+        items=[
+            item
+            for key, item in items_by_key.items()
+            if not (
+                first_operations.get(key) == "create"
+                and item.operation == "delete"
+                and not item.sections
+            )
+        ]
+    )
+
+
+def _combine_summaries(summaries: Sequence[AgentChangeSummary]) -> AgentChangeSummary:
+    items_by_key: dict[str, AgentChangeItem] = {}
+    first_operations: dict[str, str] = {}
+    for summary in summaries:
+        for item in summary.items:
+            existing = items_by_key.get(item.key)
+            if existing is None:
+                items_by_key[item.key] = _copy_item(item)
+                first_operations[item.key] = item.operation
+            else:
+                _merge_item(existing, item)
+    return AgentChangeSummary(
+        items=[
+            item
+            for key, item in items_by_key.items()
+            if not (
+                first_operations.get(key) == "create"
+                and item.operation == "delete"
+                and not item.sections
+            )
+        ]
+    )
+
+
+def _parent_revision_boundaries(
+    parent_messages: Sequence[object],
+    revisions: Sequence[Revision],
+) -> list[tuple[int, str]]:
+    boundaries: dict[int, str] = {}
+    for row in parent_messages:
+        if getattr(row, "role", None) != "user":
+            continue
+        revision_id = _string(_row_metadata(row).get("revision_id"))
+        seq = getattr(row, "seq", None)
+        if revision_id is not None and isinstance(seq, int):
+            boundaries[seq] = revision_id
+    for revision in revisions:
+        if (
+            revision.revision_type == "agent"
+            and revision.status != "rolled_back"
+            and revision.user_message_seq is not None
+        ):
+            boundaries.setdefault(revision.user_message_seq, revision.id)
+    return sorted(boundaries.items())
+
+
+def _revision_for_seq(boundaries: Sequence[tuple[int, str]], seq: int) -> str | None:
+    if not boundaries:
+        return None
+    positions = [item[0] for item in boundaries]
+    index = bisect_right(positions, seq) - 1
+    return boundaries[index][1] if index >= 0 else None
+
+
+def _request_for_seq(
+    requests: Sequence[AgentChildRunRequest],
+    seq: int,
+) -> AgentChildRunRequest | None:
+    eligible = [
+        request
+        for request in requests
+        if request.status not in {"cancelled", "failed", "error"}
+        if request.child_user_message_seq is not None
+        and request.child_user_message_seq <= seq
+    ]
+    return (
+        max(
+            eligible,
+            key=lambda request: (
+                request.child_user_message_seq
+                if request.child_user_message_seq is not None
+                else -1,
+                request.seq,
+            ),
+        )
+        if eligible
+        else None
+    )
+
+
+def build_agent_changes(
+    session_id: str,
+    *,
+    parent_messages: Sequence[object],
+    child_runs: Sequence[AgentChildRun],
+    child_requests: Sequence[AgentChildRunRequest],
+    child_messages: Sequence[object],
+    revisions: Sequence[Revision],
+) -> AgentSessionChanges:
+    """Build a hierarchical change projection from persisted agent messages."""
+    valid_revisions = {
+        revision.id
+        for revision in revisions
+        if revision.revision_type == "agent"
+        and revision.status != "rolled_back"
+    }
+    has_revision_rows = bool(revisions)
+    parent_boundaries = _parent_revision_boundaries(parent_messages, revisions)
+    parent_candidates: list[_ChangeCandidate] = []
+    for row in parent_messages:
+        row_seq = getattr(row, "seq", None)
+        candidates = _extract_candidates(
+            row,
+            revision_id=_revision_for_seq(parent_boundaries, row_seq)
+            if isinstance(row_seq, int)
+            else None,
+        )
+        parent_candidates.extend(
+            candidate
+            for candidate in candidates
+            if not has_revision_rows or candidate.revision_id in valid_revisions
+        )
+
+    runs_by_thread = {run.child_thread_id: run for run in child_runs}
+    requests_by_run: dict[str, list[AgentChildRunRequest]] = defaultdict(list)
+    for request in child_requests:
+        requests_by_run[request.child_run_id].append(request)
+    for requests in requests_by_run.values():
+        requests.sort(key=lambda request: request.seq)
+
+    child_candidates: list[_ChangeCandidate] = []
+    for row in child_messages:
+        child_run = runs_by_thread.get(str(getattr(row, "session_id", "")))
+        if child_run is None:
+            continue
+        row_seq = getattr(row, "seq", None)
+        if not isinstance(row_seq, int):
+            continue
+        request = _request_for_seq(
+            requests_by_run.get(child_run.id, []),
+            row_seq,
+        )
+        revision_id = (
+            request.parent_revision_id
+            if request is not None
+            else child_run.parent_revision_id
+        )
+        candidates = _extract_candidates(
+            row,
+            revision_id=revision_id,
+            child_run=child_run,
+            request_id=request.id if request else None,
+        )
+        if has_revision_rows:
+            candidates = [
+                candidate
+                for candidate in candidates
+                if candidate.revision_id is None or candidate.revision_id in valid_revisions
+            ]
+        child_candidates.extend(candidates)
+
+    all_candidates = [*parent_candidates, *child_candidates]
+    item_cache = {
+        id(candidate): item
+        for candidate in all_candidates
+        if (item := _build_item(candidate)) is not None
+    }
+    candidates_by_revision: dict[str, list[_ChangeCandidate]] = defaultdict(list)
+    for candidate in all_candidates:
+        if candidate.revision_id is not None:
+            candidates_by_revision[candidate.revision_id].append(candidate)
+
+    ordered_revisions = sorted(
+        (
+            revision
+            for revision in revisions
+            if revision.id in valid_revisions
+        ),
+        key=lambda revision: (
+            revision.user_message_seq if revision.user_message_seq is not None else 2**31,
+            revision.created_at,
+        ),
+    )
+    turns: list[AgentTurnChanges] = []
+    for revision in ordered_revisions:
+        revision_candidates = candidates_by_revision.get(revision.id, [])
+        primary_candidates = [
+            candidate for candidate in revision_candidates if candidate.child_run is None
+        ]
+        child_groups: dict[tuple[str, str | None], list[_ChangeCandidate]] = defaultdict(list)
+        for candidate in revision_candidates:
+            if candidate.child_run is not None:
+                child_groups[(candidate.child_run.id, candidate.request_id)].append(candidate)
+
+        subagent_runs: list[AgentSubagentRunChanges] = []
+        child_summaries: list[AgentChangeSummary] = []
+        for (child_run_id, request_id), candidates in child_groups.items():
+            child_run = candidates[0].child_run
+            if child_run is None:
+                continue
+            summary = _summary_from_candidates(candidates, item_cache=item_cache)
+            if summary.item_count == 0:
+                continue
+            child_summaries.append(summary)
+            subagent_runs.append(
+                AgentSubagentRunChanges(
+                    child_run_id=child_run_id,
+                    child_thread_id=child_run.child_thread_id,
+                    request_id=request_id,
+                    child_user_message_id=(
+                        next(
+                            (
+                                request.child_user_message_id
+                                for request in requests_by_run.get(child_run_id, [])
+                                if request.id == request_id
+                            ),
+                            None,
+                        )
+                        if request_id
+                        else None
+                    ),
+                    agent_key=child_run.agent_key,
+                    agent_number=get_child_run_agent_number(child_run.metadata_json),
+                    changes=summary,
+                )
+            )
+
+        turn_summary = _combine_summaries(
+            [
+                summary
+                for summary in [
+                    _summary_from_candidates(primary_candidates, item_cache=item_cache),
+                    *child_summaries,
+                ]
+                if summary.item_count > 0
+            ]
+        )
+        turns.append(
+            AgentTurnChanges(
+                revision_id=revision.id,
+                user_message_id=revision.user_message_id,
+                user_message_seq=revision.user_message_seq,
+                changes=turn_summary,
+                subagent_runs=subagent_runs,
+            )
+        )
+
+    return AgentSessionChanges(
+        session_id=session_id,
+        turns=turns,
+        session_changes=_summary_from_candidates(
+            all_candidates,
+            source="session",
+            item_cache=item_cache,
+        ),
+    )
+
+
+async def _list_descendant_child_runs(
+    session: AsyncSession,
+    parent_session_id: str,
+) -> list[AgentChildRun]:
+    runs_by_parent: dict[str, list[AgentChildRun]] = defaultdict(list)
+    pending_parent_ids = [parent_session_id]
+    seen_parent_ids = {parent_session_id}
+    while pending_parent_ids:
+        child_runs = await list_child_runs_for_parents(session, pending_parent_ids)
+        next_parent_ids: list[str] = []
+        for child_run in child_runs:
+            runs_by_parent[child_run.parent_session_id].append(child_run)
+            if child_run.child_thread_id not in seen_parent_ids:
+                seen_parent_ids.add(child_run.child_thread_id)
+                next_parent_ids.append(child_run.child_thread_id)
+        pending_parent_ids = next_parent_ids
+
+    descendants: list[AgentChildRun] = []
+    expanded_parent_ids: set[str] = set()
+
+    def append_descendants(current_parent_id: str) -> None:
+        if current_parent_id in expanded_parent_ids:
+            return
+        expanded_parent_ids.add(current_parent_id)
+        for child_run in runs_by_parent.get(current_parent_id, []):
+            append_descendants(child_run.child_thread_id)
+            descendants.append(child_run)
+
+    append_descendants(parent_session_id)
+    return descendants
+
+
+async def load_agent_session_changes(
+    session: AsyncSession,
+    session_id: str,
+) -> AgentSessionChanges:
+    """Load and project all parent and descendant child-run changes."""
+    child_runs = await _list_descendant_child_runs(session, session_id)
+    message_by_session = await message_repo.list_by_sessions(
+        session,
+        [session_id, *(child_run.child_thread_id for child_run in child_runs)],
+        roles=("user",),
+        tool_names=_CHANGE_TOOL_NAMES,
+    )
+    parent_messages = message_by_session.get(session_id, [])
+    child_requests: list[AgentChildRunRequest] = []
+    if child_runs:
+        result = await session.execute(
+            select(AgentChildRunRequest)
+            .where(
+                col(AgentChildRunRequest.child_run_id).in_([run.id for run in child_runs])
+            )
+            .order_by(col(AgentChildRunRequest.child_run_id), col(AgentChildRunRequest.seq)),
+        )
+        child_requests = list(result.scalars().all())
+
+    child_messages = [
+        message
+        for child_run in child_runs
+        for message in message_by_session.get(child_run.child_thread_id, [])
+    ]
+
+    revision_result = await session.execute(
+        select(Revision)
+        .where(
+            col(Revision.agent_session_id) == session_id,
+            col(Revision.revision_type) == "agent",
+        )
+        .order_by(col(Revision.user_message_seq), col(Revision.created_at)),
+    )
+    revisions = list(revision_result.scalars().all())
+    return build_agent_changes(
+        session_id,
+        parent_messages=parent_messages,
+        child_runs=child_runs,
+        child_requests=child_requests,
+        child_messages=child_messages,
+        revisions=revisions,
+    )

--- a/backend/app/agent_runtime/tools/impls/chapter/delete_chapter.py
+++ b/backend/app/agent_runtime/tools/impls/chapter/delete_chapter.py
@@ -10,6 +10,10 @@ from app.agent_runtime.revisions import (
     record_chapter_diffs,
 )
 from app.agent_runtime.tools.errors import ToolExecutionError
+from app.agent_runtime.tools.impls.chapter.diff_preview import (
+    build_chapter_diff_preview,
+    chapter_preview_from_object,
+)
 from app.agent_runtime.tools.impls.chapter.refs import (
     ChapterRef,
     VolumeRef,
@@ -54,6 +58,12 @@ class DeleteChapterTool(AgentTool):
             )
             match = resolve_chapter_from_list([matched] if matched is not None else [], ref)
             deleted_order = match.order
+            chapter_diff = build_chapter_diff_preview(
+                chapter_preview_from_object(match),
+                None,
+                path=[volume.title.strip()],
+            )
+            chapter_diff["operation"] = "delete"
             before = images_by_id(
                 await chapter_repo.list_by_volume_from_order(
                     session, volume.id, deleted_order
@@ -93,12 +103,7 @@ class DeleteChapterTool(AgentTool):
                 {
                     "success": True,
                     "metadata": {
-                        "chapter_diff": {
-                            "operation": "delete",
-                            "chapter_id": match.id,
-                            "chapter_title": match.title,
-                            "order": deleted_order,
-                        }
+                        "chapter_diff": chapter_diff,
                     },
                 },
                 ensure_ascii=False,

--- a/backend/app/agent_runtime/tools/impls/chapter/diff_preview.py
+++ b/backend/app/agent_runtime/tools/impls/chapter/diff_preview.py
@@ -67,6 +67,8 @@ def serialize_preview_chapter(chapter: ChapterPreviewData | None) -> dict[str, A
 def build_chapter_diff_preview(
     before: ChapterPreviewData | None,
     after: ChapterPreviewData | None,
+    *,
+    path: list[str] | None = None,
 ) -> dict[str, Any]:
     operation = "create" if before is None else "update"
     sections: list[dict[str, Any]] = []
@@ -100,12 +102,16 @@ def build_chapter_diff_preview(
         payload["chapter_title"] = chapter.title
         if chapter.order is not None:
             payload["order"] = chapter.order
+    if path:
+        payload["path"] = path
     return payload
 
 
 def build_tool_result_preview(
     before: ChapterPreviewData | None,
     after: ChapterPreviewData | None,
+    *,
+    path: list[str] | None = None,
 ) -> dict[str, Any]:
     return {
         "type": "preview",
@@ -114,7 +120,7 @@ def build_tool_result_preview(
         "message": "章节修改待审批",
         "chapter": serialize_preview_chapter(after or before),
         "metadata": {
-            "chapter_diff": build_chapter_diff_preview(before, after),
+            "chapter_diff": build_chapter_diff_preview(before, after, path=path),
         },
     }
 
@@ -140,7 +146,7 @@ async def build_write_chapter_tool_result_preview(
         order=order,
         word_count=word_count,
     )
-    return build_tool_result_preview(None, after)
+    return build_tool_result_preview(None, after, path=[volume.title.strip()])
 
 
 async def build_edit_chapter_tool_result_preview(
@@ -182,7 +188,7 @@ async def build_edit_chapter_tool_result_preview(
         order=before.order,
         word_count=before.word_count,
     )
-    return build_tool_result_preview(before, after)
+    return build_tool_result_preview(before, after, path=[volume.title.strip()])
 
 
 def _build_diff_lines(before: str, after: str) -> list[dict[str, Any]]:

--- a/backend/app/agent_runtime/tools/impls/chapter/edit_chapter.py
+++ b/backend/app/agent_runtime/tools/impls/chapter/edit_chapter.py
@@ -162,6 +162,7 @@ class EditChapterTool(AgentTool):
             chapter_diff = build_chapter_diff_preview(
                 before_match,
                 chapter_preview_from_object(match),
+                path=[volume.title.strip()],
             )
             after = images_by_id([match])
             affected = await record_chapter_diffs(

--- a/backend/app/agent_runtime/tools/impls/chapter/move_chapter_to_volume.py
+++ b/backend/app/agent_runtime/tools/impls/chapter/move_chapter_to_volume.py
@@ -110,6 +110,7 @@ class MoveChapterToVolumeTool(AgentTool):
                             "chapter_title": moved.title,
                             "order": moved.order,
                             "volume_id": moved.volume_id,
+                            "path": [target_volume.title.strip()],
                         }
                     },
                 },

--- a/backend/app/agent_runtime/tools/impls/chapter/write_chapter.py
+++ b/backend/app/agent_runtime/tools/impls/chapter/write_chapter.py
@@ -184,6 +184,7 @@ class WriteChapterTool(AgentTool):
                 chapter_diff = build_chapter_diff_preview(
                     None,
                     chapter_preview_from_object(chapter),
+                    path=[volume.title.strip()],
                 )
                 return json.dumps(
                     {

--- a/backend/app/agent_runtime/tools/impls/note/delete_note.py
+++ b/backend/app/agent_runtime/tools/impls/note/delete_note.py
@@ -16,6 +16,7 @@ from app.agent_runtime.revisions import (
 from app.agent_runtime.tools.errors import ToolExecutionError
 from app.agent_runtime.tools.impls.note.refs import (
     NoteRef,
+    build_category_path,
     resolve_note_from_list,
 )
 from app.agent_runtime.tools.registry import ToolRegistry
@@ -40,6 +41,7 @@ class DeleteNoteTool(AgentTool):
             raise ToolExecutionError("缺少当前 revision，无法执行笔记删除")
         session = await create_session()
         try:
+            categories = []
             ref = NoteRef.model_validate(note_ref)
             if ref.id is not None:
                 note = await note_repo.get_by_id(session, ref.id)
@@ -53,6 +55,11 @@ class DeleteNoteTool(AgentTool):
                     session, self.project_id
                 )
                 note = resolve_note_from_list(notes, ref, categories=cats)
+
+            if note.category_id is not None:
+                categories = await note_category_repo.list_by_project(
+                    session, self.project_id
+                )
 
             if note.project_id != self.project_id:
                 raise ToolExecutionError("笔记不属于当前项目")
@@ -84,15 +91,35 @@ class DeleteNoteTool(AgentTool):
             from app.background.jobs import service as background_service
 
             await background_service.commit_and_notify(session)
+            note_diff = {
+                "operation": "delete",
+                "note_id": note.id,
+                "note_title": old_title,
+                "sections": [
+                    {
+                        "type": "content",
+                        "lines": [
+                            {
+                                "type": "removed",
+                                "before_line_number": line_number,
+                                "after_line_number": None,
+                                "text": line,
+                            }
+                            for line_number, line in enumerate(
+                                note.content.splitlines(), start=1
+                            )
+                        ],
+                    }
+                ],
+            }
+            category_path = build_category_path(categories, note.category_id)
+            if category_path:
+                note_diff["path"] = category_path
             return json.dumps(
                 {
                     "success": True,
                     "metadata": {
-                        "note_diff": {
-                            "operation": "delete",
-                            "note_id": note.id,
-                            "note_title": old_title,
-                        }
+                        "note_diff": note_diff,
                     },
                 },
                 ensure_ascii=False,

--- a/backend/app/agent_runtime/tools/impls/note/edit_note.py
+++ b/backend/app/agent_runtime/tools/impls/note/edit_note.py
@@ -20,6 +20,7 @@ from app.agent_runtime.revisions import (
 from app.agent_runtime.tools.errors import ToolExecutionError
 from app.agent_runtime.tools.impls.note.refs import (
     NoteRef,
+    build_category_path,
     resolve_note_from_list,
 )
 from app.agent_runtime.tools.registry import ToolRegistry
@@ -98,6 +99,7 @@ class EditNoteTool(AgentTool):
         ):
             return None
 
+        categories = []
         ref = NoteRef.model_validate(note_ref)
         if ref.id is not None:
             note = await note_repo.get_by_id(session, ref.id)
@@ -110,6 +112,9 @@ class EditNoteTool(AgentTool):
                 note = resolve_note_from_list(notes, ref, categories=categories)
             except ToolExecutionError:
                 return None
+
+        if note.category_id is not None and not categories:
+            categories = await note_category_repo.list_by_project(session, self.project_id)
 
         if (
             note.project_id != self.project_id
@@ -128,23 +133,27 @@ class EditNoteTool(AgentTool):
             validate_editor_content(preview_content)
         except EditorContentLimitError:
             return None
+        note_diff = {
+            "operation": "update",
+            "note_id": note.id,
+            "note_title": note.title,
+            "sections": [
+                {
+                    "type": "content",
+                    "lines": _build_diff_lines(note.content, preview_content),
+                }
+            ],
+        }
+        category_path = build_category_path(categories, note.category_id)
+        if category_path:
+            note_diff["path"] = category_path
         return {
             "type": "preview",
             "success": True,
             "reason": "approval_preview",
             "message": "笔记修改待审批",
             "metadata": {
-                "note_diff": {
-                    "operation": "update",
-                    "note_id": note.id,
-                    "note_title": note.title,
-                    "sections": [
-                        {
-                            "type": "content",
-                            "lines": _build_diff_lines(note.content, preview_content),
-                        }
-                    ],
-                }
+                "note_diff": note_diff,
             },
         }
 
@@ -159,6 +168,7 @@ class EditNoteTool(AgentTool):
             raise ToolExecutionError("缺少当前 revision，无法执行笔记编辑")
         session = await create_session()
         try:
+            categories = []
             ref = NoteRef.model_validate(note_ref)
             if ref.id is not None:
                 note = await note_repo.get_by_id(session, ref.id)
@@ -168,10 +178,15 @@ class EditNoteTool(AgentTool):
                 notes = await note_repo.list_by_project(
                     session, self.project_id, include_hidden=False
                 )
-                cats = await note_category_repo.list_by_project(
+                categories = await note_category_repo.list_by_project(
                     session, self.project_id
                 )
-                note = resolve_note_from_list(notes, ref, categories=cats)
+                note = resolve_note_from_list(notes, ref, categories=categories)
+
+            if note.category_id is not None and not categories:
+                categories = await note_category_repo.list_by_project(
+                    session, self.project_id
+                )
 
             if note.project_id != self.project_id:
                 raise ToolExecutionError("笔记不属于当前项目")
@@ -218,6 +233,9 @@ class EditNoteTool(AgentTool):
                 "note_id": note.id,
                 "note_title": note.title,
             }
+            category_path = build_category_path(categories, note.category_id)
+            if category_path:
+                note_diff["path"] = category_path
 
             from app.background.jobs import service as background_service
 

--- a/backend/app/agent_runtime/tools/impls/note/move_note.py
+++ b/backend/app/agent_runtime/tools/impls/note/move_note.py
@@ -17,6 +17,7 @@ from app.agent_runtime.tools.errors import ToolExecutionError
 from app.agent_runtime.tools.impls.note.refs import (
     CategoryRef,
     NoteRef,
+    build_category_path,
     resolve_category_from_list,
     resolve_note_from_list,
 )
@@ -73,6 +74,7 @@ class MoveNoteTool(AgentTool):
 
             target_category_id: str | None = None
             target_category_title: str | None = None
+            target_category_path: list[str] = []
             if target_category_ref is not None:
                 tref = CategoryRef.model_validate(target_category_ref)
                 if tref.id is not None:
@@ -88,6 +90,14 @@ class MoveNoteTool(AgentTool):
                     raise ToolExecutionError("目标分类不属于当前项目")
                 target_category_id = target.id
                 target_category_title = target.title
+                target_category_path = build_category_path([target], target.id)
+                if target.parent_id is not None:
+                    target_category_path = build_category_path(
+                        await note_category_repo.list_by_project(
+                            session, self.project_id
+                        ),
+                        target.id,
+                    )
 
             before = note_images_by_id(
                 await note_repo.list_by_project(
@@ -113,18 +123,21 @@ class MoveNoteTool(AgentTool):
             from app.background.jobs import service as background_service
 
             await background_service.commit_and_notify(session)
+            note_diff = {
+                "operation": "move",
+                "note_id": moved.id,
+                "note_title": moved.title,
+                "category_id": moved_category_id,
+                "target_category_id": target_category_id,
+                "target_category_title": target_category_title,
+            }
+            if target_category_path:
+                note_diff["path"] = target_category_path
             return json.dumps(
                 {
                     "success": True,
                     "metadata": {
-                        "note_diff": {
-                            "operation": "move",
-                            "note_id": moved.id,
-                            "note_title": moved.title,
-                            "category_id": moved_category_id,
-                            "target_category_id": target_category_id,
-                            "target_category_title": target_category_title,
-                        }
+                        "note_diff": note_diff,
                     },
                 },
                 ensure_ascii=False,

--- a/backend/app/agent_runtime/tools/impls/note/refs.py
+++ b/backend/app/agent_runtime/tools/impls/note/refs.py
@@ -47,6 +47,30 @@ def _resolve_category_by_path(
     return match
 
 
+def build_category_path(
+    categories: Sequence[NoteCategory],
+    category_id: str | None,
+) -> list[str]:
+    """按分类层级返回从根分类到目标分类的标题路径。"""
+    if category_id is None:
+        return []
+    categories_by_id = {category.id: category for category in categories}
+    parts: list[str] = []
+    visited: set[str] = set()
+    current_id: str | None = category_id
+    while current_id is not None and current_id not in visited:
+        visited.add(current_id)
+        category = categories_by_id.get(current_id)
+        if category is None:
+            break
+        title = category.title.strip()
+        if title:
+            parts.append(title)
+        current_id = category.parent_id
+    parts.reverse()
+    return parts
+
+
 def resolve_note_from_list(
     notes: Sequence[Note],
     ref: NoteRef,

--- a/backend/app/agent_runtime/tools/impls/note/write_note.py
+++ b/backend/app/agent_runtime/tools/impls/note/write_note.py
@@ -18,6 +18,7 @@ from app.agent_runtime.revisions import (
 from app.agent_runtime.tools.errors import ToolExecutionError
 from app.agent_runtime.tools.impls.note.refs import (
     CategoryRef,
+    build_category_path,
     generate_unique_title,
     resolve_category_from_list,
 )
@@ -53,6 +54,7 @@ class WriteNoteTool(AgentTool):
             return None
 
         category_id: str | None = None
+        categories = []
         category_ref = args.get("category_ref")
         if category_ref is not None:
             if not isinstance(category_ref, dict):
@@ -62,6 +64,11 @@ class WriteNoteTool(AgentTool):
                 category = await note_category_repo.get_by_id(session, ref.id)
                 if category is None or category.project_id != self.project_id:
                     return None
+                categories = [category]
+                if category.parent_id is not None:
+                    categories = await note_category_repo.list_by_project(
+                        session, self.project_id
+                    )
             else:
                 categories = await note_category_repo.list_by_project(session, self.project_id)
                 try:
@@ -84,18 +91,22 @@ class WriteNoteTool(AgentTool):
             }
             for line_number, line in enumerate(content.splitlines(), start=1)
         ]
+        note_diff = {
+            "operation": "create",
+            "note_title": unique_title,
+            "category_id": category_id,
+            "sections": [{"type": "content", "lines": diff_lines}],
+        }
+        category_path = build_category_path(categories, category_id)
+        if category_path:
+            note_diff["path"] = category_path
         return {
             "type": "preview",
             "success": True,
             "reason": "approval_preview",
             "message": "笔记创建待审批",
             "metadata": {
-                "note_diff": {
-                    "operation": "create",
-                    "note_title": unique_title,
-                    "category_id": category_id,
-                    "sections": [{"type": "content", "lines": diff_lines}],
-                }
+                "note_diff": note_diff,
             },
         }
 
@@ -115,17 +126,23 @@ class WriteNoteTool(AgentTool):
         session = await create_session()
         try:
             category_id: str | None = None
+            categories = []
             if category_ref is not None:
                 ref = CategoryRef.model_validate(category_ref)
                 if ref.id is not None:
                     cat = await note_category_repo.get_by_id(session, ref.id)
                     if cat is None:
                         raise ToolExecutionError(f"分类不存在: {ref.id}")
+                    categories = [cat]
+                    if cat.parent_id is not None:
+                        categories = await note_category_repo.list_by_project(
+                            session, self.project_id
+                        )
                 else:
-                    cats = await note_category_repo.list_by_project(
+                    categories = await note_category_repo.list_by_project(
                         session, self.project_id
                     )
-                    cat = resolve_category_from_list(cats, ref)
+                    cat = resolve_category_from_list(categories, ref)
                 if cat.project_id != self.project_id:
                     raise ToolExecutionError("目标分类不属于当前项目")
                 category_id = cat.id
@@ -183,6 +200,9 @@ class WriteNoteTool(AgentTool):
                     "note_title": note.title,
                     "category_id": note.category_id,
                 }
+                category_path = build_category_path(categories, note.category_id)
+                if category_path:
+                    note_diff["path"] = category_path
 
                 from app.background.jobs import service as background_service
 

--- a/backend/app/api/routers/agent_runtime.py
+++ b/backend/app/api/routers/agent_runtime.py
@@ -12,6 +12,7 @@ from datetime import UTC, datetime
 from typing import TypeGuard, cast
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from fastapi.responses import JSONResponse
 from loguru import logger
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -32,6 +33,7 @@ from app.agent_runtime.persistence.child_runs import (
     list_active_child_runs,
     list_child_runs_for_parent,
 )
+from app.agent_runtime.session_changes import load_agent_session_changes
 from app.agent_runtime.persistence.child_runs import get_child_run_agent_number
 from app.agent_runtime.persistence.task_projection import (
     load_task_messages_for_agent_session,
@@ -57,6 +59,7 @@ from app.api.schemas.agent import (
     AgentCancelResponse,
     AgentAttachmentResponse,
     AgentCompactionResponse,
+    AgentSessionChangesResponse,
     AgentForkRequest,
     AgentForkResponse,
     AgentPendingMessageResponse,
@@ -1402,6 +1405,22 @@ async def get_agent_session_state(
         is_running=is_running,
         interrupts=interrupts,
     )
+
+
+@router.get(
+    "/sessions/{session_id}/changes",
+    response_model=AgentSessionChangesResponse,
+)
+async def get_agent_session_changes(
+    session_id: str,
+    session: AsyncSession = Depends(get_session),
+) -> AgentSessionChangesResponse | JSONResponse:
+    try:
+        await task_service.get_task_by_agent_session_id(session, session_id)
+        changes = await load_agent_session_changes(session, session_id)
+        return JSONResponse(content=changes.to_payload())
+    except NotFoundError as exc:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(exc)) from exc
 
 
 @router.get(

--- a/backend/app/api/schemas/agent.py
+++ b/backend/app/api/schemas/agent.py
@@ -188,6 +188,86 @@ class AgentSessionStateResponse(BaseModel):
     interrupts: list[dict] = Field(default_factory=list, description="待处理的可恢复中断")
 
 
+class AgentChangeLineResponse(BaseModel):
+    """单行 Agent 内容变更。"""
+
+    type: str = Field(description="变更行类型：context、added 或 removed")
+    before_line_number: int | None = Field(default=None, description="变更前行号")
+    after_line_number: int | None = Field(default=None, description="变更后行号")
+    text: str = Field(default="", description="变更行内容")
+
+
+class AgentChangeSectionResponse(BaseModel):
+    """Agent 内容变更。"""
+
+    type: str = Field(description="变更类型：content")
+    lines: list[AgentChangeLineResponse] = Field(default_factory=list, description="内容变更行")
+
+
+class AgentChangeItemResponse(BaseModel):
+    """单个 Agent 内容变更项。"""
+
+    key: str = Field(description="变更实体键")
+    kind: str = Field(description="实体类型")
+    title: str = Field(description="实体标题")
+    title_before: str | None = Field(default=None, description="标题变更前文本")
+    title_after: str | None = Field(default=None, description="标题变更后文本")
+    operation: str = Field(description="变更操作")
+    path: list[str] = Field(default_factory=list, description="实体所属层级路径")
+    sections: list[AgentChangeSectionResponse] = Field(default_factory=list, description="Diff 分段")
+    added: int = Field(default=0, description="新增行数")
+    removed: int = Field(default=0, description="删除行数")
+    source_message_id: str = Field(description="来源工具消息 ID")
+    source: str = Field(description="变更来源：primary、subagent 或 session")
+    child_run_id: str | None = Field(default=None, description="来源子运行 ID")
+    request_id: str | None = Field(default=None, description="来源子运行请求 ID")
+    agent_key: str | None = Field(default=None, description="来源子代理标识")
+    agent_number: str | None = Field(default=None, description="来源子代理编号")
+    revision_id: str | None = Field(default=None, description="所属 revision ID")
+
+
+class AgentChangeSummaryResponse(BaseModel):
+    """Agent 内容变更汇总。"""
+
+    item_count: int = Field(default=0, description="变更项数量")
+    added: int = Field(default=0, description="新增行数")
+    removed: int = Field(default=0, description="删除行数")
+    items: list[AgentChangeItemResponse] = Field(default_factory=list, description="变更项")
+
+
+class AgentSubagentRunChangesResponse(BaseModel):
+    """单个 subagent 请求产生的变更。"""
+
+    child_run_id: str = Field(description="子运行 ID")
+    child_thread_id: str = Field(description="子线程 ID")
+    request_id: str | None = Field(default=None, description="子运行请求 ID")
+    child_user_message_id: str | None = Field(default=None, description="子运行用户消息 ID")
+    agent_key: str = Field(description="子代理标识")
+    agent_number: str | None = Field(default=None, description="子代理编号")
+    changes: AgentChangeSummaryResponse = Field(description="该 subagent 请求的变更")
+
+
+class AgentTurnChangesResponse(BaseModel):
+    """主会话单个 turn 的变更。"""
+
+    revision_id: str = Field(description="该 turn 的 revision ID")
+    user_message_id: str | None = Field(default=None, description="触发 turn 的用户消息 ID")
+    user_message_seq: int | None = Field(default=None, description="触发 turn 的用户消息序号")
+    changes: AgentChangeSummaryResponse = Field(description="该 turn 的完整变更")
+    subagent_runs: list[AgentSubagentRunChangesResponse] = Field(
+        default_factory=list,
+        description="该 turn 下的 subagent 变更",
+    )
+
+
+class AgentSessionChangesResponse(BaseModel):
+    """主会话及其 subagent 的完整变更。"""
+
+    session_id: str = Field(description="Agent 会话 ID")
+    turns: list[AgentTurnChangesResponse] = Field(default_factory=list, description="按 turn 分组的变更")
+    session_changes: AgentChangeSummaryResponse = Field(description="整个会话的变更")
+
+
 class ActiveSubagentStateResponse(BaseModel):
     """父会话下活跃子代理的只读状态行。"""
 

--- a/backend/tests/agent_runtime/persistence/test_child_runs.py
+++ b/backend/tests/agent_runtime/persistence/test_child_runs.py
@@ -12,6 +12,7 @@ from app.agent_runtime.persistence.child_runs import (
     get_latest_child_run_requests,
     get_waiting_child_run_for_tool_call,
     list_child_runs_for_parent,
+    list_child_runs_for_parents,
     record_child_run_pending_approval,
     rollback_child_runs_for_parent_revisions,
     update_child_run_status,
@@ -165,6 +166,41 @@ async def test_list_child_runs_for_parent_orders_by_creation(
     rows = await list_child_runs_for_parent(db_session, "parent-session")
 
     assert [row.child_thread_id for row in rows] == ["child-1", "child-2"]
+
+
+@pytest.mark.asyncio
+async def test_list_child_runs_for_parents_filters_and_orders_multiple_parents(
+    db_session: AsyncSession, sample_task
+):
+    await create_child_run(
+        db_session,
+        parent_session_id="parent-a",
+        parent_task_id=sample_task.id,
+        parent_thread_id="parent-thread-a",
+        child_thread_id="child-a",
+        agent_key="writer",
+        dispatch_id="dispatch-a",
+        tool_call_id="tool-call-a",
+        request={},
+    )
+    await create_child_run(
+        db_session,
+        parent_session_id="parent-b",
+        parent_task_id=sample_task.id,
+        parent_thread_id="parent-thread-b",
+        child_thread_id="child-b",
+        agent_key="writer",
+        dispatch_id="dispatch-b",
+        tool_call_id="tool-call-b",
+        request={},
+    )
+
+    rows = await list_child_runs_for_parents(
+        db_session,
+        ["parent-b", "parent-a"],
+    )
+
+    assert {row.parent_session_id for row in rows} == {"parent-a", "parent-b"}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/agent_runtime/persistence/test_repo.py
+++ b/backend/tests/agent_runtime/persistence/test_repo.py
@@ -144,6 +144,82 @@ async def test_list_by_session_filters_by_session(db_session: AsyncSession, samp
 
 
 @pytest.mark.asyncio
+async def test_list_by_sessions_groups_messages_and_orders_each_session(
+    db_session: AsyncSession, sample_task
+):
+    for session_id, content in (("session_a", "a"), ("session_b", "b")):
+        await repo.insert_message(
+            db_session,
+            session_id=session_id,
+            task_id=sample_task.id,
+            project_id=sample_task.project_id,
+            role="user",
+            content=content,
+            status="complete",
+        )
+
+    items_by_session = await repo.list_by_sessions(
+        db_session,
+        ["session_b", "session_a"],
+    )
+
+    assert [item.content for item in items_by_session["session_a"]] == ["a"]
+    assert [item.content for item in items_by_session["session_b"]] == ["b"]
+
+
+@pytest.mark.asyncio
+async def test_list_by_sessions_can_filter_roles(db_session: AsyncSession, sample_task):
+    for role, content in (("user", "user"), ("assistant", "assistant")):
+        await repo.insert_message(
+            db_session,
+            session_id="session_a",
+            task_id=sample_task.id,
+            project_id=sample_task.project_id,
+            role=role,
+            content=content,
+            status="complete",
+        )
+
+    items_by_session = await repo.list_by_sessions(
+        db_session,
+        ["session_a"],
+        roles=["user"],
+    )
+
+    assert [item.content for item in items_by_session["session_a"]] == ["user"]
+
+
+@pytest.mark.asyncio
+async def test_list_by_sessions_can_include_selected_tool_names(
+    db_session: AsyncSession, sample_task
+):
+    for role, tool_name, content in (
+        ("user", None, "user"),
+        ("tool", "edit_chapter", "edit"),
+        ("tool", "read_chapter", "read"),
+    ):
+        await repo.insert_message(
+            db_session,
+            session_id="session_a",
+            task_id=sample_task.id,
+            project_id=sample_task.project_id,
+            role=role,
+            content=content,
+            status="complete",
+            tool_name=tool_name,
+        )
+
+    items_by_session = await repo.list_by_sessions(
+        db_session,
+        ["session_a"],
+        roles=["user"],
+        tool_names=["edit_chapter"],
+    )
+
+    assert [item.content for item in items_by_session["session_a"]] == ["user", "edit"]
+
+
+@pytest.mark.asyncio
 async def test_delete_from_seq_includes_anchor(db_session: AsyncSession, sample_task):
     for i in range(5):
         await repo.insert_message(

--- a/backend/tests/agent_runtime/test_change_projection_api.py
+++ b/backend/tests/agent_runtime/test_change_projection_api.py
@@ -1,0 +1,98 @@
+"""Agent 会话变更 API 测试。"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from app.agent_runtime.session_changes import (
+    AgentChangeItem,
+    AgentChangeSection,
+    AgentChangeSummary,
+    AgentSessionChanges,
+    AgentTurnChanges,
+)
+
+
+@pytest.mark.asyncio
+async def test_session_changes_api_returns_turn_and_subagent_changes(
+    client: AsyncClient,
+) -> None:
+    summary = AgentChangeSummary(
+        items=[
+            AgentChangeItem(
+                key="chapter:chapter-1",
+                kind="chapter",
+                title="章节",
+                title_before="旧章节",
+                title_after="章节",
+                path=["第一卷"],
+                operation="update",
+                sections=[AgentChangeSection(type="content", lines=[])],
+                source_message_id="child-tool-1",
+                source="subagent",
+                child_run_id="child-1",
+                request_id="request-1",
+                agent_key="writer",
+                agent_number="#1001",
+                revision_id="revision-1",
+            )
+        ]
+    )
+    changes = AgentSessionChanges(
+        session_id="parent-session",
+        turns=[
+            AgentTurnChanges(
+                revision_id="revision-1",
+                user_message_id="user-1",
+                user_message_seq=0,
+                changes=summary,
+                subagent_runs=[],
+            )
+        ],
+        session_changes=summary,
+    )
+
+    with patch(
+        "app.api.routers.agent_runtime.task_service.get_task_by_agent_session_id",
+        AsyncMock(return_value=object()),
+    ), patch(
+        "app.api.routers.agent_runtime.load_agent_session_changes",
+        AsyncMock(return_value=changes),
+    ):
+        response = await client.get("/api/v1/agent/sessions/parent-session/changes")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["session_id"] == "parent-session"
+    assert payload["turns"][0]["revision_id"] == "revision-1"
+    assert payload["turns"][0]["changes"]["items"][0]["child_run_id"] == "child-1"
+    assert payload["turns"][0]["changes"]["items"][0]["path"] == ["第一卷"]
+    assert payload["turns"][0]["changes"]["items"][0]["title_before"] == "旧章节"
+    assert payload["session_changes"]["item_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_session_changes_api_skips_duplicate_explicit_response_validation(
+    client: AsyncClient,
+) -> None:
+    changes = AgentSessionChanges(
+        session_id="parent-session",
+        turns=[],
+        session_changes=AgentChangeSummary(items=[]),
+    )
+
+    with patch(
+        "app.api.routers.agent_runtime.task_service.get_task_by_agent_session_id",
+        AsyncMock(return_value=object()),
+    ), patch(
+        "app.api.routers.agent_runtime.load_agent_session_changes",
+        AsyncMock(return_value=changes),
+    ), patch(
+        "app.api.routers.agent_runtime.AgentSessionChangesResponse.model_validate",
+        side_effect=AssertionError("explicit response validation should be skipped"),
+    ):
+        response = await client.get("/api/v1/agent/sessions/parent-session/changes")
+
+    assert response.status_code == 200
+    assert response.json()["session_changes"]["item_count"] == 0

--- a/backend/tests/agent_runtime/test_session_changes.py
+++ b/backend/tests/agent_runtime/test_session_changes.py
@@ -1,0 +1,905 @@
+"""Agent 会话变更投影测试。"""
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.agent_runtime.session_changes import (
+    build_agent_changes,
+    load_agent_session_changes,
+)
+from app.agent_runtime.persistence.model import (
+    AgentChildRun,
+    AgentChildRunRequest,
+    AgentRunMessage,
+)
+from app.storage.models.revision import Revision
+
+
+def _message(
+    *,
+    message_id: str,
+    session_id: str,
+    role: str,
+    seq: int,
+    content: str = "",
+    metadata: dict | None = None,
+    tool_name: str | None = None,
+    tool_call_id: str | None = None,
+    status: str = "complete",
+) -> AgentRunMessage:
+    return AgentRunMessage(
+        id=message_id,
+        session_id=session_id,
+        task_id="task-1",
+        project_id="project-1",
+        role=role,
+        status=status,
+        content=content,
+        message_metadata=json.dumps(metadata or {}, ensure_ascii=False),
+        tool_name=tool_name,
+        tool_call_id=tool_call_id,
+        seq=seq,
+    )
+
+
+def _revision(
+    revision_id: str,
+    user_message_id: str,
+    user_message_seq: int,
+    *,
+    status: str = "completed",
+) -> Revision:
+    return Revision(
+        id=revision_id,
+        project_id="project-1",
+        task_id="task-1",
+        agent_session_id="parent-session",
+        message="用户消息",
+        revision_type="agent",
+        status=status,
+        user_message_id=user_message_id,
+        user_message_seq=user_message_seq,
+        project_snapshot_title="项目",
+    )
+
+
+def _child_run(child_run_id: str = "child-1") -> AgentChildRun:
+    return AgentChildRun(
+        id=child_run_id,
+        parent_session_id="parent-session",
+        parent_task_id="task-1",
+        parent_thread_id="parent-session",
+        child_thread_id=f"thread-{child_run_id}",
+        agent_key="writer",
+        dispatch_id=f"dispatch-{child_run_id}",
+        tool_call_id=f"dispatch-call-{child_run_id}",
+        status="completed",
+    )
+
+
+def _child_request(
+    child_run_id: str,
+    *,
+    request_id: str,
+    seq: int,
+    message_seq: int,
+    revision_id: str,
+    status: str = "completed",
+) -> AgentChildRunRequest:
+    return AgentChildRunRequest(
+        id=request_id,
+        child_run_id=child_run_id,
+        parent_session_id="parent-session",
+        parent_task_id="task-1",
+        request_kind="dispatch" if seq == 0 else "notify",
+        content="执行修改",
+        parent_revision_id=revision_id,
+        child_user_message_id=f"child-user-{request_id}",
+        child_user_message_seq=message_seq,
+        seq=seq,
+        status=status,
+    )
+
+
+def _chapter_result(chapter_id: str, text: str, *, success: bool = True, reason: str | None = None) -> str:
+    result = {
+        "success": success,
+        "metadata": {
+            "chapter_diff": {
+                "operation": "update",
+                "chapter_id": chapter_id,
+                "chapter_title": "章节",
+                "sections": [
+                    {
+                        "type": "content",
+                        "lines": [
+                            {
+                                "type": "added",
+                                "before_line_number": None,
+                                "after_line_number": 1,
+                                "text": text,
+                            }
+                        ],
+                    }
+                ],
+            }
+        },
+    }
+    if reason is not None:
+        result["reason"] = reason
+    return json.dumps(result, ensure_ascii=False)
+
+
+def test_includes_subagent_changes_in_parent_turn_and_session_summary():
+    result = build_agent_changes(
+        "parent-session",
+        parent_messages=[
+            _message(
+                message_id="user-1",
+                session_id="parent-session",
+                role="user",
+                seq=0,
+                metadata={"revision_id": "revision-1"},
+            ),
+            _message(
+                message_id="parent-tool-1",
+                session_id="parent-session",
+                role="tool",
+                seq=1,
+                content=_chapter_result("chapter-primary", "来自 primary"),
+                tool_name="edit_chapter",
+                tool_call_id="parent-call-1",
+            ),
+        ],
+        child_runs=[_child_run()],
+        child_requests=[
+            _child_request(
+                "child-1",
+                request_id="request-1",
+                seq=0,
+                message_seq=0,
+                revision_id="revision-1",
+            )
+        ],
+        child_messages=[
+            _message(
+                message_id="child-tool-1",
+                session_id="thread-child-1",
+                role="tool",
+                seq=1,
+                content=_chapter_result("chapter-1", "来自 writer"),
+                tool_name="edit_chapter",
+                tool_call_id="child-call-1",
+            )
+        ],
+        revisions=[_revision("revision-1", "user-1", 0)],
+    )
+
+    assert len(result.turns) == 1
+    turn = result.turns[0]
+    assert turn.revision_id == "revision-1"
+    assert turn.changes.item_count == 2
+    assert len(turn.subagent_runs) == 1
+    assert turn.subagent_runs[0].child_run_id == "child-1"
+    assert turn.subagent_runs[0].child_user_message_id == "child-user-request-1"
+    assert turn.subagent_runs[0].changes.items[0].agent_key == "writer"
+    assert result.session_changes.item_count == 2
+    assert any(item.child_run_id == "child-1" for item in result.session_changes.items)
+
+
+def test_assigns_reused_subagent_requests_to_their_parent_turns():
+    child_run = _child_run()
+    result = build_agent_changes(
+        "parent-session",
+        parent_messages=[
+            _message(
+                message_id="user-1",
+                session_id="parent-session",
+                role="user",
+                seq=0,
+                metadata={"revision_id": "revision-1"},
+            ),
+            _message(
+                message_id="user-2",
+                session_id="parent-session",
+                role="user",
+                seq=4,
+                metadata={"revision_id": "revision-2"},
+            ),
+        ],
+        child_runs=[child_run],
+        child_requests=[
+            _child_request(
+                "child-1",
+                request_id="request-1",
+                seq=0,
+                message_seq=0,
+                revision_id="revision-1",
+            ),
+            _child_request(
+                "child-1",
+                request_id="request-2",
+                seq=1,
+                message_seq=3,
+                revision_id="revision-2",
+            ),
+        ],
+        child_messages=[
+            _message(
+                message_id="child-tool-1",
+                session_id="thread-child-1",
+                role="tool",
+                seq=1,
+                content=_chapter_result("chapter-1", "第一轮"),
+                tool_name="edit_chapter",
+                tool_call_id="child-call-1",
+            ),
+            _message(
+                message_id="child-tool-2",
+                session_id="thread-child-1",
+                role="tool",
+                seq=4,
+                content=_chapter_result("chapter-2", "第二轮"),
+                tool_name="edit_chapter",
+                tool_call_id="child-call-2",
+            ),
+        ],
+        revisions=[
+            _revision("revision-1", "user-1", 0),
+            _revision("revision-2", "user-2", 4),
+        ],
+    )
+
+    assert [turn.revision_id for turn in result.turns] == ["revision-1", "revision-2"]
+    assert [turn.changes.items[0].title for turn in result.turns] == ["章节", "章节"]
+    assert [
+        turn.subagent_runs[0].changes.items[0].key for turn in result.turns
+    ] == ["chapter:chapter-1", "chapter:chapter-2"]
+    assert result.session_changes.item_count == 2
+
+
+def test_uses_latest_request_when_child_message_sequence_is_reused():
+    result = build_agent_changes(
+        "parent-session",
+        parent_messages=[],
+        child_runs=[_child_run()],
+        child_requests=[
+            _child_request(
+                "child-1",
+                request_id="request-old",
+                seq=0,
+                message_seq=0,
+                revision_id="revision-old",
+            ),
+            _child_request(
+                "child-1",
+                request_id="request-cancelled",
+                seq=1,
+                message_seq=3,
+                revision_id="revision-rolled-back",
+                status="cancelled",
+            ),
+            _child_request(
+                "child-1",
+                request_id="request-stale",
+                seq=2,
+                message_seq=5,
+                revision_id="revision-stale",
+                status="cancelled",
+            ),
+            _child_request(
+                "child-1",
+                request_id="request-latest",
+                seq=3,
+                message_seq=3,
+                revision_id="revision-latest",
+            ),
+        ],
+        child_messages=[
+            _message(
+                message_id="child-tool-latest",
+                session_id="thread-child-1",
+                role="tool",
+                seq=6,
+                content=_chapter_result("chapter-latest", "最新请求"),
+                tool_name="edit_chapter",
+                tool_call_id="child-call-latest",
+            )
+        ],
+        revisions=[
+            _revision("revision-old", "user-old", 0),
+            _revision("revision-rolled-back", "user-rolled-back", 1, status="rolled_back"),
+            _revision("revision-stale", "user-stale", 2, status="rolled_back"),
+            _revision("revision-latest", "user-latest", 3),
+        ],
+    )
+
+    latest_turn = next(turn for turn in result.turns if turn.revision_id == "revision-latest")
+    assert latest_turn.changes.item_count == 1
+    assert latest_turn.subagent_runs[0].request_id == "request-latest"
+
+
+def test_merges_repeated_entity_changes_and_ignores_failed_or_preview_results():
+    result = build_agent_changes(
+        "parent-session",
+        parent_messages=[
+            _message(
+                message_id="user-1",
+                session_id="parent-session",
+                role="user",
+                seq=0,
+                metadata={"revision_id": "revision-1"},
+            )
+        ],
+        child_runs=[_child_run()],
+        child_requests=[
+            _child_request(
+                "child-1",
+                request_id="request-1",
+                seq=0,
+                message_seq=0,
+                revision_id="revision-1",
+            )
+        ],
+        child_messages=[
+            _message(
+                message_id="child-tool-1",
+                session_id="thread-child-1",
+                role="tool",
+                seq=1,
+                content=_chapter_result("chapter-1", "第一次"),
+                tool_name="edit_chapter",
+                tool_call_id="child-call-1",
+            ),
+            _message(
+                message_id="child-tool-2",
+                session_id="thread-child-1",
+                role="tool",
+                seq=2,
+                content=_chapter_result("chapter-1", "第二次"),
+                tool_name="edit_chapter",
+                tool_call_id="child-call-2",
+            ),
+            _message(
+                message_id="child-tool-3",
+                session_id="thread-child-1",
+                role="tool",
+                seq=3,
+                content=_chapter_result("chapter-2", "失败", success=False),
+                tool_name="edit_chapter",
+                tool_call_id="child-call-3",
+            ),
+            _message(
+                message_id="child-tool-4",
+                session_id="thread-child-1",
+                role="tool",
+                seq=4,
+                content=_chapter_result("chapter-3", "预览", reason="approval_preview"),
+                tool_name="edit_chapter",
+                tool_call_id="child-call-4",
+            ),
+        ],
+        revisions=[_revision("revision-1", "user-1", 0)],
+    )
+
+    assert result.session_changes.item_count == 1
+    item = result.session_changes.items[0]
+    assert item.key == "chapter:chapter-1"
+    assert len(item.sections) == 1
+    assert sum(len(section.lines) for section in item.sections) == 1
+
+
+def test_keeps_full_created_chapter_content_after_partial_update():
+    create_payload = json.loads(_chapter_result("chapter-1", "第一行\n第二行\n第三行"))
+    create_payload["metadata"]["chapter_diff"]["operation"] = "create"
+    create_payload["metadata"]["chapter_diff"]["sections"][0]["lines"] = [
+        {
+            "type": "added",
+            "before_line_number": None,
+            "after_line_number": index,
+            "text": text,
+        }
+        for index, text in enumerate(("第一行", "第二行", "第三行"), start=1)
+    ]
+    create_result = json.dumps(create_payload, ensure_ascii=False)
+    update_result = json.dumps(
+        {
+            "success": True,
+            "metadata": {
+                "chapter_diff": {
+                    "operation": "update",
+                    "chapter_id": "chapter-1",
+                    "chapter_title": "章节",
+                    "sections": [
+                        {
+                            "type": "content",
+                            "lines": [
+                                {
+                                    "type": "removed",
+                                    "before_line_number": 2,
+                                    "after_line_number": None,
+                                    "text": "第二行",
+                                },
+                                {
+                                    "type": "added",
+                                    "before_line_number": None,
+                                    "after_line_number": 2,
+                                    "text": "修改后的第二行",
+                                },
+                            ],
+                        }
+                    ],
+                }
+            },
+        },
+        ensure_ascii=False,
+    )
+    final_update_payload = json.loads(update_result)
+    final_update_lines = final_update_payload["metadata"]["chapter_diff"]["sections"][0]["lines"]
+    final_update_lines[0]["text"] = "修改后的第二行"
+    final_update_lines[1]["text"] = "最终的第二行"
+    final_update_result = json.dumps(final_update_payload, ensure_ascii=False)
+    result = build_agent_changes(
+        "parent-session",
+        parent_messages=[
+            _message(
+                message_id="user-1",
+                session_id="parent-session",
+                role="user",
+                seq=0,
+                metadata={"revision_id": "revision-1"},
+            )
+        ],
+        child_runs=[_child_run()],
+        child_requests=[
+            _child_request(
+                "child-1",
+                request_id="request-1",
+                seq=0,
+                message_seq=0,
+                revision_id="revision-1",
+            ),
+            _child_request(
+                "child-1",
+                request_id="request-2",
+                seq=1,
+                message_seq=3,
+                revision_id="revision-1",
+            ),
+        ],
+        child_messages=[
+            _message(
+                message_id="child-tool-create",
+                session_id="thread-child-1",
+                role="tool",
+                seq=1,
+                content=create_result,
+                tool_name="write_chapter",
+                tool_call_id="child-call-create",
+            ),
+            _message(
+                message_id="child-tool-update",
+                session_id="thread-child-1",
+                role="tool",
+                seq=2,
+                content=update_result,
+                tool_name="edit_chapter",
+                tool_call_id="child-call-update",
+            ),
+            _message(
+                message_id="child-tool-final-update",
+                session_id="thread-child-1",
+                role="tool",
+                seq=3,
+                content=final_update_result,
+                tool_name="edit_chapter",
+                tool_call_id="child-call-final-update",
+            ),
+        ],
+        revisions=[_revision("revision-1", "user-1", 0)],
+    )
+
+    first_request_item = result.turns[0].subagent_runs[0].changes.items[0]
+    assert first_request_item.operation == "create"
+    assert first_request_item.added == 3
+    assert first_request_item.removed == 0
+    assert [line.text for line in first_request_item.sections[0].lines] == [
+        "第一行",
+        "修改后的第二行",
+        "第三行",
+    ]
+    second_request_item = result.turns[0].subagent_runs[1].changes.items[0]
+    assert second_request_item.added == 1
+    assert second_request_item.removed == 1
+    assert [line.text for line in second_request_item.sections[0].lines] == [
+        "修改后的第二行",
+        "最终的第二行",
+    ]
+    turn_item = result.turns[0].changes.items[0]
+    assert turn_item.added == 3
+    assert turn_item.removed == 0
+    assert [line.text for line in turn_item.sections[0].lines] == [
+        "第一行",
+        "最终的第二行",
+        "第三行",
+    ]
+    session_item = result.session_changes.items[0]
+    assert session_item.added == 3
+    assert session_item.removed == 0
+    assert [line.text for line in session_item.sections[0].lines] == [
+        "第一行",
+        "最终的第二行",
+        "第三行",
+    ]
+
+
+def test_session_total_uses_one_net_diff_for_created_then_updated_note():
+    create_result = json.dumps(
+        {
+            "success": True,
+            "metadata": {
+                "note_diff": {
+                    "operation": "create",
+                    "note_id": "note-1",
+                    "note_title": "笔记",
+                    "sections": [
+                        {
+                            "type": "content",
+                            "lines": [
+                                {
+                                    "type": "added",
+                                    "before_line_number": None,
+                                    "after_line_number": 1,
+                                    "text": "初始内容",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+        },
+        ensure_ascii=False,
+    )
+    update_result = json.dumps(
+        {
+            "success": True,
+            "metadata": {
+                "note_diff": {
+                    "operation": "update",
+                    "note_id": "note-1",
+                    "note_title": "笔记",
+                    "sections": [
+                        {
+                            "type": "content",
+                            "lines": [
+                                {
+                                    "type": "context",
+                                    "before_line_number": 1,
+                                    "after_line_number": 1,
+                                    "text": "初始内容",
+                                },
+                                {
+                                    "type": "added",
+                                    "before_line_number": None,
+                                    "after_line_number": 2,
+                                    "text": "修改后的内容",
+                                },
+                            ],
+                        }
+                    ],
+                }
+            },
+        },
+        ensure_ascii=False,
+    )
+    result = build_agent_changes(
+        "parent-session",
+        parent_messages=[
+            _message(
+                message_id="user-1",
+                session_id="parent-session",
+                role="user",
+                seq=0,
+                metadata={"revision_id": "revision-1"},
+            ),
+            _message(
+                message_id="tool-create",
+                session_id="parent-session",
+                role="tool",
+                seq=1,
+                content=create_result,
+                tool_name="write_note",
+                tool_call_id="call-create",
+            ),
+            _message(
+                message_id="tool-update",
+                session_id="parent-session",
+                role="tool",
+                seq=2,
+                content=update_result,
+                tool_name="edit_note",
+                tool_call_id="call-update",
+            ),
+        ],
+        child_runs=[],
+        child_requests=[],
+        child_messages=[],
+        revisions=[_revision("revision-1", "user-1", 0)],
+    )
+
+    assert result.session_changes.item_count == 1
+    item = result.session_changes.items[0]
+    assert item.operation == "create"
+    assert len(item.sections) == 1
+    assert [line.type for line in item.sections[0].lines] == ["added", "added"]
+    assert [line.text for line in item.sections[0].lines] == ["初始内容", "修改后的内容"]
+    assert item.added == 2
+    assert item.removed == 0
+
+
+def test_title_only_change_is_not_counted_as_line_diff():
+    result = build_agent_changes(
+        "parent-session",
+        parent_messages=[
+            _message(
+                message_id="user-1",
+                session_id="parent-session",
+                role="user",
+                seq=0,
+                metadata={"revision_id": "revision-1"},
+            ),
+            _message(
+                message_id="tool-1",
+                session_id="parent-session",
+                role="tool",
+                seq=1,
+                content=json.dumps(
+                    {
+                        "success": True,
+                        "metadata": {
+                            "chapter_diff": {
+                                "operation": "update",
+                                "chapter_id": "chapter-1",
+                                "chapter_title": "新标题",
+                                "sections": [
+                                    {
+                                        "type": "title",
+                                        "lines": [
+                                            {
+                                                "type": "removed",
+                                                "before_line_number": 1,
+                                                "after_line_number": None,
+                                                "text": "旧标题",
+                                            },
+                                            {
+                                                "type": "added",
+                                                "before_line_number": None,
+                                                "after_line_number": 1,
+                                                "text": "新标题",
+                                            },
+                                        ],
+                                    }
+                                ],
+                            }
+                        },
+                    },
+                    ensure_ascii=False,
+                ),
+                tool_name="edit_chapter",
+                tool_call_id="call-1",
+            ),
+        ],
+        child_runs=[],
+        child_requests=[],
+        child_messages=[],
+        revisions=[_revision("revision-1", "user-1", 0)],
+    )
+
+    item = result.session_changes.items[0]
+    assert item.sections == []
+    assert item.added == 0
+    assert item.removed == 0
+    assert item.title_before == "旧标题"
+    assert item.title_after == "新标题"
+
+
+def test_projects_each_supported_editable_entity_kind():
+    metadata = {
+        "chapter_diff": {"chapter_id": "chapter-1", "chapter_title": "章节"},
+        "note_diff": {"note_id": "note-1", "note_title": "笔记"},
+        "world_entry_diff": {"entry_id": "entry-1", "entry_title": "条目"},
+        "character_diff": {"character_id": "character-1", "character_name": "角色"},
+    }
+    result = build_agent_changes(
+        "parent-session",
+        parent_messages=[
+            _message(
+                message_id="user-1",
+                session_id="parent-session",
+                role="user",
+                seq=0,
+                metadata={"revision_id": "revision-1"},
+            ),
+            _message(
+                message_id="parent-tool-1",
+                session_id="parent-session",
+                role="tool",
+                seq=1,
+                content=json.dumps({"success": True, "metadata": metadata}, ensure_ascii=False),
+                tool_name="edit_content",
+                tool_call_id="parent-call-1",
+            ),
+        ],
+        child_runs=[],
+        child_requests=[],
+        child_messages=[],
+        revisions=[_revision("revision-1", "user-1", 0)],
+    )
+
+    assert {item.kind for item in result.session_changes.items} == {
+        "chapter",
+        "note",
+        "world_entry",
+        "character",
+    }
+
+
+def test_preserves_change_item_path_from_tool_metadata():
+    result = build_agent_changes(
+        "parent-session",
+        parent_messages=[
+            _message(
+                message_id="user-1",
+                session_id="parent-session",
+                role="user",
+                seq=0,
+                metadata={"revision_id": "revision-1"},
+            ),
+            _message(
+                message_id="parent-tool-1",
+                session_id="parent-session",
+                role="tool",
+                seq=1,
+                content=json.dumps(
+                    {
+                        "success": True,
+                        "metadata": {
+                            "chapter_diff": {
+                                "operation": "update",
+                                "chapter_id": "chapter-1",
+                                "chapter_title": "第一章 xx",
+                                "path": ["第一卷"],
+                            }
+                        },
+                    },
+                    ensure_ascii=False,
+                ),
+                tool_name="edit_chapter",
+                tool_call_id="parent-call-1",
+            ),
+        ],
+        child_runs=[],
+        child_requests=[],
+        child_messages=[],
+        revisions=[_revision("revision-1", "user-1", 0)],
+    )
+
+    assert result.session_changes.items[0].path == ["第一卷"]
+
+
+def test_keeps_executed_changes_from_cancelled_revision():
+    result = build_agent_changes(
+        "parent-session",
+        parent_messages=[
+            _message(
+                message_id="user-1",
+                session_id="parent-session",
+                role="user",
+                seq=0,
+                metadata={"revision_id": "revision-1"},
+            )
+        ],
+        child_runs=[_child_run()],
+        child_requests=[
+            _child_request(
+                "child-1",
+                request_id="request-1",
+                seq=0,
+                message_seq=0,
+                revision_id="revision-1",
+            )
+        ],
+        child_messages=[
+            _message(
+                message_id="child-tool-1",
+                session_id="thread-child-1",
+                role="tool",
+                seq=1,
+                content=json.dumps(
+                    {
+                        "success": True,
+                        "metadata": {
+                            "note_diff": {
+                                "operation": "update",
+                                "note_id": "note-1",
+                                "note_title": "笔记",
+                            }
+                        },
+                    },
+                    ensure_ascii=False,
+                ),
+                tool_name="edit_note",
+                tool_call_id="child-call-1",
+            )
+        ],
+        revisions=[_revision("revision-1", "user-1", 0, status="cancelled")],
+    )
+
+    assert result.session_changes.item_count == 1
+    assert result.turns[0].changes.items[0].kind == "note"
+
+
+@pytest.mark.asyncio
+async def test_loads_parent_and_descendant_messages_before_projecting_changes():
+    child_run = _child_run()
+    parent_messages = [
+        _message(
+            message_id="user-1",
+            session_id="parent-session",
+            role="user",
+            seq=0,
+            metadata={"revision_id": "revision-1"},
+        )
+    ]
+    child_messages = [
+        _message(
+            message_id="child-tool-1",
+            session_id="thread-child-1",
+            role="tool",
+            seq=1,
+            content=_chapter_result("chapter-1", "来自 child"),
+            tool_name="edit_chapter",
+            tool_call_id="child-call-1",
+        )
+    ]
+    child_request = _child_request(
+        "child-1",
+        request_id="request-1",
+        seq=0,
+        message_seq=0,
+        revision_id="revision-1",
+    )
+    execute_results = [
+        SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: [child_request])),
+        SimpleNamespace(scalars=lambda: SimpleNamespace(all=lambda: [_revision("revision-1", "user-1", 0)])),
+    ]
+    db_session = SimpleNamespace(execute=AsyncMock(side_effect=execute_results))
+
+    async def list_messages(_session, session_id: str):
+        return parent_messages if session_id == "parent-session" else child_messages
+
+    async def list_children(_session, session_ids: list[str]):
+        return [child_run] if "parent-session" in session_ids else []
+
+    with patch(
+        "app.agent_runtime.session_changes.message_repo.list_by_session",
+        side_effect=list_messages,
+    ), patch(
+        "app.agent_runtime.session_changes.message_repo.list_by_sessions",
+        return_value={
+            "parent-session": parent_messages,
+            "thread-child-1": child_messages,
+        },
+    ) as list_messages_batch, patch(
+        "app.agent_runtime.session_changes.list_child_runs_for_parents",
+        side_effect=list_children,
+    ) as list_children_batch:
+        result = await load_agent_session_changes(db_session, "parent-session")
+
+    assert result.session_changes.item_count == 1
+    assert result.turns[0].subagent_runs[0].child_run_id == "child-1"
+    assert list_messages_batch.call_count == 1
+    assert list_children_batch.call_count == 2

--- a/backend/tests/agent_runtime/tools/test_chapter_tools.py
+++ b/backend/tests/agent_runtime/tools/test_chapter_tools.py
@@ -246,6 +246,7 @@ async def test_write_chapter_appends_to_volume_and_returns_volume_id() -> None:
     assert data["word_count"] == 3
     assert data["metadata"]["chapter_diff"]["operation"] == "create"
     assert data["metadata"]["chapter_diff"]["chapter_id"] == "chap-new"
+    assert data["metadata"]["chapter_diff"]["path"] == ["第一卷"]
     assert [section["type"] for section in data["metadata"]["chapter_diff"]["sections"]] == ["title", "content"]
     mock_repo.list_by_project.assert_not_awaited()
     mock_repo.get_max_order.assert_awaited_once_with(mock_session, "vol-1")
@@ -466,6 +467,7 @@ async def test_write_chapter_insert_order_shifts_within_volume() -> None:
     assert data["word_count"] == 4
     assert data["metadata"]["chapter_diff"]["operation"] == "create"
     assert data["metadata"]["chapter_diff"]["order"] == 2
+    assert data["metadata"]["chapter_diff"]["path"] == ["第一卷"]
     assert [section["type"] for section in data["metadata"]["chapter_diff"]["sections"]] == ["title", "content"]
     mock_repo.list_by_project.assert_not_awaited()
     mock_repo.list_by_volume.assert_not_awaited()
@@ -532,6 +534,7 @@ async def test_edit_chapter_resolves_inside_volume() -> None:
                 "chapter_id": "chap-1",
                 "chapter_title": "新标题",
                 "order": 1,
+                "path": ["第一卷"],
                 "sections": [
                     {
                         "type": "title",
@@ -617,6 +620,31 @@ async def test_delete_chapter_delegates_to_chapter_service() -> None:
         "chapter_id": "chap-1",
         "chapter_title": "第一章",
         "order": 2,
+        "path": ["第一卷"],
+        "sections": [
+            {
+                "type": "title",
+                "lines": [
+                    {
+                        "type": "removed",
+                        "before_line_number": 1,
+                        "after_line_number": None,
+                        "text": "第一章",
+                    }
+                ],
+            },
+            {
+                "type": "content",
+                "lines": [
+                    {
+                        "type": "removed",
+                        "before_line_number": 1,
+                        "after_line_number": None,
+                        "text": "内容测试",
+                    }
+                ],
+            },
+        ],
     }
     mock_chapter_service.delete_chapter.assert_awaited_once_with(
         mock_session,
@@ -938,6 +966,7 @@ async def test_move_chapter_to_volume_appends_to_target_volume() -> None:
         "chapter_title": "第一章",
         "order": 4,
         "volume_id": "vol-2",
+        "path": ["第二卷"],
     }
     move_chapter.assert_awaited_once_with(
         mock_session,

--- a/backend/tests/agent_runtime/tools/test_note_tools.py
+++ b/backend/tests/agent_runtime/tools/test_note_tools.py
@@ -64,6 +64,18 @@ def _make_category(
     return cat
 
 
+def test_build_category_path_returns_ancestor_titles_in_order() -> None:
+    from app.agent_runtime.tools.impls.note.refs import build_category_path
+
+    categories = [
+        _make_category(category_id="cat-root", title="大纲"),
+        _make_category(category_id="cat-volume", title="第一卷", parent_id="cat-root"),
+        _make_category(category_id="cat-note", title="细纲", parent_id="cat-volume"),
+    ]
+
+    assert build_category_path(categories, "cat-note") == ["大纲", "第一卷", "细纲"]
+
+
 async def test_read_note_rejects_hidden_note() -> None:
     from app.agent_runtime.tools.impls.note.read_note import ReadNoteTool
 
@@ -305,6 +317,19 @@ async def test_delete_note_returns_success_and_diff_metadata() -> None:
                 "operation": "delete",
                 "note_id": "note-1",
                 "note_title": "测试笔记",
+                "sections": [
+                    {
+                        "type": "content",
+                        "lines": [
+                            {
+                                "type": "removed",
+                                "before_line_number": 1,
+                                "after_line_number": None,
+                                "text": "测试内容",
+                            }
+                        ],
+                    }
+                ],
             }
         },
     }
@@ -645,6 +670,7 @@ async def test_move_note_returns_success_and_metadata() -> None:
                 "category_id": "cat-2",
                 "target_category_id": "cat-2",
                 "target_category_title": "目标分类",
+                "path": ["目标分类"],
             }
         },
     }

--- a/frontend/src/features/assistant/components/agent/agent-changes.css
+++ b/frontend/src/features/assistant/components/agent/agent-changes.css
@@ -1,0 +1,613 @@
+.agent-change-summary-spacing {
+  width: 100%;
+  padding-top: 8px;
+}
+
+.agent-change-summary-card {
+  width: 100%;
+  overflow: hidden;
+  border: 1px solid var(--gray-a5);
+  border-radius: 12px;
+  background: var(--color-panel);
+}
+
+.agent-change-summary-header {
+  min-width: 0;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--gray-a4);
+}
+
+.agent-change-summary-header[data-collapsible="true"] {
+  cursor: pointer;
+  transition: background-color 120ms ease;
+}
+
+.agent-change-summary-header[data-collapsible="true"]:hover,
+.agent-change-summary-header[data-collapsible="true"]:focus-visible {
+  background: var(--gray-a2);
+}
+
+.agent-change-summary-header[data-collapsible="true"]:focus-visible {
+  outline: 1px solid var(--gray-a8);
+  outline-offset: -1px;
+}
+
+.agent-change-summary-icon {
+  display: inline-grid;
+  flex: 0 0 auto;
+  width: 30px;
+  height: 30px;
+  color: var(--gray-11);
+  background: var(--gray-a3);
+  border-radius: 8px;
+  place-items: center;
+}
+
+.agent-change-summary-heading {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 3px;
+}
+
+.agent-change-summary-title {
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  color: var(--gray-12);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-change-summary-title-row,
+.agent-change-summary-stats-row {
+  min-width: 0;
+}
+
+.agent-change-summary-title-row {
+  width: 100%;
+}
+
+.agent-change-summary-stats-row {
+  display: flex;
+  width: fit-content;
+  max-width: 100%;
+  align-items: center;
+  gap: 4px;
+  padding: 0;
+  border: 0;
+  background-color: transparent;
+  font: inherit;
+  line-height: 1.2;
+  text-align: left;
+}
+
+.agent-change-summary-stats-row[data-actionable="true"] {
+  cursor: pointer;
+}
+
+.agent-change-summary-stats-row[data-actionable="true"]:hover {
+  color: var(--gray-12);
+}
+
+.agent-change-summary-stats-row[data-actionable="true"]:hover .agent-change-stat {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.agent-change-summary-open-button {
+  color: var(--gray-10);
+  background-color: transparent;
+}
+
+.agent-change-summary-open-button:hover {
+  background-color: transparent !important;
+}
+
+.agent-change-summary-toggle {
+  display: inline-flex;
+  flex: 0 0 auto;
+  color: var(--gray-10);
+  line-height: 0;
+}
+
+.agent-change-kind-icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  color: var(--gray-10);
+  line-height: 0;
+}
+
+.agent-change-summary-single-title {
+  display: inline-flex;
+  min-width: 0;
+  max-width: 100%;
+  align-items: center;
+  column-gap: 4px;
+  vertical-align: middle;
+}
+
+.agent-change-summary-single-title .agent-change-item-name {
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.agent-change-item-name {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: bottom;
+  white-space: nowrap;
+}
+
+.agent-change-item-path {
+  color: var(--gray-10);
+  font-weight: 400;
+}
+
+.agent-change-item-label {
+  color: var(--gray-12);
+}
+
+.agent-change-stats {
+  flex: 0 0 auto;
+  font-family: var(--code-font-family, monospace);
+  font-variant-numeric: tabular-nums;
+  line-height: 1.2;
+}
+
+.agent-change-stat {
+  flex: 0 0 auto;
+  font-family: inherit;
+  font-variant-numeric: inherit;
+}
+
+.agent-change-stat[data-change="added"] {
+  color: var(--green-10);
+}
+
+.agent-change-stat[data-change="removed"] {
+  color: var(--red-10);
+}
+
+.agent-change-summary-list-wrap {
+  min-width: 0;
+}
+
+.agent-change-summary-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.agent-change-summary-item {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  column-gap: 5px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--gray-a3);
+}
+
+.agent-change-summary-item > .agent-change-kind-icon,
+.agent-change-item-title-row > .agent-change-kind-icon {
+  transform: translateY(1px);
+}
+
+.agent-change-summary-item-heading {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.agent-change-summary-item-title {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--gray-12);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-change-summary-more {
+  display: block;
+  width: 100%;
+  padding: 8px 12px;
+  border: 0;
+  color: var(--gray-11);
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  font-size: var(--font-size-sm);
+  text-align: left;
+  transition:
+    color 120ms ease,
+    background-color 120ms ease;
+}
+
+.agent-change-summary-more:hover,
+.agent-change-summary-more:focus-visible {
+  color: var(--gray-12);
+  background: var(--gray-a2);
+}
+
+.agent-change-summary-more:focus-visible {
+  outline: 1px solid var(--gray-a8);
+  outline-offset: -1px;
+}
+
+.agent-session-changes-view {
+  display: flex;
+  min-width: 0;
+  height: 100%;
+  min-height: 0;
+  flex-direction: column;
+}
+
+.agent-session-changes-dialog {
+  height: min(820px, calc(100vh - 48px));
+  max-height: calc(100vh - 48px);
+}
+
+.rt-DialogContent.agent-session-changes-dialog {
+  width: min(1000px, calc(100vw - 48px)) !important;
+  min-width: min(1000px, calc(100vw - 48px));
+  max-width: calc(100vw - 48px) !important;
+  padding: 0 !important;
+  overflow: hidden;
+}
+
+.agent-session-changes-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.agent-session-changes-header {
+  flex: 0 0 auto;
+  min-width: 0;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--gray-a4);
+}
+
+.agent-session-changes-header-leading {
+  min-width: 0;
+}
+
+.agent-session-changes-header-title {
+  white-space: nowrap;
+}
+
+.agent-session-changes-actions {
+  flex: 0 0 auto;
+}
+
+.agent-session-changes-content {
+  min-width: 0;
+  min-height: 0;
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: 0;
+}
+
+.agent-session-changes-list {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0;
+}
+
+.agent-change-item {
+  min-width: 0;
+  background: transparent;
+}
+
+.agent-change-item-header {
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-width: 0;
+  padding: 9px 16px;
+  border: 0;
+  color: var(--gray-12);
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  text-align: left;
+  transition: background-color 120ms ease;
+}
+
+.agent-change-item-header:hover,
+.agent-change-item-header:focus-visible {
+  background: var(--gray-a3);
+}
+
+.agent-change-item-header:focus-visible {
+  outline: 1px solid var(--gray-a8);
+  outline-offset: -1px;
+}
+
+.agent-change-item-leading {
+  display: flex;
+  min-width: 0;
+  flex: 1 1 auto;
+  align-items: center;
+  gap: 8px;
+}
+
+.agent-change-item-title-row {
+  display: flex;
+  min-width: 0;
+  flex: 0 1 auto;
+  align-items: center;
+  column-gap: 6px;
+  line-height: 1.25;
+}
+
+.agent-change-item-title {
+  display: block;
+  min-width: 0;
+  max-width: 100%;
+  flex: 0 1 auto;
+  overflow: hidden;
+  color: var(--gray-12);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-change-item-disclosure-icon {
+  display: inline-flex;
+  flex: 0 0 auto;
+  color: var(--gray-10);
+  line-height: 0;
+}
+
+.agent-change-item-body {
+  min-width: 0;
+}
+
+.agent-change-title-change {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  overflow: hidden;
+  color: var(--gray-11);
+  font-size: var(--font-size-sm);
+  line-height: 1.45;
+}
+
+.agent-change-title-change > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-change-title-change > span:nth-child(2) {
+  flex: 0 0 auto;
+  color: var(--gray-9);
+}
+
+.agent-change-diff-lines {
+  max-height: 360px;
+  overflow: auto;
+  background: var(--color-panel);
+}
+
+.agent-change-split-scroll {
+  max-height: 360px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  background: var(--color-panel);
+}
+
+.agent-change-split-panes {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  min-width: 0;
+}
+
+.agent-change-split-pane {
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.agent-change-split-pane + .agent-change-split-pane {
+  border-inline-start: 1px solid var(--gray-a4);
+}
+
+.agent-change-split-pane-content {
+  min-width: max-content;
+  background-color: var(--gray-a2);
+  background-image: repeating-linear-gradient(
+    -45deg,
+    transparent 0,
+    transparent 6px,
+    var(--gray-a4) 6px,
+    var(--gray-a4) 7px
+  );
+}
+
+.agent-change-split-row {
+  min-height: var(--agent-change-split-row-height, 0px);
+}
+
+.agent-change-split-cell {
+  display: grid;
+  width: max-content;
+  min-width: 100%;
+  grid-template-columns: 18px 46px max-content;
+  align-items: start;
+  min-height: 24px;
+  font-family: var(--code-font-family, monospace);
+  font-size: var(--font-size-sm);
+  line-height: 1.55;
+}
+
+.agent-change-split-cell[data-type="added"] {
+  color: var(--green-12);
+  background-color: var(--green-2);
+}
+
+.agent-change-split-cell[data-type="removed"] {
+  color: var(--red-12);
+  background-color: var(--red-2);
+}
+
+.agent-change-split-cell[data-type="context"] {
+  background-color: var(--color-panel);
+}
+
+.agent-change-split-cell[data-type="empty"] {
+  background-color: transparent;
+}
+
+.agent-change-split-cell[data-type="added"] .agent-change-diff-gutter {
+  background: var(--green-3);
+}
+
+.agent-change-split-cell[data-type="removed"] .agent-change-diff-gutter {
+  background: var(--red-3);
+}
+
+.agent-change-split-cell .agent-change-diff-text {
+  min-width: max-content;
+  white-space: pre;
+  overflow-wrap: normal;
+}
+
+.agent-change-split-scroll[data-wrap="true"] .agent-change-split-pane {
+  overflow-x: hidden;
+}
+
+.agent-change-split-scroll[data-wrap="true"] .agent-change-split-pane-content,
+.agent-change-split-scroll[data-wrap="true"] .agent-change-split-row {
+  width: 100%;
+  min-width: 0;
+}
+
+.agent-change-split-scroll[data-wrap="true"] .agent-change-split-cell {
+  width: 100%;
+  min-width: 0;
+  grid-template-columns: 18px 46px minmax(0, 1fr);
+}
+
+.agent-change-split-scroll[data-wrap="true"] .agent-change-split-cell .agent-change-diff-text {
+  min-width: 0;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.agent-change-diff-line {
+  display: grid;
+  grid-template-columns: 18px 46px minmax(0, 1fr);
+  align-items: start;
+  min-width: max-content;
+  min-height: 24px;
+  font-family: var(--code-font-family, monospace);
+  font-size: var(--font-size-sm);
+  line-height: 1.55;
+}
+
+.agent-change-diff-line[data-type="added"] {
+  color: var(--green-12);
+  background: var(--green-a2);
+}
+
+.agent-change-diff-line[data-type="removed"] {
+  color: var(--red-12);
+  background: var(--red-a2);
+}
+
+.agent-change-diff-prefix {
+  padding: 4px 0 4px 8px;
+  color: var(--gray-10);
+  font-weight: 600;
+  text-align: center;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.agent-change-diff-line[data-type="added"] .agent-change-diff-prefix {
+  color: var(--green-11);
+}
+
+.agent-change-diff-line[data-type="removed"] .agent-change-diff-prefix {
+  color: var(--red-11);
+}
+
+.agent-change-diff-gutter {
+  padding: 4px 8px 4px 6px;
+  color: var(--gray-10);
+  text-align: right;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+.agent-change-diff-line[data-type="added"] .agent-change-diff-gutter {
+  background: var(--green-a3);
+}
+
+.agent-change-diff-line[data-type="removed"] .agent-change-diff-gutter {
+  background: var(--red-a3);
+}
+
+.agent-change-diff-lines[data-wrap="true"] {
+  overflow-x: hidden;
+}
+
+.agent-change-diff-lines[data-wrap="true"] .agent-change-diff-line {
+  min-width: 100%;
+}
+
+.agent-change-diff-text {
+  min-width: 0;
+  padding: 4px 10px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.agent-change-diff-empty,
+.agent-session-changes-empty {
+  display: block;
+  padding: 10px 12px;
+  color: var(--gray-10);
+}
+
+@media (max-width: 480px) {
+  .agent-session-changes-dialog {
+    height: calc(100vh - 24px);
+    max-height: calc(100vh - 24px);
+  }
+
+  .rt-DialogContent.agent-session-changes-dialog {
+    width: calc(100vw - 16px) !important;
+    min-width: calc(100vw - 16px);
+    max-width: calc(100vw - 16px) !important;
+  }
+
+  .agent-session-changes-content {
+    padding: 0;
+  }
+
+  .agent-change-item-header,
+  .agent-change-summary-header {
+    padding-inline: 10px;
+  }
+}

--- a/frontend/src/features/assistant/components/agent/agent-changes.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-changes.tsx
@@ -1,0 +1,739 @@
+import { Box, Dialog, Flex, IconButton, Text, Tooltip } from "@radix-ui/themes";
+import type { TFunction } from "i18next";
+import {
+  BookOpen,
+  ChevronDown,
+  ChevronRight,
+  Columns2,
+  ChevronsDownUp,
+  ChevronsUpDown,
+  ExternalLink,
+  FileDiff,
+  Globe,
+  Notebook,
+  Rows3,
+  TextAlignJustify,
+  UserRound,
+  WrapText,
+  X,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { useLayoutEffect, useRef, useState } from "react";
+import type { KeyboardEvent } from "react";
+import { useTranslation } from "react-i18next";
+
+import {
+  type AgentChangeItem,
+  type AgentChangeLine,
+  type AgentChangeSummary,
+  type AgentSessionChanges,
+} from "@/lib/agent.types";
+
+import "./agent-changes.css";
+
+const SUMMARY_VISIBLE_ITEM_COUNT = 3;
+
+const CHANGE_KIND_ICONS: Record<AgentChangeItem["kind"], LucideIcon> = {
+  chapter: BookOpen,
+  note: Notebook,
+  world_entry: Globe,
+  character: UserRound,
+};
+
+interface AgentChangeSummaryCardProps {
+  summary: AgentChangeSummary;
+  onOpenChanges?: () => void;
+}
+
+interface AgentChangeItemDiffProps {
+  item: AgentChangeItem;
+  isExpanded: boolean;
+  isSplitView: boolean;
+  isWrapEnabled: boolean;
+  onToggle: () => void;
+}
+
+interface AgentSessionChangesDialogProps {
+  changes: AgentSessionChanges | null;
+  summaryOverride?: AgentChangeSummary | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface SplitDiffRow {
+  before: AgentChangeLine | null;
+  after: AgentChangeLine | null;
+}
+
+const EMPTY_CHANGE_SUMMARY: AgentChangeSummary = {
+  itemCount: 0,
+  added: 0,
+  removed: 0,
+  items: [],
+};
+
+function getLinePrefix(type: AgentChangeLine["type"]): string {
+  if (type === "added") return "+";
+  if (type === "removed") return "-";
+  return " ";
+}
+
+function getItemKey(item: AgentChangeItem): string {
+  return `${item.key}:${item.source}:${item.childRunId ?? "primary"}:${item.requestId ?? "current"}`;
+}
+
+function ChangeKindIcon({ item, size = 15 }: { item: AgentChangeItem; size?: number }) {
+  const Icon = CHANGE_KIND_ICONS[item.kind];
+  return (
+    <span
+      className="agent-change-kind-icon"
+      aria-hidden="true"
+    >
+      <Icon size={size} />
+    </span>
+  );
+}
+
+function ChangeItemName({ item }: { item: AgentChangeItem }) {
+  const path = item.path.filter((part) => part.trim().length > 0);
+  return (
+    <span className="agent-change-item-name">
+      {path.length > 0 ? <span className="agent-change-item-path">{path.join("/")}/</span> : null}
+      <span className="agent-change-item-label">{item.title}</span>
+    </span>
+  );
+}
+
+function getSummaryDetails(summary: AgentChangeSummary, t: TFunction, language: string): string {
+  const counts = new Map<AgentChangeItem["kind"], number>();
+  for (const item of summary.items) {
+    counts.set(item.kind, (counts.get(item.kind) ?? 0) + 1);
+  }
+  const kindOrder: AgentChangeItem["kind"][] = ["chapter", "note", "world_entry", "character"];
+  const parts = kindOrder.flatMap((kind) => {
+    const count = counts.get(kind) ?? 0;
+    return count > 0
+      ? [t(`assistant.sessionChanges.kindCount.${kind}.${count === 1 ? "one" : "many"}`, { count })]
+      : [];
+  });
+  const formatted = new Intl.ListFormat(language, { style: "long", type: "conjunction" }).format(
+    parts,
+  );
+  return language.toLowerCase().startsWith("zh")
+    ? formatted.replace(/和(?=\S)/g, "和 ")
+    : formatted;
+}
+
+function ChangeSummaryTitle({
+  summary,
+  className,
+}: {
+  summary: AgentChangeSummary;
+  className: string;
+}) {
+  const { t, i18n } = useTranslation();
+  const item = summary.items.length === 1 ? summary.items[0] : null;
+  return (
+    <Text
+      size="2"
+      weight="medium"
+      className={className}
+    >
+      {item ? (
+        <span className="agent-change-summary-single-title">
+          <span>{t("assistant.sessionChanges.edited")}</span>
+          <ChangeKindIcon
+            item={item}
+            size={14}
+          />
+          <ChangeItemName item={item} />
+        </span>
+      ) : summary.items.length > 1 ? (
+        t("assistant.sessionChanges.editedSummary", {
+          details: getSummaryDetails(summary, t, i18n.language),
+        })
+      ) : (
+        t("assistant.sessionChanges.title")
+      )}
+    </Text>
+  );
+}
+
+function ChangeStats({ added, removed }: Pick<AgentChangeItem, "added" | "removed">) {
+  return (
+    <Flex
+      align="center"
+      gap="2"
+      className="agent-change-stats"
+      aria-label={`+${added} -${removed}`}
+    >
+      <Text
+        size="1"
+        className="agent-change-stat"
+        data-change="added"
+      >
+        +{added}
+      </Text>
+      <Text
+        size="1"
+        className="agent-change-stat"
+        data-change="removed"
+      >
+        -{removed}
+      </Text>
+    </Flex>
+  );
+}
+
+function ChangeLine({ line }: { line: AgentChangeLine }) {
+  return (
+    <div
+      className="agent-change-diff-line"
+      data-type={line.type}
+    >
+      <span className="agent-change-diff-prefix">{getLinePrefix(line.type)}</span>
+      <span className="agent-change-diff-gutter">
+        {line.afterLineNumber ?? line.beforeLineNumber ?? ""}
+      </span>
+      <span className="agent-change-diff-text">{line.text || " "}</span>
+    </div>
+  );
+}
+
+function buildSplitDiffRows(lines: AgentChangeLine[]): SplitDiffRow[] {
+  const rows: SplitDiffRow[] = [];
+  let index = 0;
+  while (index < lines.length) {
+    const line = lines[index];
+    if (line.type === "context") {
+      rows.push({ before: line, after: line });
+      index += 1;
+      continue;
+    }
+
+    const changedLines: AgentChangeLine[] = [];
+    while (index < lines.length && lines[index].type !== "context") {
+      changedLines.push(lines[index]);
+      index += 1;
+    }
+    const removedLines = changedLines.filter((changedLine) => changedLine.type === "removed");
+    const addedLines = changedLines.filter((changedLine) => changedLine.type === "added");
+    const rowCount = Math.max(removedLines.length, addedLines.length);
+    for (let rowIndex = 0; rowIndex < rowCount; rowIndex += 1) {
+      rows.push({
+        before: removedLines[rowIndex] ?? null,
+        after: addedLines[rowIndex] ?? null,
+      });
+    }
+  }
+  return rows;
+}
+
+function SplitChangeCell({
+  line,
+  side,
+}: {
+  line: AgentChangeLine | null;
+  side: "before" | "after";
+}) {
+  const lineType = line?.type ?? "empty";
+  const lineNumber = side === "before" ? line?.beforeLineNumber : line?.afterLineNumber;
+  return (
+    <div
+      className="agent-change-split-cell"
+      data-side={side}
+      data-type={lineType}
+    >
+      <span className="agent-change-diff-prefix">{line ? getLinePrefix(line.type) : ""}</span>
+      <span className="agent-change-diff-gutter">{lineNumber ?? ""}</span>
+      <span className="agent-change-diff-text">{line?.text || " "}</span>
+    </div>
+  );
+}
+
+function SplitChangeRows({
+  lines,
+  isWrapEnabled,
+}: {
+  lines: AgentChangeLine[];
+  isWrapEnabled: boolean;
+}) {
+  const rows = buildSplitDiffRows(lines);
+  const beforeRowRefs = useRef<(HTMLDivElement | null)[]>([]);
+  const afterRowRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  useLayoutEffect(() => {
+    for (const row of [...beforeRowRefs.current, ...afterRowRefs.current]) {
+      row?.style.removeProperty("--agent-change-split-row-height");
+    }
+    if (!isWrapEnabled) return;
+
+    const syncRowHeights = () => {
+      rows.forEach((_, index) => {
+        const beforeRow = beforeRowRefs.current[index];
+        const afterRow = afterRowRefs.current[index];
+        if (!beforeRow || !afterRow) return;
+        const rowHeight = Math.max(beforeRow.scrollHeight, afterRow.scrollHeight);
+        beforeRow.style.setProperty("--agent-change-split-row-height", `${rowHeight}px`);
+        afterRow.style.setProperty("--agent-change-split-row-height", `${rowHeight}px`);
+      });
+    };
+
+    syncRowHeights();
+    const observer = new ResizeObserver(syncRowHeights);
+    for (const row of [...beforeRowRefs.current, ...afterRowRefs.current]) {
+      if (row) observer.observe(row);
+    }
+    return () => observer.disconnect();
+  }, [isWrapEnabled, rows]);
+
+  return (
+    <div
+      className="agent-change-split-scroll"
+      data-wrap={isWrapEnabled ? "true" : "false"}
+    >
+      <div className="agent-change-split-panes">
+        <div
+          className="agent-change-split-pane"
+          data-side="before"
+        >
+          <div className="agent-change-split-pane-content">
+            {rows.map((row, index) => (
+              <div
+                key={`${index}-${row.before?.beforeLineNumber ?? "n"}`}
+                ref={(element) => {
+                  beforeRowRefs.current[index] = element;
+                }}
+                className="agent-change-split-row"
+              >
+                <SplitChangeCell
+                  line={row.before}
+                  side="before"
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+        <div
+          className="agent-change-split-pane"
+          data-side="after"
+        >
+          <div className="agent-change-split-pane-content">
+            {rows.map((row, index) => (
+              <div
+                key={`${index}-${row.after?.afterLineNumber ?? "n"}`}
+                ref={(element) => {
+                  afterRowRefs.current[index] = element;
+                }}
+                className="agent-change-split-row"
+              >
+                <SplitChangeCell
+                  line={row.after}
+                  side="after"
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TitleChange({ before, after }: { before: string; after: string }) {
+  return (
+    <div className="agent-change-title-change">
+      <span>{before}</span>
+      <span aria-hidden="true">→</span>
+      <span>{after}</span>
+    </div>
+  );
+}
+
+function AgentChangeItemDiff({
+  item,
+  isExpanded,
+  isSplitView,
+  isWrapEnabled,
+  onToggle,
+}: AgentChangeItemDiffProps) {
+  const { t } = useTranslation();
+  const lines = item.sections.flatMap((section) => section.lines);
+  const hasTitleChange = Boolean(item.titleBefore && item.titleAfter);
+  return (
+    <Box
+      className="agent-change-item"
+      data-kind={item.kind}
+      data-expanded={isExpanded ? "true" : "false"}
+    >
+      <button
+        type="button"
+        className="agent-change-item-header"
+        aria-expanded={isExpanded}
+        onClick={onToggle}
+      >
+        <span className="agent-change-item-leading">
+          <span className="agent-change-item-title-row">
+            <ChangeKindIcon item={item} />
+            <Text
+              size="1"
+              weight="medium"
+              className="agent-change-item-title"
+            >
+              <ChangeItemName item={item} />
+            </Text>
+          </span>
+          <ChangeStats
+            added={item.added}
+            removed={item.removed}
+          />
+        </span>
+        <span
+          className="agent-change-item-disclosure-icon"
+          aria-hidden="true"
+        >
+          {isExpanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        </span>
+      </button>
+      {isExpanded ? (
+        <Box className="agent-change-item-body">
+          {lines.length > 0 ? (
+            isSplitView ? (
+              <SplitChangeRows
+                lines={lines}
+                isWrapEnabled={isWrapEnabled}
+              />
+            ) : (
+              <div
+                className="agent-change-diff-lines"
+                data-wrap={isWrapEnabled ? "true" : "false"}
+              >
+                {lines.map((line, index) => (
+                  <ChangeLine
+                    key={`${index}-${line.beforeLineNumber ?? "n"}-${line.afterLineNumber ?? "n"}`}
+                    line={line}
+                  />
+                ))}
+              </div>
+            )
+          ) : hasTitleChange ? (
+            <TitleChange
+              before={item.titleBefore!}
+              after={item.titleAfter!}
+            />
+          ) : (
+            <Text
+              size="1"
+              className="agent-change-diff-empty"
+            >
+              {t("assistant.sessionChanges.noLines")}
+            </Text>
+          )}
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
+export function AgentChangeSummaryCard({ summary, onOpenChanges }: AgentChangeSummaryCardProps) {
+  const { t } = useTranslation();
+  const [isItemsExpanded, setIsItemsExpanded] = useState(false);
+  const [isListVisible, setIsListVisible] = useState(true);
+  const hasMultipleItems = summary.items.length > 1;
+  const visibleItems = isItemsExpanded
+    ? summary.items
+    : summary.items.slice(0, SUMMARY_VISIBLE_ITEM_COUNT);
+  const remainingCount = hasMultipleItems
+    ? Math.max(0, summary.items.length - SUMMARY_VISIBLE_ITEM_COUNT)
+    : 0;
+  const handleHeaderClick = () => {
+    if (hasMultipleItems) setIsListVisible((visible) => !visible);
+  };
+  const handleHeaderKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!hasMultipleItems || (event.key !== "Enter" && event.key !== " ")) return;
+    event.preventDefault();
+    handleHeaderClick();
+  };
+  const stats = (
+    <ChangeStats
+      added={summary.added}
+      removed={summary.removed}
+    />
+  );
+  const statsRow = onOpenChanges ? (
+    <button
+      type="button"
+      className="agent-change-summary-stats-row agent-change-summary-open-button"
+      data-actionable="true"
+      aria-label={t("assistant.sessionChanges.open")}
+      onClick={(event) => {
+        event.stopPropagation();
+        onOpenChanges();
+      }}
+      onKeyDown={(event) => event.stopPropagation()}
+    >
+      {stats}
+      <ExternalLink
+        size={14}
+        aria-hidden="true"
+      />
+    </button>
+  ) : (
+    stats
+  );
+
+  return (
+    <Box className="agent-change-summary-spacing">
+      <Box
+        asChild
+        className="agent-change-summary-card"
+      >
+        <section aria-label={t("assistant.sessionChanges.turnSummary")}>
+          <Flex
+            align="center"
+            gap="3"
+            className="agent-change-summary-header"
+            data-collapsible={hasMultipleItems ? "true" : undefined}
+            data-expanded={isListVisible ? "true" : "false"}
+            role={hasMultipleItems ? "button" : undefined}
+            tabIndex={hasMultipleItems ? 0 : undefined}
+            aria-expanded={hasMultipleItems ? isListVisible : undefined}
+            onClick={hasMultipleItems ? handleHeaderClick : undefined}
+            onKeyDown={hasMultipleItems ? handleHeaderKeyDown : undefined}
+          >
+            <span
+              className="agent-change-summary-icon"
+              aria-hidden="true"
+            >
+              <FileDiff size={17} />
+            </span>
+            <Box className="agent-change-summary-heading">
+              <Flex
+                align="center"
+                gap="1"
+                className="agent-change-summary-title-row"
+              >
+                <ChangeSummaryTitle
+                  summary={summary}
+                  className="agent-change-summary-title"
+                />
+                {hasMultipleItems ? (
+                  <span
+                    className="agent-change-summary-toggle"
+                    aria-hidden="true"
+                  >
+                    {isListVisible ? <ChevronDown size={15} /> : <ChevronRight size={15} />}
+                  </span>
+                ) : null}
+              </Flex>
+              {onOpenChanges ? (
+                <Tooltip content={t("assistant.sessionChanges.open")}>{statsRow}</Tooltip>
+              ) : (
+                statsRow
+              )}
+            </Box>
+          </Flex>
+          {hasMultipleItems && isListVisible ? (
+            <Box className="agent-change-summary-list-wrap">
+              <ul className="agent-change-summary-list">
+                {visibleItems.map((item) => (
+                  <li
+                    key={getItemKey(item)}
+                    className="agent-change-summary-item"
+                  >
+                    <ChangeKindIcon
+                      item={item}
+                      size={14}
+                    />
+                    <Box className="agent-change-summary-item-heading">
+                      <Text
+                        size="1"
+                        className="agent-change-summary-item-title"
+                      >
+                        <ChangeItemName item={item} />
+                      </Text>
+                    </Box>
+                    <ChangeStats
+                      added={item.added}
+                      removed={item.removed}
+                    />
+                  </li>
+                ))}
+              </ul>
+              {remainingCount > 0 ? (
+                <button
+                  type="button"
+                  className="agent-change-summary-more"
+                  onClick={() => setIsItemsExpanded((value) => !value)}
+                  aria-expanded={isItemsExpanded}
+                >
+                  {isItemsExpanded
+                    ? t("assistant.sessionChanges.showLess")
+                    : t("assistant.sessionChanges.showMore", { count: remainingCount })}
+                </button>
+              ) : null}
+            </Box>
+          ) : null}
+        </section>
+      </Box>
+    </Box>
+  );
+}
+
+export function AgentSessionChangesDialog({
+  changes,
+  summaryOverride,
+  open,
+  onOpenChange,
+}: AgentSessionChangesDialogProps) {
+  const { t } = useTranslation();
+  const summary = summaryOverride ?? changes?.sessionChanges ?? EMPTY_CHANGE_SUMMARY;
+  const [collapsedItemKeys, setCollapsedItemKeys] = useState<Set<string>>(() => new Set());
+  const [isSplitView, setIsSplitView] = useState(false);
+  const [isWrapEnabled, setIsWrapEnabled] = useState(false);
+  const areItemsExpanded = summary.items.every((item) => !collapsedItemKeys.has(getItemKey(item)));
+  const expandActionLabel = areItemsExpanded
+    ? t("assistant.sessionChanges.collapseAll")
+    : t("assistant.sessionChanges.expandAll");
+  const viewActionLabel = isSplitView
+    ? t("assistant.sessionChanges.unifiedView")
+    : t("assistant.sessionChanges.splitView");
+  const wrapActionLabel = isWrapEnabled
+    ? t("assistant.sessionChanges.disableWrap")
+    : t("assistant.sessionChanges.enableWrap");
+  const handleToggleAll = () => {
+    setCollapsedItemKeys(
+      areItemsExpanded ? new Set(summary.items.map((item) => getItemKey(item))) : new Set(),
+    );
+  };
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={onOpenChange}
+    >
+      <Dialog.Content
+        className="agent-session-changes-dialog"
+        maxWidth="none"
+      >
+        <Dialog.Title className="agent-session-changes-visually-hidden">
+          {t("assistant.sessionChanges.overviewTitle")}
+        </Dialog.Title>
+        <Dialog.Description className="agent-session-changes-visually-hidden">
+          {t("assistant.sessionChanges.dialogDescription")}
+        </Dialog.Description>
+        <Flex
+          direction="column"
+          className="agent-session-changes-view"
+        >
+          <Flex
+            align="center"
+            justify="between"
+            className="agent-session-changes-header"
+          >
+            <Flex
+              align="center"
+              gap="2"
+              className="agent-session-changes-header-leading"
+            >
+              <Dialog.Close>
+                <IconButton
+                  variant="ghost"
+                  color="gray"
+                  size="1"
+                  aria-label={t("common.close")}
+                >
+                  <X size={16} />
+                </IconButton>
+              </Dialog.Close>
+              <Text
+                size="2"
+                weight="medium"
+                className="agent-session-changes-header-title"
+              >
+                {t("assistant.sessionChanges.overviewTitle")}
+              </Text>
+              <ChangeStats
+                added={summary.added}
+                removed={summary.removed}
+              />
+            </Flex>
+            <Flex
+              align="center"
+              gap="1"
+              className="agent-session-changes-actions"
+            >
+              <Tooltip content={expandActionLabel}>
+                <IconButton
+                  variant="ghost"
+                  color="gray"
+                  size="1"
+                  aria-label={expandActionLabel}
+                  aria-pressed={areItemsExpanded}
+                  onClick={handleToggleAll}
+                >
+                  {areItemsExpanded ? <ChevronsDownUp size={16} /> : <ChevronsUpDown size={16} />}
+                </IconButton>
+              </Tooltip>
+              <Tooltip content={viewActionLabel}>
+                <IconButton
+                  variant="ghost"
+                  color="gray"
+                  size="1"
+                  aria-label={viewActionLabel}
+                  aria-pressed={isSplitView}
+                  onClick={() => setIsSplitView((split) => !split)}
+                >
+                  {isSplitView ? <Rows3 size={16} /> : <Columns2 size={16} />}
+                </IconButton>
+              </Tooltip>
+              <Tooltip content={wrapActionLabel}>
+                <IconButton
+                  variant="ghost"
+                  color="gray"
+                  size="1"
+                  aria-label={wrapActionLabel}
+                  aria-pressed={isWrapEnabled}
+                  onClick={() => setIsWrapEnabled((wrap) => !wrap)}
+                >
+                  {isWrapEnabled ? <TextAlignJustify size={16} /> : <WrapText size={16} />}
+                </IconButton>
+              </Tooltip>
+            </Flex>
+          </Flex>
+          <Box className="agent-session-changes-content">
+            {summary.items.length > 0 ? (
+              <Box className="agent-session-changes-list">
+                {summary.items.map((item) => (
+                  <AgentChangeItemDiff
+                    key={getItemKey(item)}
+                    item={item}
+                    isExpanded={!collapsedItemKeys.has(getItemKey(item))}
+                    isSplitView={isSplitView}
+                    isWrapEnabled={isWrapEnabled}
+                    onToggle={() => {
+                      setCollapsedItemKeys((current) => {
+                        const next = new Set(current);
+                        const key = getItemKey(item);
+                        if (next.has(key)) next.delete(key);
+                        else next.add(key);
+                        return next;
+                      });
+                    }}
+                  />
+                ))}
+              </Box>
+            ) : (
+              <Text
+                size="2"
+                className="agent-session-changes-empty"
+              >
+                {t("assistant.sessionChanges.noChanges")}
+              </Text>
+            )}
+          </Box>
+        </Flex>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/frontend/src/features/assistant/components/agent/agent-messages.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-messages.tsx
@@ -11,8 +11,13 @@ import { useTranslation } from "react-i18next";
 import { Virtuoso } from "react-virtuoso";
 
 import { ConfirmDialog, toast } from "@/components";
-import type { AgentMessage as AgentMessageType } from "@/lib/agent.types";
+import type {
+  AgentChangeSummary,
+  AgentMessage as AgentMessageType,
+  AgentSessionChanges,
+} from "@/lib/agent.types";
 
+import { AgentChangeSummaryCard } from "./agent-changes";
 import { AgentMessageRenderer } from "./agent-message-renderer";
 import {
   getStreamingFollowSignal,
@@ -50,10 +55,11 @@ const COPY_FEEDBACK_MS = 1200;
 const MIN_BOTTOM_RESTORE_ATTEMPTS = 6;
 const MAX_BOTTOM_RESTORE_ATTEMPTS = 120;
 
-function estimateAgentBlockHeight(block: AgentMessageBlock): number {
-  if (block.type === "node") return 120;
+function estimateAgentBlockHeight(block: AgentMessageBlock, hasChangeSummary = false): number {
+  const changeSummaryHeight = hasChangeSummary ? 150 : 0;
+  if (block.type === "node") return 120 + changeSummaryHeight;
   if (block.type === "user") return 100;
-  return 120 + block.messages.length * 90;
+  return 120 + block.messages.length * 90 + changeSummaryHeight;
 }
 
 function getTimestampParts(timestamp: number, timeZone?: string): Record<string, string> {
@@ -101,6 +107,8 @@ interface AgentMessagesProps {
   onFork?: (sourceRevisionId: string) => Promise<void>;
   onOpenMentionChapter?: (chapterId: string, chapterTitle: string) => void;
   onAbortRetry?: () => void;
+  changes?: AgentSessionChanges | null;
+  onOpenChanges?: (summary: AgentChangeSummary) => void;
   onAtBottomChange?: (isAtBottom: boolean) => void;
   scrollToBottomFnRef?: React.MutableRefObject<(() => void) | null>;
 }
@@ -131,6 +139,58 @@ function isAgentBlockDisplayMessage(
   return (
     message.type !== "user_request" && message.type !== "node_start" && message.type !== "node_end"
   );
+}
+
+function hasRunningAgentMessage(block: AgentMessageBlock): boolean {
+  return (
+    block.type === "agent" &&
+    block.messages.some((message) =>
+      Boolean(message.isStreaming || message.status === "running" || message.status === "pending"),
+    )
+  );
+}
+
+function buildAgentRoundChangeSummaries(
+  blocks: AgentMessageBlock[],
+  visibleBlocks: AgentMessageBlock[],
+  changes?: AgentSessionChanges | null,
+): Map<string, AgentChangeSummary> {
+  const visibleBlockIds = new Set(visibleBlocks.map((block) => block.id));
+  const rounds = new Map<
+    string,
+    { blocks: AgentMessageBlock[]; visibleBlocks: AgentMessageBlock[] }
+  >();
+
+  for (const block of blocks) {
+    if (!block.agentRoundId) continue;
+    let round = rounds.get(block.agentRoundId);
+    if (!round) {
+      round = { blocks: [], visibleBlocks: [] };
+      rounds.set(block.agentRoundId, round);
+    }
+    round.blocks.push(block);
+    if (visibleBlockIds.has(block.id)) round.visibleBlocks.push(block);
+  }
+
+  const summaries = new Map<string, AgentChangeSummary>();
+  rounds.forEach((round) => {
+    const agentBlocks = round.blocks.filter((block) => block.type === "agent");
+    if (agentBlocks.length === 0 || agentBlocks.some(hasRunningAgentMessage)) return;
+    const anchorBlock = round.visibleBlocks.at(-1);
+    if (!anchorBlock) return;
+
+    const sourceRevisionId = agentBlocks.find((block) => block.sourceRevisionId)?.sourceRevisionId;
+    const sourceUserMessageId = round.blocks.find((block) => block.type === "user")?.messages[0]
+      ?.id;
+    const summary = changes?.turns.find(
+      (turn) =>
+        (Boolean(sourceRevisionId) && turn.revisionId === sourceRevisionId) ||
+        (Boolean(sourceUserMessageId) && turn.userMessageId === sourceUserMessageId),
+    )?.changes;
+    if (!summary) return;
+    if (summary.itemCount > 0) summaries.set(anchorBlock.id, summary);
+  });
+  return summaries;
 }
 
 function areBlockMessageListsEqual(previous: BlockDisplayMessage[], next: BlockDisplayMessage[]) {
@@ -227,6 +287,8 @@ export function AgentMessages({
   onFork,
   onOpenMentionChapter,
   onAbortRetry,
+  changes,
+  onOpenChanges,
   onAtBottomChange,
   scrollToBottomFnRef,
 }: AgentMessagesProps) {
@@ -498,6 +560,10 @@ export function AgentMessages({
     () => getVisibleAgentMessageBlocks(messageBlocks, collapsedNodeIds),
     [collapsedNodeIds, messageBlocks],
   );
+  const changeSummaryByAnchorId = useMemo(
+    () => buildAgentRoundChangeSummaries(messageBlocks, visibleMessageBlocks, changes),
+    [changes, messageBlocks, visibleMessageBlocks],
+  );
   const toolbarTargets = useMemo(
     () => getAgentRoundToolbarTargets(messageBlocks, visibleMessageBlocks, isRunning),
     [messageBlocks, visibleMessageBlocks, isRunning],
@@ -614,6 +680,7 @@ export function AgentMessages({
 
   const renderBlock = (block: AgentMessageBlock) => {
     const toolbarTarget = toolbarTargetByAnchorId.get(block.id);
+    const changeSummary = changeSummaryByAnchorId.get(block.id);
     if (block.type === "node") {
       const message = block.messages[0];
       if (!message || message.type !== "node_start") return null;
@@ -638,6 +705,12 @@ export function AgentMessages({
               onOpenMentionChapter={onOpenMentionChapter}
             />
           </Box>
+          {changeSummary ? (
+            <AgentChangeSummaryCard
+              summary={changeSummary}
+              onOpenChanges={onOpenChanges ? () => onOpenChanges(changeSummary) : undefined}
+            />
+          ) : null}
           {toolbarTarget ? renderAgentRoundToolbar(toolbarTarget) : null}
         </Box>
       );
@@ -724,6 +797,12 @@ export function AgentMessages({
             onAbortRetry={onAbortRetry}
           />
         </Box>
+        {changeSummary ? (
+          <AgentChangeSummaryCard
+            summary={changeSummary}
+            onOpenChanges={onOpenChanges ? () => onOpenChanges(changeSummary) : undefined}
+          />
+        ) : null}
         {toolbarTarget ? renderAgentRoundToolbar(toolbarTarget) : null}
       </Box>
     );
@@ -741,8 +820,11 @@ export function AgentMessages({
   }, [scheduleLoadedSessionBottomRestore]);
 
   const heightEstimates = useMemo(
-    () => visibleMessageBlocks.map(estimateAgentBlockHeight),
-    [visibleMessageBlocks],
+    () =>
+      visibleMessageBlocks.map((block) =>
+        estimateAgentBlockHeight(block, changeSummaryByAnchorId.has(block.id)),
+      ),
+    [changeSummaryByAnchorId, visibleMessageBlocks],
   );
 
   const footerContext = useMemo<AgentMessagesFooterContext>(

--- a/frontend/src/features/assistant/components/agent/agent-sidebar.tsx
+++ b/frontend/src/features/assistant/components/agent/agent-sidebar.tsx
@@ -6,6 +6,7 @@ import i18n from "@/i18n";
 import type {
   AgentImageAttachment,
   AgentForkResponse,
+  AgentChangeSummary,
   AgentSessionCreateResponse,
   ReasoningEffort,
   TokenUsageState,
@@ -30,6 +31,7 @@ interface AgentSidebarProps {
   onRestoreAttachments?: (attachments: AgentImageAttachment[]) => void;
   onSetInputValue?: (value: string) => void;
   onOpenMentionChapter?: (chapterId: string, chapterTitle: string) => void;
+  onOpenChanges?: (summary: AgentChangeSummary) => void;
   onTokenUsage?: (sessionId: string, usage: TokenUsageState) => void;
   onTaskUsageSnapshot?: (payload: {
     sessionId: string;
@@ -68,6 +70,7 @@ export function useAgentSidebar({
   onRestoreAttachments,
   onSetInputValue,
   onOpenMentionChapter,
+  onOpenChanges,
   onTokenUsage,
   onTaskUsageSnapshot,
   onTaskUsageDelta,
@@ -80,6 +83,7 @@ export function useAgentSidebar({
 }: AgentSidebarProps) {
   const {
     messages: agentMessages,
+    changes: agentChanges,
     pendingMessage,
     status: agentStatus,
     isRunning: isAgentRunning,
@@ -101,6 +105,7 @@ export function useAgentSidebar({
     submitQuestionAnswer: submitAgentQuestionAnswer,
     handleBatchDecision,
     abortSession: abortAgentSession,
+    refreshChanges: refreshAgentChanges,
   } = useAgentSession({
     projectId,
     modelId,
@@ -189,6 +194,7 @@ export function useAgentSidebar({
 
   return {
     messages: agentMessages,
+    changes: agentChanges,
     pendingMessage,
     status: agentStatus,
     isRunning: isAgentRunning,
@@ -201,6 +207,7 @@ export function useAgentSidebar({
     onCancelPendingMessage: handleCancelPendingMessage,
     resetSession: resetAgentSession,
     loadSession: loadAgentSession,
+    refreshChanges: refreshAgentChanges,
     disconnectTransport: disconnectAgentTransport,
     reconnectTransport: reconnectAgentTransport,
     compactSession: compactAgentSession,
@@ -216,7 +223,9 @@ export function useAgentSidebar({
         onRollback={handleRollback}
         onFork={handleFork}
         onOpenMentionChapter={onOpenMentionChapter}
+        onOpenChanges={onOpenChanges}
         onAbortRetry={abortAgentSession}
+        changes={agentChanges}
         onAtBottomChange={onAtBottomChange}
         scrollToBottomFnRef={scrollToBottomFnRef}
       />

--- a/frontend/src/features/assistant/components/assistant-sidebar.tsx
+++ b/frontend/src/features/assistant/components/assistant-sidebar.tsx
@@ -6,6 +6,7 @@ import {
   ArrowBigUp,
   ArrowDown,
   ArrowLeft,
+  FileDiff,
   History,
   Layers2,
   ListChevronsDownUp,
@@ -35,7 +36,9 @@ import { getAgentDisplayDescription, getAgentIconColor } from "@/lib/agent-brand
 import type {
   ActiveSubagentState,
   AgentForkResponse,
+  AgentChangeSummary,
   AgentSessionCreateResponse,
+  AgentSessionChanges,
   AgentMessage,
   ReasoningEffort,
   TokenUsageState,
@@ -43,6 +46,7 @@ import type {
 import {
   fetchActiveSubagents,
   fetchAgentSessionState,
+  fetchAgentSessionChanges,
   fetchTask,
   subscribeBackgroundEvents,
 } from "@/lib/api-client";
@@ -75,6 +79,7 @@ import { joinSubagentStatusStream, subscribeSubagentStatusEvents } from "../lib/
 import { buildAgentMessagesFromTaskMessages } from "../lib/task-message-agent-mapping";
 import { AgentInput, AgentMessages, useAgentSidebar } from "./agent";
 import { ActiveSubagentList } from "./agent/active-subagent-list";
+import { AgentSessionChangesDialog } from "./agent/agent-changes";
 import { AgentSpecialPanels } from "./agent/agent-special-panels";
 import { getAgentSpecialPanels } from "./agent/agent-special-panels-state";
 import { AllTasksPage } from "./tasks/all-tasks-page";
@@ -147,6 +152,46 @@ function createSessionTotalUsageState(
     tokenOutput: 0,
     tokenCache: 0,
     cost: 0,
+  };
+}
+
+const EMPTY_AGENT_CHANGE_SUMMARY: AgentChangeSummary = {
+  itemCount: 0,
+  added: 0,
+  removed: 0,
+  items: [],
+};
+
+function buildSubagentChanges(
+  changes: AgentSessionChanges | null,
+  childRunId: string | undefined,
+  childThreadId: string | undefined,
+): AgentSessionChanges | null {
+  if (!changes || !childRunId || !childThreadId) return null;
+  const turns = changes.turns.flatMap((turn) =>
+    turn.subagentRuns.flatMap((run) => {
+      if (run.childRunId !== childRunId || run.childThreadId !== childThreadId) return [];
+      return [
+        {
+          revisionId: `${turn.revisionId}:${run.requestId ?? childRunId}`,
+          userMessageId: run.childUserMessageId,
+          changes: run.changes,
+          subagentRuns: [],
+        },
+      ];
+    }),
+  );
+  if (turns.length === 0) return null;
+  const items = turns.flatMap((turn) => turn.changes.items);
+  return {
+    sessionId: childThreadId,
+    turns,
+    sessionChanges: {
+      itemCount: items.length,
+      added: items.reduce((total, item) => total + item.added, 0),
+      removed: items.reduce((total, item) => total + item.removed, 0),
+      items,
+    },
   };
 }
 
@@ -282,6 +327,13 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
     const [inputValue, setInputValue] = useState("");
     const [pendingAttachments, setPendingAttachments] = useState<PendingAgentImageAttachment[]>([]);
     const [view, setView] = useState<AssistantView>("tasks");
+    const [isSessionChangesOpen, setIsSessionChangesOpen] = useState(false);
+    const [sessionChangesDialogSummary, setSessionChangesDialogSummary] =
+      useState<AgentChangeSummary | null>(null);
+    const handleOpenChangeSummary = useCallback((summary: AgentChangeSummary) => {
+      setSessionChangesDialogSummary(summary);
+      setIsSessionChangesOpen(true);
+    }, []);
     const [isLoadingTask, setIsLoadingTask] = useState(false);
     const [currentTaskTitle, setCurrentTaskTitle] = useState<string>("");
     const [currentTaskId, setCurrentTaskId] = useState<string | null>(null);
@@ -461,9 +513,11 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
             return;
           }
           const sessionId = fullTask.agentSessionId;
+          const sessionChanges = await fetchAgentSessionChanges(sessionId);
           agentSidebarRef.current?.loadSession(sessionId, agentMessages, {
             reconnect: false,
             isRemoteRunning: false,
+            initialChanges: sessionChanges,
           });
           setView("tasks");
           setIsLoadingTask(false);
@@ -616,6 +670,7 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
       },
       onSetInputValue: (value) => setInputValue(value),
       onOpenMentionChapter,
+      onOpenChanges: handleOpenChangeSummary,
       onTokenUsage: handleConversationTokenUsage,
       onTaskUsageSnapshot: handleTaskUsageSnapshot,
       onTaskUsageDelta: handleTaskUsageDelta,
@@ -626,17 +681,33 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
       onAtBottomChange: setIsMessagesAtBottom,
       scrollToBottomFnRef,
     });
+    const currentSubagentChanges = useMemo(
+      () =>
+        buildSubagentChanges(
+          agentSidebar.changes,
+          currentConversation?.kind === "subagent" ? currentConversation.childRunId : undefined,
+          currentConversation?.kind === "subagent" ? currentConversation.childThreadId : undefined,
+        ),
+      [agentSidebar.changes, currentConversation],
+    );
+    const sessionChangesSummary =
+      agentSidebar.changes?.sessionChanges ?? EMPTY_AGENT_CHANGE_SUMMARY;
     useEffect(() => {
       agentSidebarRef.current = agentSidebar;
     }, [agentSidebar]);
     const agentSidebarSessionId = agentSidebar.sessionId;
     const reconnectAgentTransport = agentSidebar.reconnectTransport;
+    const refreshAgentChanges = agentSidebar.refreshChanges;
     const parentConversationSessionId =
       agentSidebarSessionId ||
       (currentConversation?.kind === "parent"
         ? currentConversation.sessionId
         : currentConversation?.parentSessionId) ||
       "";
+    useEffect(() => {
+      if (!isViewingSubagent) return;
+      void refreshAgentChanges();
+    }, [isViewingSubagent, refreshAgentChanges]);
     const subagentSession = useSubagentSession(
       currentConversation?.kind === "subagent" ? currentConversation.childRunId : null,
       currentConversation?.kind === "subagent" ? currentConversation.childThreadId : null,
@@ -782,6 +853,9 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
         parentConversationSessionId,
         (event) => {
           setActiveSubagents((current) => upsertActiveSubagent(current, event));
+          if (event.status === "completed" || event.status === "error" || !event.isActive) {
+            void refreshAgentChanges();
+          }
           setConversationState((current) => {
             let changed = false;
             const nextEntries = current.entries.map((entry) => {
@@ -807,7 +881,7 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
       return () => {
         cleanup();
       };
-    }, [parentConversationSessionId]);
+    }, [parentConversationSessionId, refreshAgentChanges]);
 
     useEffect(() => {
       if (!projectId) return;
@@ -886,6 +960,7 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
             fetchTask,
             fetchAgentSessionState,
             fetchActiveSubagents,
+            fetchAgentSessionChanges,
           });
           const fullTask = bundle.task;
 
@@ -927,6 +1002,7 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
               typeof bundle.sessionState?.state.agent_key === "string"
                 ? bundle.sessionState.state.agent_key
                 : undefined,
+            initialChanges: bundle.sessionChanges,
           });
           setActiveSubagents(bundle.activeSubagentRows);
           setCurrentTaskId(fullTask.id);
@@ -1129,6 +1205,14 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
       void agentSidebar.compactSession();
     }, [agentSidebar, canCompactAgentSession]);
 
+    const canOpenSessionChanges =
+      !isViewingSubagent && Boolean(agentSidebar.sessionId) && sessionChangesSummary.itemCount > 0;
+    const handleOpenSessionChanges = useCallback(() => {
+      if (!canOpenSessionChanges) return;
+      setSessionChangesDialogSummary(null);
+      setIsSessionChangesOpen(true);
+    }, [canOpenSessionChanges]);
+
     const handleModelChange = useCallback((nextModelId: string) => {
       setSelectedModelId(nextModelId);
       window.localStorage.setItem(ASSISTANT_MODEL_STORAGE_KEY, nextModelId);
@@ -1185,6 +1269,7 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
     const handleOpenSubagent = useCallback(
       (subagent: ActiveSubagentState) => {
         if (!parentConversationSessionId) return;
+        setView("tasks");
         setConversationState((current) =>
           openSubagentConversation(current, parentConversationSessionId, subagent),
         );
@@ -1218,7 +1303,7 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
     const isSendingMessage = agentSidebar.isRunning;
     const shouldShowSubagentConversation = isViewingSubagent;
     const shouldShowParentSubagentStrip =
-      view !== "allTasks" &&
+      view === "tasks" &&
       hasActiveTask &&
       !isLoadingTask &&
       !isViewingSubagent &&
@@ -1367,6 +1452,25 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
                     ) : (
                       <ListChevronsDownUp size={16} />
                     )}
+                  </IconButton>
+                </Tooltip>
+                <Tooltip
+                  content={
+                    canOpenSessionChanges
+                      ? t("assistant.sessionChanges.open")
+                      : t("assistant.sessionChanges.noChanges")
+                  }
+                >
+                  <IconButton
+                    variant="ghost"
+                    color="gray"
+                    size="1"
+                    onClick={handleOpenSessionChanges}
+                    disabled={!canOpenSessionChanges}
+                    aria-label={t("assistant.sessionChanges.open")}
+                    aria-pressed={isSessionChangesOpen}
+                  >
+                    <FileDiff size={16} />
                   </IconButton>
                 </Tooltip>
                 <IconButton
@@ -1575,6 +1679,8 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
                   }
                   onRollback={async () => null}
                   onAbortRetry={subagentSession.cancelSession}
+                  changes={currentSubagentChanges}
+                  onOpenChanges={handleOpenChangeSummary}
                   onAtBottomChange={setIsMessagesAtBottom}
                   scrollToBottomFnRef={scrollToBottomFnRef}
                 />
@@ -1675,6 +1781,13 @@ export const AssistantSidebar = forwardRef<AssistantSidebarHandle, AssistantSide
             />
           </>
         )}
+        <AgentSessionChangesDialog
+          key={agentSidebar.sessionId ?? "no-session"}
+          changes={agentSidebar.changes}
+          summaryOverride={sessionChangesDialogSummary}
+          open={isSessionChangesOpen}
+          onOpenChange={setIsSessionChangesOpen}
+        />
       </Flex>
     );
   },

--- a/frontend/src/features/assistant/hooks/use-agent-session.ts
+++ b/frontend/src/features/assistant/hooks/use-agent-session.ts
@@ -17,6 +17,7 @@ import type {
   AgentImageAttachment,
   AgentMessage,
   AgentPendingMessage,
+  AgentSessionChanges,
   AgentSessionCreateResponse,
   AgentSessionStatus,
   AgentEvent,
@@ -35,6 +36,7 @@ import {
   submitAgentInterruptBatch,
   rollbackAgentRevision,
   cancelAgentSession,
+  fetchAgentSessionChanges,
   uploadAgentImageAttachment,
   submitAgentToolApproval,
 } from "@/lib/api-client";
@@ -306,6 +308,7 @@ export function useAgentSession({
   projectIdRef.current = projectId;
   const [sessionId, setSessionId] = useState<string | null>(null);
   const [messages, setMessages] = useState<AgentMessage[]>([]);
+  const [changes, setChanges] = useState<AgentSessionChanges | null>(null);
   const [pendingMessage, setPendingMessage] = useState<AgentPendingMessage | null>(null);
   const [status, setStatus] = useState<AgentSessionStatus>("idle");
   const [isRunning, setIsRunning] = useState(false);
@@ -433,6 +436,26 @@ export function useAgentSession({
     setIsCompacting(nextIsCompacting);
   }, []);
 
+  const refreshChanges = useCallback(
+    async (
+      targetSessionId = sessionIdRef.current ?? sessionId,
+    ): Promise<AgentSessionChanges | null> => {
+      if (!targetSessionId) {
+        setChanges(null);
+        return null;
+      }
+      try {
+        const nextChanges = await fetchAgentSessionChanges(targetSessionId);
+        if (sessionIdRef.current === targetSessionId) setChanges(nextChanges);
+        return nextChanges;
+      } catch (error) {
+        console.error("Failed to load agent session changes:", error);
+        return null;
+      }
+    },
+    [sessionId],
+  );
+
   const applyTranscriptEvent = useCallback(
     (event: AgentEvent) => {
       const result = applyAgentTranscriptEventToLiveState(transcriptStateRef.current, event, {
@@ -557,6 +580,7 @@ export function useAgentSession({
 
       const result = applyTranscriptEvent(event);
       const message = result.message;
+      if (event.type === "task_completed" || event.type === "error") void refreshChanges();
 
       if (message?.interruptBatchId && typeof message.interruptBatchTotal === "number") {
         const batchId = message.interruptBatchId;
@@ -744,6 +768,7 @@ export function useAgentSession({
       onTaskUsageSnapshot,
       projectId,
       queryClient,
+      refreshChanges,
       syncCompactingState,
       syncPendingMessageState,
       updateTranscriptState,
@@ -839,6 +864,7 @@ export function useAgentSession({
       try {
         suppressSocketEventsAfterAbortRef.current = false;
         transportRetryAttemptRef.current = 0;
+        setChanges(null);
         commitTranscriptState({
           messages: [createOptimisticUserMessage(userRequest)],
           status: "running",
@@ -1232,6 +1258,7 @@ export function useAgentSession({
     ignoredApprovalIdsRef.current.clear();
     interruptBatchRef.current = null;
     manualCompactionPreviousStateRef.current = null;
+    setChanges(null);
     syncPendingMessageState(null);
     syncCompactingState(false);
     setIsRollbacking(false);
@@ -1311,6 +1338,7 @@ export function useAgentSession({
         isRemoteRunning?: boolean;
         primaryAgentKey?: string;
         pendingInterrupts?: Record<string, unknown>[];
+        initialChanges?: AgentSessionChanges | null;
       } = {},
     ) => {
       sessionIdRef.current = existingSessionId;
@@ -1321,6 +1349,7 @@ export function useAgentSession({
       syncPendingMessageState(null);
       syncCompactingState(false);
       setSessionId(existingSessionId);
+      setChanges(options.initialChanges ?? null);
       socketUnsubscribeRef.current?.();
       socketUnsubscribeRef.current = null;
 
@@ -1454,6 +1483,7 @@ export function useAgentSession({
           invalidateNoteQueries();
           invalidateWorldEntryQueries();
           invalidateCharacterQueries();
+          void refreshChanges(sessionId);
 
           toast.success(i18n.t("assistant.rollbackSuccess"));
 
@@ -1483,6 +1513,7 @@ export function useAgentSession({
       invalidateCharacterQueries,
       invalidateNoteQueries,
       invalidateWorldEntryQueries,
+      refreshChanges,
     ],
   );
 
@@ -1534,6 +1565,8 @@ export function useAgentSession({
     sendMessage,
     resetSession,
     loadSession,
+    changes,
+    refreshChanges,
     disconnectTransport,
     reconnectTransport,
     compactSession,

--- a/frontend/src/features/assistant/lib/agent-task-bundle.ts
+++ b/frontend/src/features/assistant/lib/agent-task-bundle.ts
@@ -1,16 +1,22 @@
-import type { ActiveSubagentState, AgentSessionStateResponse } from "@/lib/agent.types";
+import type {
+  ActiveSubagentState,
+  AgentSessionChanges,
+  AgentSessionStateResponse,
+} from "@/lib/agent.types";
 import type { Task } from "@/lib/task.types";
 
 export interface AgentTaskBundleLoaders {
   fetchTask: (taskId: string) => Promise<Task>;
   fetchAgentSessionState: (sessionId: string) => Promise<AgentSessionStateResponse>;
   fetchActiveSubagents: (parentSessionId: string) => Promise<ActiveSubagentState[]>;
+  fetchAgentSessionChanges: (sessionId: string) => Promise<AgentSessionChanges>;
 }
 
 export interface AgentTaskBundle {
   task: Task;
   sessionState: AgentSessionStateResponse | null;
   activeSubagentRows: ActiveSubagentState[];
+  sessionChanges: AgentSessionChanges | null;
 }
 
 export async function loadAgentTaskBundle(
@@ -23,13 +29,16 @@ export async function loadAgentTaskBundle(
       task,
       sessionState: null,
       activeSubagentRows: [],
+      sessionChanges: null,
     };
   }
 
-  const [sessionStateResult, activeSubagentsResult] = await Promise.allSettled([
-    loaders.fetchAgentSessionState(task.agentSessionId),
-    loaders.fetchActiveSubagents(task.agentSessionId),
-  ]);
+  const [sessionStateResult, activeSubagentsResult, sessionChangesResult] =
+    await Promise.allSettled([
+      loaders.fetchAgentSessionState(task.agentSessionId),
+      loaders.fetchActiveSubagents(task.agentSessionId),
+      loaders.fetchAgentSessionChanges(task.agentSessionId),
+    ]);
 
   return {
     task,
@@ -38,5 +47,6 @@ export async function loadAgentTaskBundle(
       activeSubagentsResult.status === "fulfilled"
         ? activeSubagentsResult.value.filter((item) => item.isActive)
         : [],
+    sessionChanges: sessionChangesResult.status === "fulfilled" ? sessionChangesResult.value : null,
   };
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1705,6 +1705,43 @@
     "compactionPendingActionRequired": "Please finish the current session action first",
     "compactionAvailable": "Compact context",
     "compactionNoSession": "No Agent session is available",
+    "sessionChanges": {
+      "title": "Session changes",
+      "overviewTitle": "Diff overview",
+      "open": "View session changes",
+      "turnSummary": "Turn changes summary",
+      "dialogDescription": "View all content differences in this session",
+      "edited": "Edited",
+      "editedSummary": "Edited {{details}}",
+      "showMore": "Show {{count}} more files",
+      "showLess": "Show fewer files",
+      "noChanges": "No content changes in this session",
+      "noLines": "No line-level content differences",
+      "collapseAll": "Collapse changes",
+      "expandAll": "Expand changes",
+      "splitView": "Switch to split view",
+      "unifiedView": "Switch to unified view",
+      "enableWrap": "Enable word wrap",
+      "disableWrap": "Disable word wrap",
+      "kindCount": {
+        "chapter": {
+          "one": "{{count}} chapter",
+          "many": "{{count}} chapters"
+        },
+        "note": {
+          "one": "{{count}} note",
+          "many": "{{count}} notes"
+        },
+        "world_entry": {
+          "one": "{{count}} entry",
+          "many": "{{count}} entries"
+        },
+        "character": {
+          "one": "{{count}} character",
+          "many": "{{count}} characters"
+        }
+      }
+    },
     "mentionMetaFormat": "{{base}} · {{description}}",
     "mentionKind": {
       "volume": "Volume",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1768,6 +1768,43 @@
     "compactionPendingActionRequired": "请先处理当前会话",
     "compactionAvailable": "压缩上下文",
     "compactionNoSession": "当前没有 Agent 会话",
+    "sessionChanges": {
+      "title": "会话更改",
+      "overviewTitle": "差异总览",
+      "open": "查看会话更改",
+      "turnSummary": "本轮会话更改摘要",
+      "dialogDescription": "查看本次会话的全部内容差异",
+      "edited": "已编辑",
+      "editedSummary": "已编辑 {{details}}",
+      "showMore": "再显示 {{count}} 个文件",
+      "showLess": "收起文件",
+      "noChanges": "本次会话没有内容修改",
+      "noLines": "无行级内容差异",
+      "collapseAll": "收起差异项",
+      "expandAll": "展开差异项",
+      "splitView": "切换为拆分视图",
+      "unifiedView": "切换为统一视图",
+      "enableWrap": "开启自动换行",
+      "disableWrap": "关闭自动换行",
+      "kindCount": {
+        "chapter": {
+          "one": "{{count}} 个章节",
+          "many": "{{count}} 个章节"
+        },
+        "note": {
+          "one": "{{count}} 个笔记",
+          "many": "{{count}} 个笔记"
+        },
+        "world_entry": {
+          "one": "{{count}} 个条目",
+          "many": "{{count}} 个条目"
+        },
+        "character": {
+          "one": "{{count}} 个角色",
+          "many": "{{count}} 个角色"
+        }
+      }
+    },
     "mentionMetaFormat": "{{base}} · {{description}}",
     "mentionKind": {
       "volume": "卷",

--- a/frontend/src/lib/agent.types.ts
+++ b/frontend/src/lib/agent.types.ts
@@ -208,6 +208,73 @@ export interface AgentMessage {
   thinkingDurationMs?: number;
 }
 
+export type AgentChangeKind = "chapter" | "note" | "world_entry" | "character";
+export type AgentChangeLineType = "context" | "added" | "removed";
+export type AgentChangeSectionType = "content";
+
+export interface AgentChangeLine {
+  type: AgentChangeLineType;
+  beforeLineNumber: number | null;
+  afterLineNumber: number | null;
+  text: string;
+}
+
+export interface AgentChangeSection {
+  type: AgentChangeSectionType;
+  lines: AgentChangeLine[];
+}
+
+export interface AgentChangeItem {
+  key: string;
+  kind: AgentChangeKind;
+  title: string;
+  titleBefore?: string;
+  titleAfter?: string;
+  path: string[];
+  operation: string;
+  sections: AgentChangeSection[];
+  added: number;
+  removed: number;
+  sourceMessageId: string;
+  source: "primary" | "subagent" | "session";
+  childRunId?: string;
+  requestId?: string;
+  agentKey?: AgentType;
+  agentNumber?: string;
+  revisionId?: string;
+}
+
+export interface AgentChangeSummary {
+  itemCount: number;
+  added: number;
+  removed: number;
+  items: AgentChangeItem[];
+}
+
+export interface AgentSubagentRunChanges {
+  childRunId: string;
+  childThreadId: string;
+  requestId?: string;
+  childUserMessageId?: string;
+  agentKey: AgentType;
+  agentNumber?: string;
+  changes: AgentChangeSummary;
+}
+
+export interface AgentTurnChanges {
+  revisionId: string;
+  userMessageId?: string;
+  userMessageSeq?: number;
+  changes: AgentChangeSummary;
+  subagentRuns: AgentSubagentRunChanges[];
+}
+
+export interface AgentSessionChanges {
+  sessionId: string;
+  turns: AgentTurnChanges[];
+  sessionChanges: AgentChangeSummary;
+}
+
 export type AgentSessionStatus =
   | "idle"
   | "running"

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -2258,6 +2258,11 @@ import type {
   ActiveSubagentState,
   AgentCancelPendingMessageResponse,
   AgentCompactionResponse,
+  AgentChangeItem,
+  AgentChangeLine,
+  AgentChangeSection,
+  AgentChangeSummary,
+  AgentSessionChanges,
   AgentSessionCreateRequest,
   AgentSessionCreateResponse,
   AgentForkResponse,
@@ -2305,8 +2310,148 @@ export async function fetchAgentSessionState(
   };
 }
 
+export async function fetchAgentSessionChanges(sessionId: string): Promise<AgentSessionChanges> {
+  const response = await apiClient.get(`/agent/sessions/${sessionId}/changes`);
+  return transformAgentSessionChanges(response.data, sessionId);
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function transformAgentChangeLine(raw: unknown): AgentChangeLine | null {
+  if (!isRecord(raw)) return null;
+  const type = raw.type === "added" || raw.type === "removed" ? raw.type : "context";
+  return {
+    type,
+    beforeLineNumber: typeof raw.before_line_number === "number" ? raw.before_line_number : null,
+    afterLineNumber: typeof raw.after_line_number === "number" ? raw.after_line_number : null,
+    text: typeof raw.text === "string" ? raw.text : "",
+  };
+}
+
+function transformAgentChangeSection(raw: unknown): AgentChangeSection | null {
+  if (!isRecord(raw) || raw.type !== "content") return null;
+  const lines = Array.isArray(raw.lines)
+    ? raw.lines.flatMap((line) => {
+        const transformed = transformAgentChangeLine(line);
+        return transformed ? [transformed] : [];
+      })
+    : [];
+  return { type: raw.type, lines };
+}
+
+function transformAgentChangeItem(raw: unknown): AgentChangeItem | null {
+  if (!isRecord(raw)) return null;
+  const kind = raw.kind;
+  if (kind !== "chapter" && kind !== "note" && kind !== "world_entry" && kind !== "character") {
+    return null;
+  }
+  const source = raw.source === "subagent" || raw.source === "session" ? raw.source : "primary";
+  const sections = Array.isArray(raw.sections)
+    ? raw.sections.flatMap((section) => {
+        const transformed = transformAgentChangeSection(section);
+        return transformed ? [transformed] : [];
+      })
+    : [];
+  return {
+    key: String(raw.key ?? ""),
+    kind,
+    title: String(raw.title ?? kind),
+    titleBefore: typeof raw.title_before === "string" ? raw.title_before : undefined,
+    titleAfter: typeof raw.title_after === "string" ? raw.title_after : undefined,
+    path: Array.isArray(raw.path)
+      ? raw.path.filter(
+          (part): part is string => typeof part === "string" && part.trim().length > 0,
+        )
+      : [],
+    operation: String(raw.operation ?? "update"),
+    sections,
+    added: Number(raw.added ?? 0),
+    removed: Number(raw.removed ?? 0),
+    sourceMessageId: String(raw.source_message_id ?? ""),
+    source,
+    childRunId: typeof raw.child_run_id === "string" ? raw.child_run_id : undefined,
+    requestId: typeof raw.request_id === "string" ? raw.request_id : undefined,
+    agentKey: typeof raw.agent_key === "string" ? raw.agent_key : undefined,
+    agentNumber: typeof raw.agent_number === "string" ? raw.agent_number : undefined,
+    revisionId: typeof raw.revision_id === "string" ? raw.revision_id : undefined,
+  };
+}
+
+function transformAgentChangeSummary(raw: unknown): AgentChangeSummary {
+  if (!isRecord(raw)) return { itemCount: 0, added: 0, removed: 0, items: [] };
+  const items = Array.isArray(raw.items)
+    ? raw.items.flatMap((item) => {
+        const transformed = transformAgentChangeItem(item);
+        return transformed ? [transformed] : [];
+      })
+    : [];
+  return {
+    itemCount: Number(raw.item_count ?? items.length),
+    added: Number(raw.added ?? 0),
+    removed: Number(raw.removed ?? 0),
+    items,
+  };
+}
+
+function transformAgentSessionChanges(
+  raw: unknown,
+  fallbackSessionId: string,
+): AgentSessionChanges {
+  if (!isRecord(raw)) {
+    return {
+      sessionId: fallbackSessionId,
+      turns: [],
+      sessionChanges: transformAgentChangeSummary(null),
+    };
+  }
+  const turns = Array.isArray(raw.turns)
+    ? raw.turns.flatMap((turn) => {
+        if (!isRecord(turn)) return [];
+        const subagentRuns = Array.isArray(turn.subagent_runs)
+          ? turn.subagent_runs.flatMap((run) => {
+              if (!isRecord(run)) return [];
+              const childRunId = String(run.child_run_id ?? "");
+              const childThreadId = String(run.child_thread_id ?? "");
+              const agentKey = String(run.agent_key ?? "");
+              if (!childRunId || !childThreadId || !agentKey) return [];
+              return [
+                {
+                  childRunId,
+                  childThreadId,
+                  requestId: typeof run.request_id === "string" ? run.request_id : undefined,
+                  childUserMessageId:
+                    typeof run.child_user_message_id === "string"
+                      ? run.child_user_message_id
+                      : undefined,
+                  agentKey,
+                  agentNumber: typeof run.agent_number === "string" ? run.agent_number : undefined,
+                  changes: transformAgentChangeSummary(run.changes),
+                },
+              ];
+            })
+          : [];
+        const revisionId = String(turn.revision_id ?? "");
+        if (!revisionId) return [];
+        return [
+          {
+            revisionId,
+            userMessageId:
+              typeof turn.user_message_id === "string" ? turn.user_message_id : undefined,
+            userMessageSeq:
+              typeof turn.user_message_seq === "number" ? turn.user_message_seq : undefined,
+            changes: transformAgentChangeSummary(turn.changes),
+            subagentRuns,
+          },
+        ];
+      })
+    : [];
+  return {
+    sessionId: String(raw.session_id ?? fallbackSessionId),
+    turns,
+    sessionChanges: transformAgentChangeSummary(raw.session_changes),
+  };
 }
 
 function transformPendingAgentMessage(raw: unknown): AgentPendingMessage | null {


### PR DESCRIPTION
## PR 标题

feat(agent): 新增会话/轮次级别的变更汇总面板

## 变更说明

- 问题: Agent 执行期间产生的章节、笔记、世界观条目和角色修改缺少统一的会话级差异查看入口。
- 重要性: 主会话与 subagent 的多轮修改难以回顾，删除和移动操作的差异统计及层级路径也不完整。
- 变化: 增加持久化消息与 child run 的会话变更投影 API，按 turn 和 subagent 请求汇总变更。
- 变化: 补齐章节、笔记工具的 diff 内容与路径信息，前端增加摘要卡、差异总览、统一/拆分视图和自动换行切换。
- 验证: 相关后端测试 88 项通过；后端 Ruff、ty 及前端 type-check、lint、format:check 均通过。

## 关联 Issue / PR

无

## 变更类型

- [x] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因

无

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

无
