### PR TITLE
fix(agent): 修复会话回滚因 checkpoint 清理失败整体报 500 的问题

### DIFF
--- a/backend/app/agent_runtime/revisions.py
+++ b/backend/app/agent_runtime/revisions.py
@@ -858,6 +858,9 @@ async def rollback_revision_for_session(
         session,
         agent_session_id,
         target.user_message_seq,
+        # 重入安全：checkpoint 清理失败的回滚重做时，已 rolled_back 的
+        # revision 也要参与子代理清理边界的重算，否则残留永远清不掉。
+        include_rolled_back=True,
     )
     restore_by_chapter: dict[str, RevisionChapterSnapshot] = {}
     restore_by_note: dict[str, RevisionNoteSnapshot] = {}

--- a/backend/app/agent_runtime/runner/checkpointer.py
+++ b/backend/app/agent_runtime/runner/checkpointer.py
@@ -2,9 +2,10 @@ import asyncio
 import dataclasses
 import os
 import shutil
+import sqlite3
 import time
 from collections import deque
-from collections.abc import Callable, Mapping
+from collections.abc import Awaitable, Callable, Mapping
 from contextlib import suppress
 from pathlib import Path
 from typing import Any
@@ -28,6 +29,90 @@ from app.storage.models.revision import Revision
 from app.storage.models.task import Task
 
 _checkpointer: AsyncSqliteSaver | None = None
