### PR TITLE
fix(frontend): 修复未知代码块语言导致内容不显示

### DIFF
--- a/frontend/src/lib/limited-code-highlighter.ts
+++ b/frontend/src/lib/limited-code-highlighter.ts
@@ -66,6 +66,17 @@ function resolveLanguage(language: string): SupportedLanguage | null {
   return Object.hasOwn(LANGUAGE_ALIASES, normalized) ? LANGUAGE_ALIASES[normalized] : null;
 }
 
+function createPlainTextHighlightResult(code: string): HighlightResult {
+  let offset = 0;
+  const tokens = code.split("\n").map((line) => {
+    const token = { content: line, offset };
+    offset += line.length + 1;
+    return [token];
+  });
+
+  return { bg: "transparent", fg: "inherit", tokens };
+}
+
 function resolveTheme(theme: ThemeInput, fallback: SupportedTheme): ResolvedTheme {
   if (typeof theme !== "string") return theme;
   if (Object.hasOwn(THEME_LOADERS, theme)) return theme as SupportedTheme;
@@ -106,7 +117,7 @@ function highlightCode(
   callback?: (result: HighlightResult) => void,
 ): HighlightResult | null {
   const language = resolveLanguage(options.language);
-  if (!language) return null;
+  if (!language) return createPlainTextHighlightResult(options.code);
 
   const themes: [ResolvedTheme, ResolvedTheme] = [
     resolveTheme(options.themes[0], DEFAULT_THEMES[0]),


### PR DESCRIPTION
## PR 标题
fix(frontend): 修复未知代码块语言导致内容不显示

## 变更说明

- 问题: Agent 输出使用 `text` 或其他未识别语言标识时，代码块内容可能显示不全或为空。
- 重要性: 自定义高亮插件对未识别语言返回 `null`，流式渲染路径无法稳定保留代码内容。
- 变化: 为无法识别的语言生成逐行纯文本令牌，保留原文显示并维持现有受限语法高亮范围。
- 验证: 已运行前端类型检查、Lint、格式检查及 `text`、未知语言回退验证。

## 关联 Issue / PR

无

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因

自定义代码高亮插件只加载受限语言集合；`text` 以及其他未识别语言无法解析时直接返回 `null`，导致 Streamdown 的懒加载代码块无法稳定渲染纯文本回退内容。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [x] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

无