### PR TITLE
perf(chapter): 优化大规模章节排序性能

### DIFF
--- a/backend/app/api/routers/chapters.py
+++ b/backend/app/api/routers/chapters.py
@@ -228,9 +228,6 @@ async def reorder_chapters(
         HTTPException: 章节不存在或不属于指定卷时返回 400。
     """
     try:
-        logger.info(
-            f"批量重排章节: volume_id={data.volume_id}, chapter_ids={data.chapter_ids}"
-        )
         chapters = await chapter_service.reorder_chapters(
             session, data.volume_id, data.chapter_ids
         )

--- a/backend/app/storage/repos/chapter_repo.py
+++ b/backend/app/storage/repos/chapter_repo.py
@@ -104,6 +104,18 @@ async def get_by_ids(session: AsyncSession, chapter_ids: list[str]) -> list[Chap
     return list(result.scalars().all())
 
 
+async def get_metadata_by_ids(session: AsyncSession, chapter_ids: list[str]) -> list[Chapter]:
+    """根据 ID 列表获取章节元数据，不加载正文。"""
+    if not chapter_ids:
+        return []
+    result = await session.execute(
+        select(Chapter)
+        .options(load_only(*_chapter_metadata_attributes()))
+        .where(col(Chapter.id).in_(chapter_ids))
+    )
+    return list(result.scalars().all())
+
+
 async def list_by_project(
     session: AsyncSession,
     project_id: str,
@@ -443,7 +455,7 @@ async def delete_by_volume(session: AsyncSession, volume_id: str) -> None:
 async def update_orders(
     session: AsyncSession,
     orders: dict[str, int],
-) -> None:
+) -> datetime | None:
     """
     批量更新章节排序（两阶段，避免 UNIQUE 冲突）。
 
@@ -452,37 +464,33 @@ async def update_orders(
         orders: {chapter_id: new_order} 映射。
     """
     if not orders:
-        return
+        return None
 
     now = datetime.now(UTC)
     ids = list(orders.keys())
 
-    # Phase 1: set to negative temp values to avoid UNIQUE(volume_id, order) conflicts
-    temp_whens = {cid: -(i + 1) for i, cid in enumerate(ids)}
+    # Phase 1: move orders to distinct negative values to avoid UNIQUE conflicts.
     await session.execute(
         update(Chapter)
         .where(col(Chapter.id).in_(ids))
         .values(
-            order=case(
-                *[(col(Chapter.id) == cid, val) for cid, val in temp_whens.items()],
-            ),
+            order=-col(Chapter.order),
             updated_at=now,
         )
+        .execution_options(synchronize_session=False)
     )
     await session.flush()
 
-    # Phase 2: set final values
+    # Phase 2: use DBAPI executemany instead of a giant CASE expression.
     await session.execute(
-        update(Chapter)
-        .where(col(Chapter.id).in_(ids))
-        .values(
-            order=case(
-                *[(col(Chapter.id) == cid, order) for cid, order in orders.items()],
-            ),
-            updated_at=now,
-        )
+        update(Chapter),
+        [
+            {"id": chapter_id, "order": chapter_order, "updated_at": now}
+            for chapter_id, chapter_order in orders.items()
+        ],
     )
     await session.flush()
+    return now
 
 
 async def shift_orders(

--- a/backend/app/storage/services/chapter_service.py
+++ b/backend/app/storage/services/chapter_service.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Literal
 
+from sqlalchemy.orm.attributes import set_committed_value
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.editor_content_limits import validate_editor_content
@@ -676,7 +677,7 @@ async def reorder_chapters(
         NotFoundError: 章节不存在或不属于指定卷。
         ValueError: 章节数量不匹配。
     """
-    chapters = await chapter_repo.get_by_ids(session, chapter_ids)
+    chapters = await chapter_repo.get_metadata_by_ids(session, chapter_ids)
     chapter_map = {c.id: c for c in chapters}
 
     if len(chapters) != len(chapter_ids):
@@ -687,13 +688,20 @@ async def reorder_chapters(
         if chapter.volume_id != volume_id:
             raise ValueError(f"章节 {chapter.id} 不属于卷 {volume_id}")
 
-    orders: dict[str, int] = {}
-    for idx, cid in enumerate(chapter_ids, start=1):
-        orders[cid] = idx
+    orders = {
+        chapter_id: new_order
+        for new_order, chapter_id in enumerate(chapter_ids, start=1)
+        if chapter_map[chapter_id].order != new_order
+    }
 
-    await chapter_repo.update_orders(session, orders)
+    updated_at = await chapter_repo.update_orders(session, orders)
+    if updated_at is not None:
+        for chapter_id, chapter_order in orders.items():
+            chapter = chapter_map[chapter_id]
+            set_committed_value(chapter, "order", chapter_order)
+            set_committed_value(chapter, "updated_at", updated_at)
 
-    updated_chapters = await chapter_repo.get_by_ids(session, chapter_ids)
+    updated_chapters = chapters
     order_lookup = {cid: idx for idx, cid in enumerate(chapter_ids)}
     updated_chapters.sort(key=lambda c: order_lookup.get(c.id, 0))
     return updated_chapters

--- a/backend/tests/api/test_chapters.py
+++ b/backend/tests/api/test_chapters.py
@@ -6,11 +6,15 @@ Chapter API 测试。
 import pytest
 from httpx import AsyncClient
 
+from app.storage.models.chapter import Chapter
 from app.storage.models.chapter_summary import ChapterSummary
+from app.storage.models.project import Project
+from app.storage.models.volume import Volume
 from app.storage.repos.chapter_summary_repo import (
     SUMMARY_STATUS_READY,
     SUMMARY_TYPE_LONG_TERM,
 )
+from app.storage.services import chapter_service
 
 
 async def _create_project(client: AsyncClient) -> tuple[str, str]:
@@ -536,6 +540,36 @@ async def test_reorder_chapters(client: AsyncClient) -> None:
     items = _chapters_from_tree(tree)
     assert [item["id"] for item in items] == new_order
     assert [item["order"] for item in items] == [1, 2, 3, 4]
+
+
+@pytest.mark.asyncio
+async def test_reorder_only_updates_chapters_whose_order_changed(client: AsyncClient, session, monkeypatch):
+    project = Project(title="排序测试项目")
+    volume = Volume(project_id=project.id, title="第一卷", order=1)
+    chapters = [
+        Chapter(project_id=project.id, volume_id=volume.id, title=f"第{index}章", order=index)
+        for index in range(1, 4)
+    ]
+    session.add(project)
+    session.add(volume)
+    session.add_all(chapters)
+    await session.flush()
+
+    captured_orders: dict[str, int] = {}
+
+    async def capture_orders(_session, orders):
+        captured_orders.update(orders)
+        return None
+
+    monkeypatch.setattr(chapter_service.chapter_repo, "update_orders", capture_orders)
+
+    await chapter_service.reorder_chapters(
+        session,
+        volume.id,
+        [chapters[1].id, chapters[0].id, chapters[2].id],
+    )
+
+    assert captured_orders == {chapters[1].id: 1, chapters[0].id: 2}
 
 
 @pytest.mark.asyncio

--- a/backend/tests/storage/repos/test_chapter_repo.py
+++ b/backend/tests/storage/repos/test_chapter_repo.py
@@ -144,6 +144,31 @@ async def test_list_metadata_by_volume_does_not_load_content(session):
 
 
 @pytest.mark.asyncio
+async def test_get_metadata_by_ids_does_not_load_content(session):
+    project = Project(title="P", description="")
+    volume = Volume(project_id=project.id, title="第一卷", order=1)
+    chapter = Chapter(
+        project_id=project.id,
+        volume_id=volume.id,
+        title="C1",
+        content="正文不应被读取",
+        word_count=8,
+        order=1,
+    )
+    session.add(project)
+    session.add(volume)
+    session.add(chapter)
+    await session.commit()
+    session.sync_session.expunge_all()
+
+    chapters = await chapter_repo.get_metadata_by_ids(session, [chapter.id])
+
+    assert len(chapters) == 1
+    assert chapters[0].title == "C1"
+    assert "content" in inspect(chapters[0]).unloaded
+
+
+@pytest.mark.asyncio
 async def test_get_by_volume_ref_supports_order_and_first_matching_title(session):
     project = Project(title="P", description="")
     volume = Volume(project_id=project.id, title="第一卷", order=1)

--- a/frontend/src/features/writing/components/chapter-list-item.tsx
+++ b/frontend/src/features/writing/components/chapter-list-item.tsx
@@ -2,11 +2,10 @@
  * Chapter List Item
  *
  * 章节列表项组件，显示章节名、字数和编辑时间。
- * 普通滚动路径不接入 dnd-kit，只在拖拽模式下启用 sortable。
+ * 普通滚动路径不接入 dnd-kit，只在拖拽模式下启用 draggable。
  */
 
-import { useSortable } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
+import { useDraggable } from "@dnd-kit/core";
 import { Box, Flex, Text, Tooltip } from "@radix-ui/themes";
 import { GripVertical, MoreHorizontal } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -16,6 +15,7 @@ import type { SummaryStatus } from "@/lib/api-client";
 import type { ChapterListItem as ChapterListItemType } from "@/lib/chapter.types";
 import { formatRelativeTime } from "@/lib/time-utils";
 
+import { CHAPTER_LIST_ITEM_HEIGHT } from "../lib/chapter-list-drag";
 import { SummaryStatusDot } from "./summary-status-dot";
 
 function RenameInput({
@@ -486,38 +486,48 @@ function ChapterListItemComponent({
   );
 }
 
-interface SortableChapterListItemProps {
+interface DraggableChapterListItemProps {
   chapter: ChapterListItemType;
   isActive: boolean;
   onSelectChapter: (chapterId: string) => void;
   summaryStatus?: SummaryStatus;
   summaryIsStale?: boolean;
   onOpenSummary?: () => void;
+  isDragSource?: boolean;
+  isDragActive?: boolean;
+  dragOffset?: number;
+  isDragOverlay?: boolean;
 }
 
-function SortableChapterListItemComponent({
+function DraggableChapterListItemComponent({
   chapter,
   isActive,
   onSelectChapter,
   summaryStatus,
   summaryIsStale = false,
   onOpenSummary,
-}: SortableChapterListItemProps) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+  isDragSource = false,
+  isDragActive = false,
+  dragOffset = 0,
+  isDragOverlay = false,
+}: DraggableChapterListItemProps) {
+  const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: chapter.id,
+    disabled: isDragOverlay,
   });
 
   const style = useMemo(
     () => ({
-      transform: CSS.Transform.toString(transform),
-      transition: transition
-        ? `${transition}, background-color 0.08s ease, opacity 0.08s ease`
-        : "background-color 0.08s ease, opacity 0.08s ease",
-      opacity: isDragging ? 0.5 : 1,
-      background: isDragging ? "var(--accent-a2)" : isActive ? "var(--accent-a3)" : "transparent",
-      cursor: "grab",
+      transform: dragOffset === 0 ? undefined : `translateY(${dragOffset}px)`,
+      transition: isDragActive
+        ? "transform 0.14s ease, background-color 0.08s ease, color 0.08s ease, opacity 0.08s ease"
+        : "background-color 0.08s ease, color 0.08s ease, opacity 0.08s ease",
+      opacity: isDragSource ? 0 : 1,
+      background: isActive ? "var(--accent-a3)" : "transparent",
+      cursor: isDragging ? "grabbing" : "grab",
       width: "100%",
       minWidth: 0,
+      height: CHAPTER_LIST_ITEM_HEIGHT,
       overflow: "hidden",
       position: "relative" as const,
       contain: "layout style" as const,
@@ -527,7 +537,7 @@ function SortableChapterListItemComponent({
       WebkitTouchCallout: "none" as const,
       WebkitTapHighlightColor: "transparent",
     }),
-    [isActive, isDragging, transform, transition],
+    [dragOffset, isActive, isDragActive, isDragSource, isDragging],
   );
 
   const handleSelect = useCallback(() => {
@@ -536,6 +546,7 @@ function SortableChapterListItemComponent({
 
   const handleDragHandlePointerDown = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
+      event.stopPropagation();
       listeners?.onPointerDown?.(event);
     },
     [listeners],
@@ -546,8 +557,7 @@ function SortableChapterListItemComponent({
       ref={setNodeRef}
       className="chapter-list-item-row"
       style={style}
-      onClick={handleSelect}
-      {...attributes}
+      onClick={isDragOverlay ? undefined : handleSelect}
     >
       <ChapterRowContent
         chapter={chapter}
@@ -557,12 +567,13 @@ function SortableChapterListItemComponent({
         onOpenSummary={onOpenSummary}
         dragHandle={
           <Box
+            {...attributes}
             style={{
               color: "var(--gray-9)",
               flexShrink: 0,
               touchAction: "none",
             }}
-            onPointerDown={handleDragHandlePointerDown}
+            onPointerDown={isDragOverlay ? undefined : handleDragHandlePointerDown}
             onClick={(event) => event.stopPropagation()}
           >
             <GripVertical size={16} />
@@ -594,9 +605,9 @@ function areBaseRowPropsEqual(prev: ChapterListItemBaseProps, next: ChapterListI
   );
 }
 
-function areSortableRowPropsEqual(
-  prev: SortableChapterListItemProps,
-  next: SortableChapterListItemProps,
+function areDraggableRowPropsEqual(
+  prev: DraggableChapterListItemProps,
+  next: DraggableChapterListItemProps,
 ) {
   return (
     prev.chapter.id === next.chapter.id &&
@@ -608,12 +619,16 @@ function areSortableRowPropsEqual(
     prev.summaryStatus === next.summaryStatus &&
     prev.summaryIsStale === next.summaryIsStale &&
     prev.onOpenSummary === next.onOpenSummary &&
-    prev.onSelectChapter === next.onSelectChapter
+    prev.onSelectChapter === next.onSelectChapter &&
+    prev.isDragSource === next.isDragSource &&
+    prev.isDragActive === next.isDragActive &&
+    prev.dragOffset === next.dragOffset &&
+    prev.isDragOverlay === next.isDragOverlay
   );
 }
 
 export const ChapterListItem = memo(ChapterListItemComponent, areBaseRowPropsEqual);
-export const SortableChapterListItem = memo(
-  SortableChapterListItemComponent,
-  areSortableRowPropsEqual,
+export const DraggableChapterListItem = memo(
+  DraggableChapterListItemComponent,
+  areDraggableRowPropsEqual,
 );

--- a/frontend/src/features/writing/components/grouped-volume-list-model.ts
+++ b/frontend/src/features/writing/components/grouped-volume-list-model.ts
@@ -16,6 +16,7 @@ export type GroupedVolumeListItem =
 interface BuildGroupedVolumeListModelParams {
   volumes: VolumeWithChapters[];
   expandedVolumeIds: Set<string>;
+  chapterOrderMap?: Readonly<Record<string, number>>;
 }
 
 interface GetCollapseScrollGroupIndexParams {
@@ -35,6 +36,7 @@ export interface GroupedVolumeListModel {
   items: GroupedVolumeListItem[];
   groupCounts: number[];
   chapterById: Map<string, ChapterListItem>;
+  chapterIndexById: Map<string, number>;
   keyByInternalIndex: Map<number, string>;
   getChapterScrollIndex: (chapterId: string) => number | undefined;
 }
@@ -71,9 +73,9 @@ export function shouldAnchorCollapsedGroupScroll({
 
 export function getSortedVolumeChapters(
   chapters: ChapterListItem[],
-  dragOrderMap: Readonly<Record<string, number>>,
+  dragOrderMap?: Readonly<Record<string, number>>,
 ): ChapterListItem[] {
-  if (Object.keys(dragOrderMap).length === 0) {
+  if (!dragOrderMap || Object.keys(dragOrderMap).length === 0) {
     return chapters;
   }
 
@@ -103,16 +105,20 @@ export function getGroupedVolumeListStructureSignature(
 export function buildGroupedVolumeListModel({
   volumes,
   expandedVolumeIds,
+  chapterOrderMap,
 }: BuildGroupedVolumeListModelParams): GroupedVolumeListModel {
   const items: GroupedVolumeListItem[] = [];
   const groupCounts: number[] = [];
   const chapterById = new Map<string, ChapterListItem>();
+  const chapterIndexById = new Map<string, number>();
   const chapterScrollIndexById = new Map<string, number>();
   const keyByInternalIndex = new Map<number, string>();
   let itemIndex = 0;
   let internalIndex = 0;
 
   for (const volume of volumes) {
+    const chapters = getSortedVolumeChapters(volume.chapters, chapterOrderMap);
+
     keyByInternalIndex.set(internalIndex, `volume:${volume.id}`);
     internalIndex += 1;
 
@@ -125,7 +131,7 @@ export function buildGroupedVolumeListModel({
       continue;
     }
 
-    if (volume.chapters.length === 0) {
+    if (chapters.length === 0) {
       items.push({
         type: "empty",
         key: `empty:${volume.id}`,
@@ -138,14 +144,15 @@ export function buildGroupedVolumeListModel({
       continue;
     }
 
-    groupCounts.push(volume.chapters.length);
-    for (const chapter of volume.chapters) {
+    groupCounts.push(chapters.length);
+    for (const [chapterIndex, chapter] of chapters.entries()) {
       items.push({
         type: "chapter",
         key: `chapter:${chapter.id}`,
         volumeId: volume.id,
         chapter,
       });
+      chapterIndexById.set(chapter.id, chapterIndex);
       keyByInternalIndex.set(internalIndex, `chapter:${chapter.id}`);
       chapterScrollIndexById.set(chapter.id, itemIndex);
       internalIndex += 1;
@@ -157,6 +164,7 @@ export function buildGroupedVolumeListModel({
     items,
     groupCounts,
     chapterById,
+    chapterIndexById,
     keyByInternalIndex,
     getChapterScrollIndex: (chapterId) => chapterScrollIndexById.get(chapterId),
   };

--- a/frontend/src/features/writing/components/grouped-volume-list.tsx
+++ b/frontend/src/features/writing/components/grouped-volume-list.tsx
@@ -1,18 +1,14 @@
 import {
   DndContext,
-  closestCenter,
-  KeyboardSensor,
+  DragOverlay,
   PointerSensor,
   useSensor,
   useSensors,
   type DragEndEvent,
+  type DragMoveEvent,
+  type DragStartEvent,
 } from "@dnd-kit/core";
-import { restrictToParentElement, restrictToVerticalAxis } from "@dnd-kit/modifiers";
-import {
-  SortableContext,
-  sortableKeyboardCoordinates,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
+import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { Box, Text } from "@radix-ui/themes";
 import { AtSign, Copy, ExternalLink, MoveRight, Pencil, Trash2 } from "lucide-react";
 import {
@@ -25,6 +21,7 @@ import {
   useState,
   type ForwardedRef,
 } from "react";
+import { flushSync } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { GroupedVirtuoso, type GroupedVirtuosoHandle, type ScrollerProps } from "react-virtuoso";
 import { useShallow } from "zustand/react/shallow";
@@ -38,8 +35,15 @@ import type {
   VolumeWithChapters,
 } from "@/lib/chapter.types";
 
+import {
+  CHAPTER_LIST_ITEM_HEIGHT,
+  getAutoScrollSpeed,
+  getChapterDragGroupContentTop,
+  getChapterDragOffset,
+  getChapterDragTargetIndex,
+} from "../lib/chapter-list-drag";
 import { useWritingStore } from "../store/use-writing-store";
-import { ChapterListItem, SortableChapterListItem } from "./chapter-list-item";
+import { ChapterListItem, DraggableChapterListItem } from "./chapter-list-item";
 import {
   resolveInitialCurrentChapterNavigation,
   resolveGroupedVolumeListScrollRequest,
@@ -50,7 +54,6 @@ import {
   buildGroupedVolumeListModel,
   getCollapseScrollGroupIndex,
   getGroupedVolumeListStructureSignature,
-  getSortedVolumeChapters,
   shouldAnchorCollapsedGroupScroll,
   type GroupedVolumeListItem,
 } from "./grouped-volume-list-model";
@@ -67,6 +70,7 @@ const SCROLLBAR_MIN_THUMB_HEIGHT = 28;
 const SCROLLBAR_REFRESH_EVENT = "grouped-volume-list-scrollbar-refresh";
 const EMPTY_DRAG_ORDER_MAP: Readonly<Record<string, number>> = Object.freeze({});
 const VIRTUOSO_FALLBACK_MEASURE_HEIGHT = 1;
+const CHAPTER_LIST_VIRTUAL_OVERSCAN = 320;
 
 function assignForwardedRef<T>(ref: ForwardedRef<T>, value: T | null) {
   if (typeof ref === "function") {
@@ -352,6 +356,19 @@ interface GroupedVolumeListProps {
   onLockedAction?: () => void;
 }
 
+interface ChapterDragSession {
+  volumeId: string;
+  chapterIds: string[];
+  activeIndex: number;
+  groupContentTop: number | null;
+}
+
+interface ChapterDragState {
+  volumeId: string;
+  activeIndex: number;
+  targetIndex: number;
+}
+
 export function GroupedVolumeList({
   projectId,
   volumes,
@@ -400,15 +417,31 @@ export function GroupedVolumeList({
   const lastHandledScrollRequestKeyRef = useRef<string | null>(null);
   const lastAutoScrolledChapterKeyRef = useRef<string | null>(null);
   const lastHandledInitialCurrentChapterNavigationKeyRef = useRef<string | null>(null);
+  const dragSessionRef = useRef<ChapterDragSession | null>(null);
+  const dragTargetIndexRef = useRef<number | null>(null);
+  const lastDragClientYRef = useRef(0);
+  const autoScrollFrameRef = useRef<number | null>(null);
+  const autoScrollSpeedRef = useRef(0);
   const [measuredProjectId, setMeasuredProjectId] = useState<string | null>(null);
   const [contextMenuPos, setContextMenuPos] = useState<{ x: number; y: number } | null>(null);
   const [contextMenuChapterId, setContextMenuChapterId] = useState<string | null>(null);
   const [contextMenuChapterTitle, setContextMenuChapterTitle] = useState<string | null>(null);
   const [renamingChapterId, setRenamingChapterId] = useState<string | null>(null);
+  const [activeChapterId, setActiveChapterId] = useState<string | null>(null);
+  const [dragState, setDragState] = useState<ChapterDragState | null>(null);
 
   const listModel = useMemo(
-    () => buildGroupedVolumeListModel({ volumes, expandedVolumeIds }),
-    [expandedVolumeIds, volumes],
+    () =>
+      buildGroupedVolumeListModel({
+        volumes,
+        expandedVolumeIds,
+        chapterOrderMap: isDragMode ? dragOrderMap : undefined,
+      }),
+    [dragOrderMap, expandedVolumeIds, isDragMode, volumes],
+  );
+  const activeChapter = useMemo(
+    () => (activeChapterId ? (listModel.chapterById.get(activeChapterId) ?? null) : null),
+    [activeChapterId, listModel.chapterById],
   );
   const structureSignature = useMemo(
     () => getGroupedVolumeListStructureSignature(volumes, expandedVolumeIds),
@@ -429,9 +462,6 @@ export function GroupedVolumeList({
       activationConstraint: {
         distance: 8,
       },
-    }),
-    useSensor(KeyboardSensor, {
-      coordinateGetter: sortableKeyboardCoordinates,
     }),
   );
 
@@ -754,27 +784,206 @@ export function GroupedVolumeList({
     [expandedVolumeIds, getRegularGroupTop, getStickyGroupIndex, onToggleVolume, volumes],
   );
 
-  const handleSortableDragEnd = useCallback(
-    (event: DragEndEvent, chapterIds: string[]) => {
-      if (isAgentLocked) {
-        onLockedAction?.();
+  const stopAutoScroll = useCallback(() => {
+    autoScrollSpeedRef.current = 0;
+    if (autoScrollFrameRef.current !== null) {
+      window.cancelAnimationFrame(autoScrollFrameRef.current);
+      autoScrollFrameRef.current = null;
+    }
+  }, []);
+
+  const clearDragState = useCallback(() => {
+    setActiveChapterId(null);
+    dragTargetIndexRef.current = null;
+    dragSessionRef.current = null;
+    setDragState(null);
+  }, []);
+
+  const updateDragTargetIndex = useCallback((targetIndex: number) => {
+    if (dragTargetIndexRef.current === targetIndex) return;
+
+    dragTargetIndexRef.current = targetIndex;
+    setDragState((current) => {
+      if (!current || current.targetIndex === targetIndex) return current;
+      return { ...current, targetIndex };
+    });
+  }, []);
+
+  const getCurrentDragTargetIndex = useCallback((clientY: number) => {
+    const session = dragSessionRef.current;
+    const scroller = scrollerElementRef.current;
+    if (!session || session.groupContentTop === null || !scroller) return null;
+
+    return getChapterDragTargetIndex({
+      containerTop: scroller.getBoundingClientRect().top,
+      scrollTop: scroller.scrollTop,
+      clientY,
+      groupContentTop: session.groupContentTop,
+      itemCount: session.chapterIds.length,
+    });
+  }, []);
+
+  const startAutoScroll = useCallback(() => {
+    if (autoScrollFrameRef.current !== null) return;
+
+    const step = () => {
+      autoScrollFrameRef.current = null;
+      const scroller = scrollerElementRef.current;
+      const speed = autoScrollSpeedRef.current;
+      if (!scroller || speed === 0) return;
+
+      const maxScrollTop = scroller.scrollHeight - scroller.clientHeight;
+      const nextScrollTop = Math.max(0, Math.min(scroller.scrollTop + speed, maxScrollTop));
+      if (nextScrollTop === scroller.scrollTop) {
+        autoScrollSpeedRef.current = 0;
         return;
       }
 
-      const { active, over } = event;
-      if (!over || active.id === over.id) {
+      scroller.scrollTop = nextScrollTop;
+      const targetIndex = getCurrentDragTargetIndex(lastDragClientYRef.current);
+      if (targetIndex !== null) {
+        updateDragTargetIndex(targetIndex);
+      }
+      autoScrollFrameRef.current = window.requestAnimationFrame(step);
+    };
+
+    autoScrollFrameRef.current = window.requestAnimationFrame(step);
+  }, [getCurrentDragTargetIndex, updateDragTargetIndex]);
+
+  const handleDragStart = useCallback(
+    (event: DragStartEvent) => {
+      stopAutoScroll();
+
+      const activeChapterId = String(event.active.id);
+      const activeChapter = listModel.chapterById.get(activeChapterId);
+      const activeIndex = listModel.chapterIndexById.get(activeChapterId);
+      const initialRect = event.active.rect.current.initial;
+      const scroller = scrollerElementRef.current;
+      if (!activeChapter || activeIndex === undefined || !scroller) {
+        clearDragState();
         return;
       }
 
-      const oldIndex = chapterIds.indexOf(active.id as string);
-      const newIndex = chapterIds.indexOf(over.id as string);
-      if (oldIndex === -1 || newIndex === -1) {
+      const chapterIds = listModel.items.flatMap((row) =>
+        row.type === "chapter" && row.volumeId === activeChapter.volumeId ? [row.chapter.id] : [],
+      );
+      if (chapterIds.length === 0) {
+        clearDragState();
         return;
       }
 
-      reorderChapters(oldIndex, newIndex, chapterIds);
+      const scrollerRect = scroller.getBoundingClientRect();
+      dragSessionRef.current = {
+        volumeId: activeChapter.volumeId,
+        chapterIds,
+        activeIndex,
+        groupContentTop: getChapterDragGroupContentTop({
+          containerTop: scrollerRect.top,
+          scrollTop: scroller.scrollTop,
+          initialTop: initialRect?.top ?? null,
+          activeIndex,
+        }),
+      };
+      dragTargetIndexRef.current = activeIndex;
+      lastDragClientYRef.current = initialRect ? initialRect.top + initialRect.height / 2 : 0;
+      setActiveChapterId(activeChapterId);
+      setDragState({
+        volumeId: activeChapter.volumeId,
+        activeIndex,
+        targetIndex: activeIndex,
+      });
     },
-    [isAgentLocked, onLockedAction, reorderChapters],
+    [clearDragState, listModel, stopAutoScroll],
+  );
+
+  const handleDragMove = useCallback(
+    (event: DragMoveEvent) => {
+      if (!dragSessionRef.current) return;
+
+      const scroller = scrollerElementRef.current;
+      const translatedRect = event.active.rect.current.translated;
+      if (!scroller || !translatedRect) {
+        stopAutoScroll();
+        return;
+      }
+
+      const scrollerRect = scroller.getBoundingClientRect();
+      const session = dragSessionRef.current;
+      const initialRect = event.active.rect.current.initial;
+      if (session && session.groupContentTop === null && initialRect) {
+        session.groupContentTop = getChapterDragGroupContentTop({
+          containerTop: scrollerRect.top,
+          scrollTop: scroller.scrollTop,
+          initialTop: initialRect.top,
+          activeIndex: session.activeIndex,
+        });
+      }
+
+      lastDragClientYRef.current = translatedRect.top + translatedRect.height / 2;
+      const targetIndex = getCurrentDragTargetIndex(lastDragClientYRef.current);
+      if (targetIndex !== null) {
+        updateDragTargetIndex(targetIndex);
+      }
+
+      const speed = getAutoScrollSpeed({
+        containerTop: scrollerRect.top,
+        containerBottom: scrollerRect.bottom,
+        itemTop: translatedRect.top,
+        itemBottom: translatedRect.bottom,
+      });
+      autoScrollSpeedRef.current = speed;
+      if (speed === 0) {
+        stopAutoScroll();
+        return;
+      }
+      startAutoScroll();
+    },
+    [getCurrentDragTargetIndex, startAutoScroll, stopAutoScroll, updateDragTargetIndex],
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      stopAutoScroll();
+      const session = dragSessionRef.current;
+      const activeChapterId = String(event.active.id);
+      const newIndex = dragTargetIndexRef.current;
+      if (isAgentLocked || !session || session.groupContentTop === null || newIndex === null) {
+        if (isAgentLocked) onLockedAction?.();
+        clearDragState();
+        return;
+      }
+
+      const oldIndex = session.chapterIds.indexOf(activeChapterId);
+      if (oldIndex === -1 || oldIndex !== session.activeIndex || oldIndex === newIndex) {
+        clearDragState();
+        return;
+      }
+
+      flushSync(() => {
+        clearDragState();
+        reorderChapters(oldIndex, newIndex, session.chapterIds);
+      });
+    },
+    [clearDragState, isAgentLocked, onLockedAction, reorderChapters, stopAutoScroll],
+  );
+
+  const handleDragCancel = useCallback(() => {
+    stopAutoScroll();
+    clearDragState();
+  }, [clearDragState, stopAutoScroll]);
+
+  useEffect(() => {
+    if (isDragMode) return;
+    stopAutoScroll();
+    clearDragState();
+  }, [clearDragState, isDragMode, stopAutoScroll]);
+
+  useEffect(
+    () => () => {
+      stopAutoScroll();
+      clearDragState();
+    },
+    [clearDragState, stopAutoScroll],
   );
 
   const handleRequestContextMenu = useCallback(
@@ -959,7 +1168,11 @@ export function GroupedVolumeList({
           <Box
             px="4"
             py="3"
-            style={{ borderBottom: "1px solid var(--gray-a4)" }}
+            style={{
+              borderBottom: "1px solid var(--gray-a4)",
+              height: isDragMode ? CHAPTER_LIST_ITEM_HEIGHT : undefined,
+              boxSizing: "border-box",
+            }}
           >
             <Text
               size="1"
@@ -968,6 +1181,32 @@ export function GroupedVolumeList({
               {t("volume.empty")}
             </Text>
           </Box>
+        );
+      }
+
+      const chapterIndex = listModel.chapterIndexById.get(row.chapter.id);
+      const dragOffset =
+        isDragMode && dragState?.volumeId === row.volumeId && chapterIndex !== undefined
+          ? getChapterDragOffset({
+              chapterIndex,
+              activeIndex: dragState.activeIndex,
+              targetIndex: dragState.targetIndex,
+            })
+          : 0;
+
+      if (isDragMode) {
+        return (
+          <DraggableChapterListItem
+            chapter={row.chapter}
+            isActive={currentChapterId === row.chapter.id}
+            isDragSource={activeChapterId === row.chapter.id}
+            isDragActive={dragState !== null}
+            dragOffset={dragOffset}
+            summaryStatus={summaryStatusMap[row.chapter.id]?.status}
+            summaryIsStale={summaryStatusMap[row.chapter.id]?.isStale}
+            onOpenSummary={onOpenSummary}
+            onSelectChapter={onChapterSelect}
+          />
         );
       }
 
@@ -989,13 +1228,16 @@ export function GroupedVolumeList({
       );
     },
     [
+      activeChapterId,
       contextMenuChapterId,
       contextMenuPos,
       currentChapterId,
+      dragState,
       handleLongPressStart,
       handleRenameCancel,
       handleRenameConfirm,
       handleRequestContextMenu,
+      isDragMode,
       listModel,
       onChapterSelect,
       renamingChapterId,
@@ -1053,129 +1295,53 @@ export function GroupedVolumeList({
     ],
   );
 
-  if (isDragMode) {
-    return (
-      <GroupedVolumeListScroller
-        ref={(node) => {
-          scrollerElementRef.current = node;
-        }}
-        style={{
-          flex: 1,
-          minHeight: 0,
-          overflowY: "auto",
-          position: "relative",
-          outline: "none",
-          WebkitOverflowScrolling: "touch",
-        }}
-        tabIndex={0}
-      >
-        <Box style={{ minHeight: "100%" }}>
-          {volumes.map((volume, groupIndex) => {
-            const isExpanded = expandedVolumeIds.has(volume.id);
-            const sortedChapters = getSortedVolumeChapters(volume.chapters, dragOrderMap);
-            const chapterIds = sortedChapters.map((chapter) => chapter.id);
-
-            return (
-              <Box
-                key={volume.id}
-                style={{ minWidth: 0 }}
-              >
-                <Box
-                  style={{
-                    position: "sticky",
-                    top: 0,
-                    zIndex: 3,
-                  }}
-                >
-                  <VolumeHeader
-                    volume={volume}
-                    isExpanded={isExpanded}
-                    isRenaming={renamingVolumeId === volume.id}
-                    isFirst={groupIndex === 0}
-                    isLast={groupIndex === volumes.length - 1}
-                    canDelete={canDeleteVolume}
-                    isAgentLocked={isAgentLocked}
-                    onToggle={() => handleToggleVolume(volume.id)}
-                    onStartRename={() => onStartRenameVolume(volume.id)}
-                    onRenameConfirm={(title) => onRenameVolume(volume.id, title)}
-                    onRenameCancel={onCancelRenameVolume}
-                    onEditDescription={() => onEditVolumeDescription(volume)}
-                    onCreateChapter={() => onCreateChapterInVolume(volume.id)}
-                    onAddToConversation={onAddToConversation}
-                    onMoveUp={() => onMoveVolumeUp(volume)}
-                    onMoveDown={() => onMoveVolumeDown(volume)}
-                    onDelete={() => onDeleteVolume(volume)}
-                    onLockedAction={onLockedAction}
-                  />
-                </Box>
-
-                {isExpanded && sortedChapters.length === 0 ? (
-                  <Box
-                    px="4"
-                    py="3"
-                    style={{ borderBottom: "1px solid var(--gray-a4)" }}
-                  >
-                    <Text
-                      size="1"
-                      color="gray"
-                    >
-                      {t("volume.empty")}
-                    </Text>
-                  </Box>
-                ) : null}
-
-                {isExpanded && sortedChapters.length > 0 ? (
-                  <DndContext
-                    sensors={sensors}
-                    collisionDetection={closestCenter}
-                    onDragEnd={(event) => handleSortableDragEnd(event, chapterIds)}
-                    modifiers={[restrictToVerticalAxis, restrictToParentElement]}
-                  >
-                    <SortableContext
-                      items={chapterIds}
-                      strategy={verticalListSortingStrategy}
-                    >
-                      {sortedChapters.map((chapter) => (
-                        <SortableChapterListItem
-                          key={chapter.id}
-                          chapter={chapter}
-                          isActive={currentChapterId === chapter.id}
-                          onSelectChapter={onChapterSelect}
-                          summaryStatus={summaryStatusMap[chapter.id]?.status}
-                          summaryIsStale={summaryStatusMap[chapter.id]?.isStale}
-                          onOpenSummary={onOpenSummary}
-                        />
-                      ))}
-                    </SortableContext>
-                  </DndContext>
-                ) : null}
-              </Box>
-            );
-          })}
-        </Box>
-      </GroupedVolumeListScroller>
-    );
-  }
+  const groupedVolumeList = (
+    <GroupedVirtuoso
+      ref={virtuosoRef}
+      style={{ flex: 1, minHeight: 0 }}
+      groupCounts={listModel.groupCounts}
+      overscan={isDragMode ? CHAPTER_LIST_VIRTUAL_OVERSCAN : 5}
+      atBottomStateChange={handleAtBottomStateChange}
+      components={GROUPED_VOLUME_LIST_COMPONENTS}
+      scrollerRef={handleScrollerRef}
+      totalListHeightChanged={markListMeasured}
+      rangeChanged={markListMeasured}
+      computeItemKey={(index) => listModel.keyByInternalIndex.get(index) ?? index}
+      groupContent={renderGroupHeader}
+      itemContent={renderItem}
+    />
+  );
 
   return (
     <>
-      <GroupedVirtuoso
-        ref={virtuosoRef}
-        style={{ flex: 1, minHeight: 0 }}
-        groupCounts={listModel.groupCounts}
-        overscan={5}
-        atBottomStateChange={handleAtBottomStateChange}
-        components={GROUPED_VOLUME_LIST_COMPONENTS}
-        scrollerRef={handleScrollerRef}
-        totalListHeightChanged={markListMeasured}
-        rangeChanged={markListMeasured}
-        computeItemKey={(index) => listModel.keyByInternalIndex.get(index) ?? index}
-        groupContent={renderGroupHeader}
-        itemContent={renderItem}
-      />
-
+      <DndContext
+        sensors={sensors}
+        onDragStart={handleDragStart}
+        onDragMove={handleDragMove}
+        onDragEnd={handleDragEnd}
+        onDragCancel={handleDragCancel}
+        modifiers={[restrictToVerticalAxis]}
+        autoScroll={false}
+      >
+        {groupedVolumeList}
+        <DragOverlay dropAnimation={null}>
+          {isDragMode && activeChapter ? (
+            <Box style={{ width: scrollerElementRef.current?.clientWidth }}>
+              <DraggableChapterListItem
+                chapter={activeChapter}
+                isActive={currentChapterId === activeChapter.id}
+                isDragOverlay
+                summaryStatus={summaryStatusMap[activeChapter.id]?.status}
+                summaryIsStale={summaryStatusMap[activeChapter.id]?.isStale}
+                onOpenSummary={onOpenSummary}
+                onSelectChapter={() => undefined}
+              />
+            </Box>
+          ) : null}
+        </DragOverlay>
+      </DndContext>
       <ContextMenu
-        position={contextMenuPos}
+        position={isDragMode ? null : contextMenuPos}
         items={menuItems}
         onClose={handleCloseContextMenu}
       />

--- a/frontend/src/features/writing/lib/chapter-list-drag.ts
+++ b/frontend/src/features/writing/lib/chapter-list-drag.ts
@@ -1,0 +1,118 @@
+const AUTO_SCROLL_EDGE_THRESHOLD = 56;
+const AUTO_SCROLL_MAX_SPEED = 18;
+
+export const CHAPTER_LIST_ITEM_HEIGHT = 64;
+
+interface AutoScrollPosition {
+  containerTop: number;
+  containerBottom: number;
+  itemTop: number;
+  itemBottom: number;
+}
+
+interface ChapterDragTargetPosition {
+  containerTop: number;
+  scrollTop: number;
+  clientY: number;
+  groupContentTop: number;
+  itemCount: number;
+}
+
+interface ChapterDragGroupContentTopPosition {
+  containerTop: number;
+  scrollTop: number;
+  initialTop: number | null;
+  activeIndex: number;
+}
+
+interface ChapterDragOffsetPosition {
+  chapterIndex: number;
+  activeIndex: number;
+  targetIndex: number;
+}
+
+export function getAutoScrollSpeed({
+  containerTop,
+  containerBottom,
+  itemTop,
+  itemBottom,
+}: AutoScrollPosition): number {
+  const distanceToTop = itemTop - containerTop;
+  if (distanceToTop < AUTO_SCROLL_EDGE_THRESHOLD) {
+    const ratio = (AUTO_SCROLL_EDGE_THRESHOLD - distanceToTop) / AUTO_SCROLL_EDGE_THRESHOLD;
+    return -Math.max(4, Math.round(AUTO_SCROLL_MAX_SPEED * ratio));
+  }
+
+  const distanceToBottom = containerBottom - itemBottom;
+  if (distanceToBottom < AUTO_SCROLL_EDGE_THRESHOLD) {
+    const ratio = (AUTO_SCROLL_EDGE_THRESHOLD - distanceToBottom) / AUTO_SCROLL_EDGE_THRESHOLD;
+    return Math.max(4, Math.round(AUTO_SCROLL_MAX_SPEED * ratio));
+  }
+
+  return 0;
+}
+
+export function getChapterDragGroupContentTop({
+  containerTop,
+  scrollTop,
+  initialTop,
+  activeIndex,
+}: ChapterDragGroupContentTopPosition): number | null {
+  if (initialTop === null) return null;
+
+  return scrollTop + initialTop - containerTop - activeIndex * CHAPTER_LIST_ITEM_HEIGHT;
+}
+
+export function getChapterDragTargetIndex({
+  containerTop,
+  scrollTop,
+  clientY,
+  groupContentTop,
+  itemCount,
+}: ChapterDragTargetPosition): number {
+  if (itemCount <= 1) return 0;
+
+  const index = Math.floor(
+    (scrollTop + clientY - containerTop - groupContentTop) / CHAPTER_LIST_ITEM_HEIGHT,
+  );
+  return Math.max(0, Math.min(index, itemCount - 1));
+}
+
+export function getChapterDragOffset({
+  chapterIndex,
+  activeIndex,
+  targetIndex,
+}: ChapterDragOffsetPosition): number {
+  if (chapterIndex === activeIndex || activeIndex === targetIndex) return 0;
+
+  if (activeIndex < targetIndex && chapterIndex > activeIndex && chapterIndex <= targetIndex) {
+    return -CHAPTER_LIST_ITEM_HEIGHT;
+  }
+
+  if (activeIndex > targetIndex && chapterIndex >= targetIndex && chapterIndex < activeIndex) {
+    return CHAPTER_LIST_ITEM_HEIGHT;
+  }
+
+  return 0;
+}
+
+export function reorderChapterIds(
+  chapterIds: string[],
+  fromIndex: number,
+  toIndex: number,
+): string[] | null {
+  if (
+    fromIndex < 0 ||
+    fromIndex >= chapterIds.length ||
+    toIndex < 0 ||
+    toIndex >= chapterIds.length ||
+    fromIndex === toIndex
+  ) {
+    return null;
+  }
+
+  const reorderedIds = [...chapterIds];
+  const [movedId] = reorderedIds.splice(fromIndex, 1);
+  reorderedIds.splice(toIndex, 0, movedId);
+  return reorderedIds;
+}

--- a/frontend/src/features/writing/store/use-writing-store.ts
+++ b/frontend/src/features/writing/store/use-writing-store.ts
@@ -8,6 +8,8 @@ import { create } from "zustand";
 
 import { getPreference, setPreference } from "@/lib/local-db";
 
+import { reorderChapterIds } from "../lib/chapter-list-drag";
+
 const EXPANDED_VOLUME_IDS_KEY = "writing.expandedVolumeIds";
 const SIDEBAR_VIEW_KEY = "writing.sidebarView";
 
@@ -94,10 +96,8 @@ export const useWritingStore = create<WritingStore>((set, get) => ({
     const { dragOrderMap, originalOrder } = get();
     const newMap = { ...dragOrderMap };
 
-    // 重新计算所有章节的顺序
-    const reorderedIds = [...chapterIds];
-    const [movedId] = reorderedIds.splice(fromIndex, 1);
-    reorderedIds.splice(toIndex, 0, movedId);
+    const reorderedIds = reorderChapterIds(chapterIds, fromIndex, toIndex);
+    if (!reorderedIds) return;
 
     reorderedIds.forEach((id, index) => {
       newMap[id] = index + 1;


### PR DESCRIPTION
## PR 标题
perf(chapter): 优化大规模章节排序性能

## 变更说明

- 问题: 大量章节进入排序模式时会全量挂载拖拽节点，排序接口还会读取正文并更新未变化章节。
- 重要性: 2000 个章节项目的排序操作会造成明显卡顿和接口延迟。
- 变化: 使用分组虚拟列表和局部拖拽投影；后端仅查询元数据、仅更新顺序变化的章节，并使用通用 SQLAlchemy 批量更新。

## 关联 Issue / PR

无

## 变更类型

- [ ] 新功能 (feat)
- [ ] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [x] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因

排序模式此前会为全部章节创建 dnd-kit 节点；后端排序会读取章节正文，并对完整章节列表执行排序更新。

## 自查清单

- [x] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

验证结果:
- `uv run pytest tests/api/test_chapters.py -q`: 22 passed
- `uv run pytest tests/storage/repos/test_chapter_repo.py -q`: 7 passed
- `uv run ty check app`: 通过
- `uv run ruff check app tests/api/test_chapters.py tests/storage/repos/test_chapter_repo.py`: 通过
- `pnpm type-check`: 通过
- `pnpm lint`: 通过
- `pnpm format:check`: 通过

实现未使用 SQLite 专有 SQL，排序写入使用通用 SQLAlchemy ORM 和 DBAPI executemany。