### PR TITLE
fix(backend): 修复 tiktoken 词表缓存反复重写阻塞事件循环的问题

### DIFF
--- a/backend/app/core/utils/tiktoken.py
+++ b/backend/app/core/utils/tiktoken.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from tempfile import gettempdir
 
 import tiktoken
+from loguru import logger
 
 
 _ENCODING_RESOURCE_DIR = Path(__file__).parents[1] / "resources" / "tiktoken"
@@ -32,13 +33,34 @@ def _cache_path(encoding_name: str) -> Path:
     return _cache_dir() / sha1(source_url.encode()).hexdigest()
 
 
+def _write_atomic(path: Path, data: bytes) -> None:
+    # 临时文件 + os.replace，保证读者只会看到完整副本；Windows 上若目标
+    # 恰被其他进程打开会抛 PermissionError，此时保留旧文件并告警即可。
+    tmp_path = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path.write_bytes(data)
+        os.replace(tmp_path, path)
+    except OSError as exc:
+        logger.warning(f"写入 tiktoken 词表缓存失败 {path}: {exc}")
+        tmp_path.unlink(missing_ok=True)
+
+
 def seed_bundled_encodings() -> None:
-    """将内置词表写入 tiktoken 默认缓存，供 LangChain 直接加载。"""
+    """确保 tiktoken 缓存中存在内置词表。
+
+    token 计数是高频操作（逐消息、逐轮迭代、列表接口逐条目），缓存文件
+    已存在时必须跳过写入，否则每次计数都会产生数 MB 的同步磁盘 I/O，
+    阻塞事件循环。内容有效性不需要在这里校验：tiktoken 加载时会自行
+    做哈希校验，损坏或不匹配的缓存会被它删除重取；本地兜底见
+    get_encoding 的重建重试。
+    """
     for encoding_name in _ENCODING_URLS:
         resource_path = _ENCODING_RESOURCE_DIR / f"{encoding_name}.tiktoken"
         cache_path = _cache_path(encoding_name)
-        cache_path.parent.mkdir(parents=True, exist_ok=True)
-        cache_path.write_bytes(resource_path.read_bytes())
+        if cache_path.exists():
+            continue
+        _write_atomic(cache_path, resource_path.read_bytes())
 
 
 def get_encoding(encoding_name: str = "o200k_base") -> tiktoken.Encoding:
@@ -46,7 +68,15 @@ def get_encoding(encoding_name: str = "o200k_base") -> tiktoken.Encoding:
     if encoding_name not in _ENCODING_URLS:
         raise ValueError(f"不支持的 tiktoken 编码: {encoding_name}")
     seed_bundled_encodings()
-    return tiktoken.get_encoding(encoding_name)
+    try:
+        return tiktoken.get_encoding(encoding_name)
+    except Exception:
+        # 大小一致但内容损坏的缓存（位翻转、第三方写入）不会被跳过逻辑
+        # 识别，这里删除重写后重试一次，仍失败则让异常抛出。
+        logger.warning(f"tiktoken 编码 {encoding_name} 加载失败，重建缓存后重试")
+        resource_path = _ENCODING_RESOURCE_DIR / f"{encoding_name}.tiktoken"
+        _write_atomic(_cache_path(encoding_name), resource_path.read_bytes())
+        return tiktoken.get_encoding(encoding_name)
 
 
 def count_tokens(text: str, encoding_name: str = "o200k_base") -> int:

--- a/backend/app/core/utils/tiktoken.py
+++ b/backend/app/core/utils/tiktoken.py
@@ -15,6 +15,10 @@ _ENCODING_URLS = {
     "cl100k_base": "https://openaipublic.blob.core.windows.net/encodings/cl100k_base.tiktoken",
     "o200k_base": "https://openaipublic.blob.core.windows.net/encodings/o200k_base.tiktoken",
 }
+# 已完成内容校验的编码。校验需要完整读取缓存与内置词表（数 MB），每个
+# 编码每进程只做一次；GIL 下 set 的读取与添加均为原子操作，并发首调
+# 最坏重复校验一次，结果幂等，无需加锁。
+_VALIDATED_ENCODINGS: set[str] = set()
 
 
 def _cache_dir() -> Path:
@@ -47,13 +51,12 @@ def _write_atomic(path: Path, data: bytes) -> None:
 
 
 def seed_bundled_encodings() -> None:
-    """确保 tiktoken 缓存中存在内置词表。
+    """确保 tiktoken 缓存中存在内置词表，供 LangChain 直接加载。
 
