### PR TITLE
fix(frontend): 修复移动端左侧边栏切换动画卡顿的问题

### DIFF
--- a/frontend/src/features/app-shell/components/app-layout.css
+++ b/frontend/src/features/app-shell/components/app-layout.css
@@ -21,6 +21,17 @@
   transition: padding-left 0.24s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
+.mobile-sidebar-sheet {
+  transform: translateX(-100%);
+  transition: transform 0.24s cubic-bezier(0.22, 1, 0.36, 1);
+  pointer-events: none;
+}
+
+.mobile-sidebar-sheet[data-open="true"] {
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
 .app-layout-assistant-sidebar {
   position: fixed;
   z-index: 11;

--- a/frontend/src/features/app-shell/components/app-sidebar.tsx
+++ b/frontend/src/features/app-shell/components/app-sidebar.tsx
@@ -277,121 +277,116 @@ export function AppSidebar({ appearance, onToggleTheme }: AppSidebarProps) {
       </AnimatePresence>
 
       <AnimatePresence initial={false}>
-        {(!isMobile || isSidebarOpen) && (
-          <MotionBox
-            key={isMobile ? "mobile-sidebar" : "desktop-sidebar"}
-            position="fixed"
-            top="0"
-            left="0"
-            bottom="var(--app-status-bar-height)"
-            initial={isMobile ? { x: -SIDEBAR_EXPANDED_WIDTH } : false}
-            animate={
-              isMobile ? { x: 0, width: SIDEBAR_EXPANDED_WIDTH } : { x: 0, width: sidebarWidth }
-            }
-            exit={isMobile ? { x: -SIDEBAR_EXPANDED_WIDTH } : undefined}
-            transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
-            style={{
-              borderRight: "1px solid var(--gray-a5)",
-              background: "color-mix(in srgb, var(--color-background) 92%, transparent)",
-              backdropFilter: "blur(12px)",
-              zIndex: 100,
-              overflow: "hidden",
-              boxShadow: isMobile ? "var(--shadow-5)" : undefined,
-              clipPath: isMobile ? "inset(0 -64px 0 0)" : undefined,
-            }}
+        <MotionBox
+          className={isMobile ? "mobile-sidebar-sheet" : undefined}
+          data-open={isMobile ? String(isSidebarOpen) : undefined}
+          position="fixed"
+          top="0"
+          left="0"
+          bottom="var(--app-status-bar-height)"
+          initial={false}
+          animate={!isMobile ? { x: 0, width: sidebarWidth } : undefined}
+          transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
+          style={{
+            width: isMobile ? SIDEBAR_EXPANDED_WIDTH : undefined,
+            borderRight: "1px solid var(--gray-a5)",
+            background: "color-mix(in srgb, var(--color-background) 92%, transparent)",
+            backdropFilter: "blur(12px)",
+            zIndex: 100,
+            overflow: "hidden",
+            boxShadow: isMobile ? "var(--shadow-5)" : undefined,
+            clipPath: isMobile ? "inset(0 -64px 0 0)" : undefined,
+          }}
+        >
+          <Flex
+            direction="column"
+            height="100%"
+            p="3"
           >
-            <Flex
-              direction="column"
-              height="100%"
-              p="3"
+            <SidebarBrand
+              isExpanded={isMobile || isExpanded}
+              isHovered={isLogoHovered}
+              expandLabel={t("topbar.expand")}
+              projectsLabel={t("topbar.projects")}
+              collapseLabel={t("topbar.collapse")}
+              onToggleExpanded={toggleExpanded}
+              onNavigateHome={navigateToProjects}
+              onPointerEnter={handleLogoPointerEnter}
+              onPointerLeave={handleLogoPointerLeave}
+              onPointerMove={handleLogoPointerMove}
+            />
+
+            <Box
+              style={{
+                width: "100%",
+                height: 13,
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "flex-start",
+                margin: "6px 0",
+                flexShrink: 0,
+              }}
             >
-              <SidebarBrand
-                isExpanded={isMobile || isExpanded}
-                isHovered={isLogoHovered}
-                expandLabel={t("topbar.expand")}
-                projectsLabel={t("topbar.projects")}
-                collapseLabel={t("topbar.collapse")}
-                onToggleExpanded={toggleExpanded}
-                onNavigateHome={navigateToProjects}
-                onPointerEnter={handleLogoPointerEnter}
-                onPointerLeave={handleLogoPointerLeave}
-                onPointerMove={handleLogoPointerMove}
-              />
-
-              <Box
-                style={{
-                  width: "100%",
-                  height: 13,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "flex-start",
-                  margin: "6px 0",
-                  flexShrink: 0,
+              <MotionBox
+                initial={false}
+                animate={{
+                  width: isMobile || isExpanded ? SIDEBAR_EXPANDED_WIDTH - 40 : 32,
+                  marginLeft: isMobile || isExpanded ? 8 : 4,
                 }}
-              >
-                <MotionBox
-                  initial={false}
-                  animate={{
-                    width: isMobile || isExpanded ? SIDEBAR_EXPANDED_WIDTH - 40 : 32,
-                    marginLeft: isMobile || isExpanded ? 8 : 4,
-                  }}
-                  transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
-                  style={{
-                    height: 1,
-                    background: "var(--gray-a5)",
-                  }}
-                />
-              </Box>
-
-              <SidebarNav
-                items={navItems}
-                isExpanded={isMobile || isExpanded}
-              />
-
-              <RecentProjectsNav
-                projects={recentProjects}
-                currentProjectId={projectId}
-                isExpanded={isMobile || isExpanded}
-                ariaLabel={t("topbar.recentProjects")}
-                closeLabel={t("common.close")}
-                onRemove={handleRemoveRecentProject}
-              />
-
-              <MotionFlex
-                layout
-                mt="auto"
-                direction={isMobile || isExpanded ? "row" : "column"}
-                align="center"
-                justify={isMobile || isExpanded ? "end" : "center"}
-                gap="1"
-                width="100%"
                 transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
-              >
-                <SidebarActions
-                  appearance={appearance}
-                  isExpanded={isMobile || isExpanded}
-                  shouldAnimateTheme={shouldAnimateTheme}
-                  languageLabel={t("topbar.language")}
-                  settingsLabel={t("topbar.settings")}
-                  toggleThemeLabel={t("topbar.toggleTheme")}
-                  themeTooltip={
-                    appearance === "light"
-                      ? t("topbar.toggleDarkMode")
-                      : t("topbar.toggleLightMode")
-                  }
-                  languages={supportedLanguages.map((lang) => ({
-                    code: lang.code,
-                    name: lang.name,
-                  }))}
-                  currentLanguage={i18n.language}
-                  onLanguageChange={handleLanguageChange}
-                  onToggleTheme={handleThemeToggle}
-                  onOpenSettings={handleOpenSettings}
-                />
-              </MotionFlex>
-            </Flex>
-          </MotionBox>
-        )}
+                style={{
+                  height: 1,
+                  background: "var(--gray-a5)",
+                }}
+              />
+            </Box>
+
+            <SidebarNav
+              items={navItems}
+              isExpanded={isMobile || isExpanded}
+            />
+
+            <RecentProjectsNav
+              projects={recentProjects}
+              currentProjectId={projectId}
+              isExpanded={isMobile || isExpanded}
+              ariaLabel={t("topbar.recentProjects")}
+              closeLabel={t("common.close")}
+              onRemove={handleRemoveRecentProject}
+            />
+
+            <MotionFlex
+              layout
+              mt="auto"
+              direction={isMobile || isExpanded ? "row" : "column"}
+              align="center"
+              justify={isMobile || isExpanded ? "end" : "center"}
+              gap="1"
+              width="100%"
+              transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
+            >
+              <SidebarActions
+                appearance={appearance}
+                isExpanded={isMobile || isExpanded}
+                shouldAnimateTheme={shouldAnimateTheme}
+                languageLabel={t("topbar.language")}
+                settingsLabel={t("topbar.settings")}
+                toggleThemeLabel={t("topbar.toggleTheme")}
+                themeTooltip={
+                  appearance === "light" ? t("topbar.toggleDarkMode") : t("topbar.toggleLightMode")
+                }
+                languages={supportedLanguages.map((lang) => ({
+                  code: lang.code,
+                  name: lang.name,
+                }))}
+                currentLanguage={i18n.language}
+                onLanguageChange={handleLanguageChange}
+                onToggleTheme={handleThemeToggle}
+                onOpenSettings={handleOpenSettings}
+              />
+            </MotionFlex>
+          </Flex>
+        </MotionBox>
       </AnimatePresence>
     </>
   );

--- a/frontend/src/features/characters/pages/characters-page.css
+++ b/frontend/src/features/characters/pages/characters-page.css
@@ -244,6 +244,8 @@
   left: 0;
   bottom: 0;
   z-index: 11;
+  width: 320px;
+  min-width: 320px;
   height: 100%;
   overflow: hidden;
   border-right: 1px solid var(--gray-a4);

--- a/frontend/src/features/characters/pages/characters-page.tsx
+++ b/frontend/src/features/characters/pages/characters-page.tsx
@@ -38,8 +38,6 @@ const LAST_PROJECT_KEY = "characters.lastProjectId";
 const LAST_CHARACTER_KEY = "characters.lastCharacterId";
 const PANEL_LAYOUT_KEY = "panel-layout.characters";
 const PANEL_IDS = ["characters-list", "characters-editor", "characters-right"];
-const MotionBox = motion.create(Box);
-const MOBILE_SIDEBAR_WIDTH = 320;
 
 function toCharacterListItem(character: Character): CharacterListItem {
   return {
@@ -502,19 +500,12 @@ export function CharactersPage() {
               style={{ pointerEvents: isListOpen ? "auto" : "none" }}
             />
 
-            <MotionBox
-              initial={false}
-              animate={{ x: isListOpen ? 0 : -MOBILE_SIDEBAR_WIDTH }}
-              transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
-              className="characters-page-mobile-sidebar-sheet"
-              style={{
-                width: MOBILE_SIDEBAR_WIDTH,
-                minWidth: MOBILE_SIDEBAR_WIDTH,
-                pointerEvents: isListOpen ? "auto" : "none",
-              }}
+            <Box
+              className="mobile-sidebar-sheet characters-page-mobile-sidebar-sheet"
+              data-open={String(isListOpen)}
             >
               {list}
-            </MotionBox>
+            </Box>
           </Box>
         </Box>
       ) : currentProjectId ? (

--- a/frontend/src/features/prompt-chains/pages/prompt-chains-page.tsx
+++ b/frontend/src/features/prompt-chains/pages/prompt-chains-page.tsx
@@ -27,8 +27,6 @@ import { PromptEditor } from "../components/prompt-editor";
 import { VersionHistorySidebar } from "../components/version-history-sidebar";
 import { usePromptChain } from "../hooks/use-prompt-chain";
 
-const MotionBox = motion.create(Box);
-
 const DEFAULT_PROMPT_ID = "builtin-agent--explore";
 const VERSION_HISTORY_COLLAPSED_SIZE = 36;
 const VERSION_HISTORY_MIN_SIZE = 72;
@@ -468,15 +466,12 @@ export function PromptChainsPage() {
               style={{ pointerEvents: mobileEntriesOpen ? "auto" : "none" }}
             />
 
-            <MotionBox
-              initial={false}
-              animate={{ x: mobileEntriesOpen ? 0 : -320 }}
-              transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
-              className="prompt-chains-page-mobile-sidebar-overlay"
-              style={{ pointerEvents: mobileEntriesOpen ? "auto" : "none" }}
+            <Box
+              className="mobile-sidebar-sheet prompt-chains-page-mobile-sidebar-overlay"
+              data-open={String(mobileEntriesOpen)}
             >
               <Box className="prompt-chains-page-mobile-sidebar-sheet">{sidebarContent}</Box>
-            </MotionBox>
+            </Box>
           </>
         )}
       </Box>

--- a/frontend/src/features/world-info/pages/world-info-page.css
+++ b/frontend/src/features/world-info/pages/world-info-page.css
@@ -66,6 +66,8 @@
   left: 0;
   bottom: 0;
   z-index: 11;
+  width: 320px;
+  min-width: 320px;
   height: 100%;
   overflow: hidden;
   border-right: 1px solid var(--gray-a4);

--- a/frontend/src/features/world-info/pages/world-info-page.tsx
+++ b/frontend/src/features/world-info/pages/world-info-page.tsx
@@ -53,8 +53,6 @@ const LAST_PROJECT_KEY = "worldInfo.lastProjectId";
 const LAST_ENTRY_KEY = "worldInfo.lastEntryId";
 const PANEL_LAYOUT_KEY = "panel-layout.world-info";
 const PANEL_IDS = ["left-sidebar", "editor", "right-sidebar"];
-const MotionBox = motion.create(Box);
-const MOBILE_SIDEBAR_WIDTH = 320;
 
 function generateUniqueEntryName(baseName: string, entries: WorldInfoEntryBrief[]): string {
   const normalizedName = baseName.trim();
@@ -856,19 +854,12 @@ export function WorldInfoPage() {
                   style={{ pointerEvents: sidebarOpen ? "auto" : "none" }}
                 />
 
-                <MotionBox
-                  initial={false}
-                  animate={{ x: sidebarOpen ? 0 : -MOBILE_SIDEBAR_WIDTH }}
-                  transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
-                  className="world-info-page-mobile-sidebar-sheet"
-                  style={{
-                    width: MOBILE_SIDEBAR_WIDTH,
-                    minWidth: MOBILE_SIDEBAR_WIDTH,
-                    pointerEvents: sidebarOpen ? "auto" : "none",
-                  }}
+                <Box
+                  className="mobile-sidebar-sheet world-info-page-mobile-sidebar-sheet"
+                  data-open={String(sidebarOpen)}
                 >
                   {sidebarContent}
-                </MotionBox>
+                </Box>
               </Box>
             </Flex>
           ) : currentProjectId ? (

--- a/frontend/src/features/writing/pages/writing-page.css
+++ b/frontend/src/features/writing/pages/writing-page.css
@@ -119,6 +119,8 @@
   left: 0;
   bottom: 0;
   z-index: 11;
+  width: 320px;
+  min-width: 320px;
   height: 100%;
   overflow: hidden;
   border-right: 1px solid var(--gray-a4);

--- a/frontend/src/features/writing/pages/writing-page.tsx
+++ b/frontend/src/features/writing/pages/writing-page.tsx
@@ -26,8 +26,6 @@ import { isEmptyTab } from "../lib/tab.types";
 import { useTabsStore, useActiveTabId, useTabs, useTabsLoaded } from "../store/use-tabs-store";
 import { useWritingStore } from "../store/use-writing-store";
 
-const MotionBox = motion.create(Box);
-const MOBILE_SIDEBAR_WIDTH = 320;
 const PANEL_LAYOUT_KEY = "panel-layout.writing";
 const PANEL_IDS = ["left-sidebar", "editor", "right-sidebar"];
 const SummaryPanel = lazy(() =>
@@ -553,18 +551,9 @@ export function WritingPage() {
                 style={{ pointerEvents: isSidebarOpen ? "auto" : "none" }}
               />
 
-              <MotionBox
-                initial={false}
-                animate={{
-                  x: isSidebarOpen ? 0 : -MOBILE_SIDEBAR_WIDTH,
-                }}
-                transition={{ duration: 0.24, ease: [0.22, 1, 0.36, 1] }}
-                className="writing-page-mobile-sidebar-sheet"
-                style={{
-                  width: MOBILE_SIDEBAR_WIDTH,
-                  minWidth: MOBILE_SIDEBAR_WIDTH,
-                  pointerEvents: isSidebarOpen ? "auto" : "none",
-                }}
+              <Box
+                className="mobile-sidebar-sheet writing-page-mobile-sidebar-sheet"
+                data-open={String(isSidebarOpen)}
               >
                 <WritingSidebar
                   projectId={projectId}
@@ -576,7 +565,7 @@ export function WritingPage() {
                   initialCurrentChapterNavigationKey={initialCurrentChapterNavigationKey}
                   onOpenSummary={handleOpenSummary}
                 />
-              </MotionBox>
+              </Box>
             </div>
           </Flex>
         ) : (


### PR DESCRIPTION
## PR 标题

fix(frontend): 修复移动端左侧边栏切换动画卡顿的问题

## 变更说明

- 问题: 移动端 App Shell、章节、角色、世界书和提示词左侧边栏展开收起时存在明显卡顿。
- 重要性: 影响移动端侧栏的基础交互和使用流畅度。
- 变化: 移动端侧栏改为常驻挂载，并统一使用 CSS transform transition，避免打开时动态挂载和 Motion 位移动画带来的卡顿。

## 关联 Issue / PR

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因

移动端侧栏之前在展开时动态挂载内容，并使用 Motion 处理面板位移；侧栏内容挂载、布局计算与动画启动集中在同一时间段，导致动画出现卡顿。现在移动端侧栏保持挂载，只通过 CSS transform 控制位移。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

已通过 `pnpm format:check`、`pnpm type-check`、`pnpm lint` 和 `git diff --check`。本 PR 不包含后续移动端右滑手势改动，也未修改桌面端侧栏展开收起逻辑。