### PR TITLE
fix(backend): 修复兼容接口无法读取推理内容的问题

### DIFF
--- a/backend/app/models/clients/model_factory.py
+++ b/backend/app/models/clients/model_factory.py
@@ -347,6 +347,40 @@ def create_chat_model(config: ModelConfig) -> Runnable[LanguageModelInput, BaseM
         return model.with_thinking_mode(enabled=True) if reasoning_effort else model
 
     # OpenAI-compatible fallback (openai, huggingface, openai-compatible, unknown)
-    from langchain_openai import ChatOpenAI
+    from langchain_core.outputs import ChatGenerationChunk
+    from langchain_openai import ChatOpenAI as _ChatOpenAI
+
+    class ChatOpenAI(_ChatOpenAI):
+        def _convert_chunk_to_generation_chunk(
+            self,
+            chunk: dict,
+            default_chunk_class: type,
+            base_generation_info: dict | None,
+        ) -> ChatGenerationChunk | None:
+            generation_chunk = super()._convert_chunk_to_generation_chunk(
+                chunk,
+                default_chunk_class,
+                base_generation_info,
+            )
+            if generation_chunk is None:
+                return None
+
+            choices = chunk.get("choices")
+            if not isinstance(choices, list) or not choices:
+                return generation_chunk
+            choice = choices[0]
+            if not isinstance(choice, dict):
+                return generation_chunk
+            delta = choice.get("delta")
+            reasoning_content = (
+                delta.get("reasoning_content")
+                if isinstance(delta, dict)
+                else None
+            )
+            if isinstance(reasoning_content, str):
+                generation_chunk.message.additional_kwargs["reasoning_content"] = (
+                    reasoning_content
+                )
+            return generation_chunk
 
     return ChatOpenAI(**_openai_compatible_kwargs(config))

--- a/backend/tests/providers/test_llm_client.py
+++ b/backend/tests/providers/test_llm_client.py
@@ -6,6 +6,7 @@ import pytest
 
 from app.core.errors import LLMTimeoutError
 from app.models.clients.llm_client import LLMClient, LLMConfig, _patch_deepseek_reasoning_payload
+from app.models.clients.model_factory import ModelConfig, create_chat_model
 
 
 def test_patch_deepseek_reasoning_payload_adds_reasoning_content() -> None:
@@ -33,6 +34,48 @@ def test_patch_deepseek_reasoning_payload_adds_reasoning_content() -> None:
     _patch_deepseek_reasoning_payload(messages, payload)
 
     assert payload["messages"][1]["reasoning_content"] == "need chapter content"
+
+
+def _create_openai_compatible_model() -> Any:
+    return create_chat_model(
+        ModelConfig(
+            provider_type="openai-compatible",
+            base_url="https://example.com/v1",
+            api_key="test",
+            model_id="test-model",
+        )
+    )
+
+
+def test_openai_compatible_keeps_chat_openai_runtime_name() -> None:
+    model = _create_openai_compatible_model()
+
+    assert model.get_name() == "ChatOpenAI"
+    assert model.lc_id()[-1] == "ChatOpenAI"
+
+
+def test_openai_compatible_preserves_reasoning_content_in_stream() -> None:
+    model = _create_openai_compatible_model()
+
+    generation = model._convert_chunk_to_generation_chunk(
+        {
+            "choices": [
+                {
+                    "delta": {
+                        "role": "assistant",
+                        "content": "",
+                        "reasoning_content": "think\nnext",
+                    },
+                    "finish_reason": None,
+                }
+            ]
+        },
+        AIMessageChunk,
+        None,
+    )
+
+    assert generation is not None
+    assert generation.message.additional_kwargs["reasoning_content"] == "think\nnext"
 
 
 def test_extract_usage_prefers_usage_metadata() -> None:


### PR DESCRIPTION
## 变更说明

- 问题: 通用 OpenAI Compatible 分支会丢弃提供商返回的 `reasoning_content`。
- 重要性: 思考模型的推理内容无法进入 Agent 的事件和展示链路。
- 变化: 在通用 `ChatOpenAI` 流式转换中保留 `reasoning_content`，并保持运行名称为 `ChatOpenAI`。

## 关联 Issue / PR

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因

LangChain 的标准 `ChatOpenAI` 转换只处理标准 delta 字段，未将兼容提供商额外返回的 `reasoning_content` 写入 `AIMessageChunk.additional_kwargs`，导致后续链路无法读取。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

无