### PR TITLE
fix(frontend): 修复搜索输入和 Toast 未使用项目字体的问题

### DIFF
--- a/frontend/src/features/writing/components/find-replace-panel.tsx
+++ b/frontend/src/features/writing/components/find-replace-panel.tsx
@@ -29,6 +29,7 @@ const inputStyle: React.CSSProperties = {
   padding: "0 8px",
   paddingLeft: 32, // 为搜索图标留出空间
   paddingRight: 56, // 为计数器留出空间
+  fontFamily: "var(--app-font-family)",
   fontSize: "var(--font-size-base)",
   border: "1px solid var(--gray-a5)",
   borderRadius: 6,
@@ -44,6 +45,7 @@ const replaceInputStyle: React.CSSProperties = {
   height: 32,
   padding: "0 8px",
   paddingLeft: 12,
+  fontFamily: "var(--app-font-family)",
   fontSize: "var(--font-size-base)",
   border: "1px solid var(--gray-a5)",
   borderRadius: 6,

--- a/frontend/src/features/writing/components/sidebar-toolbar.tsx
+++ b/frontend/src/features/writing/components/sidebar-toolbar.tsx
@@ -243,6 +243,7 @@ export function SidebarToolbar({
                       border: "none",
                       outline: "none",
                       background: "transparent",
+                      fontFamily: "var(--app-font-family)",
                       fontSize: "var(--font-size-base)",
                       lineHeight: "var(--line-height-2)",
                       color: "var(--gray-12)",

--- a/frontend/src/styles/overrides/sonner.css
+++ b/frontend/src/styles/overrides/sonner.css
@@ -2,6 +2,7 @@
   background: var(--normal-bg) !important;
   border: 1px solid var(--normal-border) !important;
   color: var(--normal-text) !important;
+  font-family: var(--app-font-family) !important;
   box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1) !important;
 }
 


### PR DESCRIPTION
## PR 标题

fix(frontend): 修复搜索输入和 Toast 未使用项目字体的问题

## 变更说明

- 问题：章节侧栏内容搜索、编辑器查找/替换输入框和全局 Toast 未使用项目字体设置。
- 重要性：用户切换字体后，这些 UI 文本显示不一致。
- 变化：为相关输入和 Sonner Toast 接入 `--app-font-family`。

## 关联 Issue / PR

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因

原生 input 和 Sonner Toast 渲染节点未显式继承 `--app-font-family`，浏览器或组件默认字体覆盖了项目设置。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

已通过 `pnpm type-check`、`pnpm lint` 和 `pnpm format:check`。
