### PR TITLE
fix(desktop): 修复卸载时缺失运行环境目录报错

### DIFF
--- a/desktop/build/installer.nsh
+++ b/desktop/build/installer.nsh
@@ -151,39 +151,36 @@ Function un.openficRemoveDirect
   Push $R3
   Push $R4
 
-  IfFileExists "$INSTDIR$R0" openfic_direct_exists openfic_direct_success
-
-  openfic_direct_exists:
-    ClearErrors
-    ${GetFileAttributes} "$INSTDIR$R0" "REPARSE_POINT" $R4
-    IfErrors openfic_direct_error_no_close
-    ${if} $R4 == "1"
-      ${GetFileAttributes} "$INSTDIR$R0" "DIRECTORY" $R4
-      IfErrors openfic_direct_error_no_close
-      ${if} $R4 == "1"
-        ClearErrors
-        RMDir "$INSTDIR$R0"
-      ${else}
-        ClearErrors
-        Delete "$INSTDIR$R0"
-      ${endif}
-      IfErrors openfic_direct_error_no_close
-      Goto openfic_direct_success
-    ${endif}
-
+  ClearErrors
+  ${GetFileAttributes} "$INSTDIR$R0" "REPARSE_POINT" $R4
+  IfErrors openfic_direct_success
+  ${if} $R4 == "1"
     ${GetFileAttributes} "$INSTDIR$R0" "DIRECTORY" $R4
     IfErrors openfic_direct_error_no_close
-    ${if} $R4 != "1"
+    ${if} $R4 == "1"
+      ClearErrors
+      RMDir "$INSTDIR$R0"
+    ${else}
       ClearErrors
       Delete "$INSTDIR$R0"
-      IfErrors openfic_direct_error_no_close
-      Goto openfic_direct_success
     ${endif}
+    IfErrors openfic_direct_error_no_close
+    Goto openfic_direct_success
+  ${endif}
 
-    StrCpy $R3 "$INSTDIR$R0\*.*"
+  ${GetFileAttributes} "$INSTDIR$R0" "DIRECTORY" $R4
+  IfErrors openfic_direct_error_no_close
+  ${if} $R4 != "1"
     ClearErrors
-    FindFirst $R1 $R2 $R3
-    IfErrors openfic_direct_remove_empty
+    Delete "$INSTDIR$R0"
+    IfErrors openfic_direct_error_no_close
+    Goto openfic_direct_success
+  ${endif}
+
+  StrCpy $R3 "$INSTDIR$R0\*.*"
+  ClearErrors
+  FindFirst $R1 $R2 $R3
+  IfErrors openfic_direct_remove_empty
 
   openfic_direct_loop:
     StrCmp $R2 "" openfic_direct_done


### PR DESCRIPTION
## PR 标题

fix(desktop): 修复卸载时缺失运行环境目录报错

## 变更说明

- 问题：安装目录没有 `runtime` 文件夹时，卸载器将不存在的路径误判为清理失败。
- 重要性：用户卸载桌面版时会看到错误提示，卸载流程被中断。
- 变化：卸载前使用 `GetFileAttributes` 检查目标路径；路径不存在时直接视为已清理，保留现有文件和目录删除逻辑。

## 关联 Issue / PR

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因

原实现对 `runtime` 目录使用 `FindFirst "$INSTDIR\\runtime\\*.*"` 进行递归清理。目标目录不存在时，后续 `RMDir` 会将缺失路径报告为错误；空目录则可以正常删除，因此出现了两种行为不一致的情况。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

已运行 `pnpm type-check` 和 `pnpm lint`。当前环境为 Linux，未执行 Windows NSIS 实际卸载流程。