-    token 计数是高频操作（逐消息、逐轮迭代、列表接口逐条目），缓存文件
-    已存在时必须跳过写入，否则每次计数都会产生数 MB 的同步磁盘 I/O，
-    阻塞事件循环。内容有效性不需要在这里校验：tiktoken 加载时会自行
-    做哈希校验，损坏或不匹配的缓存会被它删除重取；本地兜底见
-    get_encoding 的重建重试。
+    token 计数是高频操作（逐消息、逐轮迭代、列表接口逐条目），这里只
+    补缺失的缓存文件（一次 exists 检查）；已存在时必须跳过写入，否则
+    每次计数都会产生数 MB 的同步磁盘 I/O，阻塞事件循环。缓存内容是否
+    与内置词表一致由 _ensure_valid_cache 在加载前校验。
     """
     for encoding_name in _ENCODING_URLS:
         resource_path = _ENCODING_RESOURCE_DIR / f"{encoding_name}.tiktoken"
@@ -63,20 +66,36 @@ def seed_bundled_encodings() -> None:
         _write_atomic(cache_path, resource_path.read_bytes())
 
 
+def _ensure_valid_cache(encoding_name: str) -> None:
+    """加载前校验缓存内容与内置词表一致，缺失或损坏时原子重写。
+
+    tiktoken 只有在缓存存在且哈希正确时才会离线命中缓存，损坏的缓存
+    会被它删除并联网重取。因此校验必须先于 tiktoken.get_encoding()，
+    否则在线机器上损坏缓存会触发不必要的联网下载，离线机器则加载
+    失败。为避免高频计数反复读文件，每个编码每进程只校验一次，后续
+    调用直接放行。
+    """
+    if encoding_name in _VALIDATED_ENCODINGS:
+        return
+    _VALIDATED_ENCODINGS.add(encoding_name)
+    bundled = (_ENCODING_RESOURCE_DIR / f"{encoding_name}.tiktoken").read_bytes()
+    cache_path = _cache_path(encoding_name)
+    try:
+        if cache_path.read_bytes() == bundled:
+            return
+    except OSError:
+        pass
+    logger.warning(f"tiktoken 词表缓存缺失或损坏，从内置词表重建: {cache_path}")
+    _write_atomic(cache_path, bundled)
+
+
 def get_encoding(encoding_name: str = "o200k_base") -> tiktoken.Encoding:
-    """将内置词表预置到 tiktoken 缓存后加载编码器。"""
+    """校验并修复缓存后加载编码器，保证不依赖网络。"""
     if encoding_name not in _ENCODING_URLS:
         raise ValueError(f"不支持的 tiktoken 编码: {encoding_name}")
     seed_bundled_encodings()
-    try:
-        return tiktoken.get_encoding(encoding_name)
-    except Exception:
-        # 大小一致但内容损坏的缓存（位翻转、第三方写入）不会被跳过逻辑
-        # 识别，这里删除重写后重试一次，仍失败则让异常抛出。
-        logger.warning(f"tiktoken 编码 {encoding_name} 加载失败，重建缓存后重试")
-        resource_path = _ENCODING_RESOURCE_DIR / f"{encoding_name}.tiktoken"
-        _write_atomic(_cache_path(encoding_name), resource_path.read_bytes())
-        return tiktoken.get_encoding(encoding_name)
+    _ensure_valid_cache(encoding_name)
+    return tiktoken.get_encoding(encoding_name)
 
 
 def count_tokens(text: str, encoding_name: str = "o200k_base") -> int:

--- a/backend/tests/core/test_tiktoken.py
+++ b/backend/tests/core/test_tiktoken.py
@@ -6,6 +6,7 @@ import tiktoken.load
 import tiktoken.registry
 import pytest
 
+from app.core.utils import tiktoken as tiktoken_utils
 from app.core.utils.tiktoken import get_encoding
 from app.storage.services import character_service, world_info_entry_service
 
@@ -64,6 +65,54 @@ def test_get_encoding_seeds_bundled_resource_for_tiktoken_registry(
     assert requested_encodings == [encoding_name]
     assert encoding.name == encoding_name
     assert encoding.encode("OpenFic 离线 Token 计数")
+
+
+def test_seed_bundled_encodings_skips_existing_cache(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("TIKTOKEN_CACHE_DIR", str(tmp_path))
+    cache_names = [
+        tiktoken_utils._cache_path(name).name for name in ("cl100k_base", "o200k_base")
+    ]
+
+    tiktoken_utils.seed_bundled_encodings()
+    seeded = {
+        name: (tmp_path / name).stat().st_mtime_ns
+        for name in cache_names
+        if (tmp_path / name).is_file()
+    }
+    assert len(seeded) == 2
+
+    tiktoken_utils.seed_bundled_encodings()
+    unchanged = {
+        name: (tmp_path / name).stat().st_mtime_ns
+        for name in cache_names
+        if (tmp_path / name).is_file()
+    }
+    assert unchanged == seeded
+
+
+def test_get_encoding_recovers_from_corrupted_cache_offline(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("TIKTOKEN_CACHE_DIR", str(tmp_path))
+    monkeypatch.setattr(tiktoken.registry, "ENCODINGS", {})
+    tiktoken_utils.seed_bundled_encodings()
+
+    cache_path = tiktoken_utils._cache_path("o200k_base")
+    garbage = b"corrupted line\n"
+    cache_path.write_bytes(garbage * (cache_path.stat().st_size // len(garbage)))
+
+    def fail_if_network_requested(_: str) -> bytes:
+        raise AssertionError("cache rebuild must not request network resources")
+
+    monkeypatch.setattr(tiktoken.load, "read_file", fail_if_network_requested)
+
+    encoding = get_encoding("o200k_base")
+
+    assert encoding.encode("OpenFic 离线缓存重建")
 
 
 def test_character_token_count_uses_shared_offline_encoding(

--- a/backend/tests/core/test_tiktoken.py
+++ b/backend/tests/core/test_tiktoken.py
@@ -67,6 +67,13 @@ def test_get_encoding_seeds_bundled_resource_for_tiktoken_registry(
     assert encoding.encode("OpenFic 离线 Token 计数")
 
 
+@pytest.fixture(autouse=True)
+def _reset_validated_encodings() -> None:
+    # _VALIDATED_ENCODINGS 是进程级状态，测试间必须清零，
+    # 否则前一个用例的校验标记会让后续用例跳过校验与修复。
+    tiktoken_utils._VALIDATED_ENCODINGS.clear()
+
+
 def test_seed_bundled_encodings_skips_existing_cache(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -93,10 +100,14 @@ def test_seed_bundled_encodings_skips_existing_cache(
     assert unchanged == seeded
 
 
-def test_get_encoding_recovers_from_corrupted_cache_offline(
+def test_get_encoding_repairs_corrupted_cache_before_tiktoken_load(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    # 损坏缓存必须在进入 tiktoken 前被本地修复：tiktoken 对哈希不匹配
+    # 的缓存会删除后联网重取，在线机器因此产生不必要的网络请求，离线
+    # 机器则直接加载失败。read_file 只有缓存未命中/损坏时才会被调用，
+    # 这里作为触网探针。
     monkeypatch.setenv("TIKTOKEN_CACHE_DIR", str(tmp_path))
     monkeypatch.setattr(tiktoken.registry, "ENCODINGS", {})
     tiktoken_utils.seed_bundled_encodings()
@@ -106,13 +117,43 @@ def test_get_encoding_recovers_from_corrupted_cache_offline(
     cache_path.write_bytes(garbage * (cache_path.stat().st_size // len(garbage)))
 
     def fail_if_network_requested(_: str) -> bytes:
-        raise AssertionError("cache rebuild must not request network resources")
+        raise AssertionError("cache repair must not request network resources")
 
     monkeypatch.setattr(tiktoken.load, "read_file", fail_if_network_requested)
 
     encoding = get_encoding("o200k_base")
 
+    bundled = (
+        tiktoken_utils._ENCODING_RESOURCE_DIR / "o200k_base.tiktoken"
+    ).read_bytes()
+    assert cache_path.read_bytes() == bundled
     assert encoding.encode("OpenFic 离线缓存重建")
+
+
+def test_cache_validation_runs_once_per_process(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    # 每进程每个编码只校验一次：首调校验后，同一进程内缓存再次损坏
+    # 不会重新校验修复，交由 tiktoken 自身的缓存处理兜底。
+    monkeypatch.setenv("TIKTOKEN_CACHE_DIR", str(tmp_path))
+    monkeypatch.setattr(tiktoken.registry, "ENCODINGS", {})
+
+    assert get_encoding("o200k_base").encode("首次加载完成校验")
+
+    cache_path = tiktoken_utils._cache_path("o200k_base")
+    garbage = b"corrupted line\n"
+    cache_path.write_bytes(garbage * (cache_path.stat().st_size // len(garbage)))
+    monkeypatch.setattr(tiktoken.registry, "ENCODINGS", {})
+
+    def fail_if_network_requested(_: str) -> bytes:
+        raise AssertionError("cache must not be re-validated in this process")
+
+    monkeypatch.setattr(tiktoken.load, "read_file", fail_if_network_requested)
+
+    # 校验被跳过 → tiktoken 读到损坏缓存 → 删除后触网 → 被探针拦截
+    with pytest.raises(AssertionError, match="re-validated"):
+        get_encoding("o200k_base")
 
 
 def test_character_token_count_uses_shared_offline_encoding(


### PR DESCRIPTION
## PR 标题

fix(backend): 修复 tiktoken 词表缓存反复重写阻塞事件循环的问题

## 变更说明

- **问题**: #187 引入的 `seed_bundled_encodings()` 会在**每次** `get_encoding()` 时无条件把约 5.6MB 的词表文件重写到 tiktoken 缓存目录。而 token 计数是高频操作：auto-compact 对上下文逐消息计数且每轮 LLM 调用都会重数一遍（`react_agent.py`）、角色列表接口对每个角色计数（`characters.py` 的 `to_list_item_response`）、每次创建 LLM 客户端（含后台摘要任务）也会 seed 一次——大项目下 Agent 运行期间会累计 GB 级同步磁盘 I/O，全部落在 asyncio 事件循环上。
- **重要性**: 事件循环被长时间占住后，Socket.IO 既无法应答心跳、也无法接受新的 WebSocket 握手，前端表现为 `ping timeout` 断连且断连期间重连持续超时（#361）。Windows 上 Defender 对临时目录的实时扫描会进一步放大每次写入耗时；tiktoken ≥0.13 校验缓存哈希失败时还会"删除缓存 + 回退联网下载"，使单次计数的代价更糟。
- **变化**:
  1. `seed_bundled_encodings()` 增加"缓存文件已存在即跳过"守卫，seeding 从每次调用降为每机器一次；
  2. 写入改为临时文件 + `os.replace` 原子写，读方只会看到完整副本；
  3. `get_encoding()` 在调用 `tiktoken.get_encoding()` **之前**校验缓存内容：缺失或与内置词表字节不一致时原子重写，每个编码每进程只校验一次，后续调用直接放行——tiktoken 看到的缓存始终有效，全程不依赖网络。

## 关联 Issue / PR (如有)

Related to #361（本 PR 修复其主要根因；issue 中提到的内置 embedding 首次加载等次要阻塞源不在本 PR 范围，见补充信息）

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [x] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因(如有)

见"变更说明-问题"。两点设计说明：缓存内容校验刻意放在 `tiktoken.get_encoding()` 之前——tiktoken（≥0.13）只有在缓存存在且哈希正确时才离线命中，损坏缓存会被它删除并**联网重取**，若依赖其自愈，在线机器会先产生不必要的网络请求，离线机器则直接加载失败，因此校验与修复必须前置；校验方式是与内置词表逐字节比较（内置资源与官方 blob 一致，重写后自然通过 tiktoken 的 sha256 校验），且每个编码每进程只做一次，高频计数不会反复读数 MB 文件。另外排查中发现 `core.autocrlf=true` 的 Windows 检出会把内置词表行尾转为 CRLF，导致缓存哈希永远校验失败、每次加载都触发删除+联网下载（即 #187 的离线修复在此类检出上实际失效）——main 上已有的 `.gitattributes`（`*.tiktoken -text`）正是对此的防护，本 PR 依赖它。

## 自查清单

- [x] 已添加/更新必要的测试（新增：seed 幂等跳过、损坏缓存在进入 tiktoken 前被本地修复且全程不触网、校验每进程仅执行一次）
- [x] 已运行 lint 和类型检查，无报错（ruff check / ruff format --check）
- [x] 已运行测试用例，全部通过（`tests/core/test_tiktoken.py` 9/9；后端全量 `tests/` 1709/1709）
- [x] 变更范围合理，未包含无关修改
- [x] 未引入未经授权的新依赖
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 数据库变更已通过 Alembic 迁移管理（本 PR 无数据库变更）
- [x] 提交信息符合规范

## 补充信息

- 热路径微基准：预热后 1000 次 `count_tokens` 约 0.1s（约 0.1ms/次）；修复前每次调用要付约 5.6MB 读 + 5.6MB 写的同步 I/O。
- 关于 #361 建议的修复方向：调大 `ping_timeout` 只能压住症状，阻塞期间 UI 依旧无响应；"后台 worker 进程隔离"对本根因非必要——后台任务本身全部是 async（aiosqlite / 异步 LLM 客户端 / LanceDB async API），它们出问题是因为同样会触发本计数路径。
- 后续可选加固（不在本 PR）：将 `count_context_tokens` 挪入 `asyncio.to_thread`；fastembed 内置向量模型首次加载目前仍会同步阻塞事件循环（最长约 120s）。
