### PR TITLE
chore(frontend): 为编辑器工具栏添加移动端适配

### DIFF
--- a/frontend/src/components/editor-toolbar.css
+++ b/frontend/src/components/editor-toolbar.css
@@ -4,7 +4,25 @@
   z-index: 10;
   width: 100%;
   min-width: 0;
+  pointer-events: auto;
   background: var(--color-background);
+}
+
+.editor-toolbar[data-mobile-viewport="true"] {
+  display: none;
+}
+
+.editor-toolbar[data-mobile-viewport="true"][data-mobile-keyboard-open="true"] {
+  position: fixed;
+  top: auto;
+  right: 0;
+  bottom: var(--editor-toolbar-keyboard-bottom, 0px);
+  left: 0;
+  z-index: 30;
+  display: block;
+  padding-bottom: calc(var(--space-2) + env(safe-area-inset-bottom));
+  border-top: 1px solid var(--gray-a5);
+  box-shadow: 0 -4px 16px var(--black-a3);
 }
 
 .editor-toolbar__layout {
@@ -24,6 +42,7 @@
   min-width: 0;
   overflow-x: auto;
   overflow-y: hidden;
+  touch-action: pan-x;
   scrollbar-width: none;
 }
 
@@ -70,15 +89,35 @@
   flex: 0 0 auto;
 }
 
