### PR TITLE
chore(frontend): 添加移动端侧栏滑动手势

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -92,6 +92,7 @@
     "react-resizable-panels": "^4.11.0",
     "react-router": "^7.15.0",
     "react-svg": "^17.2.4",
+    "react-swipeable": "^7.0.2",
     "react-virtuoso": "^4.18.6",
     "remark-breaks": "^4.0.0",
     "shiki": "^3.23.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -245,6 +245,9 @@ importers:
       react-svg:
         specifier: ^17.2.4
         version: 17.2.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-swipeable:
+        specifier: ^7.0.2
+        version: 7.0.2(react@19.2.6)
       react-virtuoso:
         specifier: ^4.18.6
         version: 4.18.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -3941,6 +3944,11 @@ packages:
     peerDependencies:
       react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-swipeable@7.0.2:
+    resolution: {integrity: sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==}
+    peerDependencies:
+      react: ^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc
 
   react-virtualized-auto-sizer@1.0.26:
     resolution: {integrity: sha512-CblNyiNVw2o+hsa5/49NH2ogGxZ+t+3aweRvNSq7TVjDIlwk7ir4lencEg5HxHeSzwNarSkNkiu0qJSOXtxm5A==}
@@ -8516,6 +8524,10 @@ snapshots:
       prop-types: 15.8.1
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
+
+  react-swipeable@7.0.2(react@19.2.6):
+    dependencies:
+      react: 19.2.6
 
   react-virtualized-auto-sizer@1.0.26(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:

--- a/frontend/src/features/app-shell/components/app-layout.css
+++ b/frontend/src/features/app-shell/components/app-layout.css
@@ -32,6 +32,13 @@
   pointer-events: auto;
 }
 