+
+_CHECKPOINT_DB_BUSY_TIMEOUT_MS = 30_000
+_CHECKPOINT_DELETE_ATTEMPTS = 3
+_CHECKPOINT_DELETE_RETRY_BACKOFF_SECONDS = (0.5, 1.0)
+_BUSY_ERROR_MARKERS = ("database is locked", "database table is locked")
+
+
+def _is_busy_error(error: BaseException) -> bool:
+    return isinstance(error, sqlite3.OperationalError) and any(
+        marker in str(error).lower() for marker in _BUSY_ERROR_MARKERS
+    )
+
+
+async def _delete_with_retry(operation: Callable[[], Awaitable[int]]) -> int:
+    """对 busy 类错误做有界重试；其余异常立即抛出。
+
+    仅重试锁竞争（瞬态）：持久性错误（磁盘 I/O、库损坏）重试无意义，
+    且会无谓拖长失败路径的响应时间。
+    """
+    for attempt in range(1, _CHECKPOINT_DELETE_ATTEMPTS + 1):
+        try:
+            return await operation()
+        except Exception as error:
+            if attempt >= _CHECKPOINT_DELETE_ATTEMPTS or not _is_busy_error(error):
+                raise
+            delay = _CHECKPOINT_DELETE_RETRY_BACKOFF_SECONDS[
+                min(attempt - 1, len(_CHECKPOINT_DELETE_RETRY_BACKOFF_SECONDS) - 1)
+            ]
+            logger.bind(attempt=attempt, delay_seconds=delay).warning(
+                "checkpoint delete blocked by busy database, retrying"
+            )
+            await asyncio.sleep(delay)
+    raise AssertionError("unreachable")  # pragma: no cover
+
+
+class _CancellationSafeSqliteSaver(AsyncSqliteSaver):
+    """写入被取消时回滚未完成的事务，避免连接滞留在打开的写事务中。
+
+    AsyncSqliteSaver 的写入路径（aput/aput_writes）在执行完 INSERT 后手动
+    ``conn.commit()``，没有事务上下文。若任务在这两者之间被取消
+    （CancelledError 不会被 ``except Exception`` 捕获），连接会一直持有
+    SQLite 写锁，之后所有会话的 checkpoint 写入与清理都会以
+    ``database is locked`` 失败，直到进程重启。
+    """
+
+    async def aput(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: Any,
+        new_versions: Any,
+    ) -> Any:
+        try:
+            return await super().aput(config, checkpoint, metadata, new_versions)
+        except asyncio.CancelledError:
+            await self._rollback_pending_transaction()
+            raise
+
+    async def aput_writes(
+        self,
+        config: RunnableConfig,
+        writes: Any,
+        task_id: str,
+        task_path: str = "",
+    ) -> None:
+        try:
+            return await super().aput_writes(config, writes, task_id, task_path)
+        except asyncio.CancelledError:
+            await self._rollback_pending_transaction()
+            raise
+
+    async def adelete_thread(self, thread_id: str) -> None:
+        try:
+            return await super().adelete_thread(thread_id)
+        except asyncio.CancelledError:
+            await self._rollback_pending_transaction()
+            raise
+
+    async def _rollback_pending_transaction(self) -> None:
+        # sqlite3 对无事务的连接是 no-op；失败只能吞掉，不能覆盖取消栈。
+        try:
+            await self.conn.rollback()
+        except Exception:
+            logger.warning("checkpoint connection rollback after cancellation failed")
 
 _ALLOWED_MSGPACK_MODULES = (
     ("app.agent_runtime.tools.impls.interaction.ask_user", "Question"),
@@ -366,7 +451,7 @@ async def get_checkpointer() -> AsyncSqliteSaver:
             await conn.execute("PRAGMA auto_vacuum = INCREMENTAL")
             await _mark_incremental_auto_vacuum_migration_completed(conn)
         await _configure_checkpoint_connection(conn)
-        _checkpointer = AsyncSqliteSaver(
+        _checkpointer = _CancellationSafeSqliteSaver(
             conn,
             serde=_CheckpointSerializer(
                 allowed_msgpack_modules=_ALLOWED_MSGPACK_MODULES,
@@ -510,26 +595,51 @@ async def _mark_incremental_auto_vacuum_migration_completed(
         await cursor.close()
 
 
-async def delete_checkpoints_for_thread(thread_id: str) -> int:
+async def _open_checkpoint_connection(db_path: str) -> aiosqlite.Connection:
+    """打开独立的 checkpoint 连接。
+
+    与常驻 saver 连接对齐 busy_timeout：裸连接默认只等 5 秒，
+    在写入方（WAL 单写者）持锁较久时会立即以 locked 失败。
+    """
+    conn = await aiosqlite.connect(db_path)
+    cursor = await conn.execute(f"PRAGMA busy_timeout = {_CHECKPOINT_DB_BUSY_TIMEOUT_MS}")
+    await cursor.close()
+    return conn
+
+
+async def delete_checkpoints_for_thread(
+    thread_id: str, *, retry_on_busy: bool = False
+) -> int:
     if not thread_id:
         return 0
 
     db_path = _get_db_path()
     Path(db_path).parent.mkdir(parents=True, exist_ok=True)
 
-    conn = await aiosqlite.connect(db_path)
+    conn = await _open_checkpoint_connection(db_path)
     try:
-        before = conn.total_changes
-        await conn.execute("DELETE FROM writes WHERE thread_id = ?", (thread_id,))
-        await conn.execute("DELETE FROM checkpoints WHERE thread_id = ?", (thread_id,))
-        await conn.commit()
-        return conn.total_changes - before
+
+        async def _delete() -> int:
+            before = conn.total_changes
+            await conn.execute("DELETE FROM writes WHERE thread_id = ?", (thread_id,))
+            await conn.execute(
+                "DELETE FROM checkpoints WHERE thread_id = ?", (thread_id,)
+            )
+            await conn.commit()
+            return conn.total_changes - before
+
+        if retry_on_busy:
+            return await _delete_with_retry(_delete)
+        return await _delete()
     finally:
         await conn.close()
 
 
 async def delete_checkpoints_after_for_thread(
-    thread_id: str, after_checkpoint_id: str
+    thread_id: str,
+    after_checkpoint_id: str,
+    *,
+    retry_on_busy: bool = False,
 ) -> int:
     # LangGraph checkpoint_id is UUID v6 (time-ordered), so lexicographic
     # comparison is equivalent to chronological order across all namespaces
@@ -540,19 +650,25 @@ async def delete_checkpoints_after_for_thread(
     db_path = _get_db_path()
     Path(db_path).parent.mkdir(parents=True, exist_ok=True)
 
-    conn = await aiosqlite.connect(db_path)
+    conn = await _open_checkpoint_connection(db_path)
     try:
-        before = conn.total_changes
-        await conn.execute(
-            "DELETE FROM writes WHERE thread_id = ? AND checkpoint_id > ?",
-            (thread_id, after_checkpoint_id),
-        )
-        await conn.execute(
-            "DELETE FROM checkpoints WHERE thread_id = ? AND checkpoint_id > ?",
-            (thread_id, after_checkpoint_id),
-        )
-        await conn.commit()
-        return conn.total_changes - before
+
+        async def _delete() -> int:
+            before = conn.total_changes
+            await conn.execute(
+                "DELETE FROM writes WHERE thread_id = ? AND checkpoint_id > ?",
+                (thread_id, after_checkpoint_id),
+            )
+            await conn.execute(
+                "DELETE FROM checkpoints WHERE thread_id = ? AND checkpoint_id > ?",
+                (thread_id, after_checkpoint_id),
+            )
+            await conn.commit()
+            return conn.total_changes - before
+
+        if retry_on_busy:
+            return await _delete_with_retry(_delete)
+        return await _delete()
     finally:
         await conn.close()
 

--- a/backend/app/api/routers/agent_runtime.py
+++ b/backend/app/api/routers/agent_runtime.py
@@ -1554,6 +1554,36 @@ async def cancel_subagent_session(
     )
 
 
+async def _cleanup_checkpoints_until_boundary(
+    thread_id: str,
+    checkpoint_id: str | None,
+    *,
+    log_context: dict[str, str],
+    failure_message: str,
+) -> None:
+    """删除回滚边界之后的 checkpoint（busy 类错误有界重试）；最终失败抛 503。
+
+    revision 层在调用前已提交，静默降级会让数据层与会话状态层无声分叉、
+    且用户没有任何修复入口；重做回滚是幂等的（包括子代理清理边界重算），
+    因此以 503 引导用户重试，由重试完成剩余清理。
+    """
+    try:
+        if checkpoint_id:
+            await delete_checkpoints_after_for_thread(
+                thread_id, checkpoint_id, retry_on_busy=True
+            )
+        else:
+            await delete_checkpoints_for_thread(thread_id, retry_on_busy=True)
+    except HTTPException:
+        raise
+    except Exception:
+        logger.bind(**log_context).opt(exception=True).error(failure_message)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="数据已回滚，但会话状态清理未完成，请再次执行回滚以完成清理",
+        )
+
+
 @router.post("/sessions/{session_id}/rollback", response_model=AgentRollbackResponse)
 async def rollback_agent_session(
     session_id: str,
@@ -1587,15 +1617,12 @@ async def rollback_agent_session(
         replay_buffer.clear_session_unlocked(session_id)
 
     if result.restored_checkpoint_id:
-        try:
-            await delete_checkpoints_after_for_thread(
-                session_id, result.restored_checkpoint_id
-            )
-        except Exception:
-            logger.bind(session_id=session_id).opt(exception=True).error(
-                "Agent graph checkpoint rollback failed after revision rollback"
-            )
-            raise
+        await _cleanup_checkpoints_until_boundary(
+            session_id,
+            result.restored_checkpoint_id,
+            log_context={"session_id": session_id},
+            failure_message="Agent graph checkpoint rollback failed after revision rollback",
+        )
     if result.affected_child_run_ids:
         status_publisher = SubagentRunner(
             session_factory=_make_status_session_factory(session),
@@ -1623,19 +1650,12 @@ async def rollback_agent_session(
             room=agent_session_room(session_id),
         )
     for child_thread_id, checkpoint_id in result.child_checkpoint_boundaries:
-        try:
-            if checkpoint_id:
-                await delete_checkpoints_after_for_thread(child_thread_id, checkpoint_id)
-            else:
-                await delete_checkpoints_for_thread(child_thread_id)
-        except Exception:
-            logger.bind(
-                session_id=session_id,
-                child_thread_id=child_thread_id,
-            ).opt(exception=True).error(
-                "Agent subagent checkpoint rollback failed after revision rollback"
-            )
-            raise
+        await _cleanup_checkpoints_until_boundary(
+            child_thread_id,
+            checkpoint_id,
+            log_context={"session_id": session_id, "child_thread_id": child_thread_id},
+            failure_message="Agent subagent checkpoint rollback failed after revision rollback",
+        )
 
     return AgentRollbackResponse(
         success=True,

--- a/backend/app/storage/repos/revision_repo.py
+++ b/backend/app/storage/repos/revision_repo.py
@@ -83,15 +83,25 @@ async def list_by_agent_session_from_seq(
     session: AsyncSession,
     agent_session_id: str,
     user_message_seq: int,
+    *,
+    include_rolled_back: bool = False,
 ) -> list[Revision]:
-    """List non-rollback agent revisions from a user message seq onward."""
-    result = await session.execute(
+    """List non-rollback agent revisions from a user message seq onward.
+
+    include_rolled_back 供回滚重入使用：部分失败的回滚（数据层已提交、
+    checkpoint 清理未完成）重做时，已标记 rolled_back 的 revision 也要
+    纳入，否则子代理清理边界无法重算。
+    """
+    query = (
         select(Revision)
         .where(col(Revision.agent_session_id) == agent_session_id)
         .where(col(Revision.revision_type) == "agent")
-        .where(col(Revision.status) != "rolled_back")
         .where(col(Revision.user_message_seq) >= user_message_seq)
-        .order_by(col(Revision.user_message_seq).asc(), col(Revision.created_at).asc())
+    )
+    if not include_rolled_back:
+        query = query.where(col(Revision.status) != "rolled_back")
+    result = await session.execute(
+        query.order_by(col(Revision.user_message_seq).asc(), col(Revision.created_at).asc())
     )
     return list(result.scalars().all())
 

--- a/backend/tests/agent_runtime/test_agent_revision_rollback.py
+++ b/backend/tests/agent_runtime/test_agent_revision_rollback.py
@@ -1514,3 +1514,85 @@ async def test_rollback_revision_restores_deleted_characters(revision_db):
     assert character_after is not None
     assert character_after.name == "已有角色"
     assert character_after.description == "原始角色描述"
+
+
+async def test_rollback_reentry_still_recomputes_child_cleanup_boundaries(revision_db):
+    """重做回滚时子代理清理边界必须重算（checkpoint 清理失败后的恢复路径）。
+
+    回滚会把范围内 revision 标记 rolled_back；若范围查询把它们过滤掉，
+    第二次回滚将拿不到子代理清理边界，残留 checkpoint 永远清不掉。
+    """
+    from app.agent_runtime.persistence.model import AgentChildRun, AgentChildRunRequest
+    from app.agent_runtime.revisions import begin_user_revision, rollback_revision_for_session
+
+    async with revision_db() as session:
+        user = await message_repo.insert_message(
+            session,
+            session_id="sess-1",
+            task_id="task-1",
+            project_id="proj-1",
+            role="user",
+            status="sent",
+            content="委派子代理写章节",
+        )
+        revision = await begin_user_revision(
+            session,
+            project_id="proj-1",
+            task_id="task-1",
+            agent_session_id="sess-1",
+            user_message_id=user.id,
+            user_message_seq=user.seq,
+            message="用户消息: 委派子代理写章节",
+            pre_run_checkpoint_id="cp-parent-before",
+            graph_thread_id="sess-1",
+        )
+        child_run = AgentChildRun(
+            parent_session_id="sess-1",
+            parent_task_id="task-1",
+            parent_thread_id="sess-1",
+            child_thread_id="sess-1:child:writer",
+            agent_key="writer",
+            dispatch_id="dispatch-1",
+            tool_call_id="call-1",
+            status="running",
+            is_active=True,
+            parent_revision_id=revision.id,
+        )
+        session.add(child_run)
+        await session.flush()
+        session.add(
+            AgentChildRunRequest(
+                child_run_id=child_run.id,
+                parent_session_id="sess-1",
+                parent_task_id="task-1",
+                request_kind="dispatch",
+                content="写章节",
+                status="running",
+                parent_revision_id=revision.id,
+                pre_request_checkpoint_id="cp-child-before",
+                seq=0,
+            )
+        )
+        await session.commit()
+
+        first = await rollback_revision_for_session(
+            session,
+            agent_session_id="sess-1",
+            revision_id=revision.id,
+        )
+        await session.commit()
+
+        assert ("sess-1:child:writer", "cp-child-before") in first.child_checkpoint_boundaries
+        assert first.affected_child_run_ids
+
+        # 模拟清理失败后的用户重试：目标 revision 已是 rolled_back，
+        # 第二次回滚仍必须给出同样的子代理清理边界。
+        second = await rollback_revision_for_session(
+            session,
+            agent_session_id="sess-1",
+            revision_id=revision.id,
+        )
+        await session.commit()
+
+    assert ("sess-1:child:writer", "cp-child-before") in second.child_checkpoint_boundaries
+    assert second.affected_child_run_ids

--- a/backend/tests/agent_runtime/test_agent_rollback_cleanup.py
+++ b/backend/tests/agent_runtime/test_agent_rollback_cleanup.py
@@ -1,0 +1,78 @@
+"""回滚时 checkpoint 清理的失败语义测试。
+
+删除失败必须抛 503 引导用户重做回滚：revision 层在此之前已提交，
+重做是幂等的（包括子代理清理边界重算），静默降级会让数据层与
+会话状态层无声分叉且没有修复入口。
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.api.routers.agent_runtime import _cleanup_checkpoints_until_boundary
+
+
+@pytest.fixture
+def delete_mocks(monkeypatch: pytest.MonkeyPatch) -> tuple[AsyncMock, AsyncMock]:
+    after = AsyncMock(return_value=3)
+    full = AsyncMock(return_value=5)
+    monkeypatch.setattr(
+        "app.api.routers.agent_runtime.delete_checkpoints_after_for_thread", after
+    )
+    monkeypatch.setattr(
+        "app.api.routers.agent_runtime.delete_checkpoints_for_thread", full
+    )
+    return after, full
+
+
+@pytest.mark.asyncio
+async def test_cleanup_uses_boundary_delete_when_checkpoint_id_present(
+    delete_mocks: tuple[AsyncMock, AsyncMock],
+):
+    after, full = delete_mocks
+
+    await _cleanup_checkpoints_until_boundary(
+        "thread-1",
+        "checkpoint-9",
+        log_context={"session_id": "s-1"},
+        failure_message="failed",
+    )
+
+    after.assert_awaited_once_with("thread-1", "checkpoint-9", retry_on_busy=True)
+    full.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_uses_full_delete_without_checkpoint_id(
+    delete_mocks: tuple[AsyncMock, AsyncMock],
+):
+    after, full = delete_mocks
+
+    await _cleanup_checkpoints_until_boundary(
+        "thread-1",
+        None,
+        log_context={"session_id": "s-1"},
+        failure_message="failed",
+    )
+
+    full.assert_awaited_once_with("thread-1", retry_on_busy=True)
+    after.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_raises_503_when_delete_finally_fails(
+    delete_mocks: tuple[AsyncMock, AsyncMock],
+):
+    after, _full = delete_mocks
+    after.side_effect = RuntimeError("database is locked")
+
+    with pytest.raises(HTTPException) as excinfo:
+        await _cleanup_checkpoints_until_boundary(
+            "thread-1",
+            "checkpoint-9",
+            log_context={"session_id": "s-1"},
+            failure_message="failed",
+        )
+
+    assert excinfo.value.status_code == 503

--- a/backend/tests/agent_runtime/test_checkpointer.py
+++ b/backend/tests/agent_runtime/test_checkpointer.py
@@ -1,5 +1,6 @@
 from contextlib import closing
 from dataclasses import dataclass
+import asyncio
 import os
 import sqlite3
 import tempfile
@@ -924,3 +925,179 @@ async def test_reset_checkpointer_closes_existing_connection(monkeypatch):
 
     close.assert_awaited_once()
     assert checkpointer_mod._checkpointer is None
+
+
+async def test_open_checkpoint_connection_sets_long_busy_timeout(tmp_path: Path):
+    db_path = tmp_path / "checkpoints.db"
+
+    conn = await checkpointer_mod._open_checkpoint_connection(str(db_path))
+    try:
+        cursor = await conn.execute("PRAGMA busy_timeout")
+        try:
+            row = await cursor.fetchone()
+        finally:
+            await cursor.close()
+        assert row is not None and row[0] == 30000
+    finally:
+        await conn.close()
+
+
+async def test_cancellation_safe_saver_rolls_back_and_reraises_on_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    db_path = tmp_path / "checkpoints.db"
+    conn = await aiosqlite.connect(str(db_path))
+    saver = checkpointer_mod._CancellationSafeSqliteSaver(conn)
+    try:
+        await saver.setup()
+        rollback_spy = AsyncMock(wraps=conn.rollback)
+        monkeypatch.setattr(conn, "rollback", rollback_spy)
+
+        async def cancelled_aput(*args, **kwargs):
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(AsyncSqliteSaver, "aput", cancelled_aput)
+        config = {"configurable": {"thread_id": "thread-1", "checkpoint_ns": ""}}
+        checkpoint = cast(Checkpoint, SimpleNamespace())
+
+        with pytest.raises(asyncio.CancelledError):
+            await saver.aput(config, checkpoint, {}, {})
+
+        rollback_spy.assert_awaited_once()
+    finally:
+        await conn.close()
+
+
+async def test_cancellation_safe_saver_keeps_error_without_rollback_on_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    db_path = tmp_path / "checkpoints.db"
+    conn = await aiosqlite.connect(str(db_path))
+    saver = checkpointer_mod._CancellationSafeSqliteSaver(conn)
+    try:
+        await saver.setup()
+        rollback_spy = AsyncMock(wraps=conn.rollback)
+        monkeypatch.setattr(conn, "rollback", rollback_spy)
+
+        async def failing_aput(*args, **kwargs):
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(AsyncSqliteSaver, "aput", failing_aput)
+        config = {"configurable": {"thread_id": "thread-1", "checkpoint_ns": ""}}
+        checkpoint = cast(Checkpoint, SimpleNamespace())
+
+        with pytest.raises(RuntimeError, match="boom"):
+            await saver.aput(config, checkpoint, {}, {})
+
+        rollback_spy.assert_not_awaited()
+    finally:
+        await conn.close()
+
+
+async def test_cancellation_safe_saver_rolls_back_pending_writes_on_cancel(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    db_path = tmp_path / "checkpoints.db"
+    conn = await aiosqlite.connect(str(db_path))
+    saver = checkpointer_mod._CancellationSafeSqliteSaver(conn)
+    try:
+        await saver.setup()
+        rollback_spy = AsyncMock(wraps=conn.rollback)
+        monkeypatch.setattr(conn, "rollback", rollback_spy)
+
+        async def cancelled_aput_writes(*args, **kwargs):
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(AsyncSqliteSaver, "aput_writes", cancelled_aput_writes)
+        config = {"configurable": {"thread_id": "thread-1", "checkpoint_ns": ""}}
+
+        with pytest.raises(asyncio.CancelledError):
+            await saver.aput_writes(config, [("channel", "value")], "task-1")
+
+        rollback_spy.assert_awaited_once()
+    finally:
+        await conn.close()
+
+
+def test_is_busy_error_classifies_lock_errors():
+    assert checkpointer_mod._is_busy_error(
+        sqlite3.OperationalError("database is locked")
+    )
+    assert checkpointer_mod._is_busy_error(
+        sqlite3.OperationalError("database table is locked")
+    )
+    assert not checkpointer_mod._is_busy_error(
+        sqlite3.OperationalError("no such table: checkpoints")
+    )
+    assert not checkpointer_mod._is_busy_error(RuntimeError("database is locked"))
+    assert not checkpointer_mod._is_busy_error(RuntimeError("boom"))
+
+
+async def test_delete_with_retry_succeeds_without_retry():
+    calls = 0
+
+    async def operation() -> int:
+        nonlocal calls
+        calls += 1
+        return 7
+
+    assert await checkpointer_mod._delete_with_retry(operation) == 7
+    assert calls == 1
+
+
+async def test_delete_with_retry_recovers_from_transient_busy(monkeypatch):
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    monkeypatch.setattr(checkpointer_mod.asyncio, "sleep", fake_sleep)
+    calls = 0
+
+    async def operation() -> int:
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise sqlite3.OperationalError("database is locked")
+        return 9
+
+    assert await checkpointer_mod._delete_with_retry(operation) == 9
+    assert calls == 3
+    assert sleep_calls == [0.5, 1.0]
+
+
+async def test_delete_with_retry_raises_after_exhausting_attempts(monkeypatch):
+    async def fake_sleep(delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(checkpointer_mod.asyncio, "sleep", fake_sleep)
+    calls = 0
+
+    async def operation() -> int:
+        nonlocal calls
+        calls += 1
+        raise sqlite3.OperationalError("database is locked")
+
+    with pytest.raises(sqlite3.OperationalError, match="database is locked"):
+        await checkpointer_mod._delete_with_retry(operation)
+    assert calls == 3
+
+
+async def test_delete_with_retry_fails_fast_on_non_busy_error(monkeypatch):
+    async def fail_fast_sleep(delay: float) -> None:
+        raise AssertionError("must not sleep on non-busy error")
+
+    monkeypatch.setattr(checkpointer_mod.asyncio, "sleep", fail_fast_sleep)
+    calls = 0
+
+    async def operation() -> int:
+        nonlocal calls
+        calls += 1
+        raise sqlite3.OperationalError("no such table: checkpoints")
+
+    with pytest.raises(sqlite3.OperationalError, match="no such table"):
+        await checkpointer_mod._delete_with_retry(operation)
+    assert calls == 1

--- a/backend/tests/api/test_agent.py
+++ b/backend/tests/api/test_agent.py
@@ -3967,9 +3967,11 @@ class TestAgentAPI:
         fake_runner.cancel.assert_called_once()
         fake_registry.cancel.assert_awaited_once_with("sess-rollback")
         delete_checkpoints_after_mock.assert_awaited_once_with(
-            "sess-rollback", "cp-before"
+            "sess-rollback", "cp-before", retry_on_busy=True
         )
-        delete_checkpoints_for_thread_mock.assert_awaited_once_with(child.child_thread_id)
+        delete_checkpoints_for_thread_mock.assert_awaited_once_with(
+            child.child_thread_id, retry_on_busy=True
+        )
         replayed = buffer.replay_events_unlocked("sess-rollback")
         assert all(event.name != "agent:tool_call" for event in replayed)
         rollback_statuses = [

--- a/frontend/src/features/assistant/hooks/use-agent-session.ts
+++ b/frontend/src/features/assistant/hooks/use-agent-session.ts
@@ -1497,7 +1497,12 @@ export function useAgentSession({
         }
       } catch (error) {
         console.error("Rollback failed:", error);
-        toast.error(i18n.t("assistant.rollbackFailed"));
+        // 503：数据层已回滚但 checkpoint 清理未完成，重做回滚可幂等补完清理
+        if ((error as { response?: { status?: number } })?.response?.status === 503) {
+          toast.error(i18n.t("assistant.rollbackCleanupPending"), { duration: 8000 });
+        } else {
+          toast.error(i18n.t("assistant.rollbackFailed"));
+        }
         return null;
       } finally {
         setIsRollbacking(false);

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1906,6 +1906,7 @@
     "rollbackOnlyUserMessage": "Rollback is only available for user messages",
     "rollbackNoRevision": "This message node has no revision info",
     "rollbackSuccess": "Rolled back to the state before this message was sent",
+    "rollbackCleanupPending": "Data was rolled back, but session state cleanup did not finish. Run rollback on that message again to complete cleanup",
     "rollbackFailed": "Rollback failed",
     "forkImpossible": "Fork cannot be performed",
     "forkNoRevision": "This message node has no revision info and cannot be forked",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1969,6 +1969,7 @@
     "rollbackOnlyUserMessage": "只能回滚到用户消息节点",
     "rollbackNoRevision": "该消息节点没有 revision 信息",
     "rollbackSuccess": "已回滚到该消息发送前的状态",
+    "rollbackCleanupPending": "数据已回滚，但会话状态清理未完成。请对该消息再次执行回滚以完成清理",
     "rollbackFailed": "回滚失败",
     "forkImpossible": "无法执行分叉操作",
     "forkNoRevision": "该消息节点没有 revision 信息，无法分叉",


### PR DESCRIPTION
## PR 标题

fix(agent): 修复会话回滚因 checkpoint 清理失败整体报 500 的问题

## 变更说明

- **问题**: #378 故障链第 1 环。回滚端点在 revision 层提交之后删除 LangGraph checkpoint，删除失败会重新抛出导致接口 500。而 revision 已不可逆提交，500 只会诱发前端重试并叠加 rollback revision，数据层与会话状态层从此分叉。
- **重要性**: issue 报告中同一次回滚"连续报错多次"与该机制吻合。删除失败的高概率诱因：① 被取消任务收尾期间的 checkpoint 写入仍持有 SQLite 写锁；`AsyncSqliteSaver` 的写入在 execute 与手动 `commit()` 之间被取消时（`CancelledError` 不被 `except Exception` 捕获），常驻连接会滞留在打开的写事务中，**锁被永久持有直到进程重启**，之后所有会话的 checkpoint 写入/清理都失败。② 清理用的裸 aiosqlite 连接 busy_timeout 只有默认 5 秒（常驻 saver 连接是 30 秒）。另外还存在一个**回滚重入盲区**：回滚会把范围内 revision 标记 `rolled_back`，而子代理清理范围查询会过滤掉它们——首次清理失败后，无论用户重试多少次回滚，子代理的残留 checkpoint 都无法再清理。
- **变化**:
  1. 新增 `_CancellationSafeSqliteSaver`：`aput` / `aput_writes` / `adelete_thread` 被取消时先回滚未完成事务再传播取消，消除脏事务锁；
  2. checkpoint 清理连接对齐 `busy_timeout=30s`；回滚路径的删除对 busy 类错误做有界重试（3 次尝试，0.5s/1s 退避；其余错误快速失败）；
  3. 清理最终失败抛 503，前端识别 503 并提示"数据已回滚，请再次执行回滚以完成清理"；重做回滚是幂等的，由重试补完剩余清理。**不提供"部分成功"的降级语义**——静默降级会让两层无声分叉且用户没有修复入口；
  4. 修复重入盲区：`list_by_agent_session_from_seq` 新增 `include_rolled_back` 参数（仅回滚路径使用），重做回滚时已 rolled_back 的 revision 也参与子代理清理边界重算。重入恢复由 `_has_changed` 守卫保证幂等，不会重复写变更/审计记录。

## 关联 Issue / PR

Related to #378（本 PR 处理其故障链第 1 环：回滚 500 与数据层/状态层不一致；在途子代理写入失败与 error+is_active 残留属于子代理生命周期问题，将另行处理，故不使用 Closes 关键词）

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因

见"变更说明-问题"。补充两点设计取舍：其一，主库（revision）与 checkpoint 库是两个数据库，不存在跨库原子性，"先删 checkpoint 再提交 revision"失败时是反向不一致（更难解释），因此不调整提交顺序，而是让删除尽量成功（消除脏事务锁 + 对齐 busy_timeout + 有界重试）+ 失败时以 503 引导幂等重试。其二，曾考虑过"删除失败降级为成功 + 响应字段告知"的方案并实现过一版，最终放弃：降级后下一次对话会从滞留的最新 checkpoint 恢复，agent 带着已回滚的上下文继续、可能重新污染已回滚的数据，故障从"明确的 500"变成"静默的状态错位"，且普通用户没有真实的修复入口。

## 自查清单

- [x] 已添加/更新必要的测试（新增 7 个用例：清理连接 busy_timeout、取消安全 saver 回滚/传播/非取消异常不回滚、busy 分类、有界重试恢复/耗尽/快速失败、清理最终失败抛 503、回滚重入仍重算子代理清理边界）
- [x] 已运行 lint 和 typecheck，无报错（`ruff check .` / `ty check app` / 前端 `type-check` / `lint`）
- [x] 已运行测试用例，全部通过（`tests/agent_runtime` 843/843；前端 `build` 通过）
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

- 503 时前端不截断本地消息列表，而服务端消息已删除，刷新后一致；此 UI 时序问题在原 500 路径同样存在，非本 PR 引入，留待后续单独处理。
- 同会话并发回滚（多标签页）仍未串行化，属既有行为；本 PR 的重试窗口并未使其显著变宽（单次删除本就可等待 busy_timeout 30s）。
- `include_rolled_back=True` 对混合回滚历史（范围内含更早回滚标记的 revision）同样安全：快照恢复按最早 revision 的 setdefault 取值，已恢复项的重复写入被 `_has_changed` 守卫跳过。
- 手动验证建议（Windows，复现 #378 的环境）：派发 Composer 子代理 → 未完成时对主会话回滚 → 回滚不再 500；若底层删除持续失败，应得到 503 与"请再次执行回滚"提示，重做后清理完成。
