### PR TITLE
fix(backend): 修复 Docker 部署版本信息读取

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,10 @@ RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
 # 复制后端源码
 COPY backend/ ./
 
+# 安装当前项目以写入发行版元数据，供运行时读取版本号
+RUN --mount=type=cache,id=uv-cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev
+
 # 前端构建产物打入包内
 COPY --from=frontend /build/dist ./app/frontend_dist
 

--- a/backend/tests/test_dockerfile.py
+++ b/backend/tests/test_dockerfile.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+
+def test_docker_runtime_installs_openfic_project_metadata() -> None:
+    dockerfile = (Path(__file__).resolve().parents[2] / "Dockerfile").read_text(encoding="utf-8")
+    source_copy = dockerfile.index("COPY backend/ ./")
+
+    assert "uv sync --frozen --no-dev\n" in dockerfile[source_copy:]


### PR DESCRIPTION
## PR 标题

fix(backend): 修复 Docker 部署版本信息读取

## 变更说明

- 问题：Docker 部署的健康接口返回 `0.0.0`，桌面端无法获取后端实际版本。
- 重要性：桌面端连接远程 Docker 服务时会误判版本不匹配，显示错误的兼容性提示。
- 变化：在复制后端源码后执行项目级 `uv sync --frozen --no-dev`，写入 `openfic` 发行版元数据。

## 关联 Issue / PR

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因

Dockerfile 原先使用 `uv sync --no-install-project` 安装依赖后直接复制源码，没有安装当前 `openfic` 项目，因此运行时通过 `importlib.metadata.version("openfic")` 查不到发行版元数据，触发 `0.0.0` 兜底值。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

- `uv run --project backend pytest backend/tests/test_dockerfile.py backend/tests/api/test_health.py`：3 项通过。
- `just lint`：Ruff 检查通过。
- `just type-check`：ty 检查通过。
- 本地执行同一条项目级 `uv sync` 后，`importlib.metadata.version("openfic")` 输出 `0.10.2`。
