### PR TITLE
fix(frontend): 修复侧栏切换主题后重启不保留外观设置的问题

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,6 @@
 import { Theme } from "@radix-ui/themes";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { lazy, StrictMode, Suspense, useState, useEffect } from "react";
+import { lazy, StrictMode, Suspense, useCallback, useEffect, useRef, useState } from "react";
 import { ErrorBoundary } from "react-error-boundary";
 import { BrowserRouter, Routes, Route } from "react-router";
 
@@ -11,7 +11,7 @@ import { AppLayout } from "./features/app-shell";
 import { AuthPage } from "./features/auth";
 import { CharactersPage } from "./features/characters";
 import { PromptChainsPage } from "./features/prompt-chains";
-import { fetchSettings } from "./features/settings/lib/settings-api";
+import { fetchSettings, updateSettings } from "./features/settings/lib/settings-api";
 import type { Settings } from "./features/settings/lib/settings.types";
 import { WorldInfoPage } from "./features/world-info";
 import { WritingPage } from "./features/writing";
@@ -62,6 +62,7 @@ const queryClient = new QueryClient({
 
 const FRONTEND_VERSION = __OPENFIC_FRONTEND_VERSION__;
 const INITIALIZATION_TIMEOUT_MS = 30_000;
+const THEME_SYNC_DEBOUNCE_MS = 400;
 
 type InitializationStage = "preferences" | "auth" | "health" | "settings" | "tiktoken" | "socket";
 
@@ -218,10 +219,44 @@ function Root() {
   const [isReady, setIsReady] = useState(false);
   const [requiresAuthentication, setRequiresAuthentication] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // 防抖触发时读取最新外观,保证连点或设置对话框在窗口期内改值后不会发送过期主题。
+  const latestAppearanceRef = useRef<"light" | "dark">("light");
+  const themeSyncTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const toggleTheme = () => {
-    setAppearance((prev) => (prev === "light" ? "dark" : "light"));
-  };
+  const applyAppearance = useCallback((next: "light" | "dark") => {
+    latestAppearanceRef.current = next;
+    setAppearance(next);
+  }, []);
+
+  const persistAppearance = useCallback(async () => {
+    try {
+      const savedSettings = await updateSettings({ theme: latestAppearanceRef.current });
+      queryClient.setQueryData<Settings>(["settings"], savedSettings);
+    } catch (error) {
+      // 持久化失败只影响下次启动,不回滚当前外观;之后任意设置保存会自动带上最新主题修正。
+      console.warn("Failed to persist theme preference:", error);
+    }
+  }, []);
+
+  const scheduleAppearanceSync = useCallback(() => {
+    if (themeSyncTimerRef.current) clearTimeout(themeSyncTimerRef.current);
+    themeSyncTimerRef.current = setTimeout(() => {
+      themeSyncTimerRef.current = null;
+      void persistAppearance();
+    }, THEME_SYNC_DEBOUNCE_MS);
+  }, [persistAppearance]);
+
+  const toggleTheme = useCallback(() => {
+    applyAppearance(latestAppearanceRef.current === "light" ? "dark" : "light");
+    scheduleAppearanceSync();
+  }, [applyAppearance, scheduleAppearanceSync]);
+
+  useEffect(
+    () => () => {
+      if (themeSyncTimerRef.current) clearTimeout(themeSyncTimerRef.current);
+    },
+    [],
+  );
 
   useEffect(() => {
     let mounted = true;
@@ -246,7 +281,7 @@ function Root() {
         if (preferences.language === "zh-CN" || preferences.language === "en") {
           await i18n.changeLanguage(preferences.language);
         }
-        if (mounted) setAppearance(preferences.theme === "dark" ? "dark" : "light");
+        if (mounted) applyAppearance(preferences.theme === "dark" ? "dark" : "light");
 
         if (authStatus.enabled && !authStatus.authenticated) {
           if (mounted) {
@@ -286,7 +321,7 @@ function Root() {
         if (mounted) {
           setRequiresAuthentication(false);
           setSettings(settings);
-          setAppearance(settings.theme);
+          applyAppearance(settings.theme);
           setIsReady(true);
         }
       } catch (initializationError) {
@@ -308,7 +343,7 @@ function Root() {
       mounted = false;
       clearTimeout(timer);
     };
-  }, []);
+  }, [applyAppearance]);
 
   useEffect(() => {
     publishDesktopAppearance({
@@ -355,7 +390,7 @@ function Root() {
                 <AppContent
                   appearance={appearance}
                   version={FRONTEND_VERSION}
-                  setAppearance={setAppearance}
+                  setAppearance={applyAppearance}
                   toggleTheme={toggleTheme}
                 />
               </ErrorBoundary>


### PR DESCRIPTION
## PR 标题

fix(frontend): 修复侧栏切换主题后重启不保留外观设置的问题

## 变更说明

- **问题**: 侧栏底部的主题切换按钮（月亮/太阳图标）只通过 `main.tsx` 的 `toggleTheme` → `setAppearance` 更新 React 内存状态，从未写入后端 settings。应用启动时从 `/auth/preferences` 恢复的 `theme` 直接读自 settings 存储，所以只要没存进去，重开后必然回到旧值。该路径自仓库初始化起就没有持久化，不是近期回归。
- **重要性**: 用户日常基本都用这个快捷按钮切主题，因此表现为"每次打开都要重新调外观"（#377）。而"设置 → 通用 → 主题"能正常记住（走 `settings-content.tsx` 的 `saveMutation`），同一文件里紧挨着的语言切换也做了 `PUT /settings` 同步——两个入口行为不一致，唯独快捷按钮缺了写入这一步。
- **变化**:
  1. 新增 `applyAppearance` 作为所有改外观入口（初始化、侧栏按钮、设置对话框）的统一出口，同时维护 `latestAppearanceRef`；
  2. `toggleTheme` 改为"更新状态 + 400ms 防抖后 `PUT /settings { theme }`"，防抖触发时读取 ref 的最新值而非点击时捕获的值——连点合并为一个请求，设置对话框在窗口期内改值也不会被过期值覆盖回去；
  3. 保存成功后用 PUT 返回值更新 `["settings"]` 查询缓存（与 AI 侧栏 `toggleToolApprovalBypass` 的既有做法一致），设置对话框不会显示过期主题；
  4. 保存失败仅 `console.warn`、不回滚 UI：外观是纯装饰操作，闪回体验差；且设置对话框每次保存都会带上当前主题，下一次任意设置保存会自动修正漂移。

## 关联 Issue / PR

Closes #377

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因

见"变更说明-问题"。补充两点：后端 `PUT /settings` 本身支持 partial 更新（`settings.py` 中 `request.theme is not None` 才写入），`/auth/preferences` 返回的 `theme` 也直接取自 settings（`auth.py`），即后端存储与启动恢复链路都是完好的，缺的仅是快捷按钮这一处写入。#377 以 feature 形式提交，但从实现看属于快捷入口漏了持久化的缺陷，故按 fix 归类。

## 自查清单

- [ ] 已添加/更新必要的测试（前端无单测框架，现有 Playwright e2e 依赖完整后端环境且未接入 CI；已在真实环境手动验证，见补充信息）
- [x] 已运行 lint 和 typecheck，无报错（`pnpm lint` / `pnpm type-check` / `pnpm build`）
- [ ] 已运行测试用例，全部通过（无覆盖本路径的自动化用例）
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

- 手动验证（vite dev 代理到运行中的桌面版后端）：点击按钮 → 后端 `theme` 由 `light` 变为 `dark`；刷新页面后主题保持 `dark`；快速连点两次（dark→light→dark）经 PerformanceObserver 统计仅发出 1 个 `/settings` 请求且最终值正确。
- 行为变化提示：切换主题从零网络操作变为一次需鉴权的 `PUT`。在开启鉴权的 Web 部署下，会话过期后点击该按钮会触发 `api-client` 401 拦截器的整页重载并跳转登录——与保存章节等其他过期会话操作一致。本 PR 未对该拦截器做豁免：只豁免主题按钮会与设置对话框内的主题保存（同样走 `/settings`）行为不一致；桌面端默认不开鉴权，不受影响。