-.editor-toolbar__divider {
+.editor-toolbar__content > :not(.editor-toolbar__right) {
+  order: 1;
+}
+
+.editor-toolbar__right {
+  order: 2;
   flex: 0 0 auto;
+  min-width: max-content;
+  margin-inline-start: auto;
+}
+
+.editor-toolbar__right .editor-toolbar__divider {
+  order: 1;
   height: 20px;
 }
 
 .editor-toolbar__actions {
+  order: 2;
   flex: 0 0 auto;
   min-width: max-content;
-  margin-inline-start: auto;
+}
+
+@media (min-width: 768px) {
+  .editor-toolbar__right {
+    position: sticky;
+    right: 0;
+    z-index: 2;
+    background: var(--color-background);
+  }
 }
 
 .editor-toolbar-button[data-active="true"] {
@@ -139,5 +178,22 @@
 
   .editor-toolbar__content {
     justify-content: flex-start;
+  }
+
+  .editor-toolbar__actions {
+    order: 1;
+  }
+
+  .editor-toolbar__right {
+    order: 1;
+    margin-inline-start: 0;
+  }
+
+  .editor-toolbar__content > :not(.editor-toolbar__right) {
+    order: 2;
+  }
+
+  .editor-toolbar__right .editor-toolbar__divider {
+    order: 2;
   }
 }

--- a/frontend/src/components/editor-toolbar.tsx
+++ b/frontend/src/components/editor-toolbar.tsx
@@ -39,7 +39,7 @@ import {
   Underline as UnderlineIcon,
   type LucideIcon,
 } from "lucide-react";
-import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useLayoutEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import {
@@ -106,6 +106,8 @@ const HEADING_OPTION_DEFINITIONS: HeadingOptionDefinition[] = [
 ];
 
 const MAX_TASK_ITEM_DEPTH = 3;
+const MOBILE_VIEWPORT_QUERY = "(max-width: 767px)";
+const MOBILE_KEYBOARD_HEIGHT_THRESHOLD = 150;
 
 const CHAPTER_PUNCTUATION_DEFINITIONS = [
   { id: "comma", symbol: "，", labelKey: "editor.quickPunctuationComma" },
@@ -261,9 +263,51 @@ export function EditorToolbar({
     canScrollLeft: false,
     canScrollRight: false,
   });
+  const [mobileToolbarState, setMobileToolbarState] = useState(() => ({
+    isMobileViewport:
+      typeof window !== "undefined" && window.matchMedia(MOBILE_VIEWPORT_QUERY).matches,
+    isKeyboardOpen: false,
+  }));
   const scrollAreaRef = useRef<HTMLDivElement>(null);
   const scrollContentRef = useRef<HTMLDivElement>(null);
+  const toolbarRef = useRef<HTMLDivElement>(null);
   const pendingLinkSelectionRef = useRef<PendingLinkSelection | null>(null);
+  const largestViewportHeightRef = useRef<number | null>(null);
+
+  const syncMobileKeyboardGeometry = useCallback(() => {
+    const toolbar = toolbarRef.current;
+    if (!toolbar || typeof window === "undefined") return;
+
+    const visualViewport = window.visualViewport;
+    const isKeyboardOpen = toolbar.dataset.mobileKeyboardOpen === "true";
+    const keyboardInset =
+      isKeyboardOpen && visualViewport
+        ? Math.max(0, window.innerHeight - visualViewport.offsetTop - visualViewport.height)
+        : 0;
+
+    toolbar.style.setProperty("--editor-toolbar-keyboard-bottom", `${keyboardInset}px`);
+    toolbar.parentElement?.style.setProperty(
+      "--editor-mobile-keyboard-inset",
+      `${keyboardInset}px`,
+    );
+  }, []);
+
+  const updateMobileToolbarState = useCallback(() => {
+    if (!editor || typeof window === "undefined") return;
+
+    const isMobileViewport = window.matchMedia(MOBILE_VIEWPORT_QUERY).matches;
+    const visualViewport = window.visualViewport;
+    const viewportHeight = visualViewport?.height ?? window.innerHeight;
+    const largestViewportHeight = Math.max(
+      largestViewportHeightRef.current ?? viewportHeight,
+      viewportHeight,
+    );
+    largestViewportHeightRef.current = largestViewportHeight;
+    const keyboardHeight = largestViewportHeight - viewportHeight;
+    const isKeyboardOpen = isMobileViewport && keyboardHeight >= MOBILE_KEYBOARD_HEIGHT_THRESHOLD;
+
+    setMobileToolbarState({ isMobileViewport, isKeyboardOpen });
+  }, [editor]);
 
   const updateUndoRedoState = useCallback(() => {
     if (!editor) return;
@@ -283,6 +327,74 @@ export function EditorToolbar({
       editor.off("selectionUpdate", updateUndoRedoState);
     };
   }, [editor, updateUndoRedoState]);
+
+  useEffect(() => {
+    if (!editor || typeof window === "undefined") return;
+
+    largestViewportHeightRef.current = null;
+    const mediaQuery = window.matchMedia(MOBILE_VIEWPORT_QUERY);
+    const visualViewport = window.visualViewport;
+    const handleEditorFocus = () => updateMobileToolbarState();
+    const handleEditorBlur = () => updateMobileToolbarState();
+    const handleOrientationChange = () => {
+      largestViewportHeightRef.current = null;
+      updateMobileToolbarState();
+    };
+
+    editor.on("focus", handleEditorFocus);
+    editor.on("blur", handleEditorBlur);
+    window.addEventListener("resize", updateMobileToolbarState);
+    window.addEventListener("orientationchange", handleOrientationChange);
+    mediaQuery.addEventListener("change", updateMobileToolbarState);
+    visualViewport?.addEventListener("resize", updateMobileToolbarState);
+
+    let frameId: number | null = null;
+    const scheduleMobileKeyboardGeometry = () => {
+      if (frameId !== null) return;
+      frameId = window.requestAnimationFrame(() => {
+        frameId = null;
+        syncMobileKeyboardGeometry();
+      });
+    };
+
+    visualViewport?.addEventListener("resize", scheduleMobileKeyboardGeometry);
+    visualViewport?.addEventListener("scroll", scheduleMobileKeyboardGeometry);
+    window.addEventListener("scroll", scheduleMobileKeyboardGeometry, { passive: true });
+
+    updateMobileToolbarState();
+    syncMobileKeyboardGeometry();
+
+    return () => {
+      editor.off("focus", handleEditorFocus);
+      editor.off("blur", handleEditorBlur);
+      window.removeEventListener("resize", updateMobileToolbarState);
+      window.removeEventListener("orientationchange", handleOrientationChange);
+      mediaQuery.removeEventListener("change", updateMobileToolbarState);
+      visualViewport?.removeEventListener("resize", updateMobileToolbarState);
+      visualViewport?.removeEventListener("resize", scheduleMobileKeyboardGeometry);
+      visualViewport?.removeEventListener("scroll", scheduleMobileKeyboardGeometry);
+      window.removeEventListener("scroll", scheduleMobileKeyboardGeometry);
+      if (frameId !== null) window.cancelAnimationFrame(frameId);
+    };
+  }, [editor, syncMobileKeyboardGeometry, updateMobileToolbarState]);
+
+  useLayoutEffect(() => {
+    syncMobileKeyboardGeometry();
+  }, [
+    mobileToolbarState.isKeyboardOpen,
+    mobileToolbarState.isMobileViewport,
+    syncMobileKeyboardGeometry,
+  ]);
+
+  useLayoutEffect(() => {
+    if (!mobileToolbarState.isKeyboardOpen || typeof document === "undefined") return;
+
+    const documentElement = document.documentElement;
+    documentElement.dataset.editorKeyboardOpen = "true";
+    return () => {
+      delete documentElement.dataset.editorKeyboardOpen;
+    };
+  }, [mobileToolbarState.isKeyboardOpen]);
 
   const updateLeftScrollState = useCallback(() => {
     const scrollArea = scrollAreaRef.current;
@@ -322,6 +434,51 @@ export function EditorToolbar({
     scrollArea.scrollLeft += event.deltaY;
     event.preventDefault();
   }, []);
+
+  const handleToolbarPointerDownCapture = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (event.pointerType !== "touch" && event.pointerType !== "pen") return;
+
+      const target = event.target;
+      if (target instanceof Element && target.closest(".select-trigger--icon")) return;
+
+      event.preventDefault();
+      editor?.view.dom.focus({ preventScroll: true });
+    },
+    [editor],
+  );
+
+  const handleToolbarSelectPointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (event.pointerType !== "touch" && event.pointerType !== "pen") return;
+
+      const target = event.target;
+      if (!(target instanceof Element) || !target.closest(".select-trigger--icon")) return;
+
+      event.preventDefault();
+      editor?.view.dom.focus({ preventScroll: true });
+    },
+    [editor],
+  );
+
+  const handleHeadingSelectContentFocusCapture = useCallback(() => {
+    if (!mobileToolbarState.isKeyboardOpen) return;
+    editor?.view.dom.focus({ preventScroll: true });
+  }, [editor, mobileToolbarState.isKeyboardOpen]);
+
+  const handleHeadingSelectCloseAutoFocus = useCallback(
+    (event: Event) => {
+      if (!mobileToolbarState.isKeyboardOpen) return;
+
+      event.preventDefault();
+      editor?.view.dom.focus({ preventScroll: true });
+    },
+    [editor, mobileToolbarState.isKeyboardOpen],
+  );
+
+  const handleHeadingSelectTouch = useCallback(() => {
+    editor?.view.dom.focus({ preventScroll: true });
+  }, [editor]);
 
   const runEditorAction = useCallback(
     (action: () => boolean | void) => {
@@ -372,7 +529,6 @@ export function EditorToolbar({
   const isCurrentParagraphIndented = isParagraphIndented(currentParagraphText);
   const canIndentParagraph = showChapterTools && !isCurrentParagraphIndented;
   const canOutdentParagraph = showChapterTools && isCurrentParagraphIndented;
-
   const handleHeadingChange = (value: string) => {
     runEditorAction(() => {
       if (value === "paragraph") {
@@ -488,9 +644,14 @@ export function EditorToolbar({
     if (!open) pendingLinkSelectionRef.current = null;
   };
 
-  return (
+  const toolbar = (
     <Box
+      ref={toolbarRef}
       className="editor-toolbar"
+      data-mobile-viewport={mobileToolbarState.isMobileViewport}
+      data-mobile-keyboard-open={mobileToolbarState.isKeyboardOpen}
+      onPointerDownCapture={handleToolbarPointerDownCapture}
+      onPointerDown={handleToolbarSelectPointerDown}
       py="2"
       px="6"
     >
@@ -592,6 +753,11 @@ export function EditorToolbar({
                     disabled={isAgentLocked}
                     variant="icon"
                     triggerAriaLabel={t("editor.heading")}
+                    onContentFocusCapture={handleHeadingSelectContentFocusCapture}
+                    onContentCloseAutoFocus={handleHeadingSelectCloseAutoFocus}
+                    keepFocusOnTouch={mobileToolbarState.isKeyboardOpen}
+                    onTouchTrigger={handleHeadingSelectTouch}
+                    preventContentFocus={mobileToolbarState.isKeyboardOpen}
                   />
 
                   <ToolbarButton
@@ -728,43 +894,48 @@ export function EditorToolbar({
                   />
                 </>
               )}
+              <Flex
+                className="editor-toolbar__right"
+                gap="1"
+                align="center"
+              >
+                {(showMarkdownTools || showChapterTools) && leftScrollState.hasOverflow && (
+                  <Separator
+                    className="editor-toolbar__divider"
+                    orientation="vertical"
+                    size="1"
+                  />
+                )}
+
+                <Flex
+                  className="editor-toolbar__actions"
+                  gap="1"
+                  align="center"
+                >
+                  <ToolbarButton
+                    icon={<Undo size={18} />}
+                    label={t("editor.undo")}
+                    disabled={!canUndo}
+                    onClick={() => runEditorAction(() => editor.chain().focus().undo().run())}
+                  />
+                  <ToolbarButton
+                    icon={<Redo size={18} />}
+                    label={t("editor.redo")}
+                    disabled={!canRedo}
+                    onClick={() => runEditorAction(() => editor.chain().focus().redo().run())}
+                  />
+
+                  <ToolbarButton
+                    icon={isSaving ? <Spinner size={18} /> : <Save size={18} />}
+                    label={t("editor.save")}
+                    disabled={isSaving || !hasChanges}
+                    onClick={() => runEditorAction(() => onSave(true))}
+                  />
+                </Flex>
+              </Flex>
             </Flex>
           </Box>
         </Box>
-
-        {(showMarkdownTools || showChapterTools) && leftScrollState.hasOverflow && (
-          <Separator
-            className="editor-toolbar__divider"
-            orientation="vertical"
-            size="1"
-          />
-        )}
-
-        <Flex
-          className="editor-toolbar__actions"
-          gap="1"
-          align="center"
-        >
-          <ToolbarButton
-            icon={<Undo size={18} />}
-            label={t("editor.undo")}
-            disabled={!canUndo}
-            onClick={() => runEditorAction(() => editor.chain().focus().undo().run())}
-          />
-          <ToolbarButton
-            icon={<Redo size={18} />}
-            label={t("editor.redo")}
-            disabled={!canRedo}
-            onClick={() => runEditorAction(() => editor.chain().focus().redo().run())}
-          />
-
-          <ToolbarButton
-            icon={isSaving ? <Spinner size={18} /> : <Save size={18} />}
-            label={t("editor.save")}
-            disabled={isSaving || !hasChanges}
-            onClick={() => runEditorAction(() => onSave(true))}
-          />
-        </Flex>
 
         <LinkInputDialog
           open={isLinkDialogOpen}
@@ -775,4 +946,6 @@ export function EditorToolbar({
       </Flex>
     </Box>
   );
+
+  return toolbar;
 }

--- a/frontend/src/components/markdown-editor.tsx
+++ b/frontend/src/components/markdown-editor.tsx
@@ -328,8 +328,8 @@ export function MarkdownEditor({
           style={{
             maxWidth,
             margin: "0 auto",
-            padding: "0 24px",
           }}
+          className="markdown-editor-content"
         >
           <TitleInput
             value={title}

--- a/frontend/src/components/select.tsx
+++ b/frontend/src/components/select.tsx
@@ -8,8 +8,8 @@
 import { Box, Button, Flex, Popover, ScrollArea, Select, Text, TextField } from "@radix-ui/themes";
 import clsx from "clsx";
 import { ChevronDown, Search } from "lucide-react";
-import { Fragment, useMemo, useState } from "react";
-import type { CSSProperties, ReactNode, ComponentProps } from "react";
+import { Fragment, useCallback, useMemo, useRef, useState } from "react";
+import type { CSSProperties, FocusEventHandler, ReactNode, ComponentProps } from "react";
 import { useTranslation } from "react-i18next";
 
 import "./select.css";
@@ -115,6 +115,11 @@ export interface LabeledSelectProps {
   hideTriggerChevron?: boolean;
   triggerClassName?: string;
   contentClassName?: string;
+  onContentFocusCapture?: FocusEventHandler<HTMLDivElement>;
+  onContentCloseAutoFocus?: ComponentProps<typeof Select.Content>["onCloseAutoFocus"];
+  keepFocusOnTouch?: boolean;
+  onTouchTrigger?: () => void;
+  preventContentFocus?: boolean;
   variant?: "default" | "icon";
   triggerAriaLabel?: string;
 }
@@ -144,19 +149,71 @@ export function LabeledSelect({
   triggerPrefix,
   triggerClassName,
   contentClassName,
+  onContentFocusCapture,
+  onContentCloseAutoFocus,
+  keepFocusOnTouch = false,
+  onTouchTrigger,
+  preventContentFocus = false,
   variant = "default",
   triggerAriaLabel,
 }: LabeledSelectProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const triggerPointerTypeRef = useRef<string | null>(null);
+  const shouldKeepFocusOnTouch = keepFocusOnTouch && Boolean(onTouchTrigger);
   const selectedOption = options.find((opt) => opt.value === value);
   const triggerLabel = selectedOption?.label || placeholder;
   const isIconVariant = variant === "icon";
   const isTriggerLabelVisible = !isIconVariant && triggerLabelVisible;
+
+  const handleTriggerPointerDown = useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>) => {
+      triggerPointerTypeRef.current = event.pointerType;
+      if (
+        !shouldKeepFocusOnTouch ||
+        (event.pointerType !== "touch" && event.pointerType !== "pen")
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      onTouchTrigger?.();
+    },
+    [onTouchTrigger, shouldKeepFocusOnTouch],
+  );
+
+  const handleTriggerClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      const pointerType = triggerPointerTypeRef.current;
+      triggerPointerTypeRef.current = null;
+      if (!shouldKeepFocusOnTouch || (pointerType !== "touch" && pointerType !== "pen")) {
+        return;
+      }
+
+      event.preventDefault();
+      onTouchTrigger?.();
+      setIsOpen((open) => !open);
+    },
+    [onTouchTrigger, shouldKeepFocusOnTouch],
+  );
+
+  const handleContentRef = useCallback(
+    (content: HTMLDivElement | null) => {
+      if (!content || !preventContentFocus) return;
+
+      content.setAttribute("inert", "");
+      window.setTimeout(() => content.removeAttribute("inert"), 0);
+    },
+    [preventContentFocus],
+  );
 
   const selectControl = (
     <Select.Root
       value={value || undefined}
       onValueChange={onChange}
       disabled={disabled}
+      open={shouldKeepFocusOnTouch ? isOpen : undefined}
+      onOpenChange={shouldKeepFocusOnTouch ? setIsOpen : undefined}
       size={size}
     >
       <Select.Trigger
@@ -171,6 +228,8 @@ export function LabeledSelect({
         }
         placeholder={placeholder}
         aria-label={triggerAriaLabel ?? label ?? triggerLabel}
+        onPointerDown={handleTriggerPointerDown}
+        onClick={handleTriggerClick}
       >
         <Flex
           align="center"
@@ -193,14 +252,29 @@ export function LabeledSelect({
         </Flex>
       </Select.Trigger>
       <Select.Content
+        ref={handleContentRef}
         position={contentPosition}
         className={contentClassName}
+        onFocusCapture={onContentFocusCapture}
+        onCloseAutoFocus={onContentCloseAutoFocus}
       >
         {options.map((option) => (
           <Fragment key={option.value}>
             <Select.Item
               value={option.value}
               disabled={option.disabled}
+              onPointerDown={(event) => {
+                if (
+                  shouldKeepFocusOnTouch &&
+                  !option.disabled &&
+                  (event.pointerType === "touch" || event.pointerType === "pen")
+                ) {
+                  event.preventDefault();
+                  onChange(option.value);
+                  onTouchTrigger?.();
+                  setIsOpen(false);
+                }
+              }}
             >
               <SelectOptionContent
                 option={option}

--- a/frontend/src/styles/base.css
+++ b/frontend/src/styles/base.css
@@ -28,6 +28,12 @@ body {
   overflow: auto;
 }
 
+html[data-editor-keyboard-open],
+html[data-editor-keyboard-open] body {
+  overflow: hidden;
+  overscroll-behavior: none;
+}
+
 ::-webkit-scrollbar-button {
   display: none;
   width: 0;

--- a/frontend/src/styles/overrides/tiptap.css
+++ b/frontend/src/styles/overrides/tiptap.css
@@ -11,6 +11,19 @@
   outline: none;
 }
 
+.tiptap-editor-wrapper {
+  overscroll-behavior-y: contain;
+}
+
+.tiptap-editor-wrapper > .chapter-editor-content,
+.tiptap-editor-wrapper > .markdown-editor-content {
+  padding-bottom: var(--editor-mobile-keyboard-inset, 0px);
+}
+
+.tiptap-editor-wrapper > .markdown-editor-content {
+  padding: 0 24px var(--editor-mobile-keyboard-inset, 0px);
+}
+
 .tiptap-editor--line-numbers .ProseMirror {
   counter-reset: editor-line;
 }


### PR DESCRIPTION
## PR 标题

chore(frontend): 为编辑器工具栏添加移动端适配

## 变更说明

- 问题: 编辑器工具栏在移动端缺少针对软键盘、触摸操作和窄屏布局的处理。
- 重要性: 移动端编辑章节或 Markdown 时，需要避免页面滚动和焦点变化影响输入。
- 变化: 为章节编辑器和 Markdown 编辑器补充移动端键盘间距、滚动约束及工具栏交互适配，并扩展选择器以保持触摸编辑焦点。

## 关联 Issue / PR

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因

无

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [ ] 提交信息符合规范

## 补充信息

本次按需求将 commit 说明设置为“为编辑器工具栏添加移动端适配”；PR 标题保留 Conventional Commits 格式。