+@media (max-width: 767px) {
+  .mobile-sidebar-swipe-surface,
+  .mobile-sidebar-sheet {
+    touch-action: pan-y;
+  }
+}
+
 .app-layout-assistant-sidebar {
   position: fixed;
   z-index: 11;

--- a/frontend/src/features/app-shell/components/app-sidebar.tsx
+++ b/frontend/src/features/app-shell/components/app-sidebar.tsx
@@ -8,6 +8,7 @@ import { useTranslation } from "react-i18next";
 import { useLocation, useNavigate, useParams } from "react-router";
 
 import { toast } from "@/components";
+import { useMobileSidebarSwipe } from "@/hooks/use-mobile-sidebar-swipe";
 import { saveLanguagePreference, supportedLanguages, type LanguageCode } from "@/i18n";
 import { apiClient, fetchProject } from "@/lib/api-client";
 import {
@@ -44,6 +45,16 @@ export function AppSidebar({ appearance, onToggleTheme }: AppSidebarProps) {
   const { projectId } = useParams<{ projectId: string }>();
   const { isMobile, isSidebarOpen, closeSidebar, openSettings } = useAppShell();
   const queryClient = useQueryClient();
+  const mobileSidebarSwipeHandlers = useMobileSidebarSwipe({
+    isEnabled: isMobile,
+    isOpen: isSidebarOpen,
+    onClose: closeSidebar,
+  });
+  const mobileSidebarBackdropSwipeHandlers = useMobileSidebarSwipe({
+    isEnabled: isMobile,
+    isOpen: isSidebarOpen,
+    onClose: closeSidebar,
+  });
 
   const [isExpanded, setIsExpanded] = useState(false);
   const [isLogoHovered, setIsLogoHovered] = useState(false);
@@ -257,6 +268,7 @@ export function AppSidebar({ appearance, onToggleTheme }: AppSidebarProps) {
       <AnimatePresence initial={false}>
         {isMobile && isSidebarOpen && (
           <motion.div
+            {...mobileSidebarBackdropSwipeHandlers}
             key="mobile-sidebar-backdrop"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
@@ -278,6 +290,7 @@ export function AppSidebar({ appearance, onToggleTheme }: AppSidebarProps) {
 
       <AnimatePresence initial={false}>
         <MotionBox
+          {...mobileSidebarSwipeHandlers}
           className={isMobile ? "mobile-sidebar-sheet" : undefined}
           data-open={isMobile ? String(isSidebarOpen) : undefined}
           position="fixed"

--- a/frontend/src/features/characters/pages/characters-page.tsx
+++ b/frontend/src/features/characters/pages/characters-page.tsx
@@ -11,6 +11,7 @@ import { PanelLayoutLoading } from "@/components";
 import { toast } from "@/components/toast";
 import { AssistantSidebarHost, MobileAppSidebarTrigger, useAppShell } from "@/features/app-shell";
 import type { AssistantSidebarState } from "@/features/assistant";
+import { useMobileSidebarSwipe } from "@/hooks/use-mobile-sidebar-swipe";
 import { usePersistedPanelLayout } from "@/hooks/use-persisted-panel-layout";
 import {
   batchDeleteCharacters,
@@ -73,6 +74,12 @@ export function CharactersPage() {
     setCurrentCharacter,
     setListOpen,
   } = useCharactersStore();
+  const mobileSidebarSwipeRef = useMobileSidebarSwipe({
+    isEnabled: isMobile && Boolean(currentProjectId),
+    isOpen: isListOpen,
+    onOpen: () => setListOpen(true),
+    onClose: () => setListOpen(false),
+  });
   const [profileCharacter, setProfileCharacter] = useState<CharacterListItem | null>(null);
   const [deleteCharacterTarget, setDeleteCharacterTarget] = useState<CharacterListItem | null>(
     null,
@@ -403,7 +410,8 @@ export function CharactersPage() {
 
   return (
     <Flex
-      className="characters-page"
+      {...mobileSidebarSwipeRef}
+      className="characters-page mobile-sidebar-swipe-surface"
       direction="column"
     >
       {currentProjectId && !isMobile && panelLayout.isLoaded ? (

--- a/frontend/src/features/dashboard/pages/dashboard-page.tsx
+++ b/frontend/src/features/dashboard/pages/dashboard-page.tsx
@@ -4,7 +4,8 @@ import { BarChart3, BookOpenText, ListTree } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import { MobileAppSidebarTrigger } from "@/features/app-shell";
+import { MobileAppSidebarTrigger, useAppShell } from "@/features/app-shell";
+import { useMobileSidebarSwipe } from "@/hooks/use-mobile-sidebar-swipe";
 
 import { DashboardFilters } from "../components/dashboard-filters";
 import { DashboardRecordsTab } from "../components/dashboard-records-tab";
@@ -48,6 +49,13 @@ function getUserTimezone(): string | undefined {
 
 export function DashboardPage() {
   const { t } = useTranslation();
+  const { closeSidebar, isMobile, isSidebarOpen, openSidebar } = useAppShell();
+  const mobileSidebarSwipeHandlers = useMobileSidebarSwipe({
+    isEnabled: isMobile,
+    isOpen: isSidebarOpen,
+    onOpen: openSidebar,
+    onClose: closeSidebar,
+  });
   const defaultDateRange = useMemo(() => getDefaultDashboardDateRange(), []);
   const [activeTab, setActiveTab] = useState<DashboardTab>("writing");
   const [llmQuery, setLlmQuery] = useState<DashboardQueryParams>(defaultLlmQuery);
@@ -171,7 +179,10 @@ export function DashboardPage() {
   );
 
   return (
-    <Box className="dashboard-page">
+    <Box
+      {...mobileSidebarSwipeHandlers}
+      className="dashboard-page mobile-sidebar-swipe-surface"
+    >
       <div className="dashboard-shell">
         <header className="dashboard-header">
           <div className="dashboard-title-block dashboard-title-row">

--- a/frontend/src/features/projects/pages/projects-page.tsx
+++ b/frontend/src/features/projects/pages/projects-page.tsx
@@ -12,7 +12,8 @@ import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { ConfirmDialog, Spinner, toast } from "@/components";
-import { MobileAppSidebarTrigger } from "@/features/app-shell";
+import { MobileAppSidebarTrigger, useAppShell } from "@/features/app-shell";
+import { useMobileSidebarSwipe } from "@/hooks/use-mobile-sidebar-swipe";
 import type { Project } from "@/lib/project.types";
 
 import { ImportDialog } from "../components/import-dialog";
@@ -42,6 +43,13 @@ function getVisiblePages(currentPage: number, totalPages: number): Array<number 
 
 export function ProjectsPage() {
   const { t } = useTranslation();
+  const { closeSidebar, isMobile, isSidebarOpen, openSidebar } = useAppShell();
+  const mobileSidebarSwipeHandlers = useMobileSidebarSwipe({
+    isEnabled: isMobile,
+    isOpen: isSidebarOpen,
+    onOpen: openSidebar,
+    onClose: closeSidebar,
+  });
 
   // 本地 UI 状态
   const { viewMode, searchQuery, sortBy, sortOrder } = useProjectsStore();
@@ -150,6 +158,8 @@ export function ProjectsPage() {
 
   return (
     <Box
+      {...mobileSidebarSwipeHandlers}
+      className="projects-page mobile-sidebar-swipe-surface"
       style={{
         height: "100%",
         minHeight: 0,

--- a/frontend/src/features/prompt-chains/pages/prompt-chains-page.tsx
+++ b/frontend/src/features/prompt-chains/pages/prompt-chains-page.tsx
@@ -17,6 +17,7 @@ import { v4 as uuidv4 } from "uuid";
 
 import { ConfirmDialog, PanelLayoutLoading, PromptChainDialog } from "@/components";
 import { MobileAppSidebarTrigger, useAppShell } from "@/features/app-shell";
+import { useMobileSidebarSwipe } from "@/hooks/use-mobile-sidebar-swipe";
 import { usePersistedPanelLayout } from "@/hooks/use-persisted-panel-layout";
 import { fetchPromptChainsMetadata, compilePromptChain, resetPromptChain } from "@/lib/api-client";
 import type { PromptEntryData, CompileResponse } from "@/lib/prompt-chain.types";
@@ -84,6 +85,12 @@ export function PromptChainsPage() {
 
   const { isMobile } = useAppShell();
   const [mobileEntriesOpen, setMobileEntriesOpen] = useState(false);
+  const mobileSidebarSwipeRef = useMobileSidebarSwipe({
+    isEnabled: isMobile,
+    isOpen: mobileEntriesOpen,
+    onOpen: () => setMobileEntriesOpen(true),
+    onClose: () => setMobileEntriesOpen(false),
+  });
   const [isVersionHistoryCollapsed, setIsVersionHistoryCollapsed] = useState(false);
   const versionHistoryPanelRef = useRef<PanelImperativeHandle | null>(null);
   const panelLayout = usePersistedPanelLayout(PANEL_LAYOUT_KEY, PANEL_IDS, !isMobile);
@@ -337,7 +344,10 @@ export function PromptChainsPage() {
   );
 
   return (
-    <Box className="prompt-chains-page-root">
+    <Box
+      {...mobileSidebarSwipeRef}
+      className="prompt-chains-page-root mobile-sidebar-swipe-surface"
+    >
       {/* 主内容区 - resizable panels */}
       <Box className="prompt-chains-page-main">
         {!isMobile && panelLayout.isLoaded ? (

--- a/frontend/src/features/world-info/pages/world-info-page.tsx
+++ b/frontend/src/features/world-info/pages/world-info-page.tsx
@@ -19,6 +19,7 @@ import { PanelLayoutLoading } from "@/components";
 import { toast } from "@/components/toast";
 import { AssistantSidebarHost, MobileAppSidebarTrigger, useAppShell } from "@/features/app-shell";
 import type { AssistantSidebarState } from "@/features/assistant";
+import { useMobileSidebarSwipe } from "@/hooks/use-mobile-sidebar-swipe";
 import { usePersistedPanelLayout } from "@/hooks/use-persisted-panel-layout";
 import {
   fetchWorldInfoByProject,
@@ -83,6 +84,12 @@ export function WorldInfoPage() {
     setSidebarOpen,
     setFromWriting,
   } = useWorldInfoStore();
+  const mobileSidebarSwipeRef = useMobileSidebarSwipe({
+    isEnabled: isMobile && Boolean(currentProjectId),
+    isOpen: sidebarOpen,
+    onOpen: () => setSidebarOpen(true),
+    onClose: () => setSidebarOpen(false),
+  });
 
   // 删除确认对话框状态
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -733,6 +740,8 @@ export function WorldInfoPage() {
 
   return (
     <Flex
+      {...mobileSidebarSwipeRef}
+      className="mobile-sidebar-swipe-surface"
       direction="column"
       style={{
         height: "100%",

--- a/frontend/src/features/writing/pages/writing-page.tsx
+++ b/frontend/src/features/writing/pages/writing-page.tsx
@@ -11,6 +11,7 @@ import "./writing-page.css";
 import { PanelLayoutLoading } from "@/components";
 import { AssistantSidebarHost, MobileAppSidebarTrigger, useAppShell } from "@/features/app-shell";
 import type { AssistantSidebarState } from "@/features/assistant";
+import { useMobileSidebarSwipe } from "@/hooks/use-mobile-sidebar-swipe";
 import { usePersistedPanelLayout } from "@/hooks/use-persisted-panel-layout";
 import { getLastChapterId, setLastChapterId } from "@/lib/local-db";
 
@@ -74,6 +75,12 @@ export function WritingPage() {
   const isPageLoading = !isTabsLoaded || isChaptersLoading;
 
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const mobileSidebarSwipeRef = useMobileSidebarSwipe({
+    isEnabled: isMobile,
+    isOpen: isSidebarOpen,
+    onOpen: () => setIsSidebarOpen(true),
+    onClose: () => setIsSidebarOpen(false),
+  });
   const [isSummaryOpen, setIsSummaryOpen] = useState(false);
   const [hasOpenedSummary, setHasOpenedSummary] = useState(false);
   const [hasEditorSelection, setHasEditorSelection] = useState(false);
@@ -372,7 +379,10 @@ export function WritingPage() {
   );
 
   return (
-    <Box className="writing-page-root">
+    <Box
+      {...mobileSidebarSwipeRef}
+      className="writing-page-root mobile-sidebar-swipe-surface"
+    >
       <PageLoadingOverlay isLoading={isPageLoading} />
 
       <Box className="writing-page-shell">

--- a/frontend/src/hooks/use-mobile-sidebar-swipe.ts
+++ b/frontend/src/hooks/use-mobile-sidebar-swipe.ts
@@ -1,0 +1,27 @@
+import { useSwipeable, type SwipeableHandlers } from "react-swipeable";
+
+interface UseMobileSidebarSwipeOptions {
+  isEnabled: boolean;
+  isOpen: boolean;
+  onOpen?: () => void;
+  onClose?: () => void;
+}
+
+export function useMobileSidebarSwipe({
+  isEnabled,
+  isOpen,
+  onOpen,
+  onClose,
+}: UseMobileSidebarSwipeOptions): SwipeableHandlers {
+  return useSwipeable({
+    delta: 40,
+    onSwipedRight: () => {
+      if (isEnabled && !isOpen) onOpen?.();
+    },
+    onSwipedLeft: () => {
+      if (isEnabled && isOpen) onClose?.();
+    },
+    trackTouch: isEnabled,
+    trackMouse: false,
+  });
+}


### PR DESCRIPTION
## PR 标题

chore(frontend): 添加移动端侧栏滑动手势

## 变更说明

- 问题: 移动端侧栏目前主要依赖按钮和遮罩点击操作，缺少统一的滑动展开与收起方式。
- 重要性: 补齐移动端 App Shell 及页面侧栏的触摸操作入口。
- 变化: 引入 `react-swipeable`，统一支持右滑打开、左滑收起，并覆盖 App Shell backdrop 区域。

## 关联 Issue / PR

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [x] 杂项 (chore)

## 问题原因

移动端页面根节点无法接收 App Shell 侧栏及其 backdrop 上的全部触摸事件，原有手势监听无法覆盖这些区域。手势识别统一封装后，页面根节点、App Shell 面板和 backdrop 分别绑定对应的打开或收起回调。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

已通过 `pnpm format:check`、`pnpm type-check`、`pnpm lint` 和 `git diff --check`。手势仅在移动端启用，不改变桌面端行为。