### PR TITLE
fix(frontend): 修复工具栏滑动误触发移动端侧栏手势的问题

### DIFF
--- a/frontend/src/components/editor-toolbar.tsx
+++ b/frontend/src/components/editor-toolbar.tsx
@@ -648,6 +648,7 @@ export function EditorToolbar({
     <Box
       ref={toolbarRef}
       className="editor-toolbar"
+      data-mobile-sidebar-swipe-ignore="true"
       data-mobile-viewport={mobileToolbarState.isMobileViewport}
       data-mobile-keyboard-open={mobileToolbarState.isKeyboardOpen}
       onPointerDownCapture={handleToolbarPointerDownCapture}

--- a/frontend/src/features/writing/pages/writing-page.tsx
+++ b/frontend/src/features/writing/pages/writing-page.tsx
@@ -33,6 +33,18 @@ const SummaryPanel = lazy(() =>
   import("../components/summary-panel").then((module) => ({ default: module.SummaryPanel })),
 );
 
+function blurMobileEditorElement(): void {
+  const activeElement = document.activeElement;
+  if (!(activeElement instanceof HTMLElement)) return;
+
+  const isTextInput =
+    activeElement instanceof HTMLInputElement || activeElement instanceof HTMLTextAreaElement;
+
+  if (!isTextInput && !activeElement.isContentEditable) return;
+
+  activeElement.blur();
+}
+
 export function WritingPage() {
   const { t } = useTranslation();
   const { projectId } = useParams<{ projectId: string }>();
@@ -80,6 +92,7 @@ export function WritingPage() {
     isOpen: isSidebarOpen,
     onOpen: () => setIsSidebarOpen(true),
     onClose: () => setIsSidebarOpen(false),
+    onSwipe: blurMobileEditorElement,
   });
   const [isSummaryOpen, setIsSummaryOpen] = useState(false);
   const [hasOpenedSummary, setHasOpenedSummary] = useState(false);
@@ -233,16 +246,8 @@ export function WritingPage() {
     if (!isMobile || !currentChapterId) return;
 
     const frameId = window.requestAnimationFrame(() => {
-      const activeElement = document.activeElement;
-      if (!(activeElement instanceof HTMLElement)) return;
-
-      const isTextInput =
-        activeElement instanceof HTMLInputElement || activeElement instanceof HTMLTextAreaElement;
-
       // Mobile browsers may restore editor/title focus after chapter navigation.
-      if (!isTextInput && !activeElement.isContentEditable) return;
-
-      activeElement.blur();
+      blurMobileEditorElement();
     });
 
     return () => window.cancelAnimationFrame(frameId);

--- a/frontend/src/hooks/use-mobile-sidebar-swipe.ts
+++ b/frontend/src/hooks/use-mobile-sidebar-swipe.ts
@@ -1,10 +1,18 @@
+import { useRef } from "react";
 import { useSwipeable, type SwipeableHandlers } from "react-swipeable";
+
+const SWIPE_IGNORE_SELECTOR = "[data-mobile-sidebar-swipe-ignore]";
+
+function isIgnoredSwipeTarget(target: EventTarget | null): boolean {
+  return target instanceof Element && target.closest(SWIPE_IGNORE_SELECTOR) !== null;
+}
 
 interface UseMobileSidebarSwipeOptions {
   isEnabled: boolean;
   isOpen: boolean;
   onOpen?: () => void;
   onClose?: () => void;
+  onSwipe?: () => void;
 }
 
 export function useMobileSidebarSwipe({
@@ -12,14 +20,27 @@ export function useMobileSidebarSwipe({
   isOpen,
   onOpen,
   onClose,
+  onSwipe,
 }: UseMobileSidebarSwipeOptions): SwipeableHandlers {
+  const shouldIgnoreSwipeRef = useRef(false);
+
   return useSwipeable({
     delta: 40,
+    onTouchStartOrOnMouseDown: ({ event }) => {
+      shouldIgnoreSwipeRef.current = isIgnoredSwipeTarget(event.target);
+    },
+    onTouchEndOrOnMouseUp: () => {
+      shouldIgnoreSwipeRef.current = false;
+    },
     onSwipedRight: () => {
-      if (isEnabled && !isOpen) onOpen?.();
+      if (shouldIgnoreSwipeRef.current || !isEnabled || isOpen) return;
+      onSwipe?.();
+      onOpen?.();
     },
     onSwipedLeft: () => {
-      if (isEnabled && isOpen) onClose?.();
+      if (shouldIgnoreSwipeRef.current || !isEnabled || !isOpen) return;
+      onSwipe?.();
+      onClose?.();
     },
     trackTouch: isEnabled,
     trackMouse: false,


### PR DESCRIPTION
## 变更说明

- 问题：PR #391 添加的页面级滑动手势会接收到工具栏的触摸事件，导致横向滑动工具栏时误触发侧栏移动。
- 重要性：工具栏本身需要横向滚动，误触发会造成侧栏意外打开或关闭，干扰编辑操作。
- 变化：忽略从工具栏开始的侧栏手势；编辑器区域的有效侧栏手势仍会在触发前使编辑器或标题输入失焦，从而收起键盘。

## 关联 Issue / PR

Related to #391

## 变更类型

- [ ] 新功能 (feat)
- [x] 错误修复 (fix)
- [ ] 文档更新 (docs)
- [ ] 代码格式调整 (style)
- [ ] 代码重构 (refactor)
- [ ] 性能优化 (perf)
- [ ] 测试相关 (test)
- [ ] 杂项 (chore)

## 问题原因

页面手势 Hook 在页面根节点注册触摸监听，工具栏的触摸事件会冒泡到该节点；原实现没有记录触摸起点是否位于工具栏，因此工具栏横向滑动会被当作侧栏手势处理。键盘收起逻辑则原本没有接入编辑器区域的有效侧栏手势回调。

## 自查清单

- [ ] 已添加/更新必要的测试
- [x] 已运行 lint 和 typecheck，无报错
- [ ] 已运行测试用例，全部通过
- [x] 变更范围合理，未包含无关修改
- [x] 未暴露敏感信息（API Key、密码等）
- [x] 提交信息符合规范

## 补充信息

无