### PR TITLE
fix(backend): 修复章节导出成品在 24 小时有效期内被清理删除的问题

### DIFF
--- a/backend/app/chapter_export/service.py
+++ b/backend/app/chapter_export/service.py
@@ -412,12 +412,16 @@ async def cleanup_chapter_export_files(session: AsyncSession) -> int:
         job = await background_service.get_job(session, job_id)
         should_keep = False
         if job is not None and job.type == EXPORT_JOB_TYPE:
-            if path.suffix in {".part", ".txt"}:
-                should_keep = job.status in {
-                    JOB_STATUS_PENDING,
-                    JOB_STATUS_RUNNING,
-                    JOB_STATUS_CANCEL_REQUESTED,
-                }
+            # 任务仍在进行时两种文件都要保留：成品是 os.replace 落盘的，
+            # 可能早于任务状态提交。任务成功后只保留 .txt，残留的 .part
+            # 已经没有读者。判断必须先看状态再看后缀，否则后缀分支会把
+            # 下面的有效期分支整个遮蔽掉。
+            if job.status in {
+                JOB_STATUS_PENDING,
+                JOB_STATUS_RUNNING,
+                JOB_STATUS_CANCEL_REQUESTED,
+            }:
+                should_keep = True
             elif path.suffix == ".txt" and job.status == JOB_STATUS_SUCCEEDED:
                 expires_at = _parse_datetime(
                     background_service.parse_json_object(job.result_json).get("expires_at")

--- a/backend/tests/api/test_chapter_exports.py
+++ b/backend/tests/api/test_chapter_exports.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 """章节导出 API 测试。"""
 
+from datetime import UTC, datetime, timedelta
+
 import pytest
 from httpx import AsyncClient
 from urllib.parse import unquote
@@ -332,3 +334,54 @@ async def test_cleanup_keeps_output_while_export_is_still_running(
 
     assert await chapter_export_service.cleanup_chapter_export_files(session) == 0
     assert output_path.exists()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_keeps_succeeded_output_until_it_expires(
+    session,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setattr(chapter_export_service.settings, "chapter_exports_dir", tmp_path)
+    expires_at = datetime.now(UTC) + timedelta(hours=12)
+    job = BackgroundJob(
+        id="succeeded-export",
+        type=chapter_export_service.EXPORT_JOB_TYPE,
+        status="succeeded",
+        payload_json='{"filename":"测试.txt"}',
+        result_json=f'{{"expires_at":"{expires_at.isoformat()}"}}',
+    )
+    session.add(job)
+    await session.commit()
+    part_path, output_path = chapter_export_service.export_file_paths(job.id)
+    output_path.write_text("finished", encoding="utf-8")
+    part_path.write_text("leftover", encoding="utf-8")
+
+    assert await chapter_export_service.cleanup_chapter_export_files(session) == 1
+    assert output_path.exists()
+    assert not part_path.exists()
+    assert chapter_export_service.is_export_download_available(job)
+
+
+@pytest.mark.asyncio
+async def test_cleanup_removes_succeeded_output_after_it_expires(
+    session,
+    monkeypatch,
+    tmp_path,
+) -> None:
+    monkeypatch.setattr(chapter_export_service.settings, "chapter_exports_dir", tmp_path)
+    expires_at = datetime.now(UTC) - timedelta(hours=1)
+    job = BackgroundJob(
+        id="stale-export",
+        type=chapter_export_service.EXPORT_JOB_TYPE,
+        status="succeeded",
+        payload_json='{"filename":"测试.txt"}',
+        result_json=f'{{"expires_at":"{expires_at.isoformat()}"}}',
+    )
+    session.add(job)
+    await session.commit()
+    _part_path, output_path = chapter_export_service.export_file_paths(job.id)
+    output_path.write_text("expired", encoding="utf-8")
+
+    assert await chapter_export_service.cleanup_chapter_export_files(session) == 1
+    assert not output_path.exists()


### PR DESCRIPTION
## PR 标题

fix(backend): 修复章节导出成品在 24 小时有效期内被清理删除的问题

## 变更说明

- **问题**: `backend/app/chapter_export/service.py` 的 `cleanup_chapter_export_files()` 里两个分支的判断顺序反了。第 415 行先判断 `if path.suffix in {".part", ".txt"}`，第 421 行才在 `elif` 里判断 `path.suffix == ".txt" and job.status == JOB_STATUS_SUCCEEDED`。但循环体只有通过第 460 行 `_job_id_from_export_path()` 的文件才会走到这里，而它已经把后缀限定成 `.part` 或 `.txt` 了，所以第一个条件恒为真，带 `expires_at` 有效期判断的 `elif` 分支是永远进不去的死代码。任务成功后状态是 `succeeded`，不在 `{pending, running, cancel_requested}` 里，`should_keep` 于是为假，成品 `.txt` 被直接 `unlink`。
- **重要性**: 这个清理由 `backend/app/background/runtime/watchdog.py` 第 48 行每 `max(background_running_stale_seconds / 2, 1.0)` 秒调用一次（默认 600 / 2 即 300 秒），`main.py` 的启动维护阶段还会再跑一次。所以导出任务成功后最多五分钟，`EXPORT_FILE_TTL` 承诺的 24 小时下载窗口就作废了：`is_export_download_available()` 因为 `output_path.is_file()` 为假返回 False，状态接口不再带 `download_url`，直接请求下载接口返回 409「导出文件不可用或已过期」。用户看到的现象是刚导完的文件放一会儿就下载不了，只能重新导出。
- **变化**: 把判断改成先看任务状态、再看后缀。任务仍在 `pending / running / cancel_requested` 时 `.part` 与 `.txt` 都保留，这一条维持原语义不变：`write_chapter_export()` 第 388 行用 `os.replace` 把 `.part` 换成 `.txt`，成品落盘可能早于任务状态提交，已有用例 `test_cleanup_keeps_output_while_export_is_still_running` 防的就是这个竞态。其余情况才看后缀，成功任务的 `.txt` 走 `expires_at` 有效期判断，口径与 `is_export_download_available()` 一致；成功任务残留的 `.part` 已经没有读者，按原意删除。
- **测试**: 在 `tests/api/test_chapter_exports.py` 新增两个用例，覆盖成功任务的两侧边界：有效期内保留 `.txt` 并删掉残留的 `.part`；过期后删除 `.txt`。

## 关联 Issue / PR

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因

`if` 与 `elif` 的条件顺序按"先后缀、后状态"写，而后缀在进入循环体前已经被 `_job_id_from_export_path()` 过滤成只剩 `.part` 和 `.txt` 两种，第一个条件因此恒真，把第二个分支完全遮蔽。两个分支想表达的是两件不同的事：`.part` 是仍在写入的临时文件，只在任务进行中有意义；`.txt` 是成品，成功后要按 `expires_at` 留满 24 小时。按状态先分流之后，两件事各自成立。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

复现与验证都在本地跑过（macOS 15，Python 3.12，`uv sync --frozen`）。复现用一次性用例串起完整链路：建项目和章节、创建导出任务、`dispatch_job` 写完成品、`mark_succeeded`，然后调一次 `cleanup_chapter_export_files()` 再请求下载接口。在未修改的 main 上，清理前下载返回 200，清理删掉 1 个文件，清理后下载返回 409 `{"detail":"导出文件不可用或已过期"}`；带本 PR 的改动则是清理删除 0 个文件，清理后下载仍为 200。该一次性用例只用于复现，没有提交。

CI 对应的命令结果：`uv run ruff check .` 全部通过，`uv run ty check app` 全部通过，`uv run pytest` 1717 passed（60.47s），`uv build` 两个产物都构建成功。单独跑改动涉及的文件：`uv run pytest tests/api/test_chapter_exports.py` 13 passed；新增的第一个用例在未修改的 main 上确实失败（`assert 2 == 1`，即成品和残留临时文件被一起删掉）。
